### PR TITLE
Merge bitcoin/bitcoin#26341: test: add BIP158 false-positive element check in rpc_scanblocks.py

### DIFF
--- a/doc/release-notes-6720.md
+++ b/doc/release-notes-6720.md
@@ -1,0 +1,4 @@
+Updated RPCs
+------------
+
+* A new optional field `submit` has been introduced to the `protx revoke`, `protx update_registrar`, `protx update_service` RPCs. It behaves identically to `submit` in `protx register` or `protx register_fund`.

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -84,6 +84,9 @@ static std::optional<CreditPoolDataPerBlock> GetCreditDataFromBlock(const gsl::n
 
     if (const auto opt_cbTx = GetTxPayload<CCbTx>(block.vtx[0]->vExtraPayload); opt_cbTx) {
         blockData.credit_pool = opt_cbTx->creditPoolBalance;
+    } else {
+        LogPrintf("%s: WARNING: No valid CbTx at height=%d\n", __func__, block_index->nHeight);
+        return std::nullopt;
     }
     for (CTransactionRef tx : block.vtx) {
         if (!tx->IsSpecialTxVersion() || tx->nType != TRANSACTION_ASSET_UNLOCK) continue;

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -67,11 +67,8 @@ static std::optional<CreditPoolDataPerBlock> GetCreditDataFromBlock(const gsl::n
     static Mutex cache_mutex;
     static unordered_lru_cache<uint256, CreditPoolDataPerBlock, StaticSaltedHasher> block_data_cache GUARDED_BY(
         cache_mutex){static_cast<size_t>(Params().CreditPoolPeriodBlocks()) * 2};
-    {
-        LOCK(cache_mutex);
-        if (block_data_cache.get(block_index->GetBlockHash(), blockData)) {
-            return blockData;
-        }
+    if (LOCK(cache_mutex); block_data_cache.get(block_index->GetBlockHash(), blockData)) {
+        return blockData;
     }
 
     CBlock block;

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -66,7 +66,7 @@ static std::optional<CreditPoolDataPerBlock> GetCreditDataFromBlock(const gsl::n
 
     static Mutex cache_mutex;
     static unordered_lru_cache<uint256, CreditPoolDataPerBlock, StaticSaltedHasher> block_data_cache GUARDED_BY(
-        cache_mutex){576 * 2};
+        cache_mutex){static_cast<size_t>(Params().CreditPoolPeriodBlocks()) * 2};
     {
         LOCK(cache_mutex);
         if (block_data_cache.get(block_index->GetBlockHash(), blockData)) {

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -95,7 +95,7 @@ static std::optional<CreditPoolDataPerBlock> GetCreditDataFromBlock(const gsl::n
         TxValidationState tx_state;
         uint64_t index{0};
         if (!GetDataFromUnlockTx(*tx, unlocked, index, tx_state)) {
-            throw std::runtime_error(strprintf("%s: GetDataFromUnlockTxfailed: %s", __func__, tx_state.ToString()));
+            throw std::runtime_error(strprintf("%s: GetDataFromUnlockTx failed: %s", __func__, tx_state.ToString()));
         }
         blockData.unlocked += unlocked;
         blockData.indexes.insert(index);

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -15,7 +15,6 @@
 #include <deploymentstatus.h>
 #include <logging.h>
 #include <node/blockstorage.h>
-#include <util/irange.h>
 #include <validation.h>
 
 #include <algorithm>
@@ -168,11 +167,7 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const gsl::not_null<const CB
         throw std::runtime_error(strprintf("%s: failed-getcreditpool-index-duplicated", __func__));
     }
 
-    const CBlockIndex* distant_block_index = block_index;
-    for ([[maybe_unused]] auto _ : irange::range(Params().CreditPoolPeriodBlocks())) {
-        distant_block_index = distant_block_index->pprev;
-        if (distant_block_index == nullptr) break;
-    }
+    const CBlockIndex* distant_block_index{block_index->GetAncestor(block_index->nHeight - Params().CreditPoolPeriodBlocks())};
     CAmount distantUnlocked{0};
     if (distant_block_index) {
         if (std::optional<CBlock> distant_block = GetBlockForCreditPool(distant_block_index, consensusParams); distant_block) {

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -48,17 +48,23 @@ static bool GetDataFromUnlockTx(const CTransaction& tx, CAmount& toUnlock, uint6
 
 namespace {
     struct UnlockDataPerBlock  {
+        CAmount credit_pool{0};
         CAmount unlocked{0};
         std::unordered_set<uint64_t> indexes;
     };
 } // anonymous namespace
 
 // it throws exception if anything went wrong
-static UnlockDataPerBlock GetDataFromUnlockTxes(const std::vector<CTransactionRef>& vtx)
+static UnlockDataPerBlock GetDataFromUnlockTxes(const CBlock& block)
 {
     UnlockDataPerBlock blockData;
 
-    for (CTransactionRef tx : vtx) {
+    const auto opt_cbTx = GetTxPayload<CCbTx>(block.vtx[0]->vExtraPayload);
+    if (!opt_cbTx) {
+        throw std::runtime_error(strprintf("%s: failed-getcreditpool-cbtx-payload", __func__));
+    }
+    blockData.credit_pool = opt_cbTx->creditPoolBalance;
+    for (CTransactionRef tx : block.vtx) {
         if (!tx->IsSpecialTxVersion() || tx->nType != TRANSACTION_ASSET_UNLOCK) continue;
 
         CAmount unlocked{0};
@@ -151,19 +157,12 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const gsl::not_null<const CB
         AddToCache(block_index->GetBlockHash(), block_index->nHeight, emptyPool);
         return emptyPool;
     }
-    CAmount locked = [&, func=__func__]() {
-        const auto opt_cbTx = GetTxPayload<CCbTx>(block->vtx[0]->vExtraPayload);
-        if (!opt_cbTx) {
-            throw std::runtime_error(strprintf("%s: failed-getcreditpool-cbtx-payload", func));
-        }
-        return opt_cbTx->creditPoolBalance;
-    }();
 
     // We use here sliding window with Params().CreditPoolPeriodBlocks to determine
     // current limits for asset unlock transactions.
     // Indexes should not be duplicated since genesis block, but the Unlock Amount
     // of withdrawal transaction is limited only by this window
-    UnlockDataPerBlock blockData = GetDataFromUnlockTxes(block->vtx);
+    const UnlockDataPerBlock blockData = GetDataFromUnlockTxes(*block);
     CRangesSet indexes{std::move(prev.indexes)};
     if (std::any_of(blockData.indexes.begin(), blockData.indexes.end(), [&](const uint64_t index) { return !indexes.Add(index); })) {
         throw std::runtime_error(strprintf("%s: failed-getcreditpool-index-duplicated", __func__));
@@ -177,28 +176,28 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const gsl::not_null<const CB
     CAmount distantUnlocked{0};
     if (distant_block_index) {
         if (std::optional<CBlock> distant_block = GetBlockForCreditPool(distant_block_index, consensusParams); distant_block) {
-            distantUnlocked = GetDataFromUnlockTxes(distant_block->vtx).unlocked;
+            distantUnlocked = GetDataFromUnlockTxes(*distant_block).unlocked;
         }
     }
 
-    CAmount currentLimit = locked;
+    CAmount currentLimit = blockData.credit_pool;
     const CAmount latelyUnlocked = prev.latelyUnlocked + blockData.unlocked - distantUnlocked;
     if (DeploymentActiveAt(*block_index, Params().GetConsensus(), Consensus::DEPLOYMENT_WITHDRAWALS)) {
         currentLimit = std::min(currentLimit, LimitAmountV22);
     } else {
         // Unlock limits in pre-v22 are max(100, min(.10 * assetlockpool, 1000)) inside window
         if (currentLimit + latelyUnlocked > LimitAmountLow) {
-            currentLimit = std::max(LimitAmountLow, locked / 10) - latelyUnlocked;
+            currentLimit = std::max(LimitAmountLow, blockData.credit_pool / 10) - latelyUnlocked;
             if (currentLimit < 0) currentLimit = 0;
         }
         currentLimit = std::min(currentLimit, LimitAmountHigh - latelyUnlocked);
     }
 
-    if (currentLimit != 0 || latelyUnlocked > 0 || locked > 0) {
+    if (currentLimit != 0 || latelyUnlocked > 0 || blockData.credit_pool > 0) {
         LogPrint(BCLog::CREDITPOOL, /* Continued */
                  "CCreditPoolManager: asset unlock limits on height: %d locked: %d.%08d limit: %d.%08d "
                  "unlocked-in-window: %d.%08d\n",
-                 block_index->nHeight, locked / COIN, locked % COIN, currentLimit / COIN, currentLimit % COIN,
+                 block_index->nHeight, blockData.credit_pool / COIN, blockData.credit_pool % COIN, currentLimit / COIN, currentLimit % COIN,
                  latelyUnlocked / COIN, latelyUnlocked % COIN);
     }
 
@@ -207,7 +206,7 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const gsl::not_null<const CB
             strprintf("Negative limit for CreditPool: %d.%08d\n", currentLimit / COIN, currentLimit % COIN));
     }
 
-    CCreditPool pool{locked, currentLimit, latelyUnlocked, indexes};
+    CCreditPool pool{blockData.credit_pool, currentLimit, latelyUnlocked, indexes};
     AddToCache(block_index->GetBlockHash(), block_index->nHeight, pool);
     return pool;
 

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -46,16 +46,16 @@ static bool GetDataFromUnlockTx(const CTransaction& tx, CAmount& toUnlock, uint6
 }
 
 namespace {
-    struct CreditPoolDataPerBlock  {
-        CAmount credit_pool{0};
-        CAmount unlocked{0};
-        std::unordered_set<uint64_t> indexes;
-    };
+struct CreditPoolDataPerBlock {
+    CAmount credit_pool{0};
+    CAmount unlocked{0};
+    std::unordered_set<uint64_t> indexes;
+};
 } // anonymous namespace
 
 // it throws exception if anything went wrong
 static std::optional<CreditPoolDataPerBlock> GetCreditDataFromBlock(const gsl::not_null<const CBlockIndex*> block_index,
-                                                   const Consensus::Params& consensusParams)
+                                                                    const Consensus::Params& consensusParams)
 {
     // There's no CbTx before DIP0003 activation
     if (!DeploymentActiveAt(*block_index, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0003)) {
@@ -65,7 +65,8 @@ static std::optional<CreditPoolDataPerBlock> GetCreditDataFromBlock(const gsl::n
     CreditPoolDataPerBlock blockData;
 
     static Mutex cache_mutex;
-    static unordered_lru_cache<uint256, CreditPoolDataPerBlock, StaticSaltedHasher> block_data_cache GUARDED_BY(cache_mutex) {576 * 2};
+    static unordered_lru_cache<uint256, CreditPoolDataPerBlock, StaticSaltedHasher> block_data_cache GUARDED_BY(
+        cache_mutex){576 * 2};
     {
         LOCK(cache_mutex);
         if (block_data_cache.get(block_index->GetBlockHash(), blockData)) {
@@ -173,10 +174,12 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const gsl::not_null<const CB
         throw std::runtime_error(strprintf("%s: failed-getcreditpool-index-duplicated", __func__));
     }
 
-    const CBlockIndex* distant_block_index{block_index->GetAncestor(block_index->nHeight - Params().CreditPoolPeriodBlocks())};
+    const CBlockIndex* distant_block_index{
+        block_index->GetAncestor(block_index->nHeight - Params().CreditPoolPeriodBlocks())};
     CAmount distantUnlocked{0};
     if (distant_block_index) {
-        if (std::optional<CreditPoolDataPerBlock> distant_block{GetCreditDataFromBlock(distant_block_index, consensusParams)}; distant_block) {
+        if (std::optional<CreditPoolDataPerBlock> distant_block{GetCreditDataFromBlock(distant_block_index, consensusParams)};
+            distant_block) {
             distantUnlocked = distant_block->unlocked;
         }
     }
@@ -198,8 +201,8 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const gsl::not_null<const CB
         LogPrint(BCLog::CREDITPOOL, /* Continued */
                  "CCreditPoolManager: asset unlock limits on height: %d locked: %d.%08d limit: %d.%08d "
                  "unlocked-in-window: %d.%08d\n",
-                 block_index->nHeight, blockData.credit_pool / COIN, blockData.credit_pool % COIN, currentLimit / COIN, currentLimit % COIN,
-                 latelyUnlocked / COIN, latelyUnlocked % COIN);
+                 block_index->nHeight, blockData.credit_pool / COIN, blockData.credit_pool % COIN, currentLimit / COIN,
+                 currentLimit % COIN, latelyUnlocked / COIN, latelyUnlocked % COIN);
     }
 
     if (currentLimit < 0) {

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -320,7 +320,7 @@ static void SignSpecialTxPayloadByHash(const CMutableTransaction& tx, SpecialTxP
     payload.sig = key.Sign(hash, use_legacy);
 }
 
-static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, CChainstateHelper& chain_helper, const ChainstateManager& chainman, const CMutableTransaction& tx, bool fSubmit = true)
+static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, CChainstateHelper& chain_helper, const ChainstateManager& chainman, const CMutableTransaction& tx, bool fSubmit)
 {
     {
     LOCK(cs_main);
@@ -551,9 +551,9 @@ static RPCHelpMan protx_register_fund_evo()
         },
         {
             RPCResult{"if \"submit\" is not set or set to true",
-                      RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+                RPCResult::Type::STR_HEX, "txid", "The transaction id"},
             RPCResult{"if \"submit\" is set to false",
-                      RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
+                RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
         },
         RPCExamples{
             HelpExampleCli("protx", "register_fund_evo \"" + EXAMPLE_ADDRESS[0] + "\" \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
@@ -590,9 +590,9 @@ static RPCHelpMan protx_register_evo()
         },
         {
             RPCResult{"if \"submit\" is not set or set to true",
-                      RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+                RPCResult::Type::STR_HEX, "txid", "The transaction id"},
             RPCResult{"if \"submit\" is set to false",
-                      RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
+                RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
         },
         RPCExamples{
             HelpExampleCli("protx", "register_evo \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
@@ -897,7 +897,7 @@ static RPCHelpMan protx_register_submit()
     ptx.vchSig = opt_vchSig.value();
 
     SetTxPayload(tx, ptx);
-    return SignAndSendSpecialTx(request, chain_helper, chainman, tx);
+    return SignAndSendSpecialTx(request, chain_helper, chainman, tx, /*fSubmit=*/true);
 },
     };
 }
@@ -915,9 +915,13 @@ static RPCHelpMan protx_update_service()
             GetRpcArg("operatorKey"),
             GetRpcArg("operatorPayoutAddress"),
             GetRpcArg("feeSourceAddress"),
+            GetRpcArg("submit"),
         },
-        RPCResult{
-            RPCResult::Type::STR_HEX, "txid", "The transaction id"
+        {
+            RPCResult{"if \"submit\" is not set or set to true",
+                RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+            RPCResult{"if \"submit\" is set to false",
+                RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
         },
         RPCExamples{
             HelpExampleCli("protx", "update_service \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" 5a2e15982e62f1e0b7cf9783c64cf7e3af3f90a52d6c40f6f95d624c0b1621cd")
@@ -947,9 +951,14 @@ static RPCHelpMan protx_update_service_evo()
             GetRpcArg("platformHTTPPort"),
             GetRpcArg("operatorPayoutAddress"),
             GetRpcArg("feeSourceAddress"),
+            GetRpcArg("submit"),
         },
-        RPCResult{
-            RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+        {
+            RPCResult{"if \"submit\" is not set or set to true",
+                RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+            RPCResult{"if \"submit\" is set to false",
+                RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
+        },
         RPCExamples{
             HelpExampleCli("protx", "update_service_evo \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" \"5a2e15982e62f1e0b7cf9783c64cf7e3af3f90a52d6c40f6f95d624c0b1621cd\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
@@ -1055,6 +1064,11 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
         }
     }
 
+    bool fSubmit{true};
+    if (!request.params[paramIdx + 2].isNull()) {
+        fSubmit = ParseBoolV(request.params[paramIdx + 2], "submit");
+    }
+
     FundSpecialTx(*wallet, tx, ptx, feeSource);
 
     const bool isV19active = DeploymentActiveAfter(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();),
@@ -1062,7 +1076,7 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
     SignSpecialTxPayloadByHash(tx, ptx, keyOperator, !isV19active);
     SetTxPayload(tx, ptx);
 
-    return SignAndSendSpecialTx(request, chain_helper, chainman, tx);
+    return SignAndSendSpecialTx(request, chain_helper, chainman, tx, fSubmit);
 }
 
 static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_scheme)
@@ -1083,9 +1097,13 @@ static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_
             GetRpcArg("votingAddress_update"),
             GetRpcArg("payoutAddress_update"),
             GetRpcArg("feeSourceAddress"),
+            GetRpcArg("submit"),
         },
-        RPCResult{
-            RPCResult::Type::STR_HEX, "txid", "The transaction id"
+        {
+            RPCResult{"if \"submit\" is not set or set to true",
+                RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+            RPCResult{"if \"submit\" is set to false",
+                RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
         },
         RPCExamples{
             HelpExampleCli("protx", rpc_example)
@@ -1166,11 +1184,16 @@ static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Dash address: ") + request.params[4].get_str());
     }
 
+    bool fSubmit{true};
+    if (!request.params[5].isNull()) {
+        fSubmit = ParseBoolV(request.params[5], "submit");
+    }
+
     FundSpecialTx(*wallet, tx, ptx, feeSourceDest);
     SignSpecialTxPayloadByHash(tx, ptx, dmn->pdmnState->keyIDOwner, *wallet);
     SetTxPayload(tx, ptx);
 
-    return SignAndSendSpecialTx(request, chain_helper, chainman, tx);
+    return SignAndSendSpecialTx(request, chain_helper, chainman, tx, fSubmit);
 },
     };
 }
@@ -1198,9 +1221,13 @@ static RPCHelpMan protx_revoke()
             GetRpcArg("operatorKey"),
             GetRpcArg("reason"),
             GetRpcArg("feeSourceAddress"),
+            GetRpcArg("submit"),
         },
-        RPCResult{
-            RPCResult::Type::STR_HEX, "txid", "The transaction id"
+        {
+            RPCResult{"if \"submit\" is not set or set to true",
+                RPCResult::Type::STR_HEX, "txid", "The transaction id"},
+            RPCResult{"if \"submit\" is set to false",
+                RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
         },
         RPCExamples{
             HelpExampleCli("protx", "revoke \"0123456701234567012345670123456701234567012345670123456701234567\" \"072f36a77261cdd5d64c32d97bac417540eddca1d5612f416feb07ff75a8e240\"")
@@ -1265,10 +1292,15 @@ static RPCHelpMan protx_revoke()
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No payout or fee source addresses found, can't revoke");
     }
 
+    bool fSubmit{true};
+    if (!request.params[4].isNull()) {
+        fSubmit = ParseBoolV(request.params[4], "submit");
+    }
+
     SignSpecialTxPayloadByHash(tx, ptx, keyOperator, !isV19active);
     SetTxPayload(tx, ptx);
 
-    return SignAndSendSpecialTx(request, chain_helper, chainman, tx);
+    return SignAndSendSpecialTx(request, chain_helper, chainman, tx, fSubmit);
 },
     };
 }

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -238,6 +238,7 @@ class DIP3Test(BitcoinTestFramework):
     def register_fund_mn(self, node, mn: MasternodeInfo):
         node.sendtoaddress(mn.fundsAddr, mn.get_collateral_value() + 0.001)
         txid = mn.register_fund(node, submit=True)
+        assert txid is not None
         vout = mn.get_collateral_vout(node, txid)
         mn.set_params(proTxHash=txid, collateral_txid=txid, collateral_vout=vout)
 

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -213,7 +213,7 @@ class DIP3Test(BitcoinTestFramework):
         assert old_voting_address != new_voting_address
         # also check if funds from payout address are used when no fee source address is specified
         node.sendtoaddress(mn.rewards_address, 0.001)
-        mn.update_registrar(node, pubKeyOperator="", votingAddr=new_voting_address, rewards_address="")
+        mn.update_registrar(node, submit=True, pubKeyOperator="", votingAddr=new_voting_address, rewards_address="")
         self.generate(node, 1)
         new_dmnState = mn.get_node(self).masternode("status")["dmnState"]
         new_voting_address_from_rpc = new_dmnState["votingAddress"]
@@ -237,14 +237,14 @@ class DIP3Test(BitcoinTestFramework):
     # register a protx MN and also fund it (using collateral inside ProRegTx)
     def register_fund_mn(self, node, mn: MasternodeInfo):
         node.sendtoaddress(mn.fundsAddr, mn.get_collateral_value() + 0.001)
-        txid = mn.register_fund(node, True)
+        txid = mn.register_fund(node, submit=True)
         vout = mn.get_collateral_vout(node, txid)
         mn.set_params(proTxHash=txid, collateral_txid=txid, collateral_vout=vout)
 
     # create a protx MN which refers to an existing collateral
     def register_mn(self, node, mn: MasternodeInfo):
         node.sendtoaddress(mn.fundsAddr, 0.001)
-        proTxHash = mn.register(node, True)
+        proTxHash = mn.register(node, submit=True)
         mn.set_params(proTxHash=proTxHash)
         self.generate(node, 1, sync_fun=self.no_op)
 
@@ -263,14 +263,14 @@ class DIP3Test(BitcoinTestFramework):
 
     def update_mn_payee(self, mn: MasternodeInfo, payee):
         self.nodes[0].sendtoaddress(mn.fundsAddr, 0.001)
-        mn.update_registrar(self.nodes[0], pubKeyOperator="", votingAddr="", rewards_address=payee, fundsAddr=mn.fundsAddr)
+        mn.update_registrar(self.nodes[0], submit=True, pubKeyOperator="", votingAddr="", rewards_address=payee, fundsAddr=mn.fundsAddr)
         self.generate(self.nodes[0], 1)
         info = self.nodes[0].protx('info', mn.proTxHash)
         assert info['state']['payoutAddress'] == payee
 
     def test_protx_update_service(self, mn: MasternodeInfo):
         self.nodes[0].sendtoaddress(mn.fundsAddr, 0.001)
-        mn.update_service(self.nodes[0], ipAndPort=f'127.0.0.2:{mn.nodePort}')
+        mn.update_service(self.nodes[0], submit=True, ipAndPort=f'127.0.0.2:{mn.nodePort}')
         self.generate(self.nodes[0], 1)
         for node in self.nodes:
             protx_info = node.protx('info', mn.proTxHash)
@@ -279,7 +279,7 @@ class DIP3Test(BitcoinTestFramework):
             assert_equal(mn_list['%s-%d' % (mn.collateral_txid, mn.collateral_vout)]['address'], '127.0.0.2:%d' % mn.nodePort)
 
         # undo
-        mn.update_service(self.nodes[0])
+        mn.update_service(self.nodes[0], submit=True)
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
 
     def assert_mnlists(self, mns):

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -237,7 +237,7 @@ class DIP3Test(BitcoinTestFramework):
     # register a protx MN and also fund it (using collateral inside ProRegTx)
     def register_fund_mn(self, node, mn: MasternodeInfo):
         node.sendtoaddress(mn.fundsAddr, mn.get_collateral_value() + 0.001)
-        txid = node.protx('register_fund' if softfork_active(node, 'v19') else 'register_fund_legacy', mn.collateral_address, '127.0.0.1:%d' % mn.nodePort, mn.ownerAddr, mn.pubKeyOperator, mn.votingAddr, mn.operator_reward, mn.rewards_address, mn.fundsAddr)
+        txid = mn.register_fund(node, True)
         vout = mn.get_collateral_vout(node, txid)
         mn.set_params(proTxHash=txid, collateral_txid=txid, collateral_vout=vout)
 

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -244,7 +244,7 @@ class DIP3Test(BitcoinTestFramework):
     # create a protx MN which refers to an existing collateral
     def register_mn(self, node, mn: MasternodeInfo):
         node.sendtoaddress(mn.fundsAddr, 0.001)
-        proTxHash = node.protx('register' if softfork_active(node, 'v19') else 'register_legacy', mn.collateral_txid, mn.collateral_vout, '127.0.0.1:%d' % mn.nodePort, mn.ownerAddr, mn.pubKeyOperator, mn.votingAddr, mn.operator_reward, mn.rewards_address, mn.fundsAddr)
+        proTxHash = mn.register(node, True)
         mn.set_params(proTxHash=proTxHash)
         self.generate(node, 1, sync_fun=self.no_op)
 

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -213,7 +213,7 @@ class DIP3Test(BitcoinTestFramework):
         assert old_voting_address != new_voting_address
         # also check if funds from payout address are used when no fee source address is specified
         node.sendtoaddress(mn.rewards_address, 0.001)
-        node.protx('update_registrar' if softfork_active(node, 'v19') else 'update_registrar_legacy', mn.proTxHash, "", new_voting_address, "")
+        mn.update_registrar(node, pubKeyOperator="", votingAddr=new_voting_address, rewards_address="")
         self.generate(node, 1)
         new_dmnState = mn.get_node(self).masternode("status")["dmnState"]
         new_voting_address_from_rpc = new_dmnState["votingAddress"]
@@ -263,7 +263,7 @@ class DIP3Test(BitcoinTestFramework):
 
     def update_mn_payee(self, mn: MasternodeInfo, payee):
         self.nodes[0].sendtoaddress(mn.fundsAddr, 0.001)
-        self.nodes[0].protx('update_registrar' if softfork_active(self.nodes[0], 'v19') else 'update_registrar_legacy', mn.proTxHash, '', '', payee, mn.fundsAddr)
+        mn.update_registrar(self.nodes[0], pubKeyOperator="", votingAddr="", rewards_address=payee, fundsAddr=mn.fundsAddr)
         self.generate(self.nodes[0], 1)
         info = self.nodes[0].protx('info', mn.proTxHash)
         assert info['state']['payoutAddress'] == payee

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -270,7 +270,7 @@ class DIP3Test(BitcoinTestFramework):
 
     def test_protx_update_service(self, mn: MasternodeInfo):
         self.nodes[0].sendtoaddress(mn.fundsAddr, 0.001)
-        self.nodes[0].protx('update_service', mn.proTxHash, '127.0.0.2:%d' % mn.nodePort, mn.keyOperator, "", mn.fundsAddr)
+        mn.update_service(self.nodes[0], ipAndPort=f'127.0.0.2:{mn.nodePort}')
         self.generate(self.nodes[0], 1)
         for node in self.nodes:
             protx_info = node.protx('info', mn.proTxHash)
@@ -279,7 +279,7 @@ class DIP3Test(BitcoinTestFramework):
             assert_equal(mn_list['%s-%d' % (mn.collateral_txid, mn.collateral_vout)]['address'], '127.0.0.2:%d' % mn.nodePort)
 
         # undo
-        self.nodes[0].protx('update_service', mn.proTxHash, '127.0.0.1:%d' % mn.nodePort, mn.keyOperator, "", mn.fundsAddr)
+        mn.update_service(self.nodes[0])
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
 
     def assert_mnlists(self, mns):

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -121,7 +121,7 @@ class DIP3V19Test(DashTestFramework):
         tip = self.generate(self.nodes[0], 1)[0]
         assert_equal(self.nodes[0].getrawtransaction(fund_txid, 1, tip)['confirmations'], 1)
 
-        protx_result = revoke_mn.revoke(self.nodes[0], reason=1, fundsAddr=funds_address)
+        protx_result = revoke_mn.revoke(self.nodes[0], submit=True, reason=1, fundsAddr=funds_address)
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         tip = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -95,10 +95,8 @@ class DIP3V19Test(DashTestFramework):
         assert evo_info_3 is not None
         self.dynamically_evo_update_service(evo_info_0, 9, should_be_rejected=True)
 
-        revoke_protx = self.mninfo[-1].proTxHash
-        revoke_keyoperator = self.mninfo[-1].keyOperator
-        self.log.info(f"Trying to revoke proTx:{revoke_protx}")
-        self.test_revoke_protx(evo_info_3.nodeIdx, revoke_protx, revoke_keyoperator)
+        self.log.info(f"Trying to revoke proTx:{self.mninfo[-1].proTxHash}")
+        self.test_revoke_protx(evo_info_3.nodeIdx, self.mninfo[-1])
 
         self.mine_quorum(llmq_type_name='llmq_test', llmq_type=100)
 
@@ -116,14 +114,14 @@ class DIP3V19Test(DashTestFramework):
 
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
-    def test_revoke_protx(self, node_idx, revoke_protx, revoke_keyoperator):
+    def test_revoke_protx(self, node_idx, revoke_mn: MasternodeInfo):
         funds_address = self.nodes[0].getnewaddress()
         fund_txid = self.nodes[0].sendtoaddress(funds_address, 1)
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         tip = self.generate(self.nodes[0], 1)[0]
         assert_equal(self.nodes[0].getrawtransaction(fund_txid, 1, tip)['confirmations'], 1)
 
-        protx_result = self.nodes[0].protx('revoke', revoke_protx, revoke_keyoperator, 1, funds_address)
+        protx_result = revoke_mn.revoke(self.nodes[0], reason=1, fundsAddr=funds_address)
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         tip = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
@@ -132,9 +130,9 @@ class DIP3V19Test(DashTestFramework):
         self.wait_until(lambda: self.nodes[node_idx].getconnectioncount() == 0)
         self.connect_nodes(node_idx, 0)
         self.sync_all()
-        self.log.info(f"Successfully revoked={revoke_protx}")
+        self.log.info(f"Successfully revoked={revoke_mn.proTxHash}")
         for mn in self.mninfo: # type: MasternodeInfo
-            if mn.proTxHash == revoke_protx:
+            if mn.proTxHash == revoke_mn.proTxHash:
                 self.mninfo.remove(mn)
                 return
 

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -208,7 +208,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
             if check_banned(self.nodes[0], mn) or check_punished(self.nodes[0], mn):
                 addr = self.nodes[0].getnewaddress()
                 self.nodes[0].sendtoaddress(addr, 0.1)
-                mn.update_service(self.nodes[0], fundsAddr=addr)
+                mn.update_service(self.nodes[0], submit=True, fundsAddr=addr)
                 if restart:
                     self.stop_node(mn.nodeIdx)
                     self.start_masternode(mn)

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -208,7 +208,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
             if check_banned(self.nodes[0], mn) or check_punished(self.nodes[0], mn):
                 addr = self.nodes[0].getnewaddress()
                 self.nodes[0].sendtoaddress(addr, 0.1)
-                self.nodes[0].protx('update_service', mn.proTxHash, f'127.0.0.1:{mn.nodePort}', mn.keyOperator, "", addr)
+                mn.update_service(self.nodes[0], fundsAddr=addr)
                 if restart:
                     self.stop_node(mn.nodeIdx)
                     self.start_masternode(mn)

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -229,7 +229,7 @@ class MnehfTest(DashTestFramework):
             self.bump_mocktime(1)
             self.generate(self.nodes[1], 1)
             return get_bip9_details(self.nodes[0], 'testdummy')['status'] == 'active'
-        self.wait_until(lambda: check_ehf_activated(self))
+        self.wait_until(lambda: check_ehf_activated(self), sleep=1)
 
 if __name__ == '__main__':
     MnehfTest().main()

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the scanblocks RPC call."""
+from test_framework.blockfilter import (
+    bip158_basic_element_hash,
+    bip158_relevant_scriptpubkeys,
+)
+from test_framework.messages import COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    MiniWallet,
+    getnewdestination,
+)
+
+
+class ScanblocksTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [["-blockfilterindex=1"], []]
+
+    def run_test(self):
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+        wallet.rescan_utxos()
+
+        # send 1.0, mempool only
+        _, spk_1, addr_1 = getnewdestination()
+        wallet.send_to(from_node=node, scriptPubKey=spk_1, amount=1 * COIN)
+
+        parent_key = "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B"
+        # send 1.0, mempool only
+        # childkey 5 of `parent_key`
+        wallet.send_to(from_node=node,
+                       scriptPubKey=bytes.fromhex(node.validateaddress("mkS4HXoTYWRTescLGaUTGbtTTYX5EjJyEE")['scriptPubKey']),
+                       amount=1 * COIN)
+
+        # mine a block and assure that the mined blockhash is in the filterresult
+        blockhash = self.generate(node, 1)[0]
+        height = node.getblockheader(blockhash)['height']
+        self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
+
+        out = node.scanblocks("start", [f"addr({addr_1})"])
+        assert(blockhash in out['relevant_blocks'])
+        assert_equal(height, out['to_height'])
+        assert_equal(0, out['from_height'])
+
+        # mine another block
+        blockhash_new = self.generate(node, 1)[0]
+        height_new = node.getblockheader(blockhash_new)['height']
+
+        # make sure the blockhash is not in the filter result if we set the start_height
+        # to the just mined block (unlikely to hit a false positive)
+        assert(blockhash not in node.scanblocks(
+            "start", [f"addr({addr_1})"], height_new)['relevant_blocks'])
+
+        # make sure the blockhash is present when using the first mined block as start_height
+        assert(blockhash in node.scanblocks(
+            "start", [f"addr({addr_1})"], height)['relevant_blocks'])
+
+        # also test the stop height
+        assert(blockhash in node.scanblocks(
+            "start", [f"addr({addr_1})"], height, height)['relevant_blocks'])
+
+        # use the stop_height to exclude the relevant block
+        assert(blockhash not in node.scanblocks(
+            "start", [f"addr({addr_1})"], 0, height - 1)['relevant_blocks'])
+
+        # make sure the blockhash is present when using the first mined block as start_height
+        assert(blockhash in node.scanblocks(
+            "start", [{"desc": f"pkh({parent_key}/*)", "range": [0, 100]}], height)['relevant_blocks'])
+
+        # check that false-positives are included in the result now; note that
+        # finding a false-positive at runtime would take too long, hence we simply
+        # use a pre-calculated one that collides with the regtest genesis block's
+        # coinbase output and verify that their BIP158 ranged hashes match
+        genesis_blockhash = node.getblockhash(0)
+        genesis_spks = bip158_relevant_scriptpubkeys(node, genesis_blockhash)
+        assert_equal(len(genesis_spks), 1)
+        genesis_coinbase_spk = list(genesis_spks)[0]
+        false_positive_spk = bytes.fromhex("001400000000000000000000000000000000000cadcb")
+
+        genesis_coinbase_hash = bip158_basic_element_hash(genesis_coinbase_spk, 1, genesis_blockhash)
+        false_positive_hash = bip158_basic_element_hash(false_positive_spk, 1, genesis_blockhash)
+        assert_equal(genesis_coinbase_hash, false_positive_hash)
+
+        assert(genesis_blockhash in node.scanblocks(
+            "start", [{"desc": f"raw({genesis_coinbase_spk.hex()})"}], 0, 0)['relevant_blocks'])
+        assert(genesis_blockhash in node.scanblocks(
+            "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0)['relevant_blocks'])
+
+        # TODO: after an "accurate" mode for scanblocks is implemented (e.g. PR #26325)
+        # check here that it filters out the false-positive
+
+        # test node with disabled blockfilterindex
+        assert_raises_rpc_error(-1, "Index is not enabled for filtertype basic",
+                                self.nodes[1].scanblocks, "start", [f"addr({addr_1})"])
+
+        # test unknown filtertype
+        assert_raises_rpc_error(-5, "Unknown filtertype",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 0, 10, "extended")
+
+        # test invalid start_height
+        assert_raises_rpc_error(-1, "Invalid start_height",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 100000000)
+
+        # test invalid stop_height
+        assert_raises_rpc_error(-1, "Invalid stop_height",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 10, 0)
+        assert_raises_rpc_error(-1, "Invalid stop_height",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 10, 100000000)
+
+        # test accessing the status (must be empty)
+        assert_equal(node.scanblocks("status"), None)
+
+        # test aborting the current scan (there is no, must return false)
+        assert_equal(node.scanblocks("abort"), False)
+
+        # test invalid command
+        assert_raises_rpc_error(-8, "Invalid command", node.scanblocks, "foobar")
+
+
+if __name__ == '__main__':
+    ScanblocksTest().main()

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021 The Bitcoin Core developers
+# Copyright (c) 2021-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the scanblocks RPC call."""
+from test_framework.address import address_to_scriptpubkey
 from test_framework.blockfilter import (
     bip158_basic_element_hash,
     bip158_relevant_scriptpubkeys,
@@ -27,7 +28,6 @@ class ScanblocksTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]
         wallet = MiniWallet(node)
-        wallet.rescan_utxos()
 
         # send 1.0, mempool only
         _, spk_1, addr_1 = getnewdestination()
@@ -37,7 +37,7 @@ class ScanblocksTest(BitcoinTestFramework):
         # send 1.0, mempool only
         # childkey 5 of `parent_key`
         wallet.send_to(from_node=node,
-                       scriptPubKey=bytes.fromhex(node.validateaddress("mkS4HXoTYWRTescLGaUTGbtTTYX5EjJyEE")['scriptPubKey']),
+                       scriptPubKey=address_to_scriptpubkey("mkS4HXoTYWRTescLGaUTGbtTTYX5EjJyEE"),
                        amount=1 * COIN)
 
         # mine a block and assure that the mined blockhash is in the filterresult
@@ -46,9 +46,10 @@ class ScanblocksTest(BitcoinTestFramework):
         self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
 
         out = node.scanblocks("start", [f"addr({addr_1})"])
-        assert(blockhash in out['relevant_blocks'])
+        assert blockhash in out['relevant_blocks']
         assert_equal(height, out['to_height'])
         assert_equal(0, out['from_height'])
+        assert_equal(True, out['completed'])
 
         # mine another block
         blockhash_new = self.generate(node, 1)[0]
@@ -56,24 +57,30 @@ class ScanblocksTest(BitcoinTestFramework):
 
         # make sure the blockhash is not in the filter result if we set the start_height
         # to the just mined block (unlikely to hit a false positive)
-        assert(blockhash not in node.scanblocks(
-            "start", [f"addr({addr_1})"], height_new)['relevant_blocks'])
+        assert blockhash not in node.scanblocks(
+            "start", [f"addr({addr_1})"], height_new)['relevant_blocks']
 
         # make sure the blockhash is present when using the first mined block as start_height
-        assert(blockhash in node.scanblocks(
-            "start", [f"addr({addr_1})"], height)['relevant_blocks'])
+        assert blockhash in node.scanblocks(
+            "start", [f"addr({addr_1})"], height)['relevant_blocks']
+        for v in [False, True]:
+            assert blockhash in node.scanblocks(
+                action="start",
+                scanobjects=[f"addr({addr_1})"],
+                start_height=height,
+                options={"filter_false_positives": v})['relevant_blocks']
 
         # also test the stop height
-        assert(blockhash in node.scanblocks(
-            "start", [f"addr({addr_1})"], height, height)['relevant_blocks'])
+        assert blockhash in node.scanblocks(
+            "start", [f"addr({addr_1})"], height, height)['relevant_blocks']
 
         # use the stop_height to exclude the relevant block
-        assert(blockhash not in node.scanblocks(
-            "start", [f"addr({addr_1})"], 0, height - 1)['relevant_blocks'])
+        assert blockhash not in node.scanblocks(
+            "start", [f"addr({addr_1})"], 0, height - 1)['relevant_blocks']
 
         # make sure the blockhash is present when using the first mined block as start_height
-        assert(blockhash in node.scanblocks(
-            "start", [{"desc": f"pkh({parent_key}/*)", "range": [0, 100]}], height)['relevant_blocks'])
+        assert blockhash in node.scanblocks(
+            "start", [{"desc": f"pkh({parent_key}/*)", "range": [0, 100]}], height)['relevant_blocks']
 
         # check that false-positives are included in the result now; note that
         # finding a false-positive at runtime would take too long, hence we simply
@@ -89,13 +96,16 @@ class ScanblocksTest(BitcoinTestFramework):
         false_positive_hash = bip158_basic_element_hash(false_positive_spk, 1, genesis_blockhash)
         assert_equal(genesis_coinbase_hash, false_positive_hash)
 
-        assert(genesis_blockhash in node.scanblocks(
-            "start", [{"desc": f"raw({genesis_coinbase_spk.hex()})"}], 0, 0)['relevant_blocks'])
-        assert(genesis_blockhash in node.scanblocks(
-            "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0)['relevant_blocks'])
+        assert genesis_blockhash in node.scanblocks(
+            "start", [{"desc": f"raw({genesis_coinbase_spk.hex()})"}], 0, 0)['relevant_blocks']
+        assert genesis_blockhash in node.scanblocks(
+            "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0)['relevant_blocks']
 
-        # TODO: after an "accurate" mode for scanblocks is implemented (e.g. PR #26325)
-        # check here that it filters out the false-positive
+        # check that the filter_false_positives option works
+        assert genesis_blockhash in node.scanblocks(
+            "start", [{"desc": f"raw({genesis_coinbase_spk.hex()})"}], 0, 0, "basic", {"filter_false_positives": True})['relevant_blocks']
+        assert genesis_blockhash not in node.scanblocks(
+            "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0, "basic", {"filter_false_positives": True})['relevant_blocks']
 
         # test node with disabled blockfilterindex
         assert_raises_rpc_error(-1, "Index is not enabled for filtertype basic",
@@ -122,8 +132,8 @@ class ScanblocksTest(BitcoinTestFramework):
         assert_equal(node.scanblocks("abort"), False)
 
         # test invalid command
-        assert_raises_rpc_error(-8, "Invalid command", node.scanblocks, "foobar")
+        assert_raises_rpc_error(-8, "Invalid action 'foobar'", node.scanblocks, "foobar")
 
 
 if __name__ == '__main__':
-    ScanblocksTest().main()
+    ScanblocksTest(__file__).main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1287,6 +1287,25 @@ class MasternodeInfo:
 
         return node.protx(command, *args)
 
+    def revoke(self, node: TestNode, reason: int, fundsAddr: Optional[str] = None) -> str:
+        # Update commands should be run from the appropriate MasternodeInfo instance, we do not allow overriding some values for this reason
+        if self.proTxHash is None:
+            raise AssertionError("proTxHash not set, did you call set_params()")
+        if self.keyOperator is None:
+            raise AssertionError("keyOperator not set, did you call generate_addresses()")
+
+        args = [
+            self.proTxHash,
+            self.keyOperator,
+            reason,
+        ]
+
+        # fundsAddr is an optional field that results in different behavior if omitted, so we don't fallback here
+        if fundsAddr is not None:
+            args = args + [fundsAddr]
+
+        return node.protx('revoke', *args)
+
 class DashTestFramework(BitcoinTestFramework):
     def set_test_params(self):
         """Tests must this method to change default values for number of nodes, topology, etc"""

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1242,6 +1242,11 @@ class MasternodeInfo:
         ]
         address_funds = fundsAddr or self.fundsAddr
 
+        # Flip a coin and decide if we will submit the transaction directly or use sendrawtransaction
+        use_srt: bool = bool(random.getrandbits(1)) and submit
+        if use_srt:
+            submit = False
+
         # Construct final command and arguments
         if self.evo:
             command = "register_evo"
@@ -1250,7 +1255,11 @@ class MasternodeInfo:
             command = "register_legacy" if self.legacy else "register"
             args = args + [address_funds, submit] # type: ignore
 
-        return node.protx(command, *args)
+        ret: str = node.protx(command, *args)
+        if use_srt:
+            ret = node.sendrawtransaction(ret)
+
+        return ret
 
     def register_fund(self, node: TestNode, submit: bool, collateral_address: Optional[str] = None, ipAndPort: Optional[str] = None,
                       ownerAddr: Optional[str] = None, pubKeyOperator: Optional[str] = None, votingAddr: Optional[str] = None,
@@ -1264,6 +1273,11 @@ class MasternodeInfo:
                 raise AssertionError("EvoNode but platform_p2p_port is missing, must be specified!")
             if platform_http_port is None:
                 raise AssertionError("EvoNode but platform_http_port is missing, must be specified!")
+
+        # Flip a coin and decide if we will submit the transaction directly or use sendrawtransaction
+        use_srt: bool = bool(random.getrandbits(1)) and submit
+        if use_srt:
+            submit = False
 
         # Common arguments shared between regular masternodes and EvoNodes
         args = [
@@ -1285,7 +1299,11 @@ class MasternodeInfo:
             command = "register_fund_legacy" if self.legacy else "register_fund"
             args = args + [address_funds, submit] # type: ignore
 
-        return node.protx(command, *args)
+        ret: str = node.protx(command, *args)
+        if use_srt:
+            ret = node.sendrawtransaction(ret)
+
+        return ret
 
     def revoke(self, node: TestNode, submit: bool, reason: int, fundsAddr: Optional[str] = None) -> str:
         # Update commands should be run from the appropriate MasternodeInfo instance, we do not allow overriding some values for this reason
@@ -1293,6 +1311,11 @@ class MasternodeInfo:
             raise AssertionError("proTxHash not set, did you call set_params()")
         if self.keyOperator is None:
             raise AssertionError("keyOperator not set, did you call generate_addresses()")
+
+        # Flip a coin and decide if we will submit the transaction directly or use sendrawtransaction
+        use_srt: bool = bool(random.getrandbits(1)) and submit and (fundsAddr is not None)
+        if use_srt:
+            submit = False
 
         args = [
             self.proTxHash,
@@ -1306,13 +1329,22 @@ class MasternodeInfo:
         elif submit is not True:
             raise AssertionError("Cannot withhold transaction if relying on fundsAddr fallback behavior")
 
-        return node.protx('revoke', *args)
+        ret: str = node.protx('revoke', *args)
+        if use_srt:
+            ret = node.sendrawtransaction(ret)
+
+        return ret
 
     def update_registrar(self, node: TestNode, submit: bool, pubKeyOperator: Optional[str] = None, votingAddr: Optional[str] = None,
                          rewards_address: Optional[str] = None, fundsAddr: Optional[str] = None) -> str:
         # Update commands should be run from the appropriate MasternodeInfo instance, we do not allow overriding proTxHash for this reason
         if self.proTxHash is None:
             raise AssertionError("proTxHash not set, did you call set_params()")
+
+        # Flip a coin and decide if we will submit the transaction directly or use sendrawtransaction
+        use_srt: bool = bool(random.getrandbits(1)) and submit and (fundsAddr is not None)
+        if use_srt:
+            submit = False
 
         command = 'update_registrar_legacy' if self.legacy else 'update_registrar'
         args = [
@@ -1328,7 +1360,11 @@ class MasternodeInfo:
         elif submit is not True:
             raise AssertionError("Cannot withhold transaction if relying on fundsAddr fallback behavior")
 
-        return node.protx(command, *args)
+        ret: str = node.protx(command, *args)
+        if use_srt:
+            ret = node.sendrawtransaction(ret)
+
+        return ret
 
     def update_service(self, node: TestNode, submit: bool, ipAndPort: Optional[str] = None, platform_node_id: Optional[str] = None, platform_p2p_port: Optional[int] = None,
                        platform_http_port: Optional[int] = None, address_operator: Optional[str] = None, fundsAddr: Optional[str] = None) -> str:
@@ -1347,6 +1383,11 @@ class MasternodeInfo:
             if platform_http_port is None:
                 raise AssertionError("EvoNode but platform_http_port is missing, must be specified!")
 
+        # Flip a coin and decide if we will submit the transaction directly or use sendrawtransaction
+        use_srt: bool = bool(random.getrandbits(1)) and submit
+        if use_srt:
+            submit = False
+
         # Common arguments shared between regular masternodes and EvoNodes
         args = [
             self.proTxHash,
@@ -1364,7 +1405,11 @@ class MasternodeInfo:
             command = "update_service"
             args = args + [address_operator, address_funds, submit] # type: ignore
 
-        return node.protx(command, *args)
+        ret: str = node.protx(command, *args)
+        if use_srt:
+            ret = node.sendrawtransaction(ret)
+
+        return ret
 
 class DashTestFramework(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1306,6 +1306,26 @@ class MasternodeInfo:
 
         return node.protx('revoke', *args)
 
+    def update_registrar(self, node: TestNode, pubKeyOperator: Optional[str] = None, votingAddr: Optional[str] = None,
+                         rewards_address: Optional[str] = None, fundsAddr: Optional[str] = None) -> str:
+        # Update commands should be run from the appropriate MasternodeInfo instance, we do not allow overriding proTxHash for this reason
+        if self.proTxHash is None:
+            raise AssertionError("proTxHash not set, did you call set_params()")
+
+        command = 'update_registrar_legacy' if self.legacy else 'update_registrar'
+        args = [
+            self.proTxHash,
+            pubKeyOperator or self.pubKeyOperator,
+            votingAddr or self.votingAddr,
+            rewards_address or self.rewards_address,
+        ]
+
+        # fundsAddr is an optional field that results in different behavior if omitted, so we don't fallback here
+        if fundsAddr is not None:
+            args = args + [fundsAddr]
+
+        return node.protx(command, *args)
+
 class DashTestFramework(BitcoinTestFramework):
     def set_test_params(self):
         """Tests must this method to change default values for number of nodes, topology, etc"""

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2091,26 +2091,19 @@ class DashTestFramework(BitcoinTestFramework):
 
         self.wait_until(check_dkg_comitments, timeout=timeout, sleep=1)
 
-    def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, sleep=2, llmq_type_name="llmq_test"):
+    def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, llmq_type_name="llmq_test"):
         def wait_func():
-            self.log.info("quorums: " + str(self.nodes[0].quorum("list")))
-            if quorum_hash in self.nodes[0].quorum("list")[llmq_type_name]:
-                return True
-            self.bump_mocktime(sleep, nodes=nodes)
-            self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(nodes))
-            return False
-        self.wait_until(wait_func, timeout=timeout, sleep=sleep)
+            quorums = self.nodes[0].quorum('list')
+            self.log.info(f"quorums: {quorums}")
+            return quorum_hash in quorums[llmq_type_name]
+        self.wait_until(wait_func, timeout=timeout, sleep=0.05)
 
-    def wait_for_quorums_list(self, quorum_hash_0, quorum_hash_1, nodes, llmq_type_name="llmq_test",  timeout=15, sleep=2):
+    def wait_for_quorums_list(self, quorum_hash_0, quorum_hash_1, nodes, llmq_type_name="llmq_test",  timeout=15):
         def wait_func():
-            self.log.info("h("+str(self.nodes[0].getblockcount())+") quorums: " + str(self.nodes[0].quorum("list")))
-            if quorum_hash_0 in self.nodes[0].quorum("list")[llmq_type_name]:
-                if quorum_hash_1 in self.nodes[0].quorum("list")[llmq_type_name]:
-                    return True
-            self.bump_mocktime(sleep, nodes=nodes)
-            self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(nodes))
-            return False
-        self.wait_until(wait_func, timeout=timeout, sleep=sleep)
+            quorums = self.nodes[0].quorum("list")
+            self.log.info(f"h({self.nodes[0].getblockcount()}) quorums: {quorums}")
+            return quorum_hash_0 in quorums[llmq_type_name] and quorum_hash_1 in quorums[llmq_type_name]
+        self.wait_until(wait_func, timeout=timeout, sleep=0.05)
 
     def move_blocks(self, nodes, num_blocks):
         self.bump_mocktime(1, nodes=nodes)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -896,7 +896,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         for node in self.nodes:
             node.mocktime = self.mocktime
 
-    def wait_until(self, test_function, timeout=60, lock=None, sleep=0.5, do_assert=True):
+    def wait_until(self, test_function, timeout=60, lock=None, sleep=0.05, do_assert=True):
         return wait_until_helper(test_function, timeout=timeout, lock=lock, timeout_factor=self.options.timeout_factor, sleep=sleep, do_assert=do_assert)
 
     # Private helper methods. These should not be accessed by the subclass test scripts.

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1969,7 +1969,7 @@ class DashTestFramework(BitcoinTestFramework):
             self.bump_mocktime(1)
             sporks = self.nodes[0].spork('show')
             return all(node.spork('show') == sporks for node in self.nodes[1:])
-        self.wait_until(check_sporks_same, timeout=timeout, sleep=0.5)
+        self.wait_until(check_sporks_same, timeout=timeout, sleep=1)
 
     def wait_for_quorum_connections(self, quorum_hash, expected_connections, mninfos, llmq_type_name="llmq_test", timeout = 60, wait_proc=None):
         def check_quorum_connections():

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2093,16 +2093,15 @@ class DashTestFramework(BitcoinTestFramework):
 
     def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, llmq_type_name="llmq_test"):
         def wait_func():
-            quorums = self.nodes[0].quorum('list')
-            self.log.info(f"quorums: {quorums}")
-            return quorum_hash in quorums[llmq_type_name]
+            return quorum_hash in self.nodes[0].quorum('list')[llmq_type_name]
+        self.log.info(f"quorums: {self.nodes[0].quorum('list')}")
         self.wait_until(wait_func, timeout=timeout, sleep=0.05)
 
     def wait_for_quorums_list(self, quorum_hash_0, quorum_hash_1, nodes, llmq_type_name="llmq_test",  timeout=15):
         def wait_func():
-            quorums = self.nodes[0].quorum("list")
-            self.log.info(f"h({self.nodes[0].getblockcount()}) quorums: {quorums}")
-            return quorum_hash_0 in quorums[llmq_type_name] and quorum_hash_1 in quorums[llmq_type_name]
+            quorums = self.nodes[0].quorum("list")[llmq_type_name]
+            return quorum_hash_0 in quorums and quorum_hash_1 in quorums
+        self.log.info(f"h({self.nodes[0].getblockcount()}) quorums: {self.nodes[0].quorum('list')}")
         self.wait_until(wait_func, timeout=timeout, sleep=0.05)
 
     def move_blocks(self, nodes, num_blocks):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -247,7 +247,7 @@ def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
 
-def wait_until_helper(predicate, *, attempts=float('inf'), timeout=float('inf'), sleep=0.5, timeout_factor=1.0, lock=None, do_assert=True, allow_exception=False):
+def wait_until_helper(predicate, *, attempts=float('inf'), timeout=float('inf'), sleep=0.05, timeout_factor=1.0, lock=None, do_assert=True, allow_exception=False):
     """Sleep until the predicate resolves to be True.
 
     Warning: Note that this method is not recommended to be used in tests as it is

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -367,6 +367,7 @@ BASE_SCRIPTS = [
     'rpc_deriveaddresses.py --usecli',
     'p2p_ping.py',
     'p2p_sendtxrcncl.py',
+    'rpc_scanblocks.py',
     'rpc_scantxoutset.py',
     'feature_txindex_compatibility.py',
     'feature_logging.py',


### PR DESCRIPTION
Backports bitcoin/bitcoin#26341

Original commit: e25de33e7

Backported from Bitcoin Core v0.25

## Changes:
- Added new functional test `rpc_scanblocks.py` with BIP158 false-positive element check
- Added test to test_runner.py list
- Note: siphash.py and blockfilter.py modules already exist in Dash at different locations (test/functional/test_framework/crypto/siphash.py and test/functional/test_framework/blockfilter.py)