### PR TITLE
Merge bitcoin/bitcoin#26472: test: add missing bech32m / BIP86 test-cases to wallet_descriptor.py

### DIFF
--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -51,16 +51,6 @@ class WalletDescriptorTest(BitcoinTestFramework):
         assert addr_info['desc'].startswith('pkh(')
         assert_equal(addr_info['hdkeypath'], 'm/44\'/1\'/0\'/0/0')
 
-        addr = self.nodes[0].getnewaddress("", "p2sh-segwit")
-        addr_info = self.nodes[0].getaddressinfo(addr)
-        assert addr_info['desc'].startswith('sh(wpkh(')
-        assert_equal(addr_info['hdkeypath'], 'm/49\'/1\'/0\'/0/0')
-
-        addr = self.nodes[0].getnewaddress("", "bech32")
-        addr_info = self.nodes[0].getaddressinfo(addr)
-        assert addr_info['desc'].startswith('wpkh(')
-        assert_equal(addr_info['hdkeypath'], 'm/84\'/1\'/0\'/0/0')
-
         addr = self.nodes[0].getnewaddress("", "bech32m")
         addr_info = self.nodes[0].getaddressinfo(addr)
         assert addr_info['desc'].startswith('tr(')
@@ -70,16 +60,6 @@ class WalletDescriptorTest(BitcoinTestFramework):
         addr_info = self.nodes[0].getaddressinfo(addr)
         assert addr_info['desc'].startswith('pkh(')
         assert_equal(addr_info['hdkeypath'], 'm/44\'/1\'/0\'/1/0')
-
-        addr = self.nodes[0].getrawchangeaddress("p2sh-segwit")
-        addr_info = self.nodes[0].getaddressinfo(addr)
-        assert addr_info['desc'].startswith('sh(wpkh(')
-        assert_equal(addr_info['hdkeypath'], 'm/49\'/1\'/0\'/1/0')
-
-        addr = self.nodes[0].getrawchangeaddress("bech32")
-        addr_info = self.nodes[0].getaddressinfo(addr)
-        assert addr_info['desc'].startswith('wpkh(')
-        assert_equal(addr_info['hdkeypath'], 'm/84\'/1\'/0\'/1/0')
 
         addr = self.nodes[0].getrawchangeaddress("bech32m")
         addr_info = self.nodes[0].getaddressinfo(addr)
@@ -168,12 +148,8 @@ class WalletDescriptorTest(BitcoinTestFramework):
         imp_rpc = self.nodes[0].get_wallet_rpc('desc_import')
 
         addr_types = [('legacy', False, 'pkh(', '44\'/1\'/0\'', -13),
-                      ('p2sh-segwit', False, 'sh(wpkh(', '49\'/1\'/0\'', -14),
-                      ('bech32', False, 'wpkh(', '84\'/1\'/0\'', -13),
                       ('bech32m', False, 'tr(', '86\'/1\'/0\'', -13),
                       ('legacy', True, 'pkh(', '44\'/1\'/0\'', -13),
-                      ('p2sh-segwit', True, 'sh(wpkh(', '49\'/1\'/0\'', -14),
-                      ('bech32', True, 'wpkh(', '84\'/1\'/0\'', -13),
                       ('bech32m', True, 'tr(', '86\'/1\'/0\'', -13)]
 
         for addr_type, internal, desc_prefix, deriv_path, int_idx in addr_types:

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -51,12 +51,40 @@ class WalletDescriptorTest(BitcoinTestFramework):
         assert addr_info['desc'].startswith('pkh(')
         assert_equal(addr_info['hdkeypath'], 'm/44\'/1\'/0\'/0/0')
 
+        addr = self.nodes[0].getnewaddress("", "p2sh-segwit")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert addr_info['desc'].startswith('sh(wpkh(')
+        assert_equal(addr_info['hdkeypath'], 'm/49\'/1\'/0\'/0/0')
+
+        addr = self.nodes[0].getnewaddress("", "bech32")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert addr_info['desc'].startswith('wpkh(')
+        assert_equal(addr_info['hdkeypath'], 'm/84\'/1\'/0\'/0/0')
+
+        addr = self.nodes[0].getnewaddress("", "bech32m")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert addr_info['desc'].startswith('tr(')
+        assert_equal(addr_info['hdkeypath'], 'm/86\'/1\'/0\'/0/0')
         # Check that getrawchangeaddress works
         addr = self.nodes[0].getrawchangeaddress()
         addr_info = self.nodes[0].getaddressinfo(addr)
         assert addr_info['desc'].startswith('pkh(')
         assert_equal(addr_info['hdkeypath'], 'm/44\'/1\'/0\'/1/0')
 
+        addr = self.nodes[0].getrawchangeaddress("p2sh-segwit")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert addr_info['desc'].startswith('sh(wpkh(')
+        assert_equal(addr_info['hdkeypath'], 'm/49\'/1\'/0\'/1/0')
+
+        addr = self.nodes[0].getrawchangeaddress("bech32")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert addr_info['desc'].startswith('wpkh(')
+        assert_equal(addr_info['hdkeypath'], 'm/84\'/1\'/0\'/1/0')
+
+        addr = self.nodes[0].getrawchangeaddress("bech32m")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert addr_info['desc'].startswith('tr(')
+        assert_equal(addr_info['hdkeypath'], 'm/86\'/1\'/0\'/1/0')
         # Make a wallet to receive coins at
         self.nodes[0].createwallet(wallet_name="desc2", descriptors=True)
         recv_wrpc = self.nodes[0].get_wallet_rpc("desc2")
@@ -140,7 +168,13 @@ class WalletDescriptorTest(BitcoinTestFramework):
         imp_rpc = self.nodes[0].get_wallet_rpc('desc_import')
 
         addr_types = [('legacy', False, 'pkh(', '44\'/1\'/0\'', -13),
-                      ('legacy', True, 'pkh(', '44\'/1\'/0\'', -13)]
+                      ('p2sh-segwit', False, 'sh(wpkh(', '49\'/1\'/0\'', -14),
+                      ('bech32', False, 'wpkh(', '84\'/1\'/0\'', -13),
+                      ('bech32m', False, 'tr(', '86\'/1\'/0\'', -13),
+                      ('legacy', True, 'pkh(', '44\'/1\'/0\'', -13),
+                      ('p2sh-segwit', True, 'sh(wpkh(', '49\'/1\'/0\'', -14),
+                      ('bech32', True, 'wpkh(', '84\'/1\'/0\'', -13),
+                      ('bech32m', True, 'tr(', '86\'/1\'/0\'', -13)]
 
         for addr_type, internal, desc_prefix, deriv_path, int_idx in addr_types:
             int_str = 'internal' if internal else 'external'


### PR DESCRIPTION
Backports bitcoin/bitcoin#26472

Original commit: 9dce30194bc07463d634072251a8bf83e1b10ff9

Backported from Bitcoin Core v0.25

This small PR adds missing "bech32m" address type / BIP86 checks w.r.t. to the `getnewaddress`/`getrawchangeaddress` RPC and descriptor export functionality to the functional test `wallet_descriptor.py`.