### PR TITLE
Merge bitcoin/bitcoin#26695: bench: BlockAssembler on a mempool with packages

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -5,6 +5,7 @@
 #include <bench/bench.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
+#include <node/miner.h>
 #include <script/standard.h>
 #include <test/util/mining.h>
 #include <test/util/script.h>
@@ -51,5 +52,18 @@ static void AssembleBlock(benchmark::Bench& bench)
         PrepareBlock(test_setup->m_node, SCRIPT_PUB);
     });
 }
+static void BlockAssemblerAddPackageTxns(benchmark::Bench& bench)
+{
+    FastRandomContext det_rand{true};
+    auto testing_setup{MakeNoLogFileContext<TestChain100Setup>()};
+    testing_setup->PopulateMempool(det_rand, /*num_transactions=*/1000, /*submit=*/true);
+    node::BlockAssembler::Options assembler_options;
+    assembler_options.test_block_validity = false;
 
-BENCHMARK(AssembleBlock);
+    bench.run([&] {
+        PrepareBlock(testing_setup->m_node, P2SH_OP_TRUE, assembler_options);
+    });
+}
+
+BENCHMARK(AssembleBlock, benchmark::PriorityLevel::HIGH);
+BENCHMARK(BlockAssemblerAddPackageTxns, benchmark::PriorityLevel::LOW);

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -67,9 +67,11 @@ BlockAssembler::Options::Options()
 {
     blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
     nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
+    test_block_validity = true;
 }
 
 BlockAssembler::BlockAssembler(CChainState& chainstate, const NodeContext& node, const CTxMemPool* mempool, const CChainParams& params, const Options& options) :
+      test_block_validity(options.test_block_validity),
       m_blockman(chainstate.m_blockman),
       m_cpoolman(*Assert(node.cpoolman)),
       m_chain_helper(chainstate.ChainHelper()),
@@ -87,11 +89,9 @@ BlockAssembler::BlockAssembler(CChainState& chainstate, const NodeContext& node,
     nBlockMaxSize = options.nBlockMaxSize;
 }
 
-static BlockAssembler::Options DefaultOptions()
+void ApplyArgsManOptions(const ArgsManager& gArgs, BlockAssembler::Options& options)
 {
     // Block resource limits
-    BlockAssembler::Options options;
-    options.nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
     if (gArgs.IsArgSet("-blockmaxsize")) {
         options.nBlockMaxSize = gArgs.GetIntArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
     }
@@ -101,11 +101,16 @@ static BlockAssembler::Options DefaultOptions()
     } else {
         options.blockMinFeeRate = CFeeRate{DEFAULT_BLOCK_MIN_TX_FEE};
     }
+}
+static BlockAssembler::Options ConfiguredOptions()
+{
+    BlockAssembler::Options options;
+    ApplyArgsManOptions(gArgs, options);
     return options;
 }
 
 BlockAssembler::BlockAssembler(CChainState& chainstate, const NodeContext& node, const CTxMemPool* mempool, const CChainParams& params)
-    : BlockAssembler(chainstate, node, mempool, params, DefaultOptions()) {}
+    : BlockAssembler(chainstate, node, mempool, params, ConfiguredOptions()) {}
 
 void BlockAssembler::resetBlock()
 {
@@ -334,7 +339,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(*pblock->vtx[0]);
 
     BlockValidationState state;
-    if (!TestBlockValidity(state, m_clhandler, m_evoDb, chainparams, m_chainstate, *pblock, pindexPrev, false, false)) {
+    if (test_block_validity && !TestBlockValidity(state, m_clhandler, m_evoDb, chainparams, m_chainstate, *pblock, pindexPrev, false, false)) {
         throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, state.ToString()));
     }
     int64_t nTime2 = GetTimeMicros();

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -19,6 +19,7 @@
 #include <boost/multi_index/tag.hpp>
 #include <boost/multi_index_container.hpp>
 
+class ArgsManager;
 class CBlockIndex;
 class CChainParams;
 class CChainstateHelper;
@@ -155,6 +156,9 @@ private:
     unsigned int nBlockMaxSigOps;
     CFeeRate blockMinFeeRate;
 
+    // Whether to call TestBlockValidity() at the end of CreateNewBlock().
+    const bool test_block_validity;
+
     // Information on the current status of the block
     uint64_t nBlockSize;
     uint64_t nBlockTx;
@@ -184,6 +188,7 @@ public:
         Options();
         size_t nBlockMaxSize;
         CFeeRate blockMinFeeRate;
+        bool test_block_validity;
     };
 
     explicit BlockAssembler(CChainState& chainstate, const node::NodeContext& node, const CTxMemPool* mempool, const CChainParams& params);
@@ -225,6 +230,9 @@ private:
 };
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
+
+/** Apply -blockmintxfee and -blockmaxweight options from ArgsManager to BlockAssembler options. */
+void ApplyArgsManOptions(const ArgsManager& gArgs, BlockAssembler::Options& options);
 } // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -9,7 +9,6 @@
 #include <evo/evodb.h>
 #include <key_io.h>
 #include <node/context.h>
