### PR TITLE
Merge bitcoin/bitcoin#26321: Adjust `.tx/config` for new Transifex CLI

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[dash.dash_ents]
+[o:dash:p:dash:r:dash_ents]
 file_filter = src/qt/locale/dash_<lang>.ts
 source_file = src/qt/locale/dash_en.xlf
 source_lang = en


### PR DESCRIPTION
Backports bitcoin/bitcoin#26321

Original commit: 5974c49f90eaece7b8ead7b98975a73e69ce4719

Backported from Bitcoin Core v0.25

---

This updates the Transifex configuration file to use the new CLI format. The old Transifex Command-Line Tool was deprecated and sunsetted on Nov 30, 2022.

The change adapts the section header from the old format to the new format:
- Bitcoin: `[bitcoin.qt-translation-024x]` → `[o:bitcoin:p:bitcoin:r:qt-translation-024x]`
- Dash: `[dash.dash_ents]` → `[o:dash:p:dash:r:dash_ents]`