### PR TITLE
[0.27] Backport d7523490

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -252,7 +252,7 @@ def check_MACHO_sdk(binary) -> bool:
     return False
 
 def check_MACHO_lld(binary) -> bool:
-    if binary.build_version.tools[0].version == [18, 1, 6]:
+    if binary.build_version.tools[0].version == [18, 1, 8]:
         return True
     return False
 

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,7 +51,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=f0bb724211872cd6158fce6162e0b8c73efed126 \
+                      --commit=efc26826400762207cde9f23802cfe75a737963c \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -128,13 +128,17 @@ desirable for building Dash Core release binaries."
   (package-with-extra-patches binutils
     (search-our-patches "binutils-unaligned-default.patch")))
 
+(define (winpthreads-patches mingw-w64-x86_64-winpthreads)
+  (package-with-extra-patches mingw-w64-x86_64-winpthreads
+    (search-our-patches "winpthreads-remap-guix-store.patch")))
+
 (define (make-mingw-pthreads-cross-toolchain target)
   "Create a cross-compilation toolchain package for TARGET"
   (let* ((xbinutils (binutils-mingw-patches (cross-binutils target)))
          (machine (substring target 0 (string-index target #\-)))
-         (pthreads-xlibc (make-mingw-w64 machine
+         (pthreads-xlibc (winpthreads-patches (make-mingw-w64 machine
                                          #:xgcc (cross-gcc target #:xgcc (gcc-mingw-patches base-gcc))
-                                         #:with-winpthreads? #t))
+                                         #:with-winpthreads? #t)))
          (pthreads-xgcc (cross-gcc target
                                     #:xgcc (gcc-mingw-patches mingw-w64-base-gcc)
                                     #:xbinutils xbinutils

--- a/contrib/guix/patches/gcc-remap-guix-store.patch
+++ b/contrib/guix/patches/gcc-remap-guix-store.patch
@@ -1,14 +1,9 @@
-From aad25427e74f387412e8bc9a9d7bbc6c496c792f Mon Sep 17 00:00:00 2001
-From: Andrew Chow <achow101-github@achow101.com>
-Date: Wed, 6 Jul 2022 16:49:41 -0400
-Subject: [PATCH] guix: remap guix store paths to /usr
+Without ffile-prefix-map, the debug symbols will contain paths for the
+guix store which will include the hashes of each package. However, the
+hash for the same package will differ when on different architectures.
+In order to be reproducible regardless of the architecture used to build
+the package, map all guix store prefixes to something fixed, e.g. /usr.
 
----
- libgcc/Makefile.in | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/libgcc/Makefile.in b/libgcc/Makefile.in
-index 851e7657d07..476c2becd1c 100644
 --- a/libgcc/Makefile.in
 +++ b/libgcc/Makefile.in
 @@ -854,7 +854,7 @@ endif

--- a/contrib/guix/patches/winpthreads-remap-guix-store.patch
+++ b/contrib/guix/patches/winpthreads-remap-guix-store.patch
@@ -1,0 +1,17 @@
+Without ffile-prefix-map, the debug symbols will contain paths for the
+guix store which will include the hashes of each package. However, the
+hash for the same package will differ when on different architectures.
+In order to be reproducible regardless of the architecture used to build
+the package, map all guix store prefixes to something fixed, e.g. /usr.
+
+--- a/mingw-w64-libraries/winpthreads/Makefile.in
++++ b/mingw-w64-libraries/winpthreads/Makefile.in
+@@ -478,7 +478,7 @@ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ SUBDIRS = . tests
+-AM_CFLAGS = -Wall -DWIN32_LEAN_AND_MEAN $(am__append_1)
++AM_CFLAGS = -Wall -DWIN32_LEAN_AND_MEAN $(am__append_1) $(shell find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
+ ACLOCAL_AMFLAGS = -I m4
+ lib_LTLIBRARIES = libwinpthread.la
+ include_HEADERS = include/pthread.h include/sched.h include/semaphore.h include/pthread_unistd.h include/pthread_time.h include/pthread_compat.h include/pthread_signal.h

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -39,16 +39,9 @@ See [dependencies.md](dependencies.md) for a complete overview.
 ## Building for 64-bit Windows
 
 The first step is to install the mingw-w64 cross-compilation tool chain:
-  - on modern systems (Ubuntu 21.04 Hirsute Hippo or newer, Debian 11 Bullseye or newer):
 
 ```sh
 sudo apt install g++-mingw-w64-x86-64-posix
-```
-
-  - on older systems:
-
-```sh
-sudo apt install g++-mingw-w64-x86-64
 ```
 
 Once the toolchain is installed the build steps are common:

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -240,17 +240,6 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     BOOST_CHECK_EQUAL(result5->GetSelectedValue(), 10 * CENT);
     expected_result.Clear();
 
-    // Negative effective value
-    // Select 10 Cent but have 1 Cent not be possible because too small
-    add_coin(5 * CENT, 5, expected_result);
-    add_coin(3 * CENT, 3, expected_result);
-    add_coin(2 * CENT, 2, expected_result);
-    const auto result6 = SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 5000);
-    BOOST_CHECK(result6);
-    BOOST_CHECK_EQUAL(result6->GetSelectedValue(), 10 * CENT);
-    // FIXME: this test is redundant with the above, because 1 Cent is selected, not "too small"
-    // BOOST_CHECK(EquivalentResult(expected_result, *result));
-
     // Select 0.25 Cent, not possible
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.25 * CENT, 0.5 * CENT));
     expected_result.Clear();


### PR DESCRIPTION
Cherry-pick d752349029 to 0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified Windows build instructions by providing a single installation command for the mingw-w64 toolchain, removing outdated alternatives for older systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->