### PR TITLE
Backport bitcoin#25464: rpc: Reduce Univalue push_backV peak memory usage in listtransactions

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -111,6 +111,8 @@ public:
         return push_back(tmpVal);
     }
     bool push_backV(const std::vector<UniValue>& vec);
+    template <class It>
+    bool push_backV(It first, It last);
 
     void __pushKV(const std::string& key, const UniValue& val);
     bool pushKV(const std::string& key, const UniValue& val);
@@ -179,6 +181,14 @@ public:
     enum VType type() const { return getType(); }
     friend const UniValue& find_value( const UniValue& obj, const std::string& name);
 };
+
+template <class It>
+bool UniValue::push_backV(It first, It last)
+{
+    if (typ != VARR) return false;
+    values.insert(values.end(), first, last);
+    return true;
+}
 
 enum jtokentype {
     JTOK_ERR        = -1,


### PR DESCRIPTION
Backports bitcoin/bitcoin#25464

Original commit: 081965cccc86dc96fea45e19bea08cb32285bd81