### PR TITLE
Backport bitcoin#25748: refactor: Avoid copies in FlatSigningProvider Merge

### DIFF
--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -620,7 +620,7 @@ public:
             assert(outscripts.size() == 1);
             subscripts.emplace_back(std::move(outscripts[0]));
         }
-        out = Merge(std::move(out), std::move(subprovider));
+        out.Merge(std::move(subprovider));
 
         std::vector<CPubKey> pubkeys;
         pubkeys.reserve(entries.size());

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -55,18 +55,13 @@ bool FlatSigningProvider::GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info)
 }
 bool FlatSigningProvider::GetKey(const CKeyID& keyid, CKey& key) const { return LookupHelper(keys, keyid, key); }
 
-FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvider& b)
+FlatSigningProvider& FlatSigningProvider::Merge(FlatSigningProvider&& b)
 {
-    FlatSigningProvider ret;
-    ret.scripts = a.scripts;
-    ret.scripts.insert(b.scripts.begin(), b.scripts.end());
-    ret.pubkeys = a.pubkeys;
-    ret.pubkeys.insert(b.pubkeys.begin(), b.pubkeys.end());
-    ret.keys = a.keys;
-    ret.keys.insert(b.keys.begin(), b.keys.end());
-    ret.origins = a.origins;
-    ret.origins.insert(b.origins.begin(), b.origins.end());
-    return ret;
+    scripts.merge(b.scripts);
+    pubkeys.merge(b.pubkeys);
+    keys.merge(b.keys);
+    origins.merge(b.origins);
+    return *this;
 }
 
 bool FillableSigningProvider::GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_SCRIPT_SIGNINGPROVIDER_H
 #define BITCOIN_SCRIPT_SIGNINGPROVIDER_H
 
+#include <attributes.h>
 #include <key.h>
 #include <pubkey.h>
 #include <script/keyorigin.h>
@@ -54,9 +55,9 @@ struct FlatSigningProvider final : public SigningProvider
     bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
-};
 
-FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvider& b);
+    FlatSigningProvider& Merge(FlatSigningProvider&& b) LIFETIMEBOUND;
+};
 
 /** Fillable signing provider that keeps keys in an address->secret map */
 class FillableSigningProvider : public SigningProvider

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -234,17 +234,13 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
             // For each of the produced scripts, verify solvability, and when possible, try to sign a transaction spending it.
             for (size_t n = 0; n < spks.size(); ++n) {
                 BOOST_CHECK_EQUAL(ref[n], HexStr(spks[n]));
-                FlatSigningProvider merged_provider = key_provider;
-                merged_provider.Merge(FlatSigningProvider(script_provider));
-                BOOST_CHECK_EQUAL(IsSolvable(merged_provider, spks[n]), (flags & UNSOLVABLE) == 0);
+                BOOST_CHECK_EQUAL(IsSolvable(FlatSigningProvider{key_provider}.Merge(FlatSigningProvider{script_provider}), spks[n]), (flags & UNSOLVABLE) == 0);
 
                 if (flags & SIGNABLE) {
                     CMutableTransaction spend;
                     spend.vin.resize(1);
                     spend.vout.resize(1);
-                    FlatSigningProvider signing_provider = keys_priv;
-                    signing_provider.Merge(FlatSigningProvider{script_provider});
-                    BOOST_CHECK_MESSAGE(SignSignature(signing_provider, spks[n], spend, 0, 1, SIGHASH_ALL), prv);
+                    BOOST_CHECK_MESSAGE(SignSignature(FlatSigningProvider{keys_priv}.Merge(FlatSigningProvider{script_provider}), spks[n], spend, 0, 1, SIGHASH_ALL), prv);
                 }
 
                 /* Infer a descriptor from the generated script, and verify its solvability and that it roundtrips. */

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -242,14 +242,9 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
                     CMutableTransaction spend;
                     spend.vin.resize(1);
                     spend.vout.resize(1);
-                    std::vector<CTxOut> utxos(1);
-                    PrecomputedTransactionData txdata;
-                    txdata.Init(spend, std::move(utxos), /*force=*/true);
-                    MutableTransactionSignatureCreator creator{&spend, 0, CAmount{0}, &txdata, SIGHASH_ALL};
-                    SignatureData sigdata;
                     FlatSigningProvider signing_provider = keys_priv;
                     signing_provider.Merge(FlatSigningProvider{script_provider});
-                    BOOST_CHECK_MESSAGE(ProduceSignature(signing_provider, creator, spks[n], sigdata), prv);
+                    BOOST_CHECK_MESSAGE(SignSignature(signing_provider, spks[n], spend, 0, 1, SIGHASH_ALL), prv);
                 }
 
                 /* Infer a descriptor from the generated script, and verify its solvability and that it roundtrips. */

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -234,7 +234,9 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
             // For each of the produced scripts, verify solvability, and when possible, try to sign a transaction spending it.
             for (size_t n = 0; n < spks.size(); ++n) {
                 BOOST_CHECK_EQUAL(ref[n], HexStr(spks[n]));
-                BOOST_CHECK_EQUAL(IsSolvable(Merge(key_provider, script_provider), spks[n]), (flags & UNSOLVABLE) == 0);
+                FlatSigningProvider merged_provider = key_provider;
+                merged_provider.Merge(FlatSigningProvider(script_provider));
+                BOOST_CHECK_EQUAL(IsSolvable(merged_provider, spks[n]), (flags & UNSOLVABLE) == 0);
 
                 if (flags & SIGNABLE) {
                     CMutableTransaction spend;
@@ -243,9 +245,11 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
                     std::vector<CTxOut> utxos(1);
                     PrecomputedTransactionData txdata;
                     txdata.Init(spend, std::move(utxos), /*force=*/true);
-                    MutableTransactionSignatureCreator creator{spend, 0, CAmount{0}, &txdata, SIGHASH_DEFAULT};
+                    MutableTransactionSignatureCreator creator{&spend, 0, CAmount{0}, &txdata, SIGHASH_ALL};
                     SignatureData sigdata;
-                    BOOST_CHECK_MESSAGE(ProduceSignature(FlatSigningProvider{keys_priv}.Merge(FlatSigningProvider{script_provider}), creator, spks[n], sigdata), prv);
+                    FlatSigningProvider signing_provider = keys_priv;
+                    signing_provider.Merge(FlatSigningProvider{script_provider});
+                    BOOST_CHECK_MESSAGE(ProduceSignature(signing_provider, creator, spks[n], sigdata), prv);
                 }
 
                 /* Infer a descriptor from the generated script, and verify its solvability and that it roundtrips. */

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -240,7 +240,12 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
                     CMutableTransaction spend;
                     spend.vin.resize(1);
                     spend.vout.resize(1);
-                    BOOST_CHECK_MESSAGE(SignSignature(Merge(keys_priv, script_provider), spks[n], spend, 0, 1, SIGHASH_ALL), prv);
+                    std::vector<CTxOut> utxos(1);
+                    PrecomputedTransactionData txdata;
+                    txdata.Init(spend, std::move(utxos), /*force=*/true);
+                    MutableTransactionSignatureCreator creator{spend, 0, CAmount{0}, &txdata, SIGHASH_DEFAULT};
+                    SignatureData sigdata;
+                    BOOST_CHECK_MESSAGE(ProduceSignature(FlatSigningProvider{keys_priv}.Merge(FlatSigningProvider{script_provider}), creator, spks[n], sigdata), prv);
                 }
 
                 /* Infer a descriptor from the generated script, and verify its solvability and that it roundtrips. */

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2193,7 +2193,7 @@ bool DescriptorScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const s
         if (!coin_keys) {
             continue;
         }
