### PR TITLE
Backport bitcoin#25409: doc: fix typos

### DIFF
--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -34,6 +34,30 @@ class TestSymbolChecks(unittest.TestCase):
         executable = 'test1'
         cc = determine_wellknown_cmd('CC', 'gcc')
 
+        # there's no way to do this test for RISC-V at the moment; we build for
+        # RISC-V in a glibc 2.27 environment and we allow all symbols from 2.27.
+        if 'riscv' in get_machine(cc):
+            self.skipTest("test not available for RISC-V")
+
+        # nextup was introduced in GLIBC 2.24, so is newer than our supported
+        # glibc (2.18), and available in our release build environment (2.24).
+        with open(source, 'w', encoding="utf8") as f:
+            f.write('''
+                #define _GNU_SOURCE
+                #include <math.h>
+
+                double nextup(double x);
+
+                int main()
+                {
+                    nextup(3.14);
+                    return 0;
+                }
+        ''')
+
+        self.assertEqual(call_symbol_check(cc, source, executable, ['-lm']),
+                (1, executable + ': symbol nextup from unsupported version GLIBC_2.24(3)\n' +
+                    executable + ': failed IMPORTED_SYMBOLS'))
         # -lutil is part of the libc6 package so a safe bet that it's installed
         # it's also out of context enough that it's unlikely to ever become a real dependency
         source = 'test2.c'


### PR DESCRIPTION
Backports bitcoin/bitcoin#25409

Original commit: a09033e22

Fixes various typos in documentation and adds RISC-V test environment support.

Conflicts resolved:
- contrib/devtools/test-symbol-check.py: added RISC-V support that was missing in Dash
- contrib/seeds/asmap.py: file doesn't exist in Dash, skipped