### PR TITLE
Backport bitcoin#26280 (v0.25): rpc: Return coinbase flag in scantxoutset

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2397,6 +2397,7 @@ static RPCHelpMan scantxoutset()
                                 {RPCResult::Type::STR_HEX, "scriptPubKey", "The script key"},
                                 {RPCResult::Type::STR, "desc", "A specialized descriptor for the matched scriptPubKey"},
                                 {RPCResult::Type::STR_AMOUNT, "amount", "The total amount in " + CURRENCY_UNIT + " of the unspent output"},
+                                {RPCResult::Type::BOOL, "coinbase", "Whether this is a coinbase output"},
                                 {RPCResult::Type::NUM, "height", "Height of the unspent transaction output"},
                             }},
                     }},
@@ -2500,6 +2501,7 @@ static RPCHelpMan scantxoutset()
             unspent.pushKV("scriptPubKey", HexStr(txo.scriptPubKey));
             unspent.pushKV("desc", descriptors[txo.scriptPubKey]);
             unspent.pushKV("amount", ValueFromAmount(txo.nValue));
+            unspent.pushKV("coinbase", coin.IsCoinBase());
             unspent.pushKV("height", (int32_t)coin.nHeight);
 
             unspents.push_back(unspent);

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -32,6 +32,9 @@ class ScantxoutsetTest(BitcoinTestFramework):
         self.wallet = MiniWallet(self.nodes[0])
         self.wallet.rescan_utxos()
 
+        self.log.info("Test if we find coinbase outputs.")
+        assert_equal(sum(u["coinbase"] for u in self.nodes[0].scantxoutset("start", [self.wallet.get_descriptor()])["unspents"]), 49)
+
         self.log.info("Create UTXOs...")
         pubk1, spk1, addr1 = getnewdestination("legacy")
         pubk2, spk2, addr2 = getnewdestination("legacy")


### PR DESCRIPTION
Backports bitcoin/bitcoin#26280

Original commit: 1d277f422236d6074ea84c407ae0863ae943f27e4

Backported from Bitcoin Core v0.25

## Summary
• Adds a `coinbase` boolean flag to the `scantxoutset` RPC response indicating whether each unspent output is from a coinbase transaction

## Test plan
- [x] Build succeeds 
- [x] Functional test `rpc_scantxoutset.py` passes
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)