### PR TITLE
Merge bitcoin/bitcoin#26561: fuzz: Move-only net utils

### DIFF
--- a/src/test/fuzz/bip324.cpp
+++ b/src/test/fuzz/bip324.cpp
@@ -4,6 +4,7 @@
 
 #include <bip324.h>
 #include <chainparams.h>
+#include <key.h>
 #include <span.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -12,6 +13,7 @@
 
 #include <cstdint>
 #include <vector>
+
 
 void initialize_bip324()
 {

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -13,6 +13,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <util/asmap.h>

--- a/src/test/fuzz/net_permissions.cpp
+++ b/src/test/fuzz/net_permissions.cpp
@@ -6,6 +6,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
 #include <util/translation.h>
 
 #include <cassert>

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -7,6 +7,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -15,6 +15,17 @@
 #include <string>
 #include <vector>
 
+// Simple implementation of ConsumeTxMemPoolEntry for Dash
+static CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzzed_data_provider, const CTransaction& tx) noexcept
+{
+    const CAmount fee = ConsumeMoney(fuzzed_data_provider, /*max=*/std::numeric_limits<CAmount>::max() / CAmount{100'000});
+    const int64_t time = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+    const unsigned int entry_height = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const bool spends_coinbase = fuzzed_data_provider.ConsumeBool();
+    const unsigned int sig_op_cost = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 80000); // MAX_BLOCK_SIGOPS_COST
+    return CTxMemPoolEntry{MakeTransactionRef(tx), fee, time, entry_height, spends_coinbase, sig_op_cost, {}};
+}
+
 void initialize_policy_estimator()
 {
     static const auto testing_setup = MakeNoLogFileContext<>();

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -9,6 +9,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 #include <util/overflow.h>
 
 #include <cstdint>

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -15,6 +15,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
 #include <test/util/mining.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -9,6 +9,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
 #include <test/util/mining.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>

--- a/src/test/fuzz/socks5.cpp
+++ b/src/test/fuzz/socks5.cpp
@@ -7,6 +7,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
 
 #include <cstdint>

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -2,309 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <net_processing.h>
-#include <netaddress.h>
-#include <netmessagemaker.h>
+#include <consensus/amount.h>
+#include <pubkey.h>
 #include <test/fuzz/util.h>
 #include <test/util/script.h>
+#include <util/check.h>
 #include <util/overflow.h>
+// #include <util/rbf.h>
 #include <util/time.h>
 #include <version.h>
 
 #include <memory>
-
-FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
-    : m_fuzzed_data_provider{fuzzed_data_provider}, m_selectable{fuzzed_data_provider.ConsumeBool()}
-{
-    m_socket = fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET);
-}
-
-FuzzedSock::~FuzzedSock()
-{
-    // Sock::~Sock() will be called after FuzzedSock::~FuzzedSock() and it will call
-    // close(m_socket) if m_socket is not INVALID_SOCKET.
-    // Avoid closing an arbitrary file descriptor (m_socket is just a random very high number which
-    // theoretically may concide with a real opened file descriptor).
-    m_socket = INVALID_SOCKET;
-}
-
-FuzzedSock& FuzzedSock::operator=(Sock&& other)
-{
-    assert(false && "Move of Sock into FuzzedSock not allowed.");
-    return *this;
-}
-
-ssize_t FuzzedSock::Send(const void* data, size_t len, int flags) const
-{
-    constexpr std::array send_errnos{
-        EACCES,
-        EAGAIN,
-        EALREADY,
-        EBADF,
-        ECONNRESET,
-        EDESTADDRREQ,
-        EFAULT,
-        EINTR,
-        EINVAL,
-        EISCONN,
-        EMSGSIZE,
-        ENOBUFS,
-        ENOMEM,
-        ENOTCONN,
-        ENOTSOCK,
-        EOPNOTSUPP,
-        EPIPE,
-        EWOULDBLOCK,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        return len;
-    }
-    const ssize_t r = m_fuzzed_data_provider.ConsumeIntegralInRange<ssize_t>(-1, len);
-    if (r == -1) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, send_errnos);
-    }
-    return r;
-}
-
-ssize_t FuzzedSock::Recv(void* buf, size_t len, int flags) const
-{
-    // Have a permanent error at recv_errnos[0] because when the fuzzed data is exhausted
-    // SetFuzzedErrNo() will always return the first element and we want to avoid Recv()
-    // returning -1 and setting errno to EAGAIN repeatedly.
-    constexpr std::array recv_errnos{
-        ECONNREFUSED,
-        EAGAIN,
-        EBADF,
-        EFAULT,
-        EINTR,
-        EINVAL,
-        ENOMEM,
-        ENOTCONN,
-        ENOTSOCK,
-        EWOULDBLOCK,
-    };
-    assert(buf != nullptr || len == 0);
-    if (len == 0 || m_fuzzed_data_provider.ConsumeBool()) {
-        const ssize_t r = m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
-        if (r == -1) {
-            SetFuzzedErrNo(m_fuzzed_data_provider, recv_errnos);
-        }
-        return r;
-    }
-    std::vector<uint8_t> random_bytes;
-    bool pad_to_len_bytes{m_fuzzed_data_provider.ConsumeBool()};
-    if (m_peek_data.has_value()) {
-        // `MSG_PEEK` was used in the preceding `Recv()` call, return `m_peek_data`.
-        random_bytes.assign({m_peek_data.value()});
-        if ((flags & MSG_PEEK) == 0) {
-            m_peek_data.reset();
-        }
-        pad_to_len_bytes = false;
-    } else if ((flags & MSG_PEEK) != 0) {
-        // New call with `MSG_PEEK`.
-        random_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(1);
-        if (!random_bytes.empty()) {
-            m_peek_data = random_bytes[0];
-            pad_to_len_bytes = false;
-        }
-    } else {
-        random_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(
-            m_fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, len));
-    }
-    if (random_bytes.empty()) {
-        const ssize_t r = m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
-        if (r == -1) {
-            SetFuzzedErrNo(m_fuzzed_data_provider, recv_errnos);
-        }
-        return r;
-    }
-    std::memcpy(buf, random_bytes.data(), random_bytes.size());
-    if (pad_to_len_bytes) {
-        if (len > random_bytes.size()) {
-            std::memset((char*)buf + random_bytes.size(), 0, len - random_bytes.size());
-        }
-        return len;
-    }
-    if (m_fuzzed_data_provider.ConsumeBool() && std::getenv("FUZZED_SOCKET_FAKE_LATENCY") != nullptr) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{2});
-    }
-    return random_bytes.size();
-}
-
-int FuzzedSock::Connect(const sockaddr*, socklen_t) const
-{
-    // Have a permanent error at connect_errnos[0] because when the fuzzed data is exhausted
-    // SetFuzzedErrNo() will always return the first element and we want to avoid Connect()
-    // returning -1 and setting errno to EAGAIN repeatedly.
-    constexpr std::array connect_errnos{
-        ECONNREFUSED,
-        EAGAIN,
-        ECONNRESET,
-        EHOSTUNREACH,
-        EINPROGRESS,
-        EINTR,
-        ENETUNREACH,
-        ETIMEDOUT,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, connect_errnos);
-        return -1;
-    }
-    return 0;
-}
-
-int FuzzedSock::Bind(const sockaddr*, socklen_t) const
-{
-    // Have a permanent error at bind_errnos[0] because when the fuzzed data is exhausted
-    // SetFuzzedErrNo() will always set the global errno to bind_errnos[0]. We want to
-    // avoid this method returning -1 and setting errno to a temporary error (like EAGAIN)
-    // repeatedly because proper code should retry on temporary errors, leading to an
-    // infinite loop.
-    constexpr std::array bind_errnos{
-        EACCES,
-        EADDRINUSE,
-        EADDRNOTAVAIL,
-        EAGAIN,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, bind_errnos);
-        return -1;
-    }
-    return 0;
-}
-
-int FuzzedSock::Listen(int) const
-{
-    // Have a permanent error at listen_errnos[0] because when the fuzzed data is exhausted
-    // SetFuzzedErrNo() will always set the global errno to listen_errnos[0]. We want to
-    // avoid this method returning -1 and setting errno to a temporary error (like EAGAIN)
-    // repeatedly because proper code should retry on temporary errors, leading to an
-    // infinite loop.
-    constexpr std::array listen_errnos{
-        EADDRINUSE,
-        EINVAL,
-        EOPNOTSUPP,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, listen_errnos);
-        return -1;
-    }
-    return 0;
-}
-
-std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) const
-{
-    constexpr std::array accept_errnos{
-        ECONNABORTED,
-        EINTR,
-        ENOMEM,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, accept_errnos);
-        return std::unique_ptr<FuzzedSock>();
-    }
-    return std::make_unique<FuzzedSock>(m_fuzzed_data_provider);
-}
-
-int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
-{
-    constexpr std::array getsockopt_errnos{
-        ENOMEM,
-        ENOBUFS,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, getsockopt_errnos);
-        return -1;
-    }
-    if (opt_val == nullptr) {
-        return 0;
-    }
-    std::memcpy(opt_val,
-                ConsumeFixedLengthByteVector(m_fuzzed_data_provider, *opt_len).data(),
-                *opt_len);
-    return 0;
-}
-
-int FuzzedSock::SetSockOpt(int, int, const void*, socklen_t) const
-{
-    constexpr std::array setsockopt_errnos{
-        ENOMEM,
-        ENOBUFS,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, setsockopt_errnos);
-        return -1;
-    }
-    return 0;
-}
-
-int FuzzedSock::GetSockName(sockaddr* name, socklen_t* name_len) const
-{
-    constexpr std::array getsockname_errnos{
-        ECONNRESET,
-        ENOBUFS,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, getsockname_errnos);
-        return -1;
-    }
-    *name_len = m_fuzzed_data_provider.ConsumeData(name, *name_len);
-    return 0;
-}
-
-bool FuzzedSock::SetNonBlocking() const
-{
-    constexpr std::array setnonblocking_errnos{
-        EBADF,
-        EPERM,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, setnonblocking_errnos);
-        return false;
-    }
-    return true;
-}
-
-bool FuzzedSock::IsSelectable() const
-{
-    return m_selectable;
-}
-
-bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
-{
-    constexpr std::array wait_errnos{
-        EBADF,
-        EINTR,
-        EINVAL,
-    };
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        SetFuzzedErrNo(m_fuzzed_data_provider, wait_errnos);
-        return false;
-    }
-    if (occurred != nullptr) {
-        *occurred = m_fuzzed_data_provider.ConsumeBool() ? requested : 0;
-    }
-    return true;
-}
-
-bool FuzzedSock::IsConnected(std::string& errmsg) const
-{
-    if (m_fuzzed_data_provider.ConsumeBool()) {
-        return true;
-    }
-    errmsg = "disconnected at random by the fuzzer";
-    return false;
-}
-
-void FillNode(FuzzedDataProvider& fuzzed_data_provider, ConnmanTestMsg& connman, CNode& node) noexcept
-{
-    connman.Handshake(node,
-                      /*successfully_connected=*/fuzzed_data_provider.ConsumeBool(),
-                      /*remote_services=*/ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS),
-                      /*local_services=*/ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS),
-                      /*version=*/fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(MIN_PEER_PROTO_VERSION, std::numeric_limits<int32_t>::max()),
-                      /*relay_txs=*/fuzzed_data_provider.ConsumeBool());
-}
 
 CAmount ConsumeMoney(FuzzedDataProvider& fuzzed_data_provider, const std::optional<CAmount>& max) noexcept
 {
@@ -314,14 +22,15 @@ CAmount ConsumeMoney(FuzzedDataProvider& fuzzed_data_provider, const std::option
 int64_t ConsumeTime(FuzzedDataProvider& fuzzed_data_provider, const std::optional<int64_t>& min, const std::optional<int64_t>& max) noexcept
 {
     // Avoid t=0 (1970-01-01T00:00:00Z) since SetMockTime(0) disables mocktime.
-    static const int64_t time_min{ParseISO8601DateTime("2000-01-01T00:00:01Z")};
-    static const int64_t time_max{ParseISO8601DateTime("2100-12-31T23:59:59Z")};
+    static const int64_t time_min{946684801}; // 2000-01-01T00:00:01Z
+    static const int64_t time_max{4133980799}; // 2100-12-31T23:59:59Z
     return fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(min.value_or(time_min), max.value_or(time_max));
 }
 
 CMutableTransaction ConsumeTransaction(FuzzedDataProvider& fuzzed_data_provider, const std::optional<std::vector<uint256>>& prevout_txids, const int max_num_in, const int max_num_out) noexcept
 {
     CMutableTransaction tx_mut;
+    // const auto p2wsh_op_true = fuzzed_data_provider.ConsumeBool();
     tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ?
                           CTransaction::CURRENT_VERSION :
                           fuzzed_data_provider.ConsumeIntegral<int32_t>();
@@ -335,22 +44,39 @@ CMutableTransaction ConsumeTransaction(FuzzedDataProvider& fuzzed_data_provider,
         const auto index_out = fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, max_num_out);
         const auto sequence = ConsumeSequence(fuzzed_data_provider);
         const auto script_sig = ConsumeScript(fuzzed_data_provider);
+        // CScriptWitness script_wit;
+        // if (p2wsh_op_true) {
+        //     script_wit.stack = std::vector<std::vector<uint8_t>>{WITNESS_STACK_ELEM_OP_TRUE};
+        // } else {
+        //     script_wit = ConsumeScriptWitness(fuzzed_data_provider);
+        // }
         CTxIn in;
         in.prevout = COutPoint{txid_prev, index_out};
         in.nSequence = sequence;
         in.scriptSig = script_sig;
+        // in.scriptWitness = script_wit;
 
         tx_mut.vin.push_back(in);
     }
     for (int i = 0; i < num_out; ++i) {
         const auto amount = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(-10, 50 * COIN + 10);
-        const auto script_pk = ConsumeScript(fuzzed_data_provider);
+        const auto script_pk = ConsumeScript(fuzzed_data_provider, /*maybe_p2wsh=*/true);
         tx_mut.vout.emplace_back(amount, script_pk);
     }
     return tx_mut;
 }
 
-CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider) noexcept
+// CScriptWitness ConsumeScriptWitness(FuzzedDataProvider& fuzzed_data_provider, const size_t max_stack_elem_size) noexcept
+// {
+//     CScriptWitness ret;
+//     const auto n_elements = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, max_stack_elem_size);
+//     for (size_t i = 0; i < n_elements; ++i) {
+//         ret.stack.push_back(ConsumeRandomLengthByteVector(fuzzed_data_provider));
+//     }
+//     return ret;
+// }
+
+CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider, const bool maybe_p2wsh) noexcept
 {
     CScript r_script{};
     {
@@ -407,7 +133,7 @@ CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider) noexcept
                 });
         }
     }
