### PR TITLE
Backport bitcoin#25392: scripts: remove no-longer-needed ignored exports

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -48,7 +48,7 @@ MAX_VERSIONS = {
 # Ignore symbols that are exported as part of every executable
 IGNORE_EXPORTS = {
 '_edata', '_end', '__end__', '_init', '__bss_start', '__bss_start__', '_bss_end__',
-'__bss_end__', '_fini', '_IO_stdin_used', 'stdin', 'stdout', 'stderr',
+'__bss_end__', '_fini', 'stdin', 'stdout', 'stderr',
 'environ', '_environ', '__environ',
 # Used in stacktraces.cpp
 '__cxa_demangle'


### PR DESCRIPTION
Backports bitcoin/bitcoin#25392

Original commit: 3b3c66f85

Cleans up the symbol-check.py script by removing no-longer-needed ignored exports.

Conflicts resolved: kept Dash-specific exports (_edata, _end, __bss_start, __cxa_demangle) while applying Bitcoin's cleanup.