### PR TITLE
Backport bitcoin#24395: build: use BOOST_MULTI_INDEX_ENABLE_SAFE_MODE when debugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1484,6 +1484,10 @@ fi
   dnl we don't use multi_index serialization
   BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION"
 
+  if test "$enable_debug" = "yes" || test "$enable_fuzz" = "yes"; then
+    BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE"
+  fi
+
 dnl Prevent use of std::unary_function, which was removed in C++17,
 dnl and will generate warnings with newer compilers for Boost
 dnl older than 1.80.


### PR DESCRIPTION
Backports bitcoin/bitcoin#24395

Original commit: 2e079c86a

Adds BOOST_MULTI_INDEX_ENABLE_SAFE_MODE flag when debugging or fuzzing is enabled, which helps catch Boost multi-index container bugs during development.

Conflicts resolved in configure.ac - merged Bitcoin's debugging flag with Dash's existing Boost configuration (BOOST_NO_CXX98_FUNCTION_BASE and Boost Process).