### PR TITLE
Backport bitcoin#26132 (v0.25): wallet: Fix nNextResend data race in ResubmitWalletTransactions

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1846,14 +1846,8 @@ std::set<uint256> CWallet::GetTxConflicts(const CWalletTx& wtx) const
     return result;
 }
 
-// Resubmit transactions from the wallet to the mempool, optionally asking the
-// mempool to relay them. On startup, we will do this for all unconfirmed
-// transactions but will not ask the mempool to relay them. We do this on startup
-// to ensure that our own mempool is aware of our transactions, and to also
-// initialize m_next_resend so that the actual rebroadcast is scheduled. There
-// is a privacy side effect here as not broadcasting on startup also means that we won't
-// inform the world of our wallet's state, particularly if the wallet (or node) is not
-// yet synced.
+// Rebroadcast transactions from the wallet. We do this on a random timer
+// to slightly obfuscate which transactions come from our wallet.
 //
 // Ideally, we'd only resend transactions that we think should have been
 // mined in the most recent block. Any transaction that wasn't in the top

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1846,8 +1846,14 @@ std::set<uint256> CWallet::GetTxConflicts(const CWalletTx& wtx) const
     return result;
 }
 
-// Rebroadcast transactions from the wallet. We do this on a random timer
-// to slightly obfuscate which transactions come from our wallet.
+// Resubmit transactions from the wallet to the mempool, optionally asking the
+// mempool to relay them. On startup, we will do this for all unconfirmed
+// transactions but will not ask the mempool to relay them. We do this on startup
+// to ensure that our own mempool is aware of our transactions, and to also
+// initialize m_next_resend so that the actual rebroadcast is scheduled. There
+// is a privacy side effect here as not broadcasting on startup also means that we won't
+// inform the world of our wallet's state, particularly if the wallet (or node) is not
+// yet synced.
 //
 // Ideally, we'd only resend transactions that we think should have been
 // mined in the most recent block. Any transaction that wasn't in the top
@@ -1863,10 +1869,10 @@ void CWallet::ResendWalletTransactions()
 
     // Do this infrequently and randomly to avoid giving away
     // that these are our transactions.
-    if (GetTime() < nNextResend || !fBroadcastTransactions) return;
-    bool fFirst = (nNextResend == 0);
+    if (GetTime() < m_next_resend || !fBroadcastTransactions) return;
+    bool fFirst = (m_next_resend == 0);
     // resend 1-3 hours from now, ~2 hours on average.
-    nNextResend = GetTime() + (1 * 60 * 60) + GetRand(2 * 60 * 60);
+    m_next_resend = GetTime() + (1 * 60 * 60) + GetRand(2 * 60 * 60);
     if (fFirst) return;
 
     int submitted_tx_count = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -269,7 +269,8 @@ private:
     //! the current wallet version: clients below this version are not able to load the wallet
     int nWalletVersion GUARDED_BY(cs_wallet){FEATURE_BASE};
 
-    int64_t nNextResend = 0;
+    /** The next scheduled rebroadcast of wallet transactions. */
+    std::atomic<int64_t> m_next_resend{};
     /** Whether this wallet will submit newly created transactions to the node's mempool and
      * prompt rebroadcasts (see ResendWalletTransactions()). */
     bool fBroadcastTransactions = false;


### PR DESCRIPTION
Backports bitcoin/bitcoin#26132

Original commit: 9e2a2b88d5cae247bd2dd5aa32743198a5d4841b

Backported from Bitcoin Core v0.25

## Summary
- Fixes a data race in `ResubmitWalletTransactions` by converting `nNextResend` to atomic `m_next_resend`
- Updates function to use thread-safe atomic variable for scheduling transaction rebroadcasts
- Preserves Dash-specific timing and broadcast logic while fixing the underlying thread safety issue

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of wallet transaction rebroadcast scheduling for enhanced reliability and thread safety. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->