### PR TITLE
Merge bitcoin/bitcoin#25112: util: Move error message formatting of NonFatalCheckError to cpp

### DIFF
--- a/ci/dash/lint-tidy.sh
+++ b/ci/dash/lint-tidy.sh
@@ -22,6 +22,7 @@ iwyu_tool.py \
   "src/rpc/signmessage.cpp" \
   "src/util/bip32.cpp" \
   "src/util/bytevectorhash.cpp" \
+  "src/util/check.cpp" \
   "src/util/error.cpp" \
   "src/util/getuniquepath.cpp" \
   "src/util/hasher.cpp" \

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -4,7 +4,22 @@
 
 #include <util/check.h>
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <tinyformat.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+
+NonFatalCheckError::NonFatalCheckError(const char* msg, const char* file, int line, const char* func)
+    : std::runtime_error{
+          strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\nPlease report this issue here: %s\n", msg, file, line, func, PACKAGE_BUGREPORT)}
+{
+}
 
 void assertion_fail(const char* file, int line, const char* func, const char* assertion)
 {

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -5,31 +5,23 @@
 #ifndef BITCOIN_UTIL_CHECK_H
 #define BITCOIN_UTIL_CHECK_H
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
-
 #include <attributes.h>
-#include <tinyformat.h>
 
 #include <stdexcept>
+#include <utility>
 
 class NonFatalCheckError : public std::runtime_error
 {
-    using std::runtime_error::runtime_error;
+public:
+    NonFatalCheckError(const char* msg, const char* file, int line, const char* func);
 };
-
-#define format_internal_error(msg, file, line, func, report)                                    \
-    strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\nPlease report this issue here: %s\n", \
-              msg, file, line, func, report)
 
 /** Helper for CHECK_NONFATAL() */
 template <typename T>
 T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, const char* func, const char* assertion)
 {
-    if (!(val)) {
-        throw NonFatalCheckError(
-            format_internal_error(assertion, file, line, func, PACKAGE_BUGREPORT));
+    if (!val) {
+        throw NonFatalCheckError{assertion, file, line, func};
     }
     return std::forward<T>(val);
 }
@@ -88,11 +80,9 @@ T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* f
 
 /**
  * NONFATAL_UNREACHABLE() is a macro that is used to mark unreachable code. It throws a NonFatalCheckError.
- * This is used to mark code that is not yet implemented or is not yet reachable.
  */
 #define NONFATAL_UNREACHABLE()                                        \
     throw NonFatalCheckError(                                         \
-        format_internal_error("Unreachable code reached (non-fatal)", \
-                              __FILE__, __LINE__, __func__, PACKAGE_BUGREPORT))
+        "Unreachable code reached (non-fatal)", __FILE__, __LINE__, __func__)
 
 #endif // BITCOIN_UTIL_CHECK_H


### PR DESCRIPTION
Backports bitcoin/bitcoin#25112

Original commit: 2222ec71fdf573a15bb593fc0dd42d2d28ca5449

This change moves the error message formatting implementation of NonFatalCheckError from the header file to the .cpp file, allowing to strip down the header file.

Key changes:
- Move NonFatalCheckError constructor implementation to check.cpp
- Remove format_internal_error macro from header
- Update template function to use direct constructor call
- Clean up includes in header file

The CI file change (ci/test/06_script_b.sh) was omitted as Dash uses its own CI system.

Backported from Bitcoin Core v0.25