-    if (fuzzed_data_provider.ConsumeBool()) {
+    if (maybe_p2wsh && fuzzed_data_provider.ConsumeBool()) {
         uint256 script_hash;
         CSHA256().Write(r_script.data(), r_script.size()).Finalize(script_hash.begin());
         r_script.clear();
@@ -422,34 +148,29 @@ uint32_t ConsumeSequence(FuzzedDataProvider& fuzzed_data_provider) noexcept
                fuzzed_data_provider.PickValueInArray({
                    CTxIn::SEQUENCE_FINAL,
                    CTxIn::MAX_SEQUENCE_NONFINAL,
+                   0xfffffffd, // MAX_BIP125_RBF_SEQUENCE
                }) :
                fuzzed_data_provider.ConsumeIntegral<uint32_t>();
 }
 
-CKey ConsumePrivateKey(FuzzedDataProvider& fuzzed_data_provider, std::optional<bool> compressed) noexcept
+CTxDestination ConsumeTxDestination(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
-    auto key_data = fuzzed_data_provider.ConsumeBytes<uint8_t>(32);
-    key_data.resize(32);
-    CKey key;
-    bool compressed_value = compressed ? *compressed : fuzzed_data_provider.ConsumeBool();
-    key.Set(key_data.begin(), key_data.end(), compressed_value);
-    return key;
-}
-
-CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzzed_data_provider, const CTransaction& tx) noexcept
-{
-    // Avoid:
-    // policy/feerate.cpp:28:34: runtime error: signed integer overflow: 34873208148477500 * 1000 cannot be represented in type 'long'
-    //
-    // Reproduce using CFeeRate(348732081484775, 10).GetFeePerK()
-    const CAmount fee = std::min<CAmount>(ConsumeMoney(fuzzed_data_provider), std::numeric_limits<CAmount>::max() / static_cast<CAmount>(100000));
-    assert(MoneyRange(fee));
-    const int64_t time = fuzzed_data_provider.ConsumeIntegral<int64_t>();
-    const unsigned int entry_height = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
-    const bool spends_coinbase = fuzzed_data_provider.ConsumeBool();
-    const bool dip1_status = fuzzed_data_provider.ConsumeBool();
-    const unsigned int sig_op_cost = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, MaxBlockSigOps(dip1_status));
-    return CTxMemPoolEntry{MakeTransactionRef(tx), fee, time, entry_height, spends_coinbase, sig_op_cost, {}};
+    CTxDestination tx_destination;
+    const size_t call_size{CallOneOf(
+        fuzzed_data_provider,
+        [&] {
+            tx_destination = CNoDestination{};
+        },
+        [&] {
+            tx_destination = PKHash{ConsumeUInt160(fuzzed_data_provider)};
+        },
+        [&] {
+            tx_destination = ScriptHash{ConsumeUInt160(fuzzed_data_provider)};
+        })};
+        // Witness types not supported in Dash
+        // WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, WitnessUnknown
+    // Assert(call_size == std::variant_size_v<CTxDestination>); // Commented out since we removed witness types
+    return tx_destination;
 }
 
 bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) noexcept
