### PR TITLE
Backport bitcoin#25503: test: pass `datacarriersize` option for tests using large outputs (instead of `acceptnonstdtxn`)

### DIFF
--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -46,8 +46,8 @@ class MaxUploadTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [[
-            "-maxuploadtarget=400",
-            "-acceptnonstdtxn=1",
+            "-maxuploadtarget=800M",
+            "-datacarriersize=100000",
         ]]
         self.supports_cli = False
 
@@ -100,7 +100,7 @@ class MaxUploadTest(BitcoinTestFramework):
         getdata_request = msg_getdata()
         getdata_request.inv.append(CInv(MSG_BLOCK, big_old_block))
 
-        max_bytes_per_day = 400*1024*1024
+        max_bytes_per_day = 800*1024*1024
         daily_buffer = 144 * MAX_BLOCK_SIZE
         max_bytes_available = max_bytes_per_day - daily_buffer
         success_count = max_bytes_available // old_block_size

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -23,7 +23,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [[
-            "-acceptnonstdtxn=1",
+            "-datacarriersize=100000",
             "-maxmempool=5",
             "-spendzeroconfchange=0",
         ]]

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -14,7 +14,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.extra_args = [[
             "-printpriority=1",
-            "-acceptnonstdtxn=1",
+            "-datacarriersize=100000",
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -602,22 +602,13 @@ def chain_transaction(node, parent_txids, vouts, value, fee, num_outputs):
 
 
 # Create large OP_RETURN txouts that can be appended to a transaction
-# to make it large (helper for constructing large transactions).
+# to make it large (helper for constructing large transactions). The
+# total serialized size of the txouts is about 66k vbytes.
 def gen_return_txouts():
-    # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
-    # So we have big transactions (and therefore can't fit very many into each block)
-    # create one script_pubkey
-    script_pubkey = "6a4d0200"  # OP_RETURN OP_PUSH2 512 bytes
-    for _ in range(512):
-        script_pubkey = script_pubkey + "01"
-    # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
-    txouts = []
     from .messages import CTxOut
-    txout = CTxOut()
-    txout.nValue = 0
-    txout.scriptPubKey = bytes.fromhex(script_pubkey)
-    for _ in range(128):
-        txouts.append(txout)
+    from .script import CScript, OP_RETURN
+    txouts = [CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, b'\x01'*67437]))]
+    assert_equal(sum([len(txout.serialize()) for txout in txouts]), 67456)
     return txouts
 
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#25503

Original commit: 1ee597817

This commit changes test parameter configuration from using acceptnonstdtxn to datacarriersize for handling large outputs in tests, and increases the maxuploadtarget from 400MB to 800MB in the maxuploadtarget test.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>