### PR TITLE
Merge bitcoin/bitcoin#26349: rpc: make `address` field optional `list{transactions, sinceblock}` response

### DIFF
--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -456,8 +456,7 @@ RPCHelpMan listtransactions()
                 {RPCResult::Type::OBJ, "", "", Cat(Cat<std::vector<RPCResult>>(
                     {
                         {RPCResult::Type::BOOL, "involvesWatchonly", /* optional */ true, "Only returns true if imported addresses were involved in transaction"},
-                        {RPCResult::Type::STR, "address", "The Dash address of the transaction. Not present for\n"
-                              "move transactions (category = move)."},
+                        {RPCResult::Type::STR, "address", /* optional */ true, "The Dash address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data)."},
                         {RPCResult::Type::STR, "category", "The transaction category.\n"
                             "\"send\"                  Transactions sent.\n"
                             "\"coinjoin\"              Transactions sent using CoinJoin funds.\n"
@@ -572,7 +571,7 @@ RPCHelpMan listsinceblock()
                     {RPCResult::Type::OBJ, "", "", Cat(Cat<std::vector<RPCResult>>(
                     {
                         {RPCResult::Type::BOOL, "involvesWatchonly", /* optional */ true, "Only returns true if imported addresses were involved in transaction"},
-                        {RPCResult::Type::STR, "address", "The Dash address of the transaction."},
+                        {RPCResult::Type::STR, "address", /* optional */ true, "The Dash address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data)."},
                         {RPCResult::Type::STR, "category", "The transaction category.\n"
                             "\"send\"                  Transactions sent.\n"
                             "\"coinjoin\"              Transactions sent using CoinJoin funds.\n"

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -41,6 +41,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         self.test_double_send()
         self.double_spends_filtered()
         self.test_targetconfirmations()
+        self.test_op_return()
 
     def test_no_blockhash(self):
         self.log.info("Test no blockhash")
@@ -387,6 +388,17 @@ class ListSinceBlockTest(BitcoinTestFramework):
                 double_found = True
         assert_equal(original_found, False)
         assert_equal(double_found, False)
+
+    def test_op_return(self):
+        """Test if OP_RETURN outputs will be displayed correctly."""
+        block_hash = self.nodes[2].getbestblockhash()
+        raw_tx = self.nodes[2].createrawtransaction([], [{'data': 'aa'}])
+        signed_raw_tx = self.nodes[2].signrawtransactionwithwallet(raw_tx)
+        tx_id = self.nodes[2].sendrawtransaction(signed_raw_tx['hex'])
+
+        op_ret_tx = [tx for tx in self.nodes[2].listsinceblock(blockhash=block_hash)["transactions"] if tx['txid'] == tx_id][0]
+
+        assert 'address' not in op_ret_tx
 
 if __name__ == '__main__':
     ListSinceBlockTest().main()

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -97,5 +97,17 @@ class ListTransactionsTest(BitcoinTestFramework):
                                 {"category": "receive", "amount": Decimal("0.1")},
                                 {"txid": txid, "label": "watchonly"})
 
+        self.test_op_return()
+
+    def test_op_return(self):
+        """Test if OP_RETURN outputs will be displayed correctly."""
+        raw_tx = self.nodes[0].createrawtransaction([], [{'data': 'aa'}])
+        signed_raw_tx = self.nodes[0].signrawtransactionwithwallet(raw_tx)
+        tx_id = self.nodes[0].sendrawtransaction(signed_raw_tx['hex'])
+
+        op_ret_tx = [tx for tx in self.nodes[0].listtransactions() if tx['txid'] == tx_id][0]
+
+        assert 'address' not in op_ret_tx
+
 if __name__ == '__main__':
     ListTransactionsTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#26349

Original commit: 551c8e952

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RPC help descriptions to clarify that the "address" field in transaction listings is optional and not present for outputs without an address (such as OP_RETURN).

* **Tests**
  * Added new tests to verify that transactions with OP_RETURN outputs do not include an "address" field in the `listtransactions` and `listsinceblock` RPC results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->