### PR TITLE
Backport bitcoin-core/gui#627: Apply translator comments to reset options confirmation dialog

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -396,9 +396,19 @@ void OptionsDialog::on_resetButton_clicked()
     if(model)
     {
         // confirmation dialog
+        /*: Text explaining that the settings changed will not come into effect
+            until the client is restarted. */
+        QString reset_dialog_text = tr("Client restart required to activate changes.") + "<br><br>";
+        /*: Text explaining to the user that the client's current settings
+            will be backed up at a specific location. %1 is a stand-in
+            argument for the backup location's path. */
+        reset_dialog_text.append(tr("Current settings will be backed up at \"%1\".").arg(GUIUtil::getDefaultDataDirectory()) + "<br><br>");
+        /*: Text asking the user to confirm if they would like to proceed
+            with a client shutdown. */
+        reset_dialog_text.append(tr("Client will be shut down. Do you want to proceed?"));
+        //: Window title text of pop-up window shown when the user has chosen to reset options.
         QMessageBox::StandardButton btnRetVal = QMessageBox::question(this, tr("Confirm options reset"),
-            tr("Client restart required to activate changes.") + "<br><br>" + tr("Client will be shut down. Do you want to proceed?"),
-            QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+            reset_dialog_text, QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
 
         if(btnRetVal == QMessageBox::Cancel)
             return;


### PR DESCRIPTION
Backports bitcoin-core/gui#627

Original commit: 27a4dd055b (Merge bitcoin-core/gui#627: Apply translator comments to reset options confirmation dialog)

## Summary
- Improves translator comments for the options reset confirmation dialog
- Makes the dialog text properly translatable by using variables instead of hardcoded strings
- Replaced `m_client_model->dataDir()` with `GUIUtil::getDefaultDataDirectory()` for Dash compatibility

## Test plan
- [x] Build succeeds
- [x] Options dialog reset functionality works correctly  
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)