### PR TITLE
Merge bitcoin/bitcoin#26402: doc: Fix typos

### DIFF
--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -76,7 +76,7 @@ the passed message.
 
 #### Tracepoint `net:outbound_message`
 
-Is called when a message is send to a peer over the P2P network. Passes
+Is called when a message is sent to a peer over the P2P network. Passes
 information about our peer, the connection and the message as arguments.
 
 Arguments passed:
@@ -116,7 +116,7 @@ added to and removed (spent) from the cache when we connect a new block.
 (`chainstate.CoinsTip()`). For example, the RPCs `generateblock` and
 `getblocktemplate` call `TestBlockValidity()`, which applies the UTXO set
 changes to a temporary cache. Similarly, mempool consistency checks, which are
-frequent on regtest, also apply the the UTXO set changes to a temporary cache.
+frequent on regtest, also apply the UTXO set changes to a temporary cache.
 Changes to the _main_ UTXO cache and to temporary caches trigger the tracepoints.
 We can't tell if a temporary cache or the _main_ cache was changed.
 
@@ -253,8 +253,8 @@ TRACE6(net, inbound_message,
 
 ### Guidelines and best practices
 
-#### Clear motivation and use-case
-Tracepoints need a clear motivation and use-case. The motivation should
+#### Clear motivation and use case
+Tracepoints need a clear motivation and use case. The motivation should
 outweigh the impact on, for example, code readability. There is no point in
 adding tracepoints that don't end up being used.
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#26402

Original commit: 2856dee80

Backported from Bitcoin Core v0.25

This commit fixes several typos in documentation:
- "send" → "sent" (doc/tracing.md)
- "apply the the" → "apply the" (doc/tracing.md)
- "use-case" → "use case" (doc/tracing.md)

Note: Bitcoin also fixed typos in src/net_processing.cpp, but Dash already had correct spelling in those locations.