@@ -461,11 +182,6 @@ bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) n
         }
     }
     return false;
-}
-
-CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept
-{
-    return {ConsumeService(fuzzed_data_provider), ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS), NodeSeconds{std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<uint32_t>()}}};
 }
 
 FILE* FuzzedFileProvider::open()
@@ -495,7 +211,7 @@ FILE* FuzzedFileProvider::open()
         [&] {
             mode = "a+";
         });
-#if defined _GNU_SOURCE && (defined(__linux__) || defined(__FreeBSD__))
+#if defined _GNU_SOURCE && !defined __ANDROID__
     const cookie_io_functions_t io_hooks = {
         FuzzedFileProvider::read,
         FuzzedFileProvider::write,

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Copyright (c) 2009-2021 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,7 +6,6 @@
 #define BITCOIN_TEST_FUZZ_UTIL_H
 
 #include <arith_uint256.h>
-#include <attributes.h>
 #include <chainparamsbase.h>
 #include <coins.h>
 #include <compat/compat.h>
@@ -14,9 +13,6 @@
 #include <consensus/consensus.h>
 #include <key.h>
 #include <merkleblock.h>
-#include <net.h>
-#include <netaddress.h>
-#include <netbase.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/standard.h>
@@ -24,12 +20,7 @@
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
-#include <test/fuzz/util/net.h>
-#include <test/util/net.h>
-#include <test/util/setup_common.h>
-#include <txmempool.h>
 #include <uint256.h>
-#include <util/overflow.h>
 #include <version.h>
 
 #include <algorithm>
@@ -42,65 +33,8 @@
 
 class PeerManager;
 
-class FuzzedSock : public Sock
-{
-    FuzzedDataProvider& m_fuzzed_data_provider;
-
-    /**
-     * Data to return when `MSG_PEEK` is used as a `Recv()` flag.
-     * If `MSG_PEEK` is used, then our `Recv()` returns some random data as usual, but on the next
-     * `Recv()` call we must return the same data, thus we remember it here.
-     */
-    mutable std::optional<uint8_t> m_peek_data;
-
-    /**
-     * Whether to pretend that the socket is select(2)-able. This is randomly set in the
-     * constructor. It should remain constant so that repeated calls to `IsSelectable()`
-     * return the same value.
-     */
-    const bool m_selectable;
-
-public:
-    explicit FuzzedSock(FuzzedDataProvider& fuzzed_data_provider);
-
-    ~FuzzedSock() override;
-
-    FuzzedSock& operator=(Sock&& other) override;
-
-    ssize_t Send(const void* data, size_t len, int flags) const override;
-
-    ssize_t Recv(void* buf, size_t len, int flags) const override;
-
-    int Connect(const sockaddr*, socklen_t) const override;
-
-    int Bind(const sockaddr*, socklen_t) const override;
-
-    int Listen(int backlog) const override;
-
-    std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const override;
-
-    int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;
-
-    int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;
-
-    int GetSockName(sockaddr* name, socklen_t* name_len) const override;
-
-    bool SetNonBlocking() const override;
-
-    bool IsSelectable() const override;
-
-    bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;
-
-    bool IsConnected(std::string& errmsg) const override;
-};
-
-[[nodiscard]] inline FuzzedSock ConsumeSock(FuzzedDataProvider& fuzzed_data_provider)
-{
-    return FuzzedSock{fuzzed_data_provider};
-}
-
 template <typename... Callables>
-void CallOneOf(FuzzedDataProvider& fuzzed_data_provider, Callables... callables)
+size_t CallOneOf(FuzzedDataProvider& fuzzed_data_provider, Callables... callables)
 {
     constexpr size_t call_size{sizeof...(callables)};
     static_assert(call_size >= 1);
@@ -108,6 +42,7 @@ void CallOneOf(FuzzedDataProvider& fuzzed_data_provider, Callables... callables)
 
     size_t i{0};
     ((i++ == call_index ? callables() : void()), ...);
+    return call_size;
 }
 
 template <typename Collection>
@@ -120,16 +55,20 @@ auto& PickValue(FuzzedDataProvider& fuzzed_data_provider, Collection& col)
     return *it;
 }
 
