### PR TITLE
Merge #20938: build: fix linking against -latomic when building for riscv

### DIFF
--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -21,6 +21,7 @@ m4_define([_CHECK_ATOMIC_testbody], [[
   int main() {
     std::atomic<bool> lock{true};
     lock.exchange(false);
+    std::atomic_exchange(&lock, false);
 
     std::atomic<std::chrono::seconds> t{0s};
     t.store(2s);


### PR DESCRIPTION
Backports bitcoin/bitcoin#20938

Original commit: c763cacb88

Backported from Bitcoin Core v0.22

**Note**: This is a partial backport. The change to `bitcoin-util.cpp` is not included because this file doesn't exist in Dash yet (it was introduced in PR #19937 which was only partially backported).