### PR TITLE
Merge bitcoin/bitcoin#26777: rpc: Remove duplicate field in RPCHelpMan for gettransactions

### DIFF
--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -435,7 +435,7 @@ static const std::vector<RPCResult> TransactionDescriptionString()
             {RPCResult::Type::NUM_TIME, "time", "The transaction time expressed in " + UNIX_EPOCH_TIME + "."},
             {RPCResult::Type::NUM_TIME, "timereceived", "The time received expressed in " + UNIX_EPOCH_TIME + ". Available \n"
                                                "for 'send' and 'receive' category of transactions."},
-            {RPCResult::Type::STR, "comment", /* optional */ "If a comment is associated with the transaction."}};
+            {RPCResult::Type::STR, "comment", /* optional */ true, "If a comment is associated with the transaction."}};
 }
 
 RPCHelpMan listtransactions()


### PR DESCRIPTION
Backports bitcoin/bitcoin#26777

Original commit: 8575d5d84

Backported from Bitcoin Core v0.25

Note: Dash already had only one "comment" field in TransactionDescriptionString, but it had incorrect optional parameter syntax. This change fixes the parameter format to match Bitcoin's style.