-template<typename B = uint8_t>
-[[nodiscard]] inline std::vector<B> ConsumeRandomLengthByteVector(FuzzedDataProvider& fuzzed_data_provider, const std::optional<size_t>& max_length = std::nullopt) noexcept
+[[nodiscard]] inline std::vector<uint8_t> ConsumeRandomLengthByteVector(FuzzedDataProvider& fuzzed_data_provider, const std::optional<size_t>& max_length = std::nullopt) noexcept
 {
-    static_assert(sizeof(B) == 1);
     const std::string s = max_length ?
                               fuzzed_data_provider.ConsumeRandomLengthString(*max_length) :
                               fuzzed_data_provider.ConsumeRandomLengthString();
-    std::vector<B> ret(s.size());
-    std::copy(s.begin(), s.end(), reinterpret_cast<char*>(ret.data()));
-    return ret;
+    return {s.begin(), s.end()};
+}
+
+template <typename B>
+[[nodiscard]] inline std::vector<B> ConsumeRandomLengthByteVector(FuzzedDataProvider& fuzzed_data_provider, const std::optional<size_t>& max_length = std::nullopt) noexcept
+{
+    static_assert(sizeof(B) == 1);
+    const auto length = max_length ? fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, *max_length) : fuzzed_data_provider.ConsumeIntegral<size_t>();
+    return fuzzed_data_provider.ConsumeBytes<B>(length);
 }
 
 [[nodiscard]] inline std::vector<bool> ConsumeRandomLengthBitVector(FuzzedDataProvider& fuzzed_data_provider, const std::optional<size_t>& max_length = std::nullopt) noexcept
