### PR TITLE
Merge bitcoin/bitcoin#24851: init: ignore BIP-30 verification in DisconnectBlock for problematic blocks

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1898,11 +1898,21 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
         return DISCONNECT_FAILED;
     }
 
+    // Ignore blocks that contain transactions which are 'overwritten' by later transactions,
+    // unless those are already completely spent.
+    // See https://github.com/bitcoin/bitcoin/issues/22596 for additional information.
+    // Note: the blocks specified here are different than the ones used in ConnectBlock because DisconnectBlock
+    // unwinds the blocks in reverse. As a result, the inconsistency is not discovered until the earlier
+    // blocks with the duplicate coinbase transactions are disconnected.
+    bool fEnforceBIP30 = !((pindex->nHeight==91722 && pindex->GetBlockHash() == uint256S("0x00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e")) ||
+                           (pindex->nHeight==91812 && pindex->GetBlockHash() == uint256S("0x00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f")));
+
     // undo transactions in reverse order
     for (int i = block.vtx.size() - 1; i >= 0; i--) {
         const CTransaction &tx = *(block.vtx[i]);
         uint256 hash = tx.GetHash();
         bool is_coinbase = tx.IsCoinBase();
+        bool is_bip30_exception = (is_coinbase && !fEnforceBIP30);
 
         if (fAddressIndex) {
             for (unsigned int k = tx.vout.size(); k-- > 0;) {
@@ -1931,7 +1941,9 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                 Coin coin;
                 bool is_spent = view.SpendCoin(out, &coin);
                 if (!is_spent || tx.vout[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.fCoinBase) {
-                    fClean = false; // transaction output mismatch
+                    if (!is_bip30_exception) {
+                        fClean = false; // transaction output mismatch
+                    }
                 }
             }
         }


### PR DESCRIPTION
Backports bitcoin/bitcoin#24851

Original commit: 0384b1941

Backported from Bitcoin Core v0.25

## Summary

This backport addresses an issue where block verification fails at checklevel=4 due to duplicate coinbase transactions in blocks 91812 and 91722. The original Bitcoin implementation already had checks in ConnectBlock to ignore these problematic blocks, but DisconnectBlock lacked similar checks.

## Changes

- Added `fEnforceBIP30` logic to ignore BIP-30 verification for specific problematic blocks (91722 and 91812)
- Added `is_bip30_exception` variable to properly handle coinbase transactions in these blocks  
- Modified transaction output validation to only set `fClean = false` when not a BIP30 exception

## Validation

- ✅ Build succeeded
- ✅ No functional tests modified  
- ✅ Backport validation: 100% size match with Bitcoin (13 additions, 1 deletion)
- ✅ Conflicts resolved while preserving Dash-specific address indexing and special transactions

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>