### PR TITLE
Merge #18628: test: Add various low-level p2p tests

### DIFF
--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -116,6 +116,11 @@ class FilterTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(['Misbehaving']):
             filter_peer.send_and_ping(msg_filterload(data=b'\xaa', nHashFuncs=MAX_BLOOM_HASH_FUNCS+1))
 
+        # Also test the check that Bitcoin added
+        self.log.info('Check that filter with excessive hash functions (51) is rejected')
+        with self.nodes[0].assert_debug_log(['Misbehaving']):
+            filter_peer.send_and_ping(msg_filterload(data=b'\xaa', nHashFuncs=51, nTweak=0, nFlags=1))
+
         self.log.info('Check that filter with max hash functions is accepted')
         with self.nodes[0].assert_debug_log([], unexpected_msgs=['Misbehaving']):
             filter_peer.send_and_ping(msg_filterload(data=b'\xaa', nHashFuncs=MAX_BLOOM_HASH_FUNCS))

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test node responses to invalid network messages."""
 
-
 from test_framework.messages import (
     CBlockHeader,
     CInv,

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -160,6 +160,15 @@ class P2PLeakTest(BitcoinTestFramework):
             p2p_old_peer.send_message(self.create_old_version(31799))
             p2p_old_peer.wait_for_disconnect()
 
+        self.log.info('Check that old nodes are disconnected')
+        p2p_old_node = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
+        old_version_msg = msg_version()
+        old_version_msg.nVersion = 31799
+        wait_until(lambda: p2p_old_node.is_connected)
+        with self.nodes[0].assert_debug_log(['peer=4 using obsolete version 31799; disconnecting']):
+            p2p_old_node.send_message(old_version_msg)
+            p2p_old_node.wait_for_disconnect()
+
 
 if __name__ == '__main__':
     P2PLeakTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#18628

Original commit: 20c0e2e0f0

Backported from Bitcoin Core v0.21

Note: This backport includes only the test additions that were not already present in Dash. Some tests like p2p_invalid_tx.py and p2p_tx_download.py already existed in Dash with different implementations (e.g., Dash-specific orphan pool size limits), so those were preserved.