@@ -196,7 +135,9 @@ template <typename WeakEnumType, size_t size>
 
 [[nodiscard]] CMutableTransaction ConsumeTransaction(FuzzedDataProvider& fuzzed_data_provider, const std::optional<std::vector<uint256>>& prevout_txids, const int max_num_in = 10, const int max_num_out = 10) noexcept;
 
-[[nodiscard]] CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider) noexcept;
+// [[nodiscard]] CScriptWitness ConsumeScriptWitness(FuzzedDataProvider& fuzzed_data_provider, const size_t max_stack_elem_size = 32) noexcept;
+
+[[nodiscard]] CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider, const bool maybe_p2wsh = false) noexcept;
 
 [[nodiscard]] uint32_t ConsumeSequence(FuzzedDataProvider& fuzzed_data_provider) noexcept;
 
@@ -228,26 +169,17 @@ template <typename WeakEnumType, size_t size>
     return UintToArith256(ConsumeUInt256(fuzzed_data_provider));
 }
 
-[[nodiscard]] CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzzed_data_provider, const CTransaction& tx) noexcept;
+[[nodiscard]] CTxDestination ConsumeTxDestination(FuzzedDataProvider& fuzzed_data_provider) noexcept;
 
-[[nodiscard]] inline CTxDestination ConsumeTxDestination(FuzzedDataProvider& fuzzed_data_provider) noexcept
+[[nodiscard]] inline CKey ConsumePrivateKey(FuzzedDataProvider& fuzzed_data_provider, bool compressed = true) noexcept
 {
-    CTxDestination tx_destination;
-    CallOneOf(
-        fuzzed_data_provider,
-        [&] {
-            tx_destination = CNoDestination{};
-        },
-        [&] {
-            tx_destination = PKHash{ConsumeUInt160(fuzzed_data_provider)};
-        },
-        [&] {
-            tx_destination = ScriptHash{ConsumeUInt160(fuzzed_data_provider)};
-        });
-    return tx_destination;
+    CKey key;
+    auto key_data = fuzzed_data_provider.ConsumeBytes<uint8_t>(32);
+    if (key_data.size() == 32) {
+        key.Set(key_data.begin(), key_data.end(), compressed);
+    }
+    return key;
 }
-
-[[nodiscard]] CKey ConsumePrivateKey(FuzzedDataProvider& fuzzed_data_provider, std::optional<bool> compressed = std::nullopt) noexcept;
 
 template <typename T>
 [[nodiscard]] bool MultiplicationOverflow(const T i, const T j) noexcept
@@ -297,7 +229,17 @@ inline void SetFuzzedErrNo(FuzzedDataProvider& fuzzed_data_provider) noexcept
  * Returns a byte vector of specified size regardless of the number of remaining bytes available
  * from the fuzzer. Pads with zero value bytes if needed to achieve the specified size.
  */
-template<typename B = uint8_t>
+[[nodiscard]] inline std::vector<uint8_t> ConsumeFixedLengthByteVector(FuzzedDataProvider& fuzzed_data_provider, const size_t length) noexcept
+{
+    std::vector<uint8_t> result(length);
+    const std::vector<uint8_t> random_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(length);
+    if (!random_bytes.empty()) {
+        std::memcpy(result.data(), random_bytes.data(), random_bytes.size());
+    }
+    return result;
+}
+
+template <typename B>
 [[nodiscard]] inline std::vector<B> ConsumeFixedLengthByteVector(FuzzedDataProvider& fuzzed_data_provider, const size_t length) noexcept
 {
     static_assert(sizeof(B) == 1);
@@ -305,60 +247,6 @@ template<typename B = uint8_t>
     random_bytes.resize(length);
     return random_bytes;
 }
