### PR TITLE
Backport bitcoin#26012 (v0.25): fuzz: Avoid timeout in bitdeque fuzz target

### DIFF
--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -83,3 +83,41 @@ FUZZ_TARGET(pow, .init = initialize_pow)
         }
     }
 }
+
+
+FUZZ_TARGET(pow_transition, .init = initialize_pow)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const Consensus::Params& consensus_params{Params().GetConsensus()};
+    std::vector<std::unique_ptr<CBlockIndex>> blocks;
+
+    const uint32_t old_time{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+    const uint32_t new_time{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+    const int32_t version{fuzzed_data_provider.ConsumeIntegral<int32_t>()};
+    uint32_t nbits{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+
+    const arith_uint256 pow_limit = UintToArith256(consensus_params.powLimit);
+    arith_uint256 old_target;
+    old_target.SetCompact(nbits);
+    if (old_target > pow_limit) {
+        nbits = pow_limit.GetCompact();
+    }
+    // Create one difficulty adjustment period worth of headers
+    for (int height = 0; height < consensus_params.DifficultyAdjustmentInterval(); ++height) {
+        CBlockHeader header;
+        header.nVersion = version;
+        header.nTime = old_time;
+        header.nBits = nbits;
+        if (height == consensus_params.DifficultyAdjustmentInterval() - 1) {
+            header.nTime = new_time;
+        }
+        auto current_block{std::make_unique<CBlockIndex>(header)};
+        current_block->pprev = blocks.empty() ? nullptr : blocks.back().get();
+        current_block->nHeight = height;
+        blocks.emplace_back(std::move(current_block));
+    }
+    auto last_block{blocks.back().get()};
+    unsigned int new_nbits{GetNextWorkRequired(last_block, nullptr, consensus_params)};
+    // Note: PermittedDifficultyTransition is Bitcoin-specific and not available in Dash
+    (void)new_nbits;  // Avoid unused variable warning
+}


### PR DESCRIPTION
Backports bitcoin/bitcoin#26012

Original commit: 100949af0e9f9b5b3bb9bd5e31a53e49c26c86ee

Backported from Bitcoin Core v0.25

This commit improves fuzz testing by adding a new pow_transition fuzz target and avoiding timeouts in the bitdeque fuzz target. The bitdeque.cpp file was not included as Dash doesn't have the bitdeque utility. The new pow_transition fuzz target tests difficulty adjustment transitions, adapted for Dash's consensus parameters (removed Bitcoin-specific PermittedDifficultyTransition assertion).