### PR TITLE
Backport bitcoin#25694: refactor: Make CTransaction constructor explicit

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -7,10 +7,15 @@
 
 #include <consensus/amount.h>
 #include <hash.h>
+#include <script/script.h>
+#include <serialize.h>
 #include <tinyformat.h>
+#include <uint256.h>
 #include <util/strencodings.h>
+#include <version.h>
 
-#include <assert.h>
+#include <cassert>
+#include <stdexcept>
 
 std::string COutPoint::ToString() const
 {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -7,10 +7,20 @@
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
 #include <consensus/amount.h>
+#include <prevector.h>
 #include <script/script.h>
 #include <serialize.h>
 #include <uint256.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <ios>
+#include <limits>
+#include <memory>
+#include <string>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 /** Transaction types */
 enum {
@@ -228,7 +238,7 @@ private:
 public:
     /** Convert a CMutableTransaction into a CTransaction. */
     explicit CTransaction(const CMutableTransaction& tx);
-    CTransaction(CMutableTransaction&& tx);
+    explicit CTransaction(CMutableTransaction&& tx);
 
     template <typename Stream>
     inline void Serialize(Stream& s) const {
@@ -305,7 +315,7 @@ struct CMutableTransaction
     uint32_t nLockTime;
     std::vector<uint8_t> vExtraPayload; // only available for special transaction types
 
-    CMutableTransaction();
+    explicit CMutableTransaction();
     explicit CMutableTransaction(const CTransaction& tx);
 
     SERIALIZE_METHODS(CMutableTransaction, obj)

--- a/src/test/evo_assetlocks_tests.cpp
+++ b/src/test/evo_assetlocks_tests.cpp
@@ -135,7 +135,7 @@ BOOST_FIXTURE_TEST_CASE(evo_assetlock, TestChain100Setup)
     CKey key;
     key.MakeNewKey(true);
 
-    const CTransaction tx = CreateAssetLockTx(keystore, coins, key);
+    const CTransaction tx{CreateAssetLockTx(keystore, coins, key)};
     std::string reason;
     BOOST_CHECK(IsStandardTx(CTransaction(tx), reason));
 
@@ -304,7 +304,7 @@ BOOST_FIXTURE_TEST_CASE(evo_assetunlock, TestChain100Setup)
     CKey key;
     key.MakeNewKey(true);
 
-    const CTransaction tx = CreateAssetUnlockTx(keystore, key);
+    const CTransaction tx{CreateAssetUnlockTx(keystore, key)};
     std::string reason;
     BOOST_CHECK(IsStandardTx(CTransaction(tx), reason));
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1410,8 +1410,8 @@ BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_returns_true)
     CScript scriptSig;
 
     scriptPubKey << OP_1;
-    CTransaction creditTx = BuildCreditingTransaction(scriptPubKey);
-    CTransaction spendTx = BuildSpendingTransaction(scriptSig, creditTx);
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;
@@ -1432,8 +1432,8 @@ BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_tx_index_err)
     CScript scriptSig;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx = BuildCreditingTransaction(scriptPubKey);
-    CTransaction spendTx = BuildSpendingTransaction(scriptSig, creditTx);
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;
@@ -1454,8 +1454,8 @@ BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_tx_size)
     CScript scriptSig;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx = BuildCreditingTransaction(scriptPubKey);
-    CTransaction spendTx = BuildSpendingTransaction(scriptSig, creditTx);
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;
@@ -1476,8 +1476,8 @@ BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_tx_serialization)
     CScript scriptSig;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx = BuildCreditingTransaction(scriptPubKey);
-    CTransaction spendTx = BuildSpendingTransaction(scriptSig, creditTx);
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << 0xffffffff;
@@ -1498,8 +1498,8 @@ BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_invalid_flags)
     CScript scriptSig;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx = BuildCreditingTransaction(scriptPubKey);
-    CTransaction spendTx = BuildSpendingTransaction(scriptSig, creditTx);
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;


### PR DESCRIPTION
Backports bitcoin/bitcoin#25694

Original commit: c90f86e4c7 (Merge bitcoin/bitcoin#25694: refactor: Make CTransaction constructor explicit)