### PR TITLE
Merge bitcoin/bitcoin#26775: ci: Revert tsan task changes

### DIFF
--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -12,6 +12,6 @@ export DEP_OPTS="CC=clang-18 CXX='clang++-18 -stdlib=libc++'"
 export TEST_RUNNER_EXTRA="--extended --exclude feature_pruning,feature_dbcrash,wallet_multiwallet.py" # Temporarily suppress ASan heap-use-after-free (see issue #14163)
 export TEST_RUNNER_EXTRA="${TEST_RUNNER_EXTRA} --timeout-factor=4"  # Increase timeout because sanitizers slow down
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --with-sanitizers=thread CXXFLAGS='-g' --with-boost-process"
+export BITCOIN_CONFIG="--enable-zmq --with-sanitizers=thread CC=clang-18 CXX=clang++-18 CXXFLAGS='-g' --with-boost-process"
 export CPPFLAGS="-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION"
 export PYZMQ=true

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -12,6 +12,6 @@ export DEP_OPTS="CC=clang-18 CXX='clang++-18 -stdlib=libc++'"
 export TEST_RUNNER_EXTRA="--extended --exclude feature_pruning,feature_dbcrash,wallet_multiwallet.py" # Temporarily suppress ASan heap-use-after-free (see issue #14163)
 export TEST_RUNNER_EXTRA="${TEST_RUNNER_EXTRA} --timeout-factor=4"  # Increase timeout because sanitizers slow down
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --with-sanitizers=thread CC=clang-18 CXX=clang++-18 CXXFLAGS='-g' --with-boost-process"
+export BITCOIN_CONFIG="--enable-zmq --with-sanitizers=thread CXXFLAGS='-g' --with-boost-process"
 export CPPFLAGS="-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION"
 export PYZMQ=true

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -48,5 +48,8 @@ race:std::__1::ios_base::flags
 # https://github.com/bitcoin/bitcoin/issues/20618
 race:CZMQAbstractPublishNotifier::SendZmqMessage
 
+# https://github.com/bitcoin/bitcoin/pull/20218, https://github.com/bitcoin/bitcoin/pull/20745
+race:epoll_ctl
+
 # https://github.com/bitcoin/bitcoin/issues/23366
 race:std::__1::ios_base::*


### PR DESCRIPTION
Backports bitcoin/bitcoin#26775

Original commit: d8bdee0fc

Backported from Bitcoin Core v0.25

Note: This backport only applies the removal of duplicate CC/CXX definitions from the tsan configuration. The clang version revert (15->13) does not apply to Dash as we're using clang-18. The .cirrus.yml changes also don't apply as this file has been removed in Dash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sanitizer suppression settings to address known issues related to "epoll_ctl".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->