### PR TITLE
Backport bitcoin#25352: test: Fix previous release binary download script for Apple ARM64

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -118,7 +118,7 @@ def download_binary(tag, args) -> int:
         bin_path = 'releases/download/test.{}'.format(
             match.group(1), match.group(2))
     platform = args.platform
-    if tag < "v20" and platform in ["x86_64-apple-darwin", "aarch64-apple-darwin"]:
+    if tag < "v20" and platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
         platform = "osx64"
     tarball = 'dashcore-{tag}-{platform}.tar.gz'.format(
         tag=tag[1:], platform=platform)
@@ -254,7 +254,7 @@ def check_host(args) -> int:
             'aarch64-*-linux*': 'aarch64-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',
-            'aarch64-apple-darwin*': 'aarch64-apple-darwin',
+            'aarch64-apple-darwin*': 'arm64-apple-darwin',
         }
         args.platform = ''
         for pattern, target in platforms.items():


### PR DESCRIPTION
Backports bitcoin/bitcoin#25352

Original commit: 3340d46cd

Fixes the platform name for Apple ARM64 from 'aarch64-apple-darwin' to 'arm64-apple-darwin' in the test binary download script.

Conflicts resolved: kept Dash version check (v20) while adopting the correct ARM64 platform name.