### PR TITLE
Backport bitcoin#26235 (v0.25): refactor: move *index constants out of validation

### DIFF
--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -12,6 +12,8 @@
 #include <index/base.h>
 #include <util/hasher.h>
 
+static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
+
 /** Interval between compact filter checkpoints. See BIP 157. */
 static constexpr int CFCHECKPT_INTERVAL = 1000;
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -11,6 +11,8 @@
 #include <index/base.h>
 #include <node/coinstats.h>
 
+static constexpr bool DEFAULT_COINSTATSINDEX{false};
+
 /**
  * CoinStatsIndex maintains statistics on the UTXO set.
  */

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -7,6 +7,8 @@
 
 #include <index/base.h>
 
+static constexpr bool DEFAULT_TXINDEX{true};
+
 /**
  * TxIndex is used to look up transactions included in the blockchain by hash.
  * The index is written to a LevelDB database and records the filesystem

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -4,9 +4,9 @@
 
 #include <node/caches.h>
 
+#include <index/txindex.h>
 #include <txdb.h>
 #include <util/system.h>
-#include <validation.h>
 
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -75,14 +75,10 @@ static const unsigned int MAX_HEADERS_COMPRESSED_RESULT = 8000;
 static const int64_t DEFAULT_MAX_TIP_AGE = 6 * 60 * 60; // ~144 blocks behind -> 2 x fork detection time, was 24 * 60 * 60 in bitcoin
 
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const bool DEFAULT_TXINDEX = true;
-static constexpr bool DEFAULT_COINSTATSINDEX{false};
-static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;
 /** Default for -syncmempool */
 static const bool DEFAULT_SYNC_MEMPOOL = true;
-
 /** Default for -stopatheight */
 static const int DEFAULT_STOPATHEIGHT = 0;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of ActiveChain().Tip() will not be pruned. */


### PR DESCRIPTION
Backports bitcoin/bitcoin#26235

Original commit: 914c00074b62b911e16103254279beb5e3255429

Backported from Bitcoin Core v0.25

Note: Preserved Dash's DEFAULT_TXINDEX=true setting in src/index/txindex.h