### PR TITLE
Merge bitcoin/bitcoin#29458: refactor: Preallocate result in TryParseHex to avoid resizing

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -41,6 +41,7 @@ bench_bench_dash_SOURCES = \
   bench/mempool_stress.cpp \
   bench/nanobench.h \
   bench/nanobench.cpp \
+  bench/parse_hex.cpp \
   bench/peer_eviction.cpp \
   bench/pool.cpp \
   bench/rpc_blockchain.cpp \

--- a/src/bench/parse_hex.cpp
+++ b/src/bench/parse_hex.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2024- The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <random.h>
+#include <stddef.h>
+#include <util/strencodings.h>
+#include <cassert>
+#include <optional>
+#include <vector>
+
+std::string generateHexString(size_t length) {
+    const auto hex_digits = "0123456789ABCDEF";
+    FastRandomContext rng(/*fDeterministic=*/true);
+
+    std::string data;
+    while (data.size() < length) {
+        auto digit = hex_digits[rng.randbits(4)];
+        data.push_back(digit);
+    }
+    return data;
+}
+
+static void HexParse(benchmark::Bench& bench)
+{
+    auto data = generateHexString(130); // Generates 678B0EDA0A1FD30904D5A65E3568DB82DB2D918B0AD8DEA18A63FECCB877D07CAD1495C7157584D877420EF38B8DA473A6348B4F51811AC13C786B962BEE5668F9 by default
+
+    bench.batch(data.size()).unit("base16").run([&] {
+        auto result = TryParseHex(data);
+        assert(result != std::nullopt); // make sure we're measuring the successful case
+        ankerl::nanobench::doNotOptimizeAway(result);
+    });
+}
+
+BENCHMARK(HexParse, benchmark::PriorityLevel::HIGH);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -82,6 +82,8 @@ template <typename Byte>
 std::vector<Byte> ParseHex(std::string_view str)
 {
     std::vector<Byte> vch;
+    vch.reserve(str.size() / 2); // two hex characters form a single byte
+
     auto it = str.begin();
     while (it != str.end() && it + 1 != str.end()) {
         if (IsSpace(*it)) {


### PR DESCRIPTION
Backports bitcoin/bitcoin#29458

Original commit: 6dda050865e298e2e3d5f23a8435981d1e017dbe

Backported from Bitcoin Core v0.28

This PR introduces optimizations to the `TryParseHex` function, focusing primarily on the ideal case (valid hexadecimal input without spaces). A new benchmark, `HexParse` was introduced in a separate commit.

The main optimization preallocates the result vector based on the input string's length. This aims to completely avoid costly dynamic reallocations when no spaces are present.

Changes:
- Add benchmark for TryParseHex
- Preallocate result in TryParseHex to avoid resizing

Files modified:
- src/Makefile.bench.include: Add new benchmark file
- src/bench/parse_hex.cpp: New benchmark implementation
- src/util/strencodings.cpp: Add vector preallocation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>