### PR TITLE
Merge bitcoin/bitcoin#22270: test: Add bitcoin-util tests (+refactors)

### DIFF
--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -1,0 +1,195 @@
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <arith_uint256.h>
+#include <chain.h>
+#include <chainparams.h>
+#include <chainparamsbase.h>
+#include <clientversion.h>
+#include <core_io.h>
+#include <streams.h>
+#include <util/system.h>
+#include <util/translation.h>
+
+#include <atomic>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <thread>
+
+#include <boost/algorithm/string.hpp>
+
+static const int CONTINUE_EXECUTION=-1;
+
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
+static void SetupBitcoinUtilArgs(ArgsManager &argsman)
+{
+    SetupHelpOptions(argsman);
+
+    argsman.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+
+    argsman.AddCommand("grind", "Perform proof of work on hex header string");
+
+    SetupChainParamsBaseOptions(argsman);
+}
+
+// This function returns either one of EXIT_ codes when it's expected to stop the process or
+// CONTINUE_EXECUTION when it's expected to continue further.
+static int AppInitUtil(ArgsManager& args, int argc, char* argv[])
+{
+    SetupBitcoinUtilArgs(args);
+    std::string error;
+    if (!args.ParseParameters(argc, argv, error)) {
+        tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error);
+        return EXIT_FAILURE;
+    }
+
+    if (HelpRequested(args) || args.IsArgSet("-version")) {
+        // First part of help message is specific to this utility
+        std::string strUsage = PACKAGE_NAME " bitcoin-util utility version " + FormatFullVersion() + "\n";
+        if (!args.IsArgSet("-version")) {
+            strUsage += "\n"
+                "Usage:  bitcoin-util [options] [commands]  Do stuff\n";
+            strUsage += "\n" + args.GetHelpMessage();
+        }
+
+        tfm::format(std::cout, "%s", strUsage);
+
+        if (argc < 2) {
+            tfm::format(std::cerr, "Error: too few parameters\n");
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
+    }
+
+    // Check for chain settings (Params() calls are only valid after this clause)
+    try {
+        SelectParams(args.GetChainName());
+    } catch (const std::exception& e) {
+        tfm::format(std::cerr, "Error: %s\n", e.what());
+        return EXIT_FAILURE;
+    }
+
+    return CONTINUE_EXECUTION;
+}
+
+static void grind_task(uint32_t nBits, CBlockHeader& header_orig, uint32_t offset, uint32_t step, std::atomic<bool>& found)
+{
+    arith_uint256 target;
+    bool neg, over;
+    target.SetCompact(nBits, &neg, &over);
+    if (target == 0 || neg || over) return;
+    CBlockHeader header = header_orig; // working copy
+    header.nNonce = offset;
+
+    uint32_t finish = std::numeric_limits<uint32_t>::max() - step;
+    finish = finish - (finish % step) + offset;
+
+    while (!found && header.nNonce < finish) {
+        const uint32_t next = (finish - header.nNonce < 5000*step) ? finish : header.nNonce + 5000*step;
+        do {
+            if (UintToArith256(header.GetHash()) <= target) {
+                if (!found.exchange(true)) {
+                    header_orig.nNonce = header.nNonce;
+                }
+                return;
+            }
+            header.nNonce += step;
+        } while(header.nNonce != next);
+    }
+}
+
+static int Grind(const std::vector<std::string>& args, std::string& strPrint)
+{
+    if (args.size() != 1) {
+        strPrint = "Must specify block header to grind";
+        return EXIT_FAILURE;
+    }
+
+    CBlockHeader header;
+    if (!DecodeHexBlockHeader(header, args[0])) {
+        strPrint = "Could not decode block header";
+        return EXIT_FAILURE;
+    }
+
+    uint32_t nBits = header.nBits;
+    std::atomic<bool> found{false};
+
+    std::vector<std::thread> threads;
+    int n_tasks = std::max(1u, std::thread::hardware_concurrency());
+    for (int i = 0; i < n_tasks; ++i) {
+        threads.emplace_back( grind_task, nBits, std::ref(header), i, n_tasks, std::ref(found) );
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+    if (!found) {
+        strPrint = "Could not satisfy difficulty target";
+        return EXIT_FAILURE;
+    }
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << header;
+    strPrint = HexStr(ss);
+    return EXIT_SUCCESS;
+}
+
+#ifdef WIN32
+// Export main() and ensure working ASLR on Windows.
+// Exporting a symbol will prevent the linker from stripping
+// the .reloc section from the binary, which is a requirement
+// for ASLR. This is a temporary workaround until a fixed
+// version of binutils is used for releases.
+__declspec(dllexport) int main(int argc, char* argv[])
+#else
+int main(int argc, char* argv[])
+#endif
+{
+    ArgsManager& args = gArgs;
+    SetupEnvironment();
+
+    try {
+        int ret = AppInitUtil(args, argc, argv);
+        if (ret != CONTINUE_EXECUTION) {
+            return ret;
+        }
+    } catch (const std::exception& e) {
+        PrintExceptionContinue(&e, "AppInitUtil()");
+        return EXIT_FAILURE;
+    } catch (...) {
+        PrintExceptionContinue(nullptr, "AppInitUtil()");
+        return EXIT_FAILURE;
+    }
+
+    const auto cmd = args.GetCommand();
+    if (!cmd) {
+        tfm::format(std::cerr, "Error: must specify a command\n");
+        return EXIT_FAILURE;
+    }
+
+    int ret = EXIT_FAILURE;
+    std::string strPrint;
+    try {
+        if (cmd->command == "grind") {
+            ret = Grind(cmd->args, strPrint);
+        } else {
+            assert(false); // unknown command should be caught earlier
+        }
+    } catch (const std::exception& e) {
+        strPrint = std::string("error: ") + e.what();
+    } catch (...) {
+        strPrint = "unknown error";
+    }
+
+    if (strPrint != "") {
+        tfm::format(ret == 0 ? std::cout : std::cerr, "%s\n", strPrint);
+    }
+
+    return ret;
+}

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -41,12 +41,12 @@ static void SetupWalletToolArgs(ArgsManager& argsman)
     argsman.AddArg("-format=<format>", "The format of the wallet file to create. Either \"bdb\" or \"sqlite\". Only used with 'createfromdump'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -debug is true, 0 otherwise).", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
 
-    argsman.AddCommand("info", "Get wallet info", OptionsCategory::COMMANDS);
-    argsman.AddCommand("create", "Create new wallet file", OptionsCategory::COMMANDS);
-    argsman.AddCommand("salvage", "Attempt to recover private keys from a corrupt wallet. Warning: 'salvage' is experimental.", OptionsCategory::COMMANDS);
-    argsman.AddCommand("wipetxes", "Wipe all transactions from a wallet", OptionsCategory::COMMANDS);
-    argsman.AddCommand("dump", "Print out all of the wallet key-value records", OptionsCategory::COMMANDS);
-    argsman.AddCommand("createfromdump", "Create new wallet file from dumped records", OptionsCategory::COMMANDS);
+    argsman.AddCommand("info", "Get wallet info");
+    argsman.AddCommand("create", "Create new wallet file");
+    argsman.AddCommand("salvage", "Attempt to recover private keys from a corrupt wallet. Warning: 'salvage' is experimental.");
+    argsman.AddCommand("wipetxes", "Wipe all transactions from a wallet");
+    argsman.AddCommand("dump", "Print out all of the wallet key-value records");
+    argsman.AddCommand("createfromdump", "Create new wallet file from dumped records");
 }
 
 static bool WalletAppInit(ArgsManager& args, int argc, char* argv[])

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -657,14 +657,14 @@ void ArgsManager::ForceSetArg(const std::string& strArg, const std::string& strV
     m_settings.forced_settings[SettingName(strArg)] = strValue;
 }
 
-void ArgsManager::AddCommand(const std::string& cmd, const std::string& help, const OptionsCategory& cat)
+void ArgsManager::AddCommand(const std::string& cmd, const std::string& help)
 {
     Assert(cmd.find('=') == std::string::npos);
     Assert(cmd.at(0) != '-');
 
     LOCK(cs_args);
     m_accept_any_command = false; // latch to false
-    std::map<std::string, Arg>& arg_map = m_available_args[cat];
+    std::map<std::string, Arg>& arg_map = m_available_args[OptionsCategory::COMMANDS];
     auto ret = arg_map.emplace(cmd, Arg{"", help, ArgsManager::COMMAND});
     Assert(ret.second); // Fail on duplicate commands
 }

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -429,7 +429,7 @@ protected:
     /**
      * Add subcommand
      */
-    void AddCommand(const std::string& cmd, const std::string& help, const OptionsCategory& cat);
+    void AddCommand(const std::string& cmd, const std::string& help);
 
     /**
      * Add many hidden arguments

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -1,4 +1,34 @@
 [
+  { "exec": "./bitcoin-util",
+    "args": ["foo"],
+    "return_code": 1,
+    "error_txt": "Error parsing command line arguments: Invalid command 'foo'",
+    "description": ""
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["help"],
+    "return_code": 1,
+    "error_txt": "Error parsing command line arguments: Invalid command 'help'",
+    "description": "`help` raises an error. Use `-help`"
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["grind"],
+    "return_code": 1,
+    "error_txt": "Must specify block header to grind",
+    "description": ""
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["grind", "1", "2"],
+    "return_code": 1,
+    "error_txt": "Must specify block header to grind",
+    "description": ""
+  },
+  { "exec": "./bitcoin-util",
+    "args": ["grind", "aa"],
+    "return_code": 1,
+    "error_txt": "Could not decode block header",
+    "description": ""
+  },
   { "exec": "./dash-tx",
     "args": ["-create", "nversion=1"],
     "output_cmp": "blanktxv1.hex",


### PR DESCRIPTION
Backports bitcoin/bitcoin#22270

Original commit: a196c89317dd876c22c8b4556f5af3ecfa251119

Backported from Bitcoin Core v0.22

## Changes
- Adds comprehensive test coverage for bitcoin-util binary
- Refactors AddCommand function to remove unused OptionsCategory parameter
- Removes unused includes from bitcoin-util.cpp  
- Improves argument handling with const reference for grind function
- MSVC build files excluded as not relevant to Dash

## Notes
- The bitcoin-util.cpp file appears as new in Dash as it didn't exist in the current branch
- All tests adapted to use bitcoin-util (as present in the repository) 
- Core functionality faithfully backported from Bitcoin