### PR TITLE
Merge bitcoin/bitcoin#23036: test: use test_framework.p2p `P2P_SERVICES` constant in functional tests

### DIFF
--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -7,17 +7,18 @@ Test addr relay
 """
 
 import random
+import time
 
 from test_framework.messages import (
     CAddress,
-    NODE_NETWORK,
     msg_addr,
     msg_getaddr,
-    msg_verack
+    msg_verack,
 )
 from test_framework.p2p import (
     P2PInterface,
     p2p_lock,
+    P2P_SERVICES,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -108,17 +109,25 @@ class AddrTest(BitcoinTestFramework):
         addrs = []
         for i in range(num):
             addr = CAddress()
-            addr.time = self.mocktime + random.randrange(-100, 100)
-            addr.nServices = NODE_NETWORK
-            if sequential_ips:
-                assert self.counter < 256 ** 2  # Don't allow the returned ip addresses to wrap.
-                addr.ip = f"123.123.{self.counter // 256}.{self.counter % 256}"
-                self.counter += 1
-            else:
-                addr.ip = f"{random.randrange(128,169)}.{random.randrange(1,255)}.{random.randrange(1,255)}.{random.randrange(1,255)}"
+            addr.time = self.mocktime + i
+            addr.nServices = P2P_SERVICES
+            addr.ip = f"123.123.123.{self.counter % 256}"
             addr.port = 8333 + i
             addrs.append(addr)
 
+        msg = msg_addr()
+        msg.addrs = addrs
+        return msg
+
+    def setup_rand_addr_msg(self, num):
+        addrs = []
+        for i in range(num):
+            addr = CAddress()
+            addr.time = self.mocktime + i
+            addr.nServices = P2P_SERVICES
+            addr.ip = f"{random.randrange(128,169)}.{random.randrange(1,255)}.{random.randrange(1,255)}.{random.randrange(1,255)}"
+            addr.port = 8333
+            addrs.append(addr)
         msg = msg_addr()
         msg.addrs = addrs
         return msg

--- a/test/functional/p2p_addrfetch.py
+++ b/test/functional/p2p_addrfetch.py
@@ -8,14 +8,21 @@ Test p2p addr-fetch connections
 
 import time
 
-from test_framework.messages import msg_addr, CAddress, NODE_NETWORK
-from test_framework.p2p import P2PInterface, p2p_lock
+from test_framework.messages import (
+    CAddress,
+    msg_addr,
+)
+from test_framework.p2p import (
+    P2PInterface,
+    p2p_lock,
+    P2P_SERVICES,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 ADDR = CAddress()
 ADDR.time = int(time.time())
-ADDR.nServices = NODE_NETWORK
+ADDR.nServices = P2P_SERVICES
 ADDR.ip = "192.0.0.8"
 ADDR.port = 18444
 

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -6,6 +6,7 @@
 Test addrv2 relay
 """
 
