### PR TITLE
Merge bitcoin/bitcoin#26419: log: mempool: log removal reason in validation interface

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1747,3 +1747,17 @@ void CTxMemPool::SetIsLoaded(bool loaded)
     LOCK(cs);
     m_is_loaded = loaded;
 }
+
+
+const std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
+{
+    switch (r) {
+        case MemPoolRemovalReason::EXPIRY: return "expiry";
+        case MemPoolRemovalReason::SIZELIMIT: return "sizelimit";
+        case MemPoolRemovalReason::REORG: return "reorg";
+        case MemPoolRemovalReason::BLOCK: return "block";
+        case MemPoolRemovalReason::CONFLICT: return "conflict";
+        case MemPoolRemovalReason::REPLACED: return "replaced";
+    }
+    assert(false);
+}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1757,7 +1757,7 @@ const std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
         case MemPoolRemovalReason::REORG: return "reorg";
         case MemPoolRemovalReason::BLOCK: return "block";
         case MemPoolRemovalReason::CONFLICT: return "conflict";
-        case MemPoolRemovalReason::REPLACED: return "replaced";
+        case MemPoolRemovalReason::MANUAL: return "manual";
     }
     assert(false);
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -356,6 +356,8 @@ enum class MemPoolRemovalReason {
     MANUAL       //!< Removed manually
 };
 
+const std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
+
 /**
  * CTxMemPool stores valid-according-to-the-current-best-chain transactions
  * that may be included in the next block.

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -23,16 +23,14 @@
 
 const std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
 
-/**
- * MainSignalsImpl manages a list of shared_ptr<CValidationInterface> callbacks.
- *
- * A std::unordered_map is used to track what callbacks are currently
- * registered, and a std::list is used to store the callbacks that are
- * currently registered as well as any callbacks that are just unregistered
- * and about to be deleted when they are done executing.
- */
-class MainSignalsImpl
-{
+//! The MainSignalsInstance manages a list of shared_ptr<CValidationInterface>
+//! callbacks.
+//!
+//! A std::unordered_map is used to track what callbacks are currently
+//! registered, and a std::list is to used to store the callbacks that are
+//! currently registered as well as any callbacks that are just unregistered
+//! and about to be deleted when they are done executing.
+struct MainSignalsInstance {
 private:
     Mutex m_mutex;
     //! List entries consist of a callback pointer and reference count. The
@@ -224,9 +222,8 @@ void CMainSignals::TransactionRemovedFromMempool(const CTransactionRef& tx, MemP
     auto event = [tx, reason, mempool_sequence, this] {
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.TransactionRemovedFromMempool(tx, reason, mempool_sequence); });
     };
-    ENQUEUE_AND_LOG_EVENT(event, "%s: txid=%s wtxid=%s reason=%s", __func__,
+    ENQUEUE_AND_LOG_EVENT(event, "%s: txid=%s reason=%s", __func__,
                           tx->GetHash().ToString(),
-                          tx->GetWitnessHash().ToString(),
                           RemovalReasonToString(reason));
 }
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -21,14 +21,18 @@
 #include <unordered_map>
 #include <utility>
 
-//! The MainSignalsInstance manages a list of shared_ptr<CValidationInterface>
-//! callbacks.
-//!
-//! A std::unordered_map is used to track what callbacks are currently
-//! registered, and a std::list is to used to store the callbacks that are
-//! currently registered as well as any callbacks that are just unregistered
-//! and about to be deleted when they are done executing.
-struct MainSignalsInstance {
+const std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
+
+/**
+ * MainSignalsImpl manages a list of shared_ptr<CValidationInterface> callbacks.
+ *
+ * A std::unordered_map is used to track what callbacks are currently
+ * registered, and a std::list is used to store the callbacks that are
+ * currently registered as well as any callbacks that are just unregistered
+ * and about to be deleted when they are done executing.
+ */
+class MainSignalsImpl
+{
 private:
     Mutex m_mutex;
     //! List entries consist of a callback pointer and reference count. The
@@ -220,8 +224,10 @@ void CMainSignals::TransactionRemovedFromMempool(const CTransactionRef& tx, MemP
     auto event = [tx, reason, mempool_sequence, this] {
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.TransactionRemovedFromMempool(tx, reason, mempool_sequence); });
     };
-    ENQUEUE_AND_LOG_EVENT(event, "%s: txid=%s", __func__,
-                          tx->GetHash().ToString());
+    ENQUEUE_AND_LOG_EVENT(event, "%s: txid=%s wtxid=%s reason=%s", __func__,
+                          tx->GetHash().ToString(),
+                          tx->GetWitnessHash().ToString(),
+                          RemovalReasonToString(reason));
 }
 
 void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &pblock, const CBlockIndex *pindex) {


### PR DESCRIPTION
Backports bitcoin/bitcoin#26419

Original commit: 50422b770a40f5fa964201d1e99fd6b5dc1653ca

Backported from Bitcoin Core v0.25

Changes made for Dash compatibility:
- Adapted MemPoolRemovalReason::REPLACED to MemPoolRemovalReason::MANUAL (Dash's equivalent)
- Removed GetWitnessHash() calls as Dash doesn't support Segwit
- Updated MainSignalsInstance to MainSignalsImpl class structure to match Bitcoin changes