### PR TITLE
Merge bitcoin/bitcoin#26328: doc: fix -netinfo relaytxes help

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -668,7 +668,7 @@ public:
         "  send     Time since last message sent to the peer, in seconds\n"
         "  recv     Time since last message received from the peer, in seconds\n"
         "  txn      Time since last novel transaction received from the peer and accepted into our mempool, in minutes\n"
-        "           \"*\" - the peer requested we not relay transactions to it (relaytxes is false)\n"
+        "           \"*\" - we do not relay transactions to this peer (relaytxes is false)\n"
         "  blk      Time since last novel block passing initial validity checks received from the peer, in minutes\n"
         "  hb       High-bandwidth BIP152 compact block relay\n"
         "           \".\" (to)   - we selected the peer as a high-bandwidth peer\n"


### PR DESCRIPTION
Backports bitcoin/bitcoin#26328

Original commit: 329d7e379d09fa5db9c057baa0e100d2b174427d

This is a simple documentation improvement that makes the -netinfo help text clearer and more direct. The change improves the explanation of the "*" indicator in the transaction relay status:

**Before**: "the peer requested we not relay transactions to it (relaytxes is false)"
**After**: "we do not relay transactions to this peer (relaytxes is false)"

This backport applies cleanly with only minor conflict resolution in the help text.

Backported from Bitcoin Core v0.25