### PR TITLE
Merge bitcoin/bitcoin#26673: univalue: Remove confusing getBool method

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(result.isObject());
         const UniValue& success = find_value(result, "success");
         BOOST_CHECK(!success.isNull());
-        BOOST_CHECK_EQUAL(success.getBool(), true);
+        BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
     {
         // An invalid command is handled by Boost
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(result.isObject());
         const UniValue& success = find_value(result, "success");
         BOOST_CHECK(!success.isNull());
-        BOOST_CHECK_EQUAL(success.getBool(), true);
+        BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
 #endif
 }

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -65,7 +65,6 @@ public:
 
     size_t size() const { return values.size(); }
 
-    bool getBool() const { return isTrue(); }
     void getObjMap(std::map<std::string,UniValue>& kv) const;
     bool checkObject(const std::map<std::string,UniValue::VType>& memberTypes) const;
     const UniValue& operator[](const std::string& key) const;

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -92,7 +92,7 @@ bool UniValue::get_bool() const
 {
     if (typ != VBOOL)
         throw std::runtime_error("JSON value is not a boolean as expected");
-    return getBool();
+    return isTrue();
 }
 
 const std::string& UniValue::get_str() const

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -170,13 +170,13 @@ BOOST_AUTO_TEST_CASE(univalue_set)
     BOOST_CHECK_EQUAL(v.isBool(), true);
     BOOST_CHECK_EQUAL(v.isTrue(), false);
     BOOST_CHECK_EQUAL(v.isFalse(), true);
-    BOOST_CHECK_EQUAL(v.getBool(), false);
+    BOOST_CHECK_EQUAL(v.get_bool(), false);
 
     BOOST_CHECK(v.setBool(true));
     BOOST_CHECK_EQUAL(v.isBool(), true);
     BOOST_CHECK_EQUAL(v.isTrue(), true);
     BOOST_CHECK_EQUAL(v.isFalse(), false);
-    BOOST_CHECK_EQUAL(v.getBool(), true);
+    BOOST_CHECK_EQUAL(v.get_bool(), true);
 
     BOOST_CHECK(!v.setNumStr("zombocom"));
 


### PR DESCRIPTION
## Summary  
Backports bitcoin/bitcoin#26673

Original commit: a28fb36c4

This PR removes the confusing `getBool` method from UniValue and replaces its usage with `isTrue()` or `get_bool()` as appropriate. The `getBool` method was problematic because it didn't ensure the value was boolean and returned false for all non-boolean values instead of throwing exceptions.

## Test plan
- Build succeeds
- All affected files have been updated to use `get_bool()` instead of `getBool()`
- No functional changes expected

🤖 Generated with [Claude Code](https://claude.ai/code)