### PR TITLE
Backport bitcoin#25813: build: move raw rule into Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1095,6 +1095,15 @@ nodist_libbitcoin_ipc_a_SOURCES = $(libbitcoin_ipc_mpgen_output)
 CLEANFILES += $(libbitcoin_ipc_mpgen_output)
 endif
 
+%.raw.h: %.raw
+	@$(MKDIR_P) $(@D)
+	@{ \
+	 echo "static unsigned const char $(*F)_raw[] = {" && \
+	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
+	 echo "};"; \
+	} > "$@.new" && mv -f "$@.new" "$@"
+	@echo "Generated $@"
+
 include Makefile.minisketch.include
 
 include Makefile.crc32c.include


### PR DESCRIPTION
Backports bitcoin/bitcoin#25813

Original commit: deb7ad35e687e1ff0e5578d389c6617d93bef296

Moves duplicated makefile rule for generating raw headers to the main Makefile.am to avoid code duplication. Preserves Dash-specific namespace rules for tests and benchmarks.