### PR TITLE
Merge bitcoin/bitcoin#25471: rpc: Disallow gettxoutsetinfo queries for a specific block with `use_index=false`

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1189,7 +1189,6 @@ static RPCHelpMan gettxoutsetinfo()
         if (!stats.index_requested) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot set use_index to false when querying for a specific block");
         }
-
         pindex = ParseHashOrHeight(request.params[1], chainman);
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1148,6 +1148,7 @@ static RPCHelpMan gettxoutsetinfo()
                 HelpExampleCli("gettxoutsetinfo", R"("none")") +
                 HelpExampleCli("gettxoutsetinfo", R"("none" 1000)") +
                 HelpExampleCli("gettxoutsetinfo", R"("none" '"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09"')") +
+                HelpExampleCli("-named gettxoutsetinfo", R"(hash_type='muhash' use_index='false')") +
                 HelpExampleRpc("gettxoutsetinfo", "") +
                 HelpExampleRpc("gettxoutsetinfo", R"("none")") +
                 HelpExampleRpc("gettxoutsetinfo", R"("none", 1000)") +
@@ -1183,6 +1184,10 @@ static RPCHelpMan gettxoutsetinfo()
 
         if (stats.m_hash_type == CoinStatsHashType::HASH_SERIALIZED) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "hash_serialized_2 hash type cannot be queried for a specific block");
+        }
+
+        if (!stats.index_requested) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot set use_index to false when querying for a specific block");
         }
 
         pindex = ParseHashOrHeight(request.params[1], chainman);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1112,7 +1112,7 @@ static RPCHelpMan gettxoutsetinfo()
         "Note this call may take some time if you are not using coinstatsindex.\n",
         {
             {"hash_type", RPCArg::Type::STR, RPCArg::Default{"hash_serialized_2"}, "Which UTXO set hash should be calculated. Options: 'hash_serialized_2' (the legacy algorithm), 'muhash', 'none'."},
-            {"hash_or_height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "The block hash or height of the target height (only available with coinstatsindex).", "", {"", "string or numeric"}},
+            {"hash_or_height", RPCArg::Type::NUM, RPCArg::DefaultHint{"the current best block"}, "The block hash or height of the target height (only available with coinstatsindex).", "", {"", "string or numeric"}},
             {"use_index", RPCArg::Type::BOOL, RPCArg::Default{true}, "Use coinstatsindex, if available."},
         },
         RPCResult{


### PR DESCRIPTION
Backports bitcoin/bitcoin#25471

Original commit: 53b1a2426

Backported from Bitcoin Core v0.24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI example for the `gettxoutsetinfo` command, demonstrating usage with named parameters.

* **Bug Fixes**
  * Improved validation for the `gettxoutsetinfo` command to prevent invalid parameter combinations when querying a specific block.

* **Documentation**
  * Updated help text to clarify default behavior for the `"hash_or_height"` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->