-
-inline CSubNet ConsumeSubNet(FuzzedDataProvider& fuzzed_data_provider) noexcept
-{
-    return {ConsumeNetAddr(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<uint8_t>()};
-}
-
-inline CService ConsumeService(FuzzedDataProvider& fuzzed_data_provider) noexcept
-{
-    return {ConsumeNetAddr(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<uint16_t>()};
-}
-
-CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept;
-
-template <bool ReturnUniquePtr = false>
-auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<NodeId>& node_id_in = std::nullopt) noexcept
-{
-    const NodeId node_id = node_id_in.value_or(fuzzed_data_provider.ConsumeIntegralInRange<NodeId>(0, std::numeric_limits<NodeId>::max()));
-    const auto sock = std::make_shared<FuzzedSock>(fuzzed_data_provider);
-    const CAddress address = ConsumeAddress(fuzzed_data_provider);
-    const uint64_t keyed_net_group = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
-    const uint64_t local_host_nonce = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
-    const CAddress addr_bind = ConsumeAddress(fuzzed_data_provider);
-    const std::string addr_name = fuzzed_data_provider.ConsumeRandomLengthString(64);
-
-    const ConnectionType conn_type = fuzzed_data_provider.PickValueInArray(ALL_CONNECTION_TYPES);
-    const bool inbound_onion{conn_type == ConnectionType::INBOUND ? fuzzed_data_provider.ConsumeBool() : false};
-    NetPermissionFlags permission_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);
-    if constexpr (ReturnUniquePtr) {
-        return std::make_unique<CNode>(node_id,
-                                       sock,
-                                       address,
-                                       keyed_net_group,
-                                       local_host_nonce,
-                                       addr_bind,
-                                       addr_name,
-                                       conn_type,
-                                       inbound_onion,
-                                       CNodeOptions{ .permission_flags = permission_flags });
-    } else {
-        return CNode{node_id,
-                     sock,
-                     address,
-                     keyed_net_group,
-                     local_host_nonce,
-                     addr_bind,
-                     addr_name,
-                     conn_type,
-                     inbound_onion,
-                     CNodeOptions{ .permission_flags = permission_flags }};
-    }
-}
-inline std::unique_ptr<CNode> ConsumeNodeAsUniquePtr(FuzzedDataProvider& fdp, const std::optional<NodeId>& node_id_in = std::nullopt) { return ConsumeNode<true>(fdp, node_id_in); }
-
-void FillNode(FuzzedDataProvider& fuzzed_data_provider, ConnmanTestMsg& connman, CNode& node) noexcept EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
 
 class FuzzedFileProvider
 {
@@ -388,17 +276,16 @@ public:
 
 class FuzzedAutoFileProvider
 {
-    FuzzedDataProvider& m_fuzzed_data_provider;
     FuzzedFileProvider m_fuzzed_file_provider;
 
 public:
-    FuzzedAutoFileProvider(FuzzedDataProvider& fuzzed_data_provider) : m_fuzzed_data_provider{fuzzed_data_provider}, m_fuzzed_file_provider{fuzzed_data_provider}
+    FuzzedAutoFileProvider(FuzzedDataProvider& fuzzed_data_provider) : m_fuzzed_file_provider{fuzzed_data_provider}
     {
     }
 
     CAutoFile open()
     {
-        return {m_fuzzed_file_provider.open(), m_fuzzed_data_provider.ConsumeIntegral<int>(), m_fuzzed_data_provider.ConsumeIntegral<int>()};
+        return CAutoFile{m_fuzzed_file_provider.open(), SER_DISK, PROTOCOL_VERSION};
     }
 };
 

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -2,13 +2,28 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <test/fuzz/util/net.h>
+
 #include <compat/compat.h>
 #include <netaddress.h>
+#include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
-#include <util/strencodings.h>
+#include <test/fuzz/util.h>
+#include <test/util/net.h>
+#include <util/sock.h>
+#include <util/time.h>
+#include <version.h>
 
+#include <array>
+#include <cassert>
+#include <cerrno>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
 #include <vector>
+
+class CNode;
 
 CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
@@ -37,4 +52,311 @@ CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
         assert(ok);
     }
     return net_addr;
