### PR TITLE
Merge bitcoin/bitcoin#26508: RPC/Blockchain: Minor improvements for scanblocks & scantxoutset docs/errors

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2507,7 +2507,7 @@ static RPCHelpMan scantxoutset()
         result.pushKV("unspents", unspents);
         result.pushKV("total_amount", ValueFromAmount(total_in));
     } else {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
     }
     return result;
 },

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -123,5 +123,8 @@ class ScantxoutsetTest(BitcoinTestFramework):
         # Check that second arg is needed for start
         assert_raises_rpc_error(-1, "scanobjects argument is required for the start action", self.nodes[0].scantxoutset, "start")
 
+        # Test invalid action
+        assert_raises_rpc_error(-8, "Invalid action 'foobar'", self.nodes[0].scantxoutset, "foobar")
+
 if __name__ == '__main__':
     ScantxoutsetTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#26508

Original commit: df2f16666c05f8fef2eab0811f87e60b7fb18224

Backported from Bitcoin Core v0.25

## Changes Made

This backport implements only the `scantxoutset` portion of the Bitcoin changes, since Dash Core does not have the `scanblocks` RPC method.

The key improvement is a better error message when an invalid action is provided to `scantxoutset`:
- Before: "Invalid command"  
- After: "Invalid action 'foo'" (showing the actual invalid action provided)

## Notes  

- The original Bitcoin commit also modified `scanblocks` RPC and its test file, but these are not applicable to Dash Core as it doesn't have the `scanblocks` RPC
- This is a faithful adaptation focusing only on the `scantxoutset` improvements that are relevant to Dash Core
- The change improves error reporting for users by showing exactly what invalid action they provided