### PR TITLE
Merge bitcoin/bitcoin#24051: Bugfix: configure: bitcoin-{cli,tx,util} don't need UPnP, NAT-PMP, or ZMQ

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1425,7 +1425,7 @@ if test "$use_usdt" != "no"; then
 fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 
-if test "$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nononono"; then
+if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nononononono"; then
   use_upnp=no
   use_natpmp=no
   use_zmq=no

--- a/configure.ac
+++ b/configure.ac
@@ -1425,7 +1425,7 @@ if test "$use_usdt" != "no"; then
 fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 
-if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nononononono"; then
+if test "$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nononono"; then
   use_upnp=no
   use_natpmp=no
   use_zmq=no

--- a/configure.ac
+++ b/configure.ac
@@ -1425,6 +1425,12 @@ if test "$use_usdt" != "no"; then
 fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 
+if test "$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nononono"; then
+  use_upnp=no
+  use_natpmp=no
+  use_zmq=no
+fi
+
 dnl Check for libminiupnpc (optional)
 if test "$use_upnp" != "no"; then
   TEMP_CPPFLAGS="$CPPFLAGS"


### PR DESCRIPTION
Backports bitcoin/bitcoin#24051

Original commit: 4766cd198172225c66a0adb01f6cb9513c3d0e66

Backported from Bitcoin Core v0.25

---

This backport adds a build optimization that disables UPnP, NAT-PMP, and ZMQ dependencies when they're not needed. The optimization checks if only bitcoind, Qt, bench, or tests are being built, and if none of them are enabled, it disables these optional dependencies.

The change is minimal and focused, adding just the conditional check in configure.ac to improve build efficiency by avoiding unnecessary dependency compilation.