### PR TITLE
Merge bitcoin-core/gui#685: clang-tidy: Fix `readability-redundant-string-init` in headers

### DIFF
--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -92,13 +92,13 @@ public:
     static const int RecommendedNumConfirmations = 6;
 
     TransactionRecord():
-            hash(), time(0), type(Other), strAddress(""), debit(0), credit(0), idx(0)
+            hash(), time(0), type(Other), debit(0), credit(0), idx(0)
     {
         txDest = DecodeDestination(strAddress);
     }
 
     TransactionRecord(uint256 _hash, qint64 _time):
-            hash(_hash), time(_time), type(Other), strAddress(""), debit(0),
+            hash(_hash), time(_time), type(Other), debit(0),
             credit(0), idx(0)
     {
         txDest = DecodeDestination(strAddress);


### PR DESCRIPTION
Backports bitcoin-core/gui#685

Original commit: 5055d07ed

Backported from Bitcoin Core v0.25