+import time
 from typing import List
 
 from test_framework.messages import (

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -11,16 +11,30 @@ from typing import List
 from test_framework.messages import (
     CAddress,
     msg_addrv2,
-    NODE_NETWORK,
 )
-from test_framework.p2p import P2PInterface
+from test_framework.p2p import (
+    P2PInterface,
+    P2P_SERVICES,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 I2P_ADDR = "c4gfnttsuwqomiygupdqqqyy5y5emnk5c73hrfvatri67prd7vyq.b32.i2p"
 ONION_ADDR = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"
 
-ADDRS: List[CAddress] = []
+ADDRS = []
+for i in range(10):
+    addr = CAddress()
+    addr.time = int(time.time()) + i
+    addr.nServices = P2P_SERVICES
+    # Add one I2P address at an arbitrary position.
+    if i == 5:
+        addr.net = addr.NET_I2P
+        addr.ip = I2P_ADDR
+    else:
+        addr.ip = f"123.123.123.{i % 256}"
+    addr.port = 8333 + i
+    ADDRS.append(addr)
 
 
 class AddrReceiver(P2PInterface):

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -7,11 +7,8 @@
 Tests correspond to code in rpc/net.cpp.
 """
 
-from decimal import Decimal
 from itertools import product
-import time
 
-from test_framework.blocktools import COINBASE_MATURITY
 import test_framework.messages
 from test_framework.messages import (
     MAX_PROTOCOL_MESSAGE_LENGTH,
@@ -20,8 +17,6 @@ from test_framework.p2p import (
     P2PInterface,
     P2P_SERVICES,
 )
-
-from itertools import product
 
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -7,11 +7,18 @@
 Tests correspond to code in rpc/net.cpp.
 """
 
-from test_framework.p2p import P2PInterface
+from decimal import Decimal
+from itertools import product
+import time
+
+from test_framework.blocktools import COINBASE_MATURITY
 import test_framework.messages
 from test_framework.messages import (
     MAX_PROTOCOL_MESSAGE_LENGTH,
-    NODE_NETWORK,
+)
+from test_framework.p2p import (
+    P2PInterface,
+    P2P_SERVICES,
 )
 
 from itertools import product
@@ -270,7 +277,6 @@ class NetTest(DashTestFramework):
     def test_getnodeaddresses(self):
         self.log.info("Test getnodeaddresses")
         self.nodes[0].add_p2p_connection(P2PInterface())
-        services = NODE_NETWORK
 
         # Add an IPv6 address to the address manager.
         ipv6_addr = "1233:3432:2434:2343:3234:2345:6546:4534"
@@ -297,8 +303,8 @@ class NetTest(DashTestFramework):
         assert_greater_than(len(node_addresses), 5000)
         assert_greater_than(10000, len(node_addresses))
         for a in node_addresses:
-            assert_equal(a["time"], self.mocktime)
-            assert_equal(a["services"], services)
+            assert_greater_than(a["time"], 1527811200)  # 1st June 2018
+            assert_equal(a["services"], P2P_SERVICES)
             assert a["address"] in imported_addrs
             assert_equal(a["port"], 8333)
             assert_equal(a["network"], "ipv4")
@@ -309,7 +315,7 @@ class NetTest(DashTestFramework):
         assert_equal(res[0]["address"], ipv6_addr)
         assert_equal(res[0]["network"], "ipv6")
         assert_equal(res[0]["port"], 8333)
-        assert_equal(res[0]["services"], services)
+        assert_equal(res[0]["services"], P2P_SERVICES)
 
         # Test for the absence of onion, I2P and CJDNS addresses.
         for network in ["onion", "i2p", "cjdns"]:

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -514,7 +514,7 @@ class P2PInterface(P2PConnection):
 
         return create_conn
 
-    def peer_accept_connection(self, *args, services=NODE_NETWORK | NODE_HEADERS_COMPRESSED, **kwargs):
+    def peer_accept_connection(self, *args, services=P2P_SERVICES, **kwargs):
         create_conn = super().peer_accept_connection(*args, **kwargs)
         self.peer_connect_send_version(services)
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#23036

Original commit: 86c3b84388813c9d6cab6031bc36d87a8a169fee

Backported from Bitcoin Core v0.23

This change replaces hardcoded `NODE_NETWORK | NODE_WITNESS` combinations with the `P2P_SERVICES` constant in functional tests. In Dash, `P2P_SERVICES` is defined as `NODE_NETWORK | NODE_HEADERS_COMPRESSED` which is the appropriate equivalent since Dash doesn't support witness/segwit functionality.

Note: The segwit test file `test/functional/p2p_segwit.py` was removed during backport as Dash does not support segwit functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the use of service flags across P2P address relay, address fetch, and related tests by replacing older constants with updated ones.
  * Simplified and unified address message creation in tests, including more consistent IP and time assignment.
  * Improved import organization and updated default parameter values for connection methods in test utilities.
* **Tests**
  * Added a new helper for generating randomized address messages in address relay tests.
  * Enhanced initialization of test addresses with more realistic and varied data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->