### PR TITLE
Backport bitcoin#25307: doc: add desig to ignore-words

### DIFF
--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -4,6 +4,7 @@ blockin
 cachable
 creat
 crypted
+desig
 fo
 fpr
 hights


### PR DESCRIPTION
Backports bitcoin/bitcoin#25307

Original commit: e3c08eb62

Adds 'desig' to spelling ignore-words list as it's a valid word used in the codebase.

Note: The typo fix in src/kernel/context.h was skipped as Dash doesn't have the kernel modularization yet.