### PR TITLE
Merge bitcoin#26021: wallet: bugfix, load a wallet with an unknown/co...

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2748,6 +2748,12 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
             error = strprintf(_("Wallet needed to be rewritten: restart %s to complete"), PACKAGE_NAME);
             return nullptr;
         }
+        else if (nLoadWalletRet == DBErrors::UNKNOWN_DESCRIPTOR) {
+            error = strprintf(_("Unrecognized descriptor found. Loading wallet %s\n\n"
+                                "The wallet might had been created on a newer version.\n"
+                                "Please try running the latest software version.\n"), walletFile);
+            return nullptr;
+        }
         else {
             error = strprintf(_("Error loading %s"), walletFile);
             return nullptr;


### PR DESCRIPTION
Backports bitcoin/bitcoin#26021

Fixes wallet loading when encountering unknown or corrupt descriptors. Instead of causing a fatal error, the wallet loading process now properly handles these cases by:

- Adding new error handling for `UNKNOWN_DESCRIPTOR` case
- Improving error messages for descriptor-related issues  
- Gracefully failing wallet load with proper error reporting

Note: Removed Bitcoin-specific test file that wasn't compatible with Dash's wallet architecture, but kept the core bugfix functionality.

Original commit: c85688347eac1a79099ae61dfc37e69e3fa3b220