### PR TITLE
Merge bitcoin/bitcoin#25714: univalue: Avoid std::string copies

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -25,7 +25,6 @@ public:
               std::enable_if_t<std::is_floating_point_v<T> ||                      // setFloat
                                    std::is_same_v<bool, T> ||                      // setBool
                                    std::is_signed_v<T> || std::is_unsigned_v<T> || // setInt
-                                   std::is_enum_v<T> ||                            // setInt (for enums)
                                    std::is_constructible_v<std::string, T>,        // setStr
                                bool> = true>
     UniValue(Ref&& val)
@@ -38,8 +37,6 @@ public:
             setInt(int64_t{val});
         } else if constexpr (std::is_unsigned_v<T>) {
             setInt(uint64_t{val});
-        } else if constexpr (std::is_enum_v<T>) {
-            setInt(static_cast<std::underlying_type_t<T>>(val));
         } else {
             setStr(std::string{std::forward<Ref>(val)});
         }

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <map>
 #include <cassert>
+#include <type_traits>
 
 class UniValue {
 public:
@@ -24,6 +25,7 @@ public:
               std::enable_if_t<std::is_floating_point_v<T> ||                      // setFloat
                                    std::is_same_v<bool, T> ||                      // setBool
                                    std::is_signed_v<T> || std::is_unsigned_v<T> || // setInt
+                                   std::is_enum_v<T> ||                            // setInt (for enums)
                                    std::is_constructible_v<std::string, T>,        // setStr
                                bool> = true>
     UniValue(Ref&& val)
@@ -36,6 +38,8 @@ public:
             setInt(int64_t{val});
         } else if constexpr (std::is_unsigned_v<T>) {
             setInt(uint64_t{val});
+        } else if constexpr (std::is_enum_v<T>) {
+            setInt(static_cast<std::underlying_type_t<T>>(val));
         } else {
             setStr(std::string{std::forward<Ref>(val)});
         }

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -19,43 +19,38 @@ public:
     enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };
 
     UniValue() { typ = VNULL; }
-    UniValue(UniValue::VType initialType, const std::string& initialStr = "") {
-        typ = initialType;
-        val = initialStr;
-    }
-    UniValue(uint64_t val_) {
-        setInt(val_);
-    }
-    UniValue(int64_t val_) {
-        setInt(val_);
-    }
-    UniValue(bool val_) {
-        setBool(val_);
-    }
-    UniValue(int val_) {
-        setInt(val_);
-    }
-    UniValue(double val_) {
-        setFloat(val_);
-    }
-    UniValue(const std::string& val_) {
-        setStr(val_);
-    }
-    UniValue(const char *val_) {
-        std::string s(val_);
-        setStr(s);
+    UniValue(UniValue::VType type, std::string str = {}) : typ{type}, val{std::move(str)} {}
+    template <typename Ref, typename T = std::remove_cv_t<std::remove_reference_t<Ref>>,
+              std::enable_if_t<std::is_floating_point_v<T> ||                      // setFloat
+                                   std::is_same_v<bool, T> ||                      // setBool
+                                   std::is_signed_v<T> || std::is_unsigned_v<T> || // setInt
+                                   std::is_constructible_v<std::string, T>,        // setStr
+                               bool> = true>
+    UniValue(Ref&& val)
+    {
+        if constexpr (std::is_floating_point_v<T>) {
+            setFloat(val);
+        } else if constexpr (std::is_same_v<bool, T>) {
+            setBool(val);
+        } else if constexpr (std::is_signed_v<T>) {
+            setInt(int64_t{val});
+        } else if constexpr (std::is_unsigned_v<T>) {
+            setInt(uint64_t{val});
+        } else {
+            setStr(std::string{std::forward<Ref>(val)});
+        }
     }
 
     void clear();
 
     bool setNull();
     bool setBool(bool val);
-    bool setNumStr(const std::string& val);
+    bool setNumStr(std::string str);
     bool setInt(uint64_t val);
     bool setInt(int64_t val);
-    bool setInt(int val_) { return setInt((int64_t)val_); }
+    bool setInt(int val_) { return setInt(int64_t{val_}); }
     bool setFloat(double val);
-    bool setStr(const std::string& val);
+    bool setStr(std::string str);
     bool setArray();
     bool setObject();
 

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -43,14 +43,14 @@ static bool validNumStr(const std::string& s)
     return (tt == JTOK_NUMBER);
 }
 
-bool UniValue::setNumStr(const std::string& val_)
+bool UniValue::setNumStr(std::string str)
 {
-    if (!validNumStr(val_))
+    if (!validNumStr(str))
         return false;
 
     clear();
     typ = VNUM;
-    val = val_;
+    val = std::move(str);
     return true;
 }
 
@@ -83,11 +83,11 @@ bool UniValue::setFloat(double val_)
     return ret;
 }
 
-bool UniValue::setStr(const std::string& val_)
+bool UniValue::setStr(std::string str)
 {
     clear();
     typ = VSTR;
-    val = val_;
+    val = std::move(str);
     return true;
 }
 

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -3,12 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <stdint.h>
-#include <vector>
-#include <string>
-#include <map>
 #include <cassert>
+#include <cstdint>
+#include <map>
+#include <memory>
 #include <stdexcept>
+#include <stdint.h>
+#include <string>
+#include <string_view>
+#include <vector>
 #include <univalue.h>
 
 #define BOOST_FIXTURE_TEST_SUITE(a, b)
@@ -145,6 +148,14 @@ BOOST_AUTO_TEST_CASE(univalue_set)
     BOOST_CHECK(v.setStr("zum"));
     BOOST_CHECK(v.isStr());
     BOOST_CHECK_EQUAL(v.getValStr(), "zum");
+
+    {
+        std::string_view sv{"ab\0c", 4};
+        UniValue j{sv};
+        BOOST_CHECK(j.isStr());
+        BOOST_CHECK_EQUAL(j.getValStr(), sv);
+        BOOST_CHECK_EQUAL(j.write(), "\"ab\\u0000c\"");
+    }
 
     BOOST_CHECK(v.setFloat(-1.01));
     BOOST_CHECK(v.isNum());


### PR DESCRIPTION
Backports bitcoin/bitcoin#25714

Original commit: 59e00c7e03107e7d2582a0c14431bb4e62cccd77

Backported from Bitcoin Core v0.25

This change optimizes UniValue to avoid unnecessary std::string copies by:
1. Using std::move in constructor and setter functions
2. Adding template constructor for type-safe initialization
3. Adding string_view test for null character handling

The backport required adaptation to maintain Dash's bool return types for setter functions while still implementing the std::move optimizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined and modernized the construction and assignment interface for value handling, consolidating multiple constructors into a single flexible template.
  * Improved internal string handling for better efficiency.

* **Tests**
  * Added a test to ensure correct handling and serialization of strings containing embedded null characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->