### PR TITLE
[0.28] Backport bacab138

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,7 +51,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=efc26826400762207cde9f23802cfe75a737963c \
+                      --commit=7bf1d7aeaffba15c4f680f93ae88fbef25427252 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
Cherry-pick bacab1380e to 0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the pinned commit for the Guix time-machine command to ensure continued reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->