### PR TITLE
Backport bitcoin#26231 (v0.25): doc: bump bips.md up-to-date version to v24.0

### DIFF
--- a/doc/bips.md
+++ b/doc/bips.md
@@ -1,4 +1,5 @@
-BIPs that are implemented by Bitcoin Core, some of them are relevant for Dash Core, some are just mentioned as a reference.
+BIPs that are implemented by Bitcoin Core (up-to-date up to **v24.0**):
+Some of them are relevant for Dash Core, some are just mentioned as a reference.
 Versions and PRs are relevant to Bitcoin's core if not mentioned other.
 
 * [`BIP 9`](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki): The changes allowing multiple soft-forks to be deployed in parallel have been implemented since **v0.12.1**  ([PR #7575](https://github.com/bitcoin/bitcoin/pull/7575))


### PR DESCRIPTION
Backports bitcoin/bitcoin#26231

Original commit: 25742aa3e37bffa28dcccf0c2e73e4d0cf8d096f

Backported from Bitcoin Core v0.25

This commit updates the documentation in doc/bips.md to clarify that the BIP implementation status is up-to-date as of Bitcoin Core v24.0. This helps developers understand which Bitcoin Improvement Proposals have been implemented and when they were added.