### PR TITLE
Merge bitcoin/bitcoin#27498: test: Remove unused sanitizer suppressions

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -17,7 +17,7 @@ race:bitcoin-qt
 # deadlock (TODO fix)
 # To reproduce, see:
 # https://github.com/bitcoin/bitcoin/issues/19303#issuecomment-1514926359
-deadlock:Chainstate::ConnectTip
+deadlock:CChainstate::ConnectTip
 deadlock:wallet_tests::CreateWallet
 
 # deadlock false positive (see: https://github.com/dashpay/dash/pull/4563)

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -17,7 +17,7 @@ race:bitcoin-qt
 # deadlock (TODO fix)
 # To reproduce, see:
 # https://github.com/bitcoin/bitcoin/issues/19303#issuecomment-1514926359
-deadlock:CChainstate::ConnectTip
+deadlock:CChainState::ConnectTip
 deadlock:wallet_tests::CreateWallet
 
 # deadlock false positive (see: https://github.com/dashpay/dash/pull/4563)

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -15,7 +15,9 @@ race:DatabaseBatch
 race:zmq::*
 race:bitcoin-qt
 # deadlock (TODO fix)
-deadlock:CChainState::ConnectTip
+# To reproduce, see:
+# https://github.com/bitcoin/bitcoin/issues/19303#issuecomment-1514926359
+deadlock:Chainstate::ConnectTip
 deadlock:wallet_tests::CreateWallet
 
 # deadlock false positive (see: https://github.com/dashpay/dash/pull/4563)
@@ -47,6 +49,9 @@ race:std::__1::ios_base::flags
 
 # https://github.com/bitcoin/bitcoin/issues/20618
 race:CZMQAbstractPublishNotifier::SendZmqMessage
+
+# https://github.com/bitcoin/bitcoin/pull/27498#issuecomment-1517410478
+race:epoll_ctl
 
 # https://github.com/bitcoin/bitcoin/issues/23366
 race:std::__1::ios_base::*

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -5,16 +5,12 @@
 # names can be used.
 # See https://github.com/google/sanitizers/issues/1364
 
-# https://github.com/bitcoin/bitcoin/pull/21798#issuecomment-829180719
-signed-integer-overflow:policy/feerate.cpp
-
 # -fsanitize=integer suppressions
 # ===============================
 # Dependencies
 # ------------
 # Suppressions in dependencies that are developed outside this repository.
 unsigned-integer-overflow:*/include/c++/
-unsigned-integer-overflow:bench/bench.h
 # unsigned-integer-overflow in FuzzedDataProvider's ConsumeIntegralInRange
 unsigned-integer-overflow:FuzzedDataProvider.h
 unsigned-integer-overflow:leveldb/
@@ -34,8 +30,6 @@ implicit-unsigned-integer-truncation:*/include/c++/
 implicit-unsigned-integer-truncation:leveldb/
 implicit-unsigned-integer-truncation:secp256k1/
 implicit-unsigned-integer-truncation:test/fuzz/crypto_diff_fuzz_chacha20.cpp
-# std::variant warning fixed in https://github.com/gcc-mirror/gcc/commit/074436cf8cdd2a9ce75cadd36deb8301f00e55b9
-implicit-unsigned-integer-truncation:std::__detail::__variant::_Variant_storage
 shift-base:*/include/c++/
 shift-base:leveldb/
 shift-base:minisketch/


### PR DESCRIPTION
Backports bitcoin/bitcoin#27498

Original commit: fa15a9934ee1d331737c631e6ffc2ddfafaddb7f

Backported from Bitcoin Core v0.26