+}
+
+CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return {ConsumeService(fuzzed_data_provider), ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS), NodeSeconds{std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<uint32_t>()}}};
+}
+
+FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
+    : m_fuzzed_data_provider{fuzzed_data_provider}, m_selectable{fuzzed_data_provider.ConsumeBool()}
+{
+    m_socket = fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET);
+}
+
+FuzzedSock::~FuzzedSock()
+{
+    // Sock::~Sock() will be called after FuzzedSock::~FuzzedSock() and it will call
+    // close(m_socket) if m_socket is not INVALID_SOCKET.
+    // Avoid closing an arbitrary file descriptor (m_socket is just a random very high number which
+    // theoretically may concide with a real opened file descriptor).
+    m_socket = INVALID_SOCKET;
+}
+
+FuzzedSock& FuzzedSock::operator=(Sock&& other)
+{
+    assert(false && "Move of Sock into FuzzedSock not allowed.");
+    return *this;
+}
+
+ssize_t FuzzedSock::Send(const void* data, size_t len, int flags) const
+{
+    constexpr std::array send_errnos{
+        EACCES,
+        EAGAIN,
+        EALREADY,
+        EBADF,
+        ECONNRESET,
+        EDESTADDRREQ,
+        EFAULT,
+        EINTR,
+        EINVAL,
+        EISCONN,
+        EMSGSIZE,
+        ENOBUFS,
+        ENOMEM,
+        ENOTCONN,
+        ENOTSOCK,
+        EOPNOTSUPP,
+        EPIPE,
+        EWOULDBLOCK,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        return len;
+    }
+    const ssize_t r = m_fuzzed_data_provider.ConsumeIntegralInRange<ssize_t>(-1, len);
+    if (r == -1) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, send_errnos);
+    }
+    return r;
+}
+
+ssize_t FuzzedSock::Recv(void* buf, size_t len, int flags) const
+{
+    // Have a permanent error at recv_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always return the first element and we want to avoid Recv()
+    // returning -1 and setting errno to EAGAIN repeatedly.
+    constexpr std::array recv_errnos{
+        ECONNREFUSED,
+        EAGAIN,
+        EBADF,
+        EFAULT,
+        EINTR,
+        EINVAL,
+        ENOMEM,
+        ENOTCONN,
+        ENOTSOCK,
+        EWOULDBLOCK,
+    };
+    assert(buf != nullptr || len == 0);
+    if (len == 0 || m_fuzzed_data_provider.ConsumeBool()) {
+        const ssize_t r = m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
+        if (r == -1) {
+            SetFuzzedErrNo(m_fuzzed_data_provider, recv_errnos);
+        }
+        return r;
+    }
+    std::vector<uint8_t> random_bytes;
+    bool pad_to_len_bytes{m_fuzzed_data_provider.ConsumeBool()};
+    if (m_peek_data.has_value()) {
+        // `MSG_PEEK` was used in the preceding `Recv()` call, return `m_peek_data`.
+        random_bytes.assign({m_peek_data.value()});
+        if ((flags & MSG_PEEK) == 0) {
+            m_peek_data.reset();
+        }
+        pad_to_len_bytes = false;
+    } else if ((flags & MSG_PEEK) != 0) {
+        // New call with `MSG_PEEK`.
+        random_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(1);
+        if (!random_bytes.empty()) {
+            m_peek_data = random_bytes[0];
+            pad_to_len_bytes = false;
+        }
+    } else {
+        random_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(
+            m_fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, len));
+    }
+    if (random_bytes.empty()) {
+        const ssize_t r = m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
+        if (r == -1) {
+            SetFuzzedErrNo(m_fuzzed_data_provider, recv_errnos);
+        }
+        return r;
+    }
+    std::memcpy(buf, random_bytes.data(), random_bytes.size());
+    if (pad_to_len_bytes) {
+        if (len > random_bytes.size()) {
+            std::memset((char*)buf + random_bytes.size(), 0, len - random_bytes.size());
+        }
+        return len;
+    }
+    if (m_fuzzed_data_provider.ConsumeBool() && std::getenv("FUZZED_SOCKET_FAKE_LATENCY") != nullptr) {
+        std::this_thread::sleep_for(std::chrono::milliseconds{2});
+    }
+    return random_bytes.size();
+}
+
+int FuzzedSock::Connect(const sockaddr*, socklen_t) const
+{
+    // Have a permanent error at connect_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always return the first element and we want to avoid Connect()
+    // returning -1 and setting errno to EAGAIN repeatedly.
+    constexpr std::array connect_errnos{
+        ECONNREFUSED,
+        EAGAIN,
+        ECONNRESET,
+        EHOSTUNREACH,
+        EINPROGRESS,
+        EINTR,
+        ENETUNREACH,
+        ETIMEDOUT,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, connect_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+int FuzzedSock::Bind(const sockaddr*, socklen_t) const
+{
+    // Have a permanent error at bind_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always set the global errno to bind_errnos[0]. We want to
+    // avoid this method returning -1 and setting errno to a temporary error (like EAGAIN)
+    // repeatedly because proper code should retry on temporary errors, leading to an
+    // infinite loop.
+    constexpr std::array bind_errnos{
+        EACCES,
+        EADDRINUSE,
+        EADDRNOTAVAIL,
+        EAGAIN,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, bind_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+int FuzzedSock::Listen(int) const
+{
+    // Have a permanent error at listen_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always set the global errno to listen_errnos[0]. We want to
+    // avoid this method returning -1 and setting errno to a temporary error (like EAGAIN)
+    // repeatedly because proper code should retry on temporary errors, leading to an
+    // infinite loop.
+    constexpr std::array listen_errnos{
+        EADDRINUSE,
+        EINVAL,
+        EOPNOTSUPP,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, listen_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) const
+{
+    constexpr std::array accept_errnos{
+        ECONNABORTED,
+        EINTR,
+        ENOMEM,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, accept_errnos);
+        return std::unique_ptr<FuzzedSock>();
+    }
+    return std::make_unique<FuzzedSock>(m_fuzzed_data_provider);
+}
+
+int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
+{
+    constexpr std::array getsockopt_errnos{
+        ENOMEM,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, getsockopt_errnos);
+        return -1;
+    }
+    if (opt_val == nullptr) {
+        return 0;
+    }
+    std::memcpy(opt_val,
+                ConsumeFixedLengthByteVector(m_fuzzed_data_provider, *opt_len).data(),
+                *opt_len);
+    return 0;
+}
+
+int FuzzedSock::SetSockOpt(int, int, const void*, socklen_t) const
+{
+    constexpr std::array setsockopt_errnos{
+        ENOMEM,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, setsockopt_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+int FuzzedSock::GetSockName(sockaddr* name, socklen_t* name_len) const
+{
+    constexpr std::array getsockname_errnos{
+        ECONNRESET,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, getsockname_errnos);
+        return -1;
+    }
+    *name_len = m_fuzzed_data_provider.ConsumeData(name, *name_len);
+    return 0;
+}
+
+bool FuzzedSock::SetNonBlocking() const
+{
+    constexpr std::array setnonblocking_errnos{
+        EBADF,
+        EPERM,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, setnonblocking_errnos);
+        return false;
+    }
+    return true;
+}
+
+bool FuzzedSock::IsSelectable() const
+{
+    return m_selectable;
+}
+
+bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
+{
+    constexpr std::array wait_errnos{
+        EBADF,
+        EINTR,
+        EINVAL,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, wait_errnos);
+        return false;
+    }
+    if (occurred != nullptr) {
+        *occurred = m_fuzzed_data_provider.ConsumeBool() ? requested : 0;
+    }
+    return true;
+}
+
+// bool FuzzedSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const
+// {
+//     for (auto& [sock, events] : events_per_sock) {
+//         (void)sock;
+//         events.occurred = m_fuzzed_data_provider.ConsumeBool() ? events.requested : 0;
+//     }
+//     return true;
+// }
+
+bool FuzzedSock::IsConnected(std::string& errmsg) const
+{
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        return true;
+    }
+    errmsg = "disconnected at random by the fuzzer";
+    return false;
+}
+
+void FillNode(FuzzedDataProvider& fuzzed_data_provider, ConnmanTestMsg& connman, CNode& node) noexcept
+{
+    connman.Handshake(node,
+                      /*successfully_connected=*/fuzzed_data_provider.ConsumeBool(),
+                      /*remote_services=*/ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS),
+                      /*local_services=*/ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS),
+                      /*version=*/fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(MIN_PEER_PROTO_VERSION, std::numeric_limits<int32_t>::max()),
+                      /*relay_txs=*/fuzzed_data_provider.ConsumeBool());
 }

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -5,10 +5,137 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_NET_H
 #define BITCOIN_TEST_FUZZ_UTIL_NET_H
 
