### PR TITLE
Merge bitcoin/bitcoin#26265: POLICY: Relax MIN_STANDARD_TX_NONWITNESS_SIZE to 65 non-witness bytes

### DIFF
--- a/doc/release-notes-26265.md
+++ b/doc/release-notes-26265.md
@@ -1,0 +1,6 @@
+P2P and network changes
+---------
+
+- Transactions of non-witness size 65 and above are now allowed by mempool
+  and relay policy. This is to better reflect the actual afforded protections
+  against CVE-2017-12842 and open up additional use-cases of smaller transaction sizes. (#26265)

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -25,8 +25,8 @@ static constexpr unsigned int DEFAULT_BLOCK_MAX_SIZE{2000000};
 static constexpr unsigned int DEFAULT_BLOCK_MIN_TX_FEE{1000};
 /** The maximum size for transactions we're willing to relay/mine */
 static constexpr unsigned int MAX_STANDARD_TX_SIZE{100000};
-/** The minimum size for transactions we're willing to relay/mine (1 empty scriptSig input + 1 P2SH output = 83 bytes) */
-static constexpr unsigned int MIN_STANDARD_TX_SIZE{83};
+/** The minimum size for transactions we're willing to relay/mine: one larger than 64 */
+static constexpr unsigned int MIN_STANDARD_TX_SIZE{65};
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static constexpr unsigned int MAX_P2SH_SIGOPS{15};
 /** The maximum number of sigops we're willing to relay/mine in a single tx */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -735,10 +735,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     if (fRequireStandard && !IsStandardTx(tx, reason))
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
 
-    // Do not work on transactions that are too small.
-    // A transaction with 1 empty scriptSig input and 1 P2SH output has size of 83 bytes.
-    // Transactions smaller than this are not relayed to mitigate CVE-2017-12842 by not relaying
-    // 64-byte transactions.
+    // Transactions smaller than 65 bytes are not relayed to mitigate CVE-2017-12842.
     if (::GetSerializeSize(tx, PROTOCOL_VERSION) < MIN_STANDARD_TX_SIZE)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "tx-size-small");
 

--- a/test/functional/data/invalid_txs.py
+++ b/test/functional/data/invalid_txs.py
@@ -36,12 +36,25 @@ from test_framework.script import (
     OP_0,
     OP_CHECKSIG,
     OP_TRUE,
+    OP_DIV,
+    OP_INVERT,
+    OP_LEFT,
+    OP_LSHIFT,
+    OP_MOD,
+    OP_MUL,
+    OP_OR,
+    OP_RETURN,
+    OP_RIGHT,
+    OP_RSHIFT,
+    OP_SUBSTR,
+    OP_XOR,
 )
 from test_framework.script_util import (
+    MIN_PADDING,
+    MIN_STANDARD_TX_SIZE,
     script_to_p2sh_script,
 )
 basic_p2sh = script_to_p2sh_script(CScript([OP_0]))
-
 
 class BadTxTemplate:
     """Allows simple construction of a certain kind of invalid tx. Base class to be subclassed."""
@@ -103,7 +116,9 @@ class SizeTooSmall(BadTxTemplate):
     def get_tx(self):
         tx = CTransaction()
         tx.vin.append(self.valid_txin)
-        tx.vout.append(CTxOut(0, CScript([OP_TRUE])))
+        tx.vout.append(CTxOut(0, CScript([OP_RETURN] + ([OP_0] * (MIN_PADDING - 2)))))
+        assert len(tx.serialize_without_witness()) == 64
+        assert MIN_STANDARD_TX_SIZE - 1 == 64
         tx.calc_sha256()
         return tx
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -14,7 +14,9 @@ from test_framework.messages import (
     BIP125_SEQUENCE_NUMBER,
     COIN,
     COutPoint,
+    CTransaction,
     CTxIn,
+    CTxInWitness,
     CTxOut,
     MAX_BLOCK_SIZE,
     MAX_MONEY,
@@ -26,13 +28,19 @@ from test_framework.script import (
     OP_0,
     OP_HASH160,
     OP_RETURN,
+    OP_TRUE,
 )
 from test_framework.script_util import (
+    DUMMY_MIN_OP_RETURN_SCRIPT,
     keys_to_multisig_script,
+    MIN_PADDING,
+    MIN_STANDARD_TX_NONWITNESS_SIZE,
     script_to_p2sh_script,
+    script_to_p2wsh_script,
 )
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import MiniWallet
@@ -337,6 +345,35 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             maxfeerate=0,
         )
 
