### PR TITLE
Merge bitcoin/bitcoin#26424: doc: correct deriveaddresses RPC name

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -240,6 +240,6 @@ ones. For larger numbers of errors, or other types of errors, there is a
 roughly 1 in a trillion chance of not detecting the errors.
 
 All RPCs in Dash Core will include the checksum in their output. Only
-certain RPCs require checksums on input, including `deriveaddress` and
+certain RPCs require checksums on input, including `deriveaddresses` and
 `importmulti`. The checksum for a descriptor without one can be computed
 using the `getdescriptorinfo` RPC.


### PR DESCRIPTION
Backports bitcoin/bitcoin#26424

Original commit: c75c0d8e1147079ab1aef088e0a2486d295ab625

This is a simple documentation fix correcting the RPC name from "deriveaddress" to "deriveaddresses" in doc/descriptors.md. The conflict resolution preserves the Dash-specific "Dash Core" branding while applying the Bitcoin fix.

Backported from Bitcoin Core v0.25