-#include <node/miner.h>
 #include <pow.h>
 #include <script/standard.h>
 #include <spork.h>
@@ -76,11 +75,12 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
     return CTxIn{block->vtx[0]->GetHash(), 0};
 }
 
-std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
+std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey,
+                                     const BlockAssembler::Options& assembler_options)
 {
     assert(node.mempool);
     auto block = std::make_shared<CBlock>(
-        BlockAssembler{node.chainman->ActiveChainstate(), node, Assert(node.mempool.get()), Params()}
+        BlockAssembler{node.chainman->ActiveChainstate(), node, Assert(node.mempool.get()), Params(), assembler_options}
             .CreateNewBlock(coinbase_scriptPubKey)
             ->block);
 
@@ -88,4 +88,10 @@ std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coi
     block->hashMerkleRoot = BlockMerkleRoot(*block);
 
     return block;
+}
+std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
+{
+    BlockAssembler::Options assembler_options;
+    ApplyArgsManOptions(*node.args, assembler_options);
+    return PrepareBlock(node, coinbase_scriptPubKey, assembler_options);
 }

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_TEST_UTIL_MINING_H
 #define BITCOIN_TEST_UTIL_MINING_H
 
+#include <node/miner.h>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -25,6 +27,8 @@ CTxIn MineBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
 
 /** Prepare a block to be mined */
 std::shared_ptr<CBlock> PrepareBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
+std::shared_ptr<CBlock> PrepareBlock(const node::NodeContext& node, const CScript& coinbase_scriptPubKey,
+                                     const node::BlockAssembler::Options& assembler_options);
 
 /** RPC-like helper function, returns the generated coin */
 CTxIn generatetoaddress(const node::NodeContext&, const std::string& address);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -636,15 +636,15 @@ std::vector<CTransactionRef> TestChainSetup::PopulateMempool(FastRandomContext& 
             unspent_prevouts.pop_front();
         }
         const size_t num_outputs = det_rand.randrange(24) + 1;
-        // Approximately 1000sat "fee," equal output amounts.
-        const CAmount amount_per_output = (total_in - 1000) / num_outputs;
+        const CAmount fee = 100 * det_rand.randrange(30);
+        const CAmount amount_per_output = (total_in - fee) / num_outputs;
         for (size_t n{0}; n < num_outputs; ++n) {
             CScript spk = CScript() << CScriptNum(num_transactions + n);
             mtx.vout.push_back(CTxOut(amount_per_output, spk));
         }
         CTransactionRef ptx = MakeTransactionRef(mtx);
         mempool_transactions.push_back(ptx);
-        if (amount_per_output > 2000) {
+        if (amount_per_output > 3000) {
             // If the value is high enough to fund another transaction + fees, keep track of it so
             // it can be used to build a more complex transaction graph. Insert randomly into
             // unspent_prevouts for extra randomness in the resulting structures.
@@ -654,9 +654,11 @@ std::vector<CTransactionRef> TestChainSetup::PopulateMempool(FastRandomContext& 
             }
         }
         if (submit) {
-            LOCK2(m_node.mempool->cs, cs_main);
+            LOCK2(cs_main, m_node.mempool->cs);
             LockPoints lp;
-            m_node.mempool->addUnchecked(CTxMemPoolEntry(ptx, 1000, 0, 1, false, 4, lp));
+            m_node.mempool->addUnchecked(CTxMemPoolEntry(ptx, /*fee=*/(total_in - num_outputs * amount_per_output),
+                                                         /*time=*/0, /*entry_height=*/1,
+                                                         /*spends_coinbase=*/false, /*sigops_cost=*/4, lp));
         }
         --num_transactions;
     }


### PR DESCRIPTION
## Summary
Backporting Bitcoin Core PR #26695 which adds benchmark for BlockAssembler with mempool packages and related improvements.

This PR:
- Adds a new benchmark `BlockAssemblerAddPackageTxns` to test block assembly performance with complex mempool packages
- Adds helper function `ApplyArgsManOptions` to apply ArgsManager settings to BlockAssembler options
- Parameterizes `PrepareBlock` to accept custom BlockAssembler options
- Adds `test_block_validity` flag to skip validation during benchmarking
- Improves PopulateMempool test utility with randomized fees

## Changes
- Replaced `P2WSH_OP_TRUE` with `P2SH_OP_TRUE` (Dash doesn't have SegWit)
- Adapted constructor signatures to match Dash's codebase structure
- Replaced `DefaultOptions` with `ConfiguredOptions` pattern
- Added necessary forward declarations and includes

## Test plan
- [x] Build succeeds
- [x] Backport validation passed (100% size ratio)
- [ ] Run benchmarks to verify they work correctly

🤖 Generated by Claude-3.5-Sonnet