### PR TITLE
Backport bitcoin#25298: doc: Improve wallet dependencies section in OpenBSD Build Guide

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -32,7 +32,12 @@ the same executable will result in errors.
 
 ### Building BerkeleyDB
 
-BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
+#### Wallet Dependencies
+
+It is not necessary to build wallet functionality to run either `dashd` or `dash-qt`.
+
+###### Legacy Wallet Support
+BerkeleyDB is required for wallet functionality. To skip this, pass
 `--disable-wallet` to `./configure` and skip to the next section.
 
 It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library


### PR DESCRIPTION
Backports bitcoin#25298

## Summary
- Reorganizes wallet dependency information for better clarity
- Clarifies that wallet functionality is optional for running dashd/dash-qt
- Better separates legacy wallet requirements (BerkeleyDB)
- Adapts content for Dash (removes descriptor wallet section not applicable to Dash)

Original commit: bbf2a25044

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>