+        # Prep for tiny-tx tests with wsh(OP_TRUE) output
+        seed_tx = self.wallet.send_to(from_node=node, scriptPubKey=script_to_p2wsh_script(CScript([OP_TRUE])), amount=COIN)
+        self.generate(node, 1)
+
+        self.log.info('A tiny transaction(in non-witness bytes) that is disallowed')
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(int(seed_tx[0], 16), seed_tx[1]), b"", SEQUENCE_FINAL))
+        tx.wit.vtxinwit = [CTxInWitness()]
+        tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
+        tx.vout.append(CTxOut(0, CScript([OP_RETURN] + ([OP_0] * (MIN_PADDING - 2)))))
+        # Note it's only non-witness size that matters!
+        assert_equal(len(tx.serialize_without_witness()), 64)
+        assert_equal(MIN_STANDARD_TX_NONWITNESS_SIZE - 1, 64)
+        assert_greater_than(len(tx.serialize()), 64)
+
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'tx-size-small'}],
+            rawtxs=[tx.serialize().hex()],
+            maxfeerate=0,
+        )
+
+        self.log.info('Minimally-small transaction(in non-witness bytes) that is allowed')
+        tx.vout[0] = CTxOut(COIN - 1000, DUMMY_MIN_OP_RETURN_SCRIPT)
+        assert_equal(len(tx.serialize_without_witness()), MIN_STANDARD_TX_NONWITNESS_SIZE)
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.rehash(), 'allowed': True, 'vsize': tx.get_vsize(), 'fees': { 'base': Decimal('0.00001000')}}],
+            rawtxs=[tx.serialize().hex()],
+            maxfeerate=0,
+        )
 
 if __name__ == '__main__':
     MempoolAcceptanceTest().main()

--- a/test/functional/test_framework/script_util.py
+++ b/test/functional/test_framework/script_util.py
@@ -12,11 +12,12 @@ from test_framework.script import (
     OP_EQUAL,
     OP_EQUALVERIFY,
     OP_HASH160,
+    OP_RETURN,
     hash160,
 )
 
 # To prevent a "tx-size-small" policy rule error, a transaction has to have a
-# size of at least 83 bytes (MIN_STANDARD_TX_SIZE in
+# size of at least 65 bytes (MIN_STANDARD_TX_SIZE in
 # src/policy/policy.h). Considering a Tx with the smallest possible single
 # input (blank, empty scriptSig), and with an output omitting the scriptPubKey,
 # we get to a minimum size of 60 bytes:
@@ -26,15 +27,20 @@ from test_framework.script import (
 # Output:      8 [Amount] + 1 [scriptPubKeyLen] = 9 bytes
 #
 # Hence, the scriptPubKey of the single output has to have a size of at
-# least 23 bytes, which corresponds to the size of a P2SH scriptPubKey.
-# The following script constant consists of a single push of 22 bytes of 'a':
-#   <PUSH_22> <22-bytes of 'a'>
-# resulting in a 23-byte size. It should be used whenever (small) fake
-# scriptPubKeys are needed, to guarantee that the minimum transaction size is
-# met.
+# least 5 bytes.
+MIN_STANDARD_TX_SIZE = 65
+MIN_PADDING = MIN_STANDARD_TX_SIZE - 10 - 41 - 9
+assert MIN_PADDING == 5
+
+# The following script constants used to be used for padding to meet the minimum
+# transaction size but are kept for compatibility with existing tests.
 DUMMY_P2SH_SCRIPT = CScript([b'a' * 22])
 DUMMY_2_P2SH_SCRIPT = CScript([b'b' * 22])
 
+# This script cannot be spent, allowing dust output values under
+# standardness checks
+DUMMY_MIN_OP_RETURN_SCRIPT = CScript([OP_RETURN] + ([OP_0] * (MIN_PADDING - 1)))
+assert len(DUMMY_MIN_OP_RETURN_SCRIPT) == MIN_PADDING
 
 def key_to_p2pk_script(key):
     key = check_key(key)


### PR DESCRIPTION
Backports bitcoin/bitcoin#26265

Original commit: f3bc1a72825fe2b51f4bc20e004cef464f05b965

Backported from Bitcoin Core v0.25