### PR TITLE
Backport bitcoin#26099 (v0.25): build: remove duplicate / unneeded libs from bench_bitcoin

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -59,7 +59,9 @@ nodist_bench_bench_dash_SOURCES = $(GENERATED_BENCH_FILES)
 
 bench_bench_dash_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_dash_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+bench_bench_dash_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
 bench_bench_dash_LDADD = \
+  $(LIBTEST_UTIL) \
   $(LIBBITCOIN_NODE) \
   $(LIBBITCOIN_WALLET) \
   $(LIBBITCOIN_COMMON) \
@@ -74,7 +76,9 @@ bench_bench_dash_LDADD = \
   $(LIBSECP256K1) \
   $(LIBUNIVALUE) \
   $(EVENT_PTHREADS_LIBS) \
-  $(EVENT_LIBS)
+  $(EVENT_LIBS) \
+  $(MINIUPNPC_LIBS) \
+  $(NATPMP_LIBS)
 
 if ENABLE_ZMQ
 bench_bench_dash_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
@@ -84,11 +88,11 @@ if ENABLE_WALLET
 bench_bench_dash_SOURCES += bench/coin_selection.cpp
 bench_bench_dash_SOURCES += bench/wallet_balance.cpp
 bench_bench_dash_SOURCES += bench/wallet_create.cpp
+bench_bench_dash_LDADD += $(BDB_LIBS) $(SQLITE_LIBS)
 endif
 
-bench_bench_dash_LDADD += $(BACKTRACE_LIB) $(BDB_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(MINIUPNPC_LIBS) $(NATPMP_LIBS) $(SQLITE_LIBS) $(GMP_LIBS)
+bench_bench_dash_LDADD += $(BACKTRACE_LIB) $(GMP_LIBS)
 bench_bench_dash_LDFLAGS = $(LDFLAGS_WRAP_EXCEPTIONS) $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
-
 CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno $(GENERATED_BENCH_FILES)
 
 CLEANFILES += $(CLEAN_BITCOIN_BENCH)


### PR DESCRIPTION
Backports bitcoin/bitcoin#26099

Original commit: 80d159813306fa4137afd35e280e14568bf94f0e

Backported from Bitcoin Core v0.25

## Summary
- Removes duplicate EVENT_*_LIBS from bench_dash LDADD (already included in LDADD)
- Moves wallet libraries (BDB_LIBS, SQLITE_LIBS) into wallet conditional section
- Adds LIBTEST_UTIL and proper LDFLAGS to bench configuration
- Maintains Dash-specific libraries (BACKTRACE_LIB, GMP_LIBS) while cleaning up duplicates

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>