### PR TITLE
Backport bitcoin#25288: test: Reliably don't run all-lint.py itself

### DIFF
--- a/test/lint/all-lint.py
+++ b/test/lint/all-lint.py
@@ -15,22 +15,10 @@ from subprocess import run
 
 exit_code = 0
 mod_path = Path(__file__).parent
-lints = glob(f"{mod_path}/lint-*")
-if which("parallel") and which("column"):
-    logfile = "parallel_out.log"
-    command = ["parallel", "--jobs", "100%", "--will-cite", "--joblog", logfile, ":::"] + lints
-    result = run(command)
+for lint in glob(f"{mod_path}/lint-*.py"):
+    result = run([lint])
     if result.returncode != 0:
-        print(f"^---- failure generated")
-        exit_code = result.returncode
-    result = run(["column", "-t", logfile])
-    if os_path.isfile(logfile):
-        remove(logfile)
-else:
-    for lint in lints:
-        result = run([lint])
-        if result.returncode != 0:
-            print(f"^---- failure generated from {lint.split('/')[-1]}")
-            exit_code |= result.returncode
+        print(f"^---- failure generated from {lint.split('/')[-1]}")
+        exit_code |= result.returncode
 
 exit(exit_code)


### PR DESCRIPTION
Backports bitcoin#25288

## Summary
- Fixes issue where all-lint.py would run itself recursively
- Changes glob pattern from 'lint-*' to 'lint-*.py' to exclude all-lint.py
- Simplifies script by removing complex parallel execution logic
- Prevents lint tests from running twice

Original commit: f66633d9cb

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>