-        *keys = Merge(*keys, *coin_keys);
+        keys->Merge(std::move(*coin_keys));
     }
 
     return ::SignTransaction(tx, keys.get(), coins, sighash, input_errors);
@@ -2265,7 +2265,7 @@ TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction&
         std::unique_ptr<FlatSigningProvider> keys = std::make_unique<FlatSigningProvider>();
         std::unique_ptr<FlatSigningProvider> script_keys = GetSigningProvider(script, sign);
         if (script_keys) {
-            *keys = Merge(*keys, *script_keys);
+            keys->Merge(std::move(*script_keys));
         } else {
             // Maybe there are pubkeys listed that we can sign for
             script_keys = std::make_unique<FlatSigningProvider>();
@@ -2273,7 +2273,7 @@ TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction&
                 const CPubKey& pubkey = pk_pair.first;
                 std::unique_ptr<FlatSigningProvider> pk_keys = GetSigningProvider(pubkey);
                 if (pk_keys) {
-                    *keys = Merge(*keys, *pk_keys);
+                    keys->Merge(std::move(*pk_keys));
                 }
             }
         }


### PR DESCRIPTION
Backports bitcoin/bitcoin#25748

Original commit: a8f69541ad53a76d5f69044ba829069d225a4af1

Performance optimization that changes FlatSigningProvider::Merge to use move semantics instead of creating unnecessary copies. Changes signature from `Merge(a, b)` to `a.Merge(std::move(b))` and merges in-place rather than creating a return object.

Adaptations for Dash:
- Excluded Taproot-related tr_trees merging (not applicable to Dash)
- Used SIGHASH_ALL instead of SIGHASH_DEFAULT in tests
- Adapted MutableTransactionSignatureCreator constructor signature
- Excluded Bitcoin-specific caching infrastructure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced merging of signing providers by replacing the standalone merge function with an in-place member function for better efficiency.
  * Updated transaction signing and PSBT handling to use the new merging method.
* **Tests**
  * Modified tests to reflect changes in signing provider merging, maintaining test accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->