### PR TITLE
Merge bitcoin/bitcoin#26294: build: move util/url to common/url

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -164,7 +164,6 @@ BITCOIN_CORE_H = \
   coinjoin/util.h \
   coins.h \
   common/bloom.h \
-  common/run_command.h \
   common/url.h \
   compat/assumptions.h \
   compat/byteswap.h \
@@ -870,7 +869,6 @@ libbitcoin_util_a_SOURCES = \
   util/tokenpipe.cpp \
   util/wpipe.cpp \
   $(BITCOIN_CORE_H)
-#
 
 # cli: shared between dash-cli and dash-qt
 libbitcoin_cli_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -164,6 +164,8 @@ BITCOIN_CORE_H = \
   coinjoin/util.h \
   coins.h \
   common/bloom.h \
+  common/run_command.h \
+  common/url.h \
   compat/assumptions.h \
   compat/byteswap.h \
   compat/compat.h \
@@ -384,7 +386,6 @@ BITCOIN_CORE_H = \
   util/translation.h \
   util/types.h \
   util/ui_change_type.h \
-  util/url.h \
   util/vector.h \
   util/wpipe.h \
   validation.h \
@@ -809,6 +810,12 @@ libbitcoin_common_a_SOURCES = \
   warnings.cpp \
   $(BITCOIN_CORE_H)
 
+if USE_LIBEVENT
+libbitcoin_common_a_CPPFLAGS += $(EVENT_CFLAGS)
+libbitcoin_common_a_SOURCES += common/url.cpp
+endif
+#
+
 # util: shared between all executables.
 libbitcoin_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -863,10 +870,7 @@ libbitcoin_util_a_SOURCES = \
   util/tokenpipe.cpp \
   util/wpipe.cpp \
   $(BITCOIN_CORE_H)
-
-if USE_LIBEVENT
-libbitcoin_util_a_SOURCES += util/url.cpp
-endif
+#
 
 # cli: shared between dash-cli and dash-qt
 libbitcoin_cli_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
@@ -931,6 +935,7 @@ endif
 dash_cli_LDADD = \
   $(LIBBITCOIN_CLI) \
   $(LIBUNIVALUE) \
+  $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CRYPTO)
 dash_cli_LDADD += $(BACKTRACE_LIB) $(EVENT_LIBS) $(GMP_LIBS)

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -10,6 +10,7 @@
 
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>
 #include <policy/feerate.h>
@@ -23,7 +24,6 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 
 #include <algorithm>
 #include <chrono>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,16 +8,16 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <util/strencodings.h>
-#include <clientversion.h>
 #include <key.h>
 #include <pubkey.h>
 #include <tinyformat.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <wallet/wallettool.h>
 
 #include <exception>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,11 +8,11 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
-#include <clientversion.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <util/strencodings.h>
+#include <clientversion.h>
 #include <key.h>
 #include <pubkey.h>
 #include <tinyformat.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,12 +8,12 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <clientversion.h>
 #include <common/url.h>
 #include <compat/compat.h>
+#include <key.h>
 #include <logging.h>
 #include <util/strencodings.h>
-#include <clientversion.h>
-#include <key.h>
 #include <pubkey.h>
 #include <tinyformat.h>
 #include <util/system.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -10,6 +10,7 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <init.h>
 #include <interfaces/chain.h>
@@ -26,7 +27,6 @@
 #include <util/tokenpipe.h>
 #include <util/translation.h>
 #include <stacktraces.h>
-#include <util/url.h>
 
 #include <cstdio>
 #include <functional>

--- a/src/common/url.cpp
+++ b/src/common/url.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/url.h>
+#include <common/url.h>
 
 #include <event2/http.h>
 

--- a/src/common/url.cpp
+++ b/src/common/url.cpp
@@ -20,3 +20,5 @@ std::string urlDecode(const std::string &urlEncoded) {
     }
     return res;
 }
+
+UrlDecodeFn* const URL_DECODE = &urlDecode;

--- a/src/common/url.h
+++ b/src/common/url.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_URL_H
-#define BITCOIN_UTIL_URL_H
+#ifndef BITCOIN_COMMON_URL_H
+#define BITCOIN_COMMON_URL_H
 
 #include <string>
 
@@ -11,4 +11,4 @@ using UrlDecodeFn = std::string(const std::string& url_encoded);
 UrlDecodeFn urlDecode;
 extern UrlDecodeFn* const URL_DECODE;
 
-#endif // BITCOIN_UTIL_URL_H
+#endif // BITCOIN_COMMON_URL_H

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -4,9 +4,9 @@
 
 #include <qt/bitcoin.h>
 
+#include <common/url.h>
 #include <compat/compat.h>
 #include <util/translation.h>
-#include <util/url.h>
 
 #include <QCoreApplication>
 

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -4,6 +4,7 @@
 
 #include <blockfilter.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -25,7 +26,6 @@
 #include <util/string.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <version.h>
 
 #include <cstdint>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -71,7 +71,6 @@
 #include <memory>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
-UrlDecodeFn* const URL_DECODE = nullptr;
 
 FastRandomContext g_insecure_rand_ctx;
 /** Random context to get unique temp data dirs. Separate from g_insecure_rand_ctx, which can be seeded from a const env var */

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -7,6 +7,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <chainparams.h>
+#include <common/url.h>
 #include <consensus/consensus.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
@@ -38,7 +39,6 @@
 #include <util/threadnames.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <util/vector.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/rpc/util.h>
 
+#include <common/url.h>
 #include <rpc/util.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -15,7 +15,7 @@
 #include <util/bip32.h>
 #include <util/fees.h>
 #include <util/translation.h>
-#include <util/url.h>
+#include <common/url.h>
 #include <util/vector.h>
 #include <wallet/context.h>
 #include <wallet/receive.h>

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -12,10 +12,10 @@
 #include <rpc/rawtransaction_util.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
+#include <common/url.h>
 #include <util/bip32.h>
 #include <util/fees.h>
 #include <util/translation.h>
-#include <common/url.h>
 #include <util/vector.h>
 #include <wallet/context.h>
 #include <wallet/receive.h>


### PR DESCRIPTION
Backports bitcoin/bitcoin#26294

Original commit: 27e76afe24c390cc091e246bdbc691bdf5bb090c

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal references for URL handling utilities to use a common header, improving consistency across the application.
  * Adjusted build configuration to reflect these changes, with no impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->