### PR TITLE
Merge bitcoin/bitcoin#23927: rpc: Pruning nodes can not fetch blocks before syncing past their height

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -506,6 +506,12 @@ static RPCHelpMan getblockfrompeer()
         throw JSONRPCError(RPC_MISC_ERROR, "Block header missing");
     }
 
+    // Fetching blocks before the node has syncing past their height can prevent block files from
+    // being pruned, so we avoid it if the node is in prune mode.
+    if (index->nHeight > chainman.ActiveChain().Tip()->nHeight && fPruneMode) {
+        throw JSONRPCError(RPC_MISC_ERROR, "In prune mode, only blocks that the node has already synced previously can be fetched from a peer");
+    }
+
     const bool block_has_data = WITH_LOCK(::cs_main, return index->nStatus & BLOCK_HAVE_DATA);
     if (block_has_data) {
         throw JSONRPCError(RPC_MISC_ERROR, "Block already downloaded");

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -9,20 +9,18 @@ from test_framework.messages import (
     CBlock,
     from_hex,
     msg_headers,
-    NODE_WITNESS,
 )
 from test_framework.p2p import (
-    P2P_SERVICES,
     P2PInterface,
 )
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
 
 
-class GetBlockFromPeerTest(BitcoinTestFramework):
+class GetBlockFromPeerTest(DashTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
 

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -5,11 +5,22 @@
 """Test the getblockfrompeer RPC."""
 
 from test_framework.authproxy import JSONRPCException
+from test_framework.messages import (
+    CBlock,
+    from_hex,
+    msg_headers,
+    NODE_WITNESS,
+)
+from test_framework.p2p import (
+    P2P_SERVICES,
+    P2PInterface,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
+
 
 class GetBlockFromPeerTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -68,6 +79,31 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
 
         self.log.info("Don't fetch blocks we already have")
         assert_raises_rpc_error(-1, "Block already downloaded", self.nodes[0].getblockfrompeer, short_tip, peer_0_peer_1_id)
+
+        self.log.info("Don't fetch blocks while the node has not synced past it yet")
+        # For this test we need node 1 in prune mode and as a side effect this also disconnects
+        # the nodes which is also necessary for the rest of the test.
+        self.restart_node(1, ["-prune=550"])
+
+        # Generate a block on the disconnected node that the pruning node is not connected to
+        blockhash = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
+        block_hex = self.nodes[0].getblock(blockhash=blockhash, verbosity=0)
+        block = from_hex(CBlock(), block_hex)
+
+        # Connect a P2PInterface to the pruning node and have it submit only the header of the
+        # block that the pruning node has not seen
+        node1_interface = self.nodes[1].add_p2p_connection(P2PInterface())
+        node1_interface.send_message(msg_headers([block]))
+
+        # Get the peer id of the P2PInterface from the pruning node
+        node1_peers = self.nodes[1].getpeerinfo()
+        assert_equal(len(node1_peers), 1)
+        node1_interface_id = node1_peers[0]["id"]
+
+        # Trying to fetch this block from the P2PInterface should not be possible
+        error_msg = "In prune mode, only blocks that the node has already synced previously can be fetched from a peer"
+        assert_raises_rpc_error(-1, error_msg, self.nodes[1].getblockfrompeer, blockhash, node1_interface_id)
+
 
 if __name__ == '__main__':
     GetBlockFromPeerTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#23927

Original commit: 88502ecf0

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation to prevent fetching blocks from peers in prune mode if the requested block height exceeds the current chain tip.

* **Tests**
  * Expanded test coverage to verify correct behavior when attempting to fetch unsynced blocks in prune mode, ensuring an appropriate error is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->