### PR TITLE
Merge bitcoin/bitcoin#26409: refactor: Silence GCC Wmissing-field-initializers in ChainstateManagerOpts

### DIFF
--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
+#define BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
+
+#include <arith_uint256.h>
+#include <uint256.h>
+#include <util/time.h>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+class CChainParams;
+
+static constexpr bool DEFAULT_CHECKPOINTS_ENABLED{true};
+static constexpr auto DEFAULT_MAX_TIP_AGE{24h};
+
+namespace kernel {
+
+/**
+ * An options struct for `ChainstateManager`, more ergonomically referred to as
+ * `ChainstateManager::Options` due to the using-declaration in
+ * `ChainstateManager`.
+ */
+struct ChainstateManagerOpts {
+    const CChainParams& chainparams;
+    const std::function<NodeClock::time_point()> adjusted_time_callback{nullptr};
+    std::optional<bool> check_block_index{};
+    bool checkpoints_enabled{DEFAULT_CHECKPOINTS_ENABLED};
+    //! If set, it will override the minimum work we will assume exists on some valid chain.
+    std::optional<arith_uint256> minimum_chain_work{};
+    //! If set, it will override the block hash whose ancestors we will assume to have valid scripts without checking them.
+    std::optional<uint256> assumed_valid_block{};
+    //! If the tip is older than this, the node is considered to be in initial block download.
+    std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
+};
+
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H


### PR DESCRIPTION
Backports bitcoin/bitcoin#26409

Original commit: 8b050762b1b44aa6a0b29f7cf7d14e58312ecd12

Backported from Bitcoin Core v0.25

This commit adds the missing initialization for std::optional fields in ChainstateManagerOpts to silence GCC Wmissing-field-initializers warnings. The file src/kernel/chainstatemanager_opts.h didn't exist on the base branch but was created with the proper Bitcoin changes applied.