### PR TITLE
Merge #19519: ci: Increase CCACHE_SIZE in some builds on Travis

### DIFF
--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -16,3 +16,4 @@ export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address,undefined,integer CC='clang-18 -ftrivial-auto-var-init=pattern' CXX='clang++-18 -ftrivial-auto-var-init=pattern' --with-boost-process"
+export CCACHE_SIZE=200M


### PR DESCRIPTION
Backports bitcoin/bitcoin#19519

Original commit: 24ead1a923

Backported from Bitcoin Core v0.21

Notes:
- Only applied to ci/test/00_setup_env_native_fuzz.sh as the other files either already had CCACHE_SIZE set (valgrind) or don't exist in Dash (msan)