### PR TITLE
Merge bitcoin/bitcoin#26306: add lock annotation for FeeFilterRounder::round()

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -1027,3 +1027,38 @@ void CBlockPolicyEstimator::FlushUnconfirmed() {
     int64_t endclear = GetTimeMicros();
     LogPrint(BCLog::ESTIMATEFEE, "Recorded %u unconfirmed txs from mempool in %ld micros\n", num_entries, endclear - startclear);
 }
+
+static std::set<double> MakeFeeSet(const CFeeRate& min_incremental_fee,
+                                   double max_filter_fee_rate,
+                                   double fee_filter_spacing)
+{
+    std::set<double> fee_set;
+
+    const CAmount min_fee_limit{std::max(CAmount(1), min_incremental_fee.GetFeePerK() / 2)};
+    fee_set.insert(0);
+    for (double bucket_boundary = min_fee_limit;
+         bucket_boundary <= max_filter_fee_rate;
+         bucket_boundary *= fee_filter_spacing) {
+
+        fee_set.insert(bucket_boundary);
+    }
+
+    return fee_set;
+}
+
+FeeFilterRounder::FeeFilterRounder(const CFeeRate& minIncrementalFee)
+    : m_fee_set{MakeFeeSet(minIncrementalFee, MAX_FILTER_FEERATE, FEE_FILTER_SPACING)}
+{
+}
+
+CAmount FeeFilterRounder::round(CAmount currentMinFee)
+{
+    AssertLockNotHeld(m_insecure_rand_mutex);
+    std::set<double>::iterator it = m_fee_set.lower_bound(currentMinFee);
+    if (it == m_fee_set.end() ||
+        (it != m_fee_set.begin() &&
+         WITH_LOCK(m_insecure_rand_mutex, return insecure_rand.rand32()) % 3 != 0)) {
+        --it;
+    }
+    return static_cast<CAmount>(*it);
+}

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -285,4 +285,26 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(m_cs_fee_estimator);
 };
 
+class FeeFilterRounder
+{
+private:
+    static constexpr double MAX_FILTER_FEERATE = 1e7;
+    /** FEE_FILTER_SPACING is just used to provide some quantization of fee
+     * filter results.  Historically it reused FEE_SPACING, but it is completely
+     * unrelated, and was made a separate constant so the two concepts are not
+     * tied together */
+    static constexpr double FEE_FILTER_SPACING = 1.1;
+
+public:
+    /** Create new FeeFilterRounder */
+    explicit FeeFilterRounder(const CFeeRate& min_incremental_fee);
+
+    /** Quantize a minimum fee for privacy purpose before broadcast. */
+    CAmount round(CAmount currentMinFee) EXCLUSIVE_LOCKS_REQUIRED(!m_insecure_rand_mutex);
+
+private:
+    const std::set<double> m_fee_set;
+    Mutex m_insecure_rand_mutex;
+    FastRandomContext insecure_rand GUARDED_BY(m_insecure_rand_mutex);
+};
 #endif // BITCOIN_POLICY_FEES_H


### PR DESCRIPTION
Backports bitcoin/bitcoin#26306

Original commit: deeb70a16

**Background**: This commit adds a lock annotation to the `FeeFilterRounder::round()` method to ensure proper thread safety. The `FeeFilterRounder` class was not previously present in Dash, so this backport includes both the class implementation and the lock annotation.

**Changes**:
- Adds `FeeFilterRounder` class to `src/policy/fees.h`
- Implements `FeeFilterRounder` methods in `src/policy/fees.cpp`
- Adds `EXCLUSIVE_LOCKS_REQUIRED(!m_insecure_rand_mutex)` annotation to `round()` method
- Adds `AssertLockNotHeld(m_insecure_rand_mutex)` assertion in `round()` implementation

**Note**: The size difference from the original Bitcoin commit is due to `FeeFilterRounder` not existing in Dash previously. This backport brings both the class and the lock annotation together as a single unit.

Backported from Bitcoin Core v0.25