### PR TITLE
Merge bitcoin/bitcoin#26286: test: Remove unused txmempool include from tests

### DIFF
--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -5,7 +5,7 @@
 LIBTEST_UTIL=libtest_util.a
 
 EXTRA_LIBRARIES += \
-    $(LIBTEST_UTIL)
+  $(LIBTEST_UTIL)
 
 TEST_UTIL_H = \
     test/util/blockfilter.h \
@@ -19,6 +19,7 @@ TEST_UTIL_H = \
     test/util/setup_common.h \
     test/util/str.h \
     test/util/transaction_utils.h \
+    test/util/txmempool.h \
     test/util/wallet.h \
     test/util/validation.h \
     test/util/xoroshiro128plusplus.h
@@ -35,6 +36,7 @@ libtest_util_a_SOURCES = \
   test/util/setup_common.cpp \
   test/util/str.cpp \
   test/util/transaction_utils.cpp \
+  test/util/txmempool.cpp \
   test/util/validation.cpp \
   test/util/wallet.cpp \
   $(TEST_UTIL_H)

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/merkle.h>
 #include <pow.h>
 #include <streams.h>
+#include <test/util/txmempool.h>
 
 #include <test/util/setup_common.h>
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 
 #include <base58.h>
 #include <chainparams.h>

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -10,6 +10,7 @@
 #include <test/util/mining.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -7,6 +7,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/time.h>
 #include <validation.h>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/policy.h>
+#include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -18,6 +18,7 @@
 #include <pow.h>
 #include <script/standard.h>
 #include <spork.h>
+#include <test/util/txmempool.h>
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <util/system.h>

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <policy/fees.h>
 #include <policy/policy.h>
+#include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/time.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -586,17 +586,6 @@ TestChainSetup::~TestChainSetup()
     g_txindex.reset();
 }
 
-CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction& tx) const
-{
-    return FromTx(MakeTransactionRef(tx));
-}
-
-CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransactionRef& tx) const
-{
-    return CTxMemPoolEntry(tx, nFee, nTime, nHeight,
-                           spendsCoinbase, sigOpCount, lp);
-}
-
 /**
  * @returns a real block (0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af)
  *      with 9 txs.

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -9,14 +9,13 @@
 #include <chainparamsbase.h>
 #include <fs.h>
 #include <key.h>
-#include <util/system.h>
 #include <node/caches.h>
 #include <node/context.h> // IWYU pragma: export
 #include <pubkey.h>
 #include <random.h>
-#include <txmempool.h>
 #include <util/check.h>
 #include <util/string.h>
+#include <util/system.h>
 #include <util/vector.h>
 
 #include <functional>
@@ -209,33 +208,6 @@ std::unique_ptr<T> MakeNoLogFileContext(const std::string& chain_name = CBaseCha
 
     return std::make_unique<T>(chain_name, arguments);
 }
-
-class CTxMemPoolEntry;
-
-struct TestMemPoolEntryHelper
-{
-    // Default values
-    CAmount nFee;
-    int64_t nTime;
-    unsigned int nHeight;
-    bool spendsCoinbase;
-    unsigned int sigOpCount;
-    LockPoints lp;
-
-    TestMemPoolEntryHelper() :
-        nFee(0), nTime(0), nHeight(1),
-        spendsCoinbase(false), sigOpCount(1) { }
-
-    CTxMemPoolEntry FromTx(const CMutableTransaction& tx) const;
-    CTxMemPoolEntry FromTx(const CTransactionRef& tx) const;
-
-    // Change the default value
-    TestMemPoolEntryHelper &Fee(CAmount _fee) { nFee = _fee; return *this; }
-    TestMemPoolEntryHelper &Time(int64_t _time) { nTime = _time; return *this; }
-    TestMemPoolEntryHelper &Height(unsigned int _height) { nHeight = _height; return *this; }
-    TestMemPoolEntryHelper &SpendsCoinbase(bool _flag) { spendsCoinbase = _flag; return *this; }
-    TestMemPoolEntryHelper &SigOps(unsigned int _sigops) { sigOpCount = _sigops; return *this; }
-};
 
 CBlock getBlock13b8a();
 

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/txmempool.h>
+
+#include <chainparams.h>
+#include <node/context.h>
+#include <node/mempool_args.h>
+#include <txmempool.h>
+#include <util/check.h>
+#include <util/time.h>
+#include <util/translation.h>
+
+using node::NodeContext;
+
+CTxMemPool::Options MemPoolOptionsForTest(const NodeContext& node)
+{
+    CTxMemPool::Options mempool_opts{
+        .estimator = node.fee_estimator.get(),
+        // Default to always checking mempool regardless of
+        // chainparams.DefaultConsistencyChecks for tests
+        .check_ratio = 1,
+    };
+    const auto err{ApplyArgsManOptions(*node.args, ::Params(), mempool_opts)};
+    Assert(!err);
+    return mempool_opts;
+}
+
+CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction& tx) const
+{
+    return FromTx(MakeTransactionRef(tx));
+}
+
+CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransactionRef& tx) const
+{
+    return CTxMemPoolEntry(tx, nFee, nTime, nHeight,
+                           spendsCoinbase, sigOpCost, lp);
+}

--- a/src/test/util/txmempool.h
+++ b/src/test/util/txmempool.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_TXMEMPOOL_H
+#define BITCOIN_TEST_UTIL_TXMEMPOOL_H
+
+#include <txmempool.h>
+
+namespace node {
+struct NodeContext;
+}
+
+CTxMemPool::Options MemPoolOptionsForTest(const node::NodeContext& node);
+
+struct TestMemPoolEntryHelper
+{
+    // Default values
+    CAmount nFee{0};
+    int64_t nTime{0};
+    unsigned int nHeight{1};
+    bool spendsCoinbase{false};
+    unsigned int sigOpCost{4};
+    LockPoints lp;
+
+    CTxMemPoolEntry FromTx(const CMutableTransaction& tx) const;
+    CTxMemPoolEntry FromTx(const CTransactionRef& tx) const;
+
+    // Change the default value
+    TestMemPoolEntryHelper &Fee(CAmount _fee) { nFee = _fee; return *this; }
+    TestMemPoolEntryHelper &Time(int64_t _time) { nTime = _time; return *this; }
+    TestMemPoolEntryHelper &Height(unsigned int _height) { nHeight = _height; return *this; }
+    TestMemPoolEntryHelper &SpendsCoinbase(bool _flag) { spendsCoinbase = _flag; return *this; }
+    TestMemPoolEntryHelper &SigOpsCost(unsigned int _sigopsCost) { sigOpCost = _sigopsCost; return *this; }
+};
+
+#endif // BITCOIN_TEST_UTIL_TXMEMPOOL_H

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -24,6 +24,7 @@
 #include <util/vector.h>
 
 #include <array>
+#include <cmath>
 #include <fstream>
 #include <deque>
 #include <optional>


### PR DESCRIPTION
Backports bitcoin/bitcoin#26286

Original commit: 003050dfa

Backported from Bitcoin Core v0.25