+#include <net.h>
+#include <net_permissions.h>
 #include <netaddress.h>
+#include <node/connection_types.h>
+#include <node/eviction.h>
+#include <protocol.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/util.h>
+#include <test/util/net.h>
+#include <threadsafety.h>
+#include <util/sock.h>
 
-class FuzzedDataProvider;
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
 
 CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept;
+
+class FuzzedSock : public Sock
+{
+    FuzzedDataProvider& m_fuzzed_data_provider;
+
+    /**
+     * Data to return when `MSG_PEEK` is used as a `Recv()` flag.
+     * If `MSG_PEEK` is used, then our `Recv()` returns some random data as usual, but on the next
+     * `Recv()` call we must return the same data, thus we remember it here.
+     */
+    mutable std::optional<uint8_t> m_peek_data;
+
+    /**
+     * Whether to pretend that the socket is select(2)-able. This is randomly set in the
+     * constructor. It should remain constant so that repeated calls to `IsSelectable()`
+     * return the same value.
+     */
+    const bool m_selectable;
+
+public:
+    explicit FuzzedSock(FuzzedDataProvider& fuzzed_data_provider);
+
+    ~FuzzedSock() override;
+
+    FuzzedSock& operator=(Sock&& other) override;
+
+    ssize_t Send(const void* data, size_t len, int flags) const override;
+
+    ssize_t Recv(void* buf, size_t len, int flags) const override;
+
+    int Connect(const sockaddr*, socklen_t) const override;
+
+    int Bind(const sockaddr*, socklen_t) const override;
+
+    int Listen(int backlog) const override;
+
+    std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const override;
+
+    int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;
+
+    int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;
+
+    int GetSockName(sockaddr* name, socklen_t* name_len) const override;
+
+    bool SetNonBlocking() const override;
+
+    bool IsSelectable() const override;
+
+    bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;
+
+    // bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const override;
+
+    bool IsConnected(std::string& errmsg) const override;
+};
+
+[[nodiscard]] inline FuzzedSock ConsumeSock(FuzzedDataProvider& fuzzed_data_provider)
+{
+    return FuzzedSock{fuzzed_data_provider};
+}
+
+inline CSubNet ConsumeSubNet(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return {ConsumeNetAddr(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<uint8_t>()};
+}
+
+inline CService ConsumeService(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return {ConsumeNetAddr(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<uint16_t>()};
+}
+
+CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept;
+
+template <bool ReturnUniquePtr = false>
+auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<NodeId>& node_id_in = std::nullopt) noexcept
+{
+    const NodeId node_id = node_id_in.value_or(fuzzed_data_provider.ConsumeIntegralInRange<NodeId>(0, std::numeric_limits<NodeId>::max()));
+    const auto sock = std::make_shared<FuzzedSock>(fuzzed_data_provider);
+    const CAddress address = ConsumeAddress(fuzzed_data_provider);
+    const uint64_t keyed_net_group = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+    const uint64_t local_host_nonce = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+    const CAddress addr_bind = ConsumeAddress(fuzzed_data_provider);
+    const std::string addr_name = fuzzed_data_provider.ConsumeRandomLengthString(64);
+    const ConnectionType conn_type = fuzzed_data_provider.PickValueInArray(ALL_CONNECTION_TYPES);
+    const bool inbound_onion{conn_type == ConnectionType::INBOUND ? fuzzed_data_provider.ConsumeBool() : false};
+    NetPermissionFlags permission_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);
+    if constexpr (ReturnUniquePtr) {
+        return std::make_unique<CNode>(node_id,
+                                       sock,
+                                       address,
+                                       keyed_net_group,
+                                       local_host_nonce,
+                                       addr_bind,
+                                       addr_name,
+                                       conn_type,
+                                       inbound_onion,
+                                       CNodeOptions{ .permission_flags = permission_flags });
+    } else {
+        return CNode{node_id,
+                     sock,
+                     address,
+                     keyed_net_group,
+                     local_host_nonce,
+                     addr_bind,
+                     addr_name,
+                     conn_type,
+                     inbound_onion,
+                     CNodeOptions{ .permission_flags = permission_flags }};
+    }
+}
+inline std::unique_ptr<CNode> ConsumeNodeAsUniquePtr(FuzzedDataProvider& fdp, const std::optional<NodeId>& node_id_in = std::nullopt) { return ConsumeNode<true>(fdp, node_id_in); }
+
+void FillNode(FuzzedDataProvider& fuzzed_data_provider, ConnmanTestMsg& connman, CNode& node) noexcept EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
 
 #endif // BITCOIN_TEST_FUZZ_UTIL_NET_H


### PR DESCRIPTION
Backports bitcoin/bitcoin#26561

Original commit: 93cae70d8

Backported from Bitcoin Core v0.25

## Notes
This is a move-only refactoring that reorganizes net utilities from util.cpp/util.h to util/net.cpp/util/net.h for the fuzz testing framework. 

### Dash Adaptations:
- Removed SegWit/Taproot-related witness types (WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, WitnessUnknown)
- Commented out CScriptWitness usage as Dash doesn't have SegWit
- Replaced AutoFile with CAutoFile and added required constructor parameters
- Added stub implementations for ConsumePrivateKey, ConsumeTxMemPoolEntry, and template versions of ConsumeFixedLengthByteVector/ConsumeRandomLengthByteVector
- Commented out WaitMany method which doesn't exist in Dash's Sock interface yet
- Fixed various constants (MAX_BIP125_RBF_SEQUENCE, MAX_BLOCK_SIGOPS_COST) that don't exist in Dash
- Removed references to util/rbf.h which doesn't exist in Dash