### PR TITLE
Merge bitcoin/bitcoin#26625: test: Run mempool_packages.py with MiniWallet

### DIFF
--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -1,30 +1,21 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021 The Bitcoin Core developers
+# Copyright (c) 2021-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test logic for limiting mempool and package ancestors/descendants."""
 
 from decimal import Decimal
 
-from test_framework.address import ADDRESS_BCRT1_P2SH_OP_TRUE
+from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import (
     COIN,
-    CTransaction,
-    tx_from_hex,
-)
-from test_framework.script import (
-    CScript,
-    OP_TRUE,
+    WITNESS_SCALE_FACTOR,
 )
 from test_framework.util import (
     assert_equal,
 )
-from test_framework.wallet import (
-    bulk_transaction,
-    create_child_with_parents,
-    make_chain,
-)
+from test_framework.wallet import MiniWallet
 
 class MempoolPackageLimitsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -32,50 +23,34 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        self.log.info("Generate blocks to create UTXOs")
-        node = self.nodes[0]
-        self.privkeys = [node.get_deterministic_priv_key().key]
-        self.address = node.get_deterministic_priv_key().address
-        self.coins = []
-        # The last 100 coinbase transactions are premature
-        for b in self.generatetoaddress(node, 200, self.address)[:100]:
-            coinbase = node.getblock(blockhash=b, verbosity=2)["tx"][0]
-            self.coins.append({
-                "txid": coinbase["txid"],
-                "amount": coinbase["vout"][0]["value"],
-                "scriptPubKey": coinbase["vout"][0]["scriptPubKey"],
-            })
+        self.wallet = MiniWallet(self.nodes[0])
+        # Add enough mature utxos to the wallet so that all txs spend confirmed coins.
+        self.generate(self.wallet, 35)
+        self.generate(self.nodes[0], COINBASE_MATURITY)
 
         self.test_chain_limits()
         self.test_desc_count_limits()
+        self.test_desc_count_limits_2()
         self.test_anc_count_limits()
         self.test_anc_count_limits_2()
         self.test_anc_count_limits_bushy()
 
-        # The node will accept our (nonstandard) extra large OP_RETURN outputs
-        self.restart_node(0, extra_args=["-acceptnonstdtxn=1"])
+        # The node will accept (nonstandard) extra large OP_RETURN outputs
+        self.restart_node(0, extra_args=["-datacarriersize=100000"])
         self.test_anc_size_limits()
         self.test_desc_size_limits()
 
     def test_chain_limits_helper(self, mempool_count, package_count):
         node = self.nodes[0]
         assert_equal(0, node.getmempoolinfo()["size"])
-        first_coin = self.coins.pop()
-        spk = None
-        txid = first_coin["txid"]
         chain_hex = []
-        chain_txns = []
-        value = first_coin["amount"]
 
-        for i in range(mempool_count + package_count):
-            (tx, txhex, value, spk) = make_chain(node, self.address, self.privkeys, txid, value, 0, spk)
-            txid = tx.rehash()
-            if i < mempool_count:
-                node.sendrawtransaction(txhex)
-                assert_equal(node.getmempoolentry(txid)["ancestorcount"], i + 1)
-            else:
-                chain_hex.append(txhex)
-                chain_txns.append(tx)
+        chaintip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=mempool_count)[-1]["new_utxo"]
+        # in-package transactions
+        for _ in range(package_count):
+            tx = self.wallet.create_self_transfer(utxo_to_spend=chaintip_utxo)
+            chaintip_utxo = tx["new_utxo"]
+            chain_hex.append(tx["hex"])
         testres_too_long = node.testmempoolaccept(rawtxs=chain_hex)
         for txres in testres_too_long:
             assert_equal(txres["package-error"], "package-mempool-limits")
@@ -121,53 +96,70 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         assert_equal(0, node.getmempoolinfo()["size"])
         self.log.info("Check that in-mempool and in-package descendants are calculated properly in packages")
         # Top parent in mempool, M1
-        first_coin = self.coins.pop()
-        parent_value = (first_coin["amount"] - Decimal("0.0002")) / 2 # Deduct reasonable fee and make 2 outputs
-        inputs = [{"txid": first_coin["txid"], "vout": 0}]
-        outputs = [{self.address : parent_value}, {ADDRESS_BCRT1_P2SH_OP_TRUE : parent_value}]
-        rawtx = node.createrawtransaction(inputs, outputs)
-
-        parent_signed = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=self.privkeys)
-        assert parent_signed["complete"]
-        parent_tx = tx_from_hex(parent_signed["hex"])
-        parent_txid = parent_tx.rehash()
-        node.sendrawtransaction(parent_signed["hex"])
+        m1_utxos = self.wallet.send_self_transfer_multi(from_node=node, num_outputs=2)['new_utxos']
 
         package_hex = []
+        # Chain A (M2a... M12a)
+        chain_a_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=11, utxo_to_spend=m1_utxos[0])[-1]["new_utxo"]
+        # Pa
+        pa_hex = self.wallet.create_self_transfer(utxo_to_spend=chain_a_tip_utxo)["hex"]
+        package_hex.append(pa_hex)
 
-        # Chain A
-        spk = parent_tx.vout[0].scriptPubKey.hex()
-        value = parent_value
-        txid = parent_txid
-        for i in range(12):
-            (tx, txhex, value, spk) = make_chain(node, self.address, self.privkeys, txid, value, 0, spk)
-            txid = tx.rehash()
-            if i < 11: # M2a... M12a
-                node.sendrawtransaction(txhex)
-            else: # Pa
-                package_hex.append(txhex)
-
-        # Chain B
-        value = parent_value - Decimal("0.0001")
-        rawtx_b = node.createrawtransaction([{"txid": parent_txid, "vout": 1}], {self.address : value})
-        tx_child_b = tx_from_hex(rawtx_b) # M2b
-        tx_child_b.vin[0].scriptSig = CScript([CScript([OP_TRUE])])
-        tx_child_b_hex = tx_child_b.serialize().hex()
-        node.sendrawtransaction(tx_child_b_hex)
-        spk = tx_child_b.vout[0].scriptPubKey.hex()
-        txid = tx_child_b.rehash()
-        for i in range(12):
-            (tx, txhex, value, spk) = make_chain(node, self.address, self.privkeys, txid, value, 0, spk)
-            txid = tx.rehash()
-            if i < 11: # M3b... M13b
-                node.sendrawtransaction(txhex)
-            else: # Pb
-                package_hex.append(txhex)
+        # Chain B (M2b... M13b)
+        chain_b_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12, utxo_to_spend=m1_utxos[1])[-1]["new_utxo"]
+        # Pb
+        pb_hex = self.wallet.create_self_transfer(utxo_to_spend=chain_b_tip_utxo)["hex"]
+        package_hex.append(pb_hex)
 
         assert_equal(24, node.getmempoolinfo()["size"])
         assert_equal(2, len(package_hex))
         testres_too_long = node.testmempoolaccept(rawtxs=package_hex)
         for txres in testres_too_long:
+            assert_equal(txres["package-error"], "package-mempool-limits")
+
+        # Clear mempool and check that the package passes now
+        self.generate(node, 1)
+        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=package_hex)])
+
+    def test_desc_count_limits_2(self):
+        """Create a Package with 24 transaction in mempool and 2 transaction in package:
+                      M1
+                     ^  ^
+                   M2    ^
+                   .      ^
+                  .        ^
+                 .          ^
+                M24          ^
+                              ^
+                              P1
+                              ^
+                              P2
+        P1 has M1 as a mempool ancestor, P2 has no in-mempool ancestors, but when
+        combined P2 has M1 as an ancestor and M1 exceeds descendant_limits(23 in-mempool
+        descendants + 2 in-package descendants, a total of 26 including itself).
+        """
+
+        node = self.nodes[0]
+        package_hex = []
+        # M1
+        m1_utxos = self.wallet.send_self_transfer_multi(from_node=node, num_outputs=2)['new_utxos']
+
+        # Chain M2...M24
+        self.wallet.send_self_transfer_chain(from_node=node, chain_length=23, utxo_to_spend=m1_utxos[0])[-1]["new_utxo"]
+
+        # P1
+        p1_tx = self.wallet.create_self_transfer(utxo_to_spend=m1_utxos[1])
+        package_hex.append(p1_tx["hex"])
+
+        # P2
+        p2_tx = self.wallet.create_self_transfer(utxo_to_spend=p1_tx["new_utxo"])
+        package_hex.append(p2_tx["hex"])
+
+        assert_equal(24, node.getmempoolinfo()["size"])
+        assert_equal(2, len(package_hex))
+        testres = node.testmempoolaccept(rawtxs=package_hex)
+        assert_equal(len(testres), len(package_hex))
+        for txres in testres:
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
@@ -193,32 +185,21 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         node = self.nodes[0]
         assert_equal(0, node.getmempoolinfo()["size"])
         package_hex = []
-        parents_tx = []
-        values = []
-        scripts = []
+        pc_parent_utxos = []
 
         self.log.info("Check that in-mempool and in-package ancestors are calculated properly in packages")
 
         # Two chains of 13 transactions each
         for _ in range(2):
-            spk = None
-            top_coin = self.coins.pop()
-            txid = top_coin["txid"]
-            value = top_coin["amount"]
-            for i in range(13):
-                (tx, txhex, value, spk) = make_chain(node, self.address, self.privkeys, txid, value, 0, spk)
-                txid = tx.rehash()
-                if i < 12:
-                    node.sendrawtransaction(txhex)
-                else: # Save the 13th transaction for the package
-                    package_hex.append(txhex)
-                    parents_tx.append(tx)
-                    scripts.append(spk)
-                    values.append(value)
+            chain_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12)[-1]["new_utxo"]
+            # Save the 13th transaction for the package
+            tx = self.wallet.create_self_transfer(utxo_to_spend=chain_tip_utxo)
+            package_hex.append(tx["hex"])
+            pc_parent_utxos.append(tx["new_utxo"])
 
         # Child Pc
-        child_hex = create_child_with_parents(node, self.address, self.privkeys, parents_tx, values, scripts)
-        package_hex.append(child_hex)
+        pc_hex = self.wallet.create_self_transfer_multi(utxos_to_spend=pc_parent_utxos)["hex"]
+        package_hex.append(pc_hex)
 
         assert_equal(24, node.getmempoolinfo()["size"])
         assert_equal(3, len(package_hex))
@@ -248,45 +229,29 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         """
         node = self.nodes[0]
         assert_equal(0, node.getmempoolinfo()["size"])
-        parents_tx = []
-        values = []
-        scripts = []
+        pc_parent_utxos = []
 
         self.log.info("Check that in-mempool and in-package ancestors are calculated properly in packages")
         # Two chains of 12 transactions each
         for _ in range(2):
-            spk = None
-            top_coin = self.coins.pop()
-            txid = top_coin["txid"]
-            value = top_coin["amount"]
-            for i in range(12):
-                (tx, txhex, value, spk) = make_chain(node, self.address, self.privkeys, txid, value, 0, spk)
-                txid = tx.rehash()
-                value -= Decimal("0.0001")
-                node.sendrawtransaction(txhex)
-                if i == 11:
-                    # last 2 transactions will be the parents of Pc
-                    parents_tx.append(tx)
-                    values.append(value)
-                    scripts.append(spk)
+            chaintip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12)[-1]["new_utxo"]
+            # last 2 transactions will be the parents of Pc
+            pc_parent_utxos.append(chaintip_utxo)
 
         # Child Pc
-        pc_hex = create_child_with_parents(node, self.address, self.privkeys, parents_tx, values, scripts)
-        pc_tx = tx_from_hex(pc_hex)
-        pc_value = sum(values) - Decimal("0.0002")
-        pc_spk = pc_tx.vout[0].scriptPubKey.hex()
+        pc_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=pc_parent_utxos)
 
         # Child Pd
-        (_, pd_hex, _, _) = make_chain(node, self.address, self.privkeys, pc_tx.rehash(), pc_value, 0, pc_spk)
+        pd_tx = self.wallet.create_self_transfer(utxo_to_spend=pc_tx["new_utxos"][0])
 
         assert_equal(24, node.getmempoolinfo()["size"])
-        testres_too_long = node.testmempoolaccept(rawtxs=[pc_hex, pd_hex])
+        testres_too_long = node.testmempoolaccept(rawtxs=[pc_tx["hex"], pd_tx["hex"]])
         for txres in testres_too_long:
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
         self.generate(node, 1)
-        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=[pc_hex, pd_hex])])
+        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=[pc_tx["hex"], pd_tx["hex"]])])
 
     def test_anc_count_limits_bushy(self):
         """Create a tree with 20 transactions in the mempool and 6 in the package:
@@ -302,31 +267,18 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         node = self.nodes[0]
         assert_equal(0, node.getmempoolinfo()["size"])
         package_hex = []
-        parent_txns = []
-        parent_values = []
-        scripts = []
+        pc_parent_utxos = []
         for _ in range(5): # Make package transactions P0 ... P4
-            gp_tx = []
-            gp_values = []
-            gp_scripts = []
+            pc_grandparent_utxos = []
             for _ in range(4): # Make mempool transactions M(4i+1)...M(4i+4)
-                parent_coin = self.coins.pop()
-                value = parent_coin["amount"]
-                txid = parent_coin["txid"]
-                (tx, txhex, value, spk) = make_chain(node, self.address, self.privkeys, txid, value)
-                gp_tx.append(tx)
-                gp_values.append(value)
-                gp_scripts.append(spk)
-                node.sendrawtransaction(txhex)
+                pc_grandparent_utxos.append(self.wallet.send_self_transfer(from_node=node)["new_utxo"])
             # Package transaction Pi
-            pi_hex = create_child_with_parents(node, self.address, self.privkeys, gp_tx, gp_values, gp_scripts)
-            package_hex.append(pi_hex)
-            pi_tx = tx_from_hex(pi_hex)
-            parent_txns.append(pi_tx)
-            parent_values.append(Decimal(pi_tx.vout[0].nValue) / COIN)
-            scripts.append(pi_tx.vout[0].scriptPubKey.hex())
+            pi_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=pc_grandparent_utxos)
+            package_hex.append(pi_tx["hex"])
+            pc_parent_utxos.append(pi_tx["new_utxos"][0])
         # Package transaction PC
-        package_hex.append(create_child_with_parents(node, self.address, self.privkeys, parent_txns, parent_values, scripts))
+        pc_hex = self.wallet.create_self_transfer_multi(utxos_to_spend=pc_parent_utxos)["hex"]
+        package_hex.append(pc_hex)
 
         assert_equal(20, node.getmempoolinfo()["size"])
         assert_equal(6, len(package_hex))
@@ -351,51 +303,30 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         """
         node = self.nodes[0]
         assert_equal(0, node.getmempoolinfo()["size"])
-        parents_tx = []
-        values = []
-        scripts = []
-        target_weight = 1000 * 30 # 30KvB
+        parent_utxos = []
+        target_weight = WITNESS_SCALE_FACTOR * 1000 * 30 # 30KvB
         high_fee = Decimal("0.003") # 10 sats/vB
         self.log.info("Check that in-mempool and in-package ancestor size limits are calculated properly in packages")
         # Mempool transactions A and B
         for _ in range(2):
-            spk = None
-            top_coin = self.coins.pop()
-            txid = top_coin["txid"]
-            value = top_coin["amount"]
-            (tx, _, _, _) = make_chain(node, self.address, self.privkeys, txid, value, 0, spk, high_fee)
-            bulked_tx = bulk_transaction(tx, node, target_weight, self.privkeys)
-            node.sendrawtransaction(bulked_tx.serialize().hex())
-            parents_tx.append(bulked_tx)
-            values.append(Decimal(bulked_tx.vout[0].nValue) / COIN)
-            scripts.append(bulked_tx.vout[0].scriptPubKey.hex())
+            bulked_tx = self.wallet.create_self_transfer(target_weight=target_weight)
+            self.wallet.sendrawtransaction(from_node=node, tx_hex=bulked_tx["hex"])
+            parent_utxos.append(bulked_tx["new_utxo"])
 
         # Package transaction C
-        small_pc_hex = create_child_with_parents(node, self.address, self.privkeys, parents_tx, values, scripts, high_fee)
-        pc_tx = bulk_transaction(tx_from_hex(small_pc_hex), node, target_weight, self.privkeys)
-        pc_value = Decimal(pc_tx.vout[0].nValue) / COIN
-        pc_spk = pc_tx.vout[0].scriptPubKey.hex()
-        pc_hex = pc_tx.serialize().hex()
+        pc_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_utxos, fee_per_output=int(high_fee * COIN), target_weight=target_weight)
 
         # Package transaction D
-        (small_pd, _, val, spk) = make_chain(node, self.address, self.privkeys, pc_tx.rehash(), pc_value, 0, pc_spk, high_fee)
-        prevtxs = [{
-            "txid": pc_tx.rehash(),
-            "vout": 0,
-            "scriptPubKey": spk,
-            "amount": val,
-        }]
-        pd_tx = bulk_transaction(small_pd, node, target_weight, self.privkeys, prevtxs)
-        pd_hex = pd_tx.serialize().hex()
+        pd_tx = self.wallet.create_self_transfer(utxo_to_spend=pc_tx["new_utxos"][0], target_weight=target_weight)
 
         assert_equal(2, node.getmempoolinfo()["size"])
-        testres_too_heavy = node.testmempoolaccept(rawtxs=[pc_hex, pd_hex])
+        testres_too_heavy = node.testmempoolaccept(rawtxs=[pc_tx["hex"], pd_tx["hex"]])
         for txres in testres_too_heavy:
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
         self.generate(node, 1)
-        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=[pc_hex, pd_hex])])
+        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=[pc_tx["hex"], pd_tx["hex"]])])
 
     def test_desc_size_limits(self):
         """Create 3 mempool transactions and 2 package transactions (25KvB each):
@@ -409,54 +340,22 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         """
         node = self.nodes[0]
         assert_equal(0, node.getmempoolinfo()["size"])
-        target_weight = 21 * 1000
+        target_weight = 21 * 1000 * WITNESS_SCALE_FACTOR
         high_fee = Decimal("0.0021") # 10 sats/vB
         self.log.info("Check that in-mempool and in-package descendant sizes are calculated properly in packages")
         # Top parent in mempool, Ma
-        first_coin = self.coins.pop()
-        parent_value = (first_coin["amount"] - high_fee) / 2 # Deduct fee and make 2 outputs
-        inputs = [{"txid": first_coin["txid"], "vout": 0}]
-        outputs = [{self.address : parent_value}, {ADDRESS_BCRT1_P2SH_OP_TRUE:  parent_value}]
-        rawtx = node.createrawtransaction(inputs, outputs)
-        parent_tx = bulk_transaction(tx_from_hex(rawtx), node, target_weight, self.privkeys)
-        node.sendrawtransaction(parent_tx.serialize().hex())
+        ma_tx = self.wallet.create_self_transfer_multi(num_outputs=2, fee_per_output=int(high_fee / 2 * COIN), target_weight=target_weight)
+        self.wallet.sendrawtransaction(from_node=node, tx_hex=ma_tx["hex"])
 
         package_hex = []
         for j in range(2): # Two legs (left and right)
             # Mempool transaction (Mb and Mc)
-            mempool_tx = CTransaction()
-            spk = parent_tx.vout[j].scriptPubKey.hex()
-            value = Decimal(parent_tx.vout[j].nValue) / COIN
-            txid = parent_tx.rehash()
-            prevtxs = [{
-                "txid": txid,
-                "vout": j,
-                "scriptPubKey": spk,
-                "amount": value,
-            }]
-            if j == 0: # normal key
-                (tx_small, _, _, _) = make_chain(node, self.address, self.privkeys, txid, value, j, spk, high_fee)
-                mempool_tx = bulk_transaction(tx_small, node, target_weight, self.privkeys, prevtxs)
-            else: # OP_TRUE
-                inputs = [{"txid": txid, "vout": 1}]
-                outputs = {self.address: value - high_fee}
-                small_tx = tx_from_hex(node.createrawtransaction(inputs, outputs))
-                mempool_tx = bulk_transaction(small_tx, node, target_weight, None, prevtxs)
-            node.sendrawtransaction(mempool_tx.serialize().hex())
+            mempool_tx = self.wallet.create_self_transfer(utxo_to_spend=ma_tx["new_utxos"][j], target_weight=target_weight)
+            self.wallet.sendrawtransaction(from_node=node, tx_hex=mempool_tx["hex"])
 
             # Package transaction (Pd and Pe)
-            spk = mempool_tx.vout[0].scriptPubKey.hex()
-            value = Decimal(mempool_tx.vout[0].nValue) / COIN
-            txid = mempool_tx.rehash()
-            (tx_small, _, _, _) = make_chain(node, self.address, self.privkeys, txid, value, 0, spk, high_fee)
-            prevtxs = [{
-                "txid": txid,
-                "vout": 0,
-                "scriptPubKey": spk,
-                "amount": value,
-            }]
-            package_tx = bulk_transaction(tx_small, node, target_weight, self.privkeys, prevtxs)
-            package_hex.append(package_tx.serialize().hex())
+            package_tx = self.wallet.create_self_transfer(utxo_to_spend=mempool_tx["new_utxo"], target_weight=target_weight)
+            package_hex.append(package_tx["hex"])
 
         assert_equal(3, node.getmempoolinfo()["size"])
         assert_equal(2, len(package_hex))

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -1,100 +1,109 @@
 #!/usr/bin/env python3
-# Copyright (c) 2014-2020 The Bitcoin Core developers
+# Copyright (c) 2014-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test descendant package tracking code."""
 
 from decimal import Decimal
 
-from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.messages import COIN
+from test_framework.messages import (
+    COIN,
+    DEFAULT_ANCESTOR_LIMIT,
+    DEFAULT_DESCENDANT_LIMIT,
+)
 from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    chain_transaction,
 )
+from test_framework.wallet import MiniWallet
 
-# default limits
-MAX_ANCESTORS = 25
-MAX_DESCENDANTS = 25
 # custom limits for node1
-MAX_ANCESTORS_CUSTOM = 5
-MAX_DESCENDANTS_CUSTOM = 10
-assert MAX_DESCENDANTS_CUSTOM >= MAX_ANCESTORS_CUSTOM
+CUSTOM_ANCESTOR_LIMIT = 5
+CUSTOM_DESCENDANT_LIMIT = 10
+assert CUSTOM_DESCENDANT_LIMIT >= CUSTOM_ANCESTOR_LIMIT
+
 
 class MempoolPackagesTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [
             [
-                "-maxorphantxsize=1000",
+                "-maxorphantx=1000",
                 "-whitelist=noban@127.0.0.1",  # immediate tx relay
             ],
             [
-                "-maxorphantxsize=1000",
-                "-limitancestorcount={}".format(MAX_ANCESTORS_CUSTOM),
-                "-limitdescendantcount={}".format(MAX_DESCENDANTS_CUSTOM),
+                "-maxorphantx=1000",
+                "-limitancestorcount={}".format(CUSTOM_ANCESTOR_LIMIT),
+                "-limitdescendantcount={}".format(CUSTOM_DESCENDANT_LIMIT),
             ],
         ]
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
-        # Mine some blocks and have them mature.
-        peer_inv_store = self.nodes[0].add_p2p_connection(P2PTxInvStore()) # keep track of invs
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
-        utxo = self.nodes[0].listunspent(10)
-        txid = utxo[0]['txid']
-        vout = utxo[0]['vout']
-        value = utxo[0]['amount']
-        assert 'ancestorcount' not in utxo[0]
-        assert 'ancestorsize' not in utxo[0]
-        assert 'ancestorfees' not in utxo[0]
+        self.wallet = MiniWallet(self.nodes[0])
+        self.wallet.rescan_utxos()
 
-        fee = Decimal("0.0001")
-        # MAX_ANCESTORS transactions off a confirmed tx should be fine
-        chain = []
+        if self.is_specified_wallet_compiled():
+            self.nodes[0].createwallet("watch_wallet", disable_private_keys=True)
+            self.nodes[0].importaddress(self.wallet.get_address())
+
+        peer_inv_store = self.nodes[0].add_p2p_connection(P2PTxInvStore()) # keep track of invs
+
+        # DEFAULT_ANCESTOR_LIMIT transactions off a confirmed tx should be fine
+        chain = self.wallet.create_self_transfer_chain(chain_length=DEFAULT_ANCESTOR_LIMIT)
+        witness_chain = [t["wtxid"] for t in chain]
         ancestor_vsize = 0
         ancestor_fees = Decimal(0)
-        for i in range(MAX_ANCESTORS):
-            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [0], value, fee, 1)
-            value = sent_value
-            chain.append(txid)
 
+        for i, t in enumerate(chain):
+            ancestor_vsize += t["tx"].get_vsize()
+            ancestor_fees += t["fee"]
+            self.wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=t["hex"])
             # Check that listunspent ancestor{count, size, fees} yield the correct results
-            wallet_unspent = self.nodes[0].listunspent(minconf=0)
-            this_unspent = next(utxo_info for utxo_info in wallet_unspent if utxo_info['txid'] == txid)
-            assert_equal(this_unspent['ancestorcount'], i + 1)
-            ancestor_vsize += self.nodes[0].getrawtransaction(txid=txid, verbose=True)['size']
-            assert_equal(this_unspent['ancestorsize'], ancestor_vsize)
-            ancestor_fees -= self.nodes[0].gettransaction(txid=txid)['fee']
-            assert_equal(this_unspent['ancestorfees'], ancestor_fees * COIN)
+            if self.is_specified_wallet_compiled():
+                wallet_unspent = self.nodes[0].listunspent(minconf=0)
+                this_unspent = next(utxo_info for utxo_info in wallet_unspent if utxo_info["txid"] == t["txid"])
+                assert_equal(this_unspent['ancestorcount'], i + 1)
+                assert_equal(this_unspent['ancestorsize'], ancestor_vsize)
+                assert_equal(this_unspent['ancestorfees'], ancestor_fees * COIN)
 
         # Wait until mempool transactions have passed initial broadcast (sent inv and received getdata)
         # Otherwise, getrawmempool may be inconsistent with getmempoolentry if unbroadcast changes in between
-        peer_inv_store.wait_for_broadcast(chain)
+        peer_inv_store.wait_for_broadcast(witness_chain)
 
-        # Check mempool has MAX_ANCESTORS transactions in it, and descendant and ancestor
+        # Check mempool has DEFAULT_ANCESTOR_LIMIT transactions in it, and descendant and ancestor
         # count and fees should look correct
         mempool = self.nodes[0].getrawmempool(True)
-        assert_equal(len(mempool), MAX_ANCESTORS)
+        assert_equal(len(mempool), DEFAULT_ANCESTOR_LIMIT)
         descendant_count = 1
         descendant_fees = 0
         descendant_vsize = 0
 
         assert_equal(ancestor_vsize, sum([mempool[tx]['vsize'] for tx in mempool]))
-        ancestor_count = MAX_ANCESTORS
+        ancestor_count = DEFAULT_ANCESTOR_LIMIT
         assert_equal(ancestor_fees, sum([mempool[tx]['fees']['base'] for tx in mempool]))
 
+        # Adding one more transaction on to the chain should fail.
+        next_hop = self.wallet.create_self_transfer(utxo_to_spend=chain[-1]["new_utxo"])["hex"]
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", lambda: self.nodes[0].sendrawtransaction(next_hop))
+
         descendants = []
-        ancestors = list(chain)
+        ancestors = [t["txid"] for t in chain]
+        chain = [t["txid"] for t in chain]
         for x in reversed(chain):
             # Check that getmempoolentry is consistent with getrawmempool
             entry = self.nodes[0].getmempoolentry(x)
             assert_equal(entry, mempool[x])
+
+            # Check that gettxspendingprevout is consistent with getrawmempool
+            witnesstx = self.nodes[0].getrawtransaction(txid=x, verbose=True)
+            for tx_in in witnesstx["vin"]:
+                spending_result = self.nodes[0].gettxspendingprevout([ {'txid' : tx_in["txid"], 'vout' : tx_in["vout"]} ])
+                assert_equal(spending_result, [ {'txid' : tx_in["txid"], 'vout' : tx_in["vout"], 'spendingtxid' : x} ])
 
             # Check that the descendant calculations are correct
             assert_equal(entry['descendantcount'], descendant_count)
@@ -157,7 +166,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
         # Check that ancestor modified fees includes fee deltas from
         # prioritisetransaction
-        self.nodes[0].prioritisetransaction(chain[0], 1000)
+        self.nodes[0].prioritisetransaction(txid=chain[0], fee_delta=1000)
         ancestor_fees = 0
         for x in chain:
             entry = self.nodes[0].getmempoolentry(x)
@@ -165,11 +174,11 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(entry['fees']['ancestor'], ancestor_fees + Decimal('0.00001'))
 
         # Undo the prioritisetransaction for later tests
-        self.nodes[0].prioritisetransaction(chain[0], -1000)
+        self.nodes[0].prioritisetransaction(txid=chain[0], fee_delta=-1000)
 
         # Check that descendant modified fees includes fee deltas from
         # prioritisetransaction
-        self.nodes[0].prioritisetransaction(chain[-1], 1000)
+        self.nodes[0].prioritisetransaction(txid=chain[-1], fee_delta=1000)
 
         descendant_fees = 0
         for x in reversed(chain):
@@ -177,16 +186,13 @@ class MempoolPackagesTest(BitcoinTestFramework):
             descendant_fees += entry['fees']['base']
             assert_equal(entry['fees']['descendant'], descendant_fees + Decimal('0.00001'))
 
-        # Adding one more transaction on to the chain should fail.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain", chain_transaction, self.nodes[0], [txid], [vout], value, fee, 1)
-
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
         self.generate(self.nodes[0], 1)
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         # Prioritise a transaction that has been mined, then add it back to the
         # mempool by using invalidateblock.
-        self.nodes[0].prioritisetransaction(chain[-1], 2000)
+        self.nodes[0].prioritisetransaction(txid=chain[-1], fee_delta=2000)
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # Keep node1's tip synced with node0
         self.nodes[1].invalidateblock(self.nodes[1].getbestblockhash())
@@ -203,75 +209,66 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Check that node1's mempool is as expected (-> custom ancestor limit)
         mempool0 = self.nodes[0].getrawmempool(False)
         mempool1 = self.nodes[1].getrawmempool(False)
-        assert_equal(len(mempool1), MAX_ANCESTORS_CUSTOM)
+        assert_equal(len(mempool1), CUSTOM_ANCESTOR_LIMIT)
         assert set(mempool1).issubset(set(mempool0))
-        for tx in chain[:MAX_ANCESTORS_CUSTOM]:
+        for tx in chain[:CUSTOM_ANCESTOR_LIMIT]:
             assert tx in mempool1
-            entry0 = self.nodes[0].getmempoolentry(tx)
-            entry1 = self.nodes[1].getmempoolentry(tx)
-            assert not entry0['unbroadcast']
-            assert not entry1['unbroadcast']
-            assert_equal(entry1['fees']['base'], entry0['fees']['base'])
-            assert_equal(entry1['vsize'], entry0['vsize'])
-            assert_equal(entry1['depends'], entry0['depends'])
+        # TODO: more detailed check of node1's mempool (fees etc.)
+        # check transaction unbroadcast info (should be false if in both mempools)
+        mempool = self.nodes[0].getrawmempool(True)
+        for tx in mempool:
+            assert_equal(mempool[tx]['unbroadcast'], False)
+
+        # TODO: test ancestor size limits
 
         # Now test descendant chain limits
-        txid = utxo[1]['txid']
-        value = utxo[1]['amount']
-        vout = utxo[1]['vout']
 
-        transaction_package = []
         tx_children = []
         # First create one parent tx with 10 children
-        (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 10)
-        parent_transaction = txid
-        for i in range(10):
-            transaction_package.append({'txid': txid, 'vout': i, 'amount': sent_value})
+        tx_with_children = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], num_outputs=10)
+        parent_transaction = tx_with_children["txid"]
+        transaction_package = tx_with_children["new_utxos"]
 
         # Sign and send up to MAX_DESCENDANT transactions chained off the parent tx
         chain = [] # save sent txs for the purpose of checking node1's mempool later (see below)
-        for _ in range(MAX_DESCENDANTS - 1):
+        for _ in range(DEFAULT_DESCENDANT_LIMIT - 1):
             utxo = transaction_package.pop(0)
-            (txid, sent_value) = chain_transaction(self.nodes[0], [utxo['txid']], [utxo['vout']], utxo['amount'], fee, 10)
+            new_tx = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], num_outputs=10, utxos_to_spend=[utxo])
+            txid = new_tx["txid"]
             chain.append(txid)
             if utxo['txid'] is parent_transaction:
                 tx_children.append(txid)
-            for j in range(10):
-                transaction_package.append({'txid': txid, 'vout': j, 'amount': sent_value})
+            transaction_package.extend(new_tx["new_utxos"])
 
         mempool = self.nodes[0].getrawmempool(True)
-        assert_equal(mempool[parent_transaction]['descendantcount'], MAX_DESCENDANTS)
+        assert_equal(mempool[parent_transaction]['descendantcount'], DEFAULT_DESCENDANT_LIMIT)
         assert_equal(sorted(mempool[parent_transaction]['spentby']), sorted(tx_children))
 
         for child in tx_children:
             assert_equal(mempool[child]['depends'], [parent_transaction])
 
         # Sending one more chained transaction will fail
-        utxo = transaction_package.pop(0)
-        assert_raises_rpc_error(-26, "too-long-mempool-chain", chain_transaction, self.nodes[0], [utxo['txid']], [utxo['vout']], utxo['amount'], fee, 10)
+        next_hop = self.wallet.create_self_transfer(utxo_to_spend=transaction_package.pop(0))["hex"]
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", lambda: self.nodes[0].sendrawtransaction(next_hop))
 
         # Check that node1's mempool is as expected, containing:
         # - txs from previous ancestor test (-> custom ancestor limit)
         # - parent tx for descendant test
         # - txs chained off parent tx (-> custom descendant limit)
         self.wait_until(lambda: len(self.nodes[1].getrawmempool()) ==
-                                MAX_ANCESTORS_CUSTOM + 1 + MAX_DESCENDANTS_CUSTOM, timeout=10)
+                                CUSTOM_ANCESTOR_LIMIT + 1 + CUSTOM_DESCENDANT_LIMIT, timeout=10)
         mempool0 = self.nodes[0].getrawmempool(False)
         mempool1 = self.nodes[1].getrawmempool(False)
         assert set(mempool1).issubset(set(mempool0))
         assert parent_transaction in mempool1
-        for tx in chain[:MAX_DESCENDANTS_CUSTOM]:
+        for tx in chain[:CUSTOM_DESCENDANT_LIMIT]:
             assert tx in mempool1
-        for tx in chain[MAX_DESCENDANTS_CUSTOM:]:
+        for tx in chain[CUSTOM_DESCENDANT_LIMIT:]:
             assert tx not in mempool1
-        for tx in mempool1:
-            entry0 = self.nodes[0].getmempoolentry(tx)
-            entry1 = self.nodes[1].getmempoolentry(tx)
-            assert not entry0['unbroadcast']
-            assert not entry1['unbroadcast']
-            assert_equal(entry1['fees']['base'], entry0['fees']['base'])
-            assert_equal(entry1['vsize'], entry0['vsize'])
-            assert_equal(entry1['depends'], entry0['depends'])
+        # TODO: more detailed check of node1's mempool (fees etc.)
+
+        # TODO: test descendant size limits
+
         # Test reorg handling
         # First, the basics:
         self.generate(self.nodes[0], 1)
@@ -292,42 +289,19 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # last block.
 
         # Create tx0 with 2 outputs
-        utxo = self.nodes[0].listunspent()
-        txid = utxo[0]['txid']
-        value = utxo[0]['amount']
-        vout = utxo[0]['vout']
-
-        send_value = (value - fee) / 2
-        inputs = [ {'txid' : txid, 'vout' : vout} ]
-        outputs = {}
-        for _ in range(2):
-            outputs[self.nodes[0].getnewaddress()] = send_value
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx)
-        txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
-        tx0_id = txid
-        value = send_value
+        tx0 = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], num_outputs=2)
 
         # Create tx1
-        tx1_id, _ = chain_transaction(self.nodes[0], [tx0_id], [0], value, fee, 1)
+        tx1 = self.wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=tx0["new_utxos"][0])
 
         # Create tx2-7
-        vout = 1
-        txid = tx0_id
-        for _ in range(6):
-            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 1)
-            vout = 0
-            value = sent_value
+        tx7 = self.wallet.send_self_transfer_chain(from_node=self.nodes[0], utxo_to_spend=tx0["new_utxos"][1], chain_length=6)[-1]
 
         # Mine these in a block
         self.generate(self.nodes[0], 1)
 
         # Now generate tx8, with a big fee
-        inputs = [ {'txid' : tx1_id, 'vout': 0}, {'txid' : txid, 'vout': 0} ]
-        outputs = { self.nodes[0].getnewaddress() : send_value + value - 4*fee }
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx)
-        txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
+        self.wallet.send_self_transfer_multi(from_node=self.nodes[0], utxos_to_spend=[tx1["new_utxo"], tx7["new_utxo"]], fee_per_output=40000)
         self.sync_mempools()
 
         # Now try to disconnect the tip on each node...

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021 The Bitcoin Core developers
+# Copyright (c) 2021-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """RPCs that handle raw transaction packages."""
@@ -7,28 +7,30 @@
 from decimal import Decimal
 import random
 
-from test_framework.address import ADDRESS_BCRT1_P2SH_OP_TRUE
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.messages import (
+    MAX_BIP125_RBF_SEQUENCE,
     tx_from_hex,
 )
-from test_framework.script import (
-    CScript,
-    OP_TRUE,
-)
+from test_framework.p2p import P2PTxInvStore
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_fee_amount,
+    assert_raises_rpc_error,
 )
 from test_framework.wallet import (
-    create_child_with_parents,
-    create_raw_chain,
-    make_chain,
+    COIN,
+    DEFAULT_FEE,
+    MiniWallet,
 )
+
 
 class RPCPackagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
+        self.extra_args = [["-whitelist=noban@127.0.0.1"]] # noban speeds up tx relay
 
     def assert_testres_equal(self, package_hex, testres_expected):
         """Shuffle package_hex and assert that the testmempoolaccept result matches testres_expected. This should only
@@ -42,98 +44,96 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert_equal(shuffled_testres, self.nodes[0].testmempoolaccept(shuffled_package))
 
     def run_test(self):
-        self.log.info("Generate blocks to create UTXOs")
         node = self.nodes[0]
-        self.privkeys = [node.get_deterministic_priv_key().key]
-        self.address = node.get_deterministic_priv_key().address
-        self.coins = []
-        # The last 100 coinbase transactions are premature
-        for b in self.generatetoaddress(node, 200, self.address)[:100]:
-            coinbase = node.getblock(blockhash=b, verbosity=2)["tx"][0]
-            self.coins.append({
+
+        # get an UTXO that requires signature to be spent
+        deterministic_address = node.get_deterministic_priv_key().address
+        blockhash = self.generatetoaddress(node, 1, deterministic_address)[0]
+        coinbase = node.getblock(blockhash=blockhash, verbosity=2)["tx"][0]
+        coin = {
                 "txid": coinbase["txid"],
                 "amount": coinbase["vout"][0]["value"],
                 "scriptPubKey": coinbase["vout"][0]["scriptPubKey"],
-            })
+                "vout": 0,
+                "height": 0
+            }
 
+        self.wallet = MiniWallet(self.nodes[0])
+        self.generate(self.wallet, COINBASE_MATURITY + 100)  # blocks generated for inputs
+
+        self.log.info("Create some transactions")
         # Create some transactions that can be reused throughout the test. Never submit these to mempool.
         self.independent_txns_hex = []
         self.independent_txns_testres = []
         for _ in range(3):
-            coin = self.coins.pop()
-            rawtx = node.createrawtransaction([{"txid": coin["txid"], "vout": 0}],
-                {self.address : coin["amount"] - Decimal("0.0001")})
-            signedtx = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=self.privkeys)
-            assert signedtx["complete"]
-            testres = node.testmempoolaccept([signedtx["hex"]])
+            tx_hex = self.wallet.create_self_transfer(fee_rate=Decimal("0.0001"))["hex"]
+            testres = self.nodes[0].testmempoolaccept([tx_hex])
             assert testres[0]["allowed"]
-            self.independent_txns_hex.append(signedtx["hex"])
+            self.independent_txns_hex.append(tx_hex)
             # testmempoolaccept returns a list of length one, avoid creating a 2D list
             self.independent_txns_testres.append(testres[0])
         self.independent_txns_testres_blank = [{
-            "txid": res["txid"]} for res in self.independent_txns_testres]
+            "txid": res["txid"], "wtxid": res["wtxid"]} for res in self.independent_txns_testres]
 
-        self.test_independent()
+        self.test_independent(coin)
         self.test_chain()
         self.test_multiple_children()
         self.test_multiple_parents()
         self.test_conflicting()
+        self.test_rbf()
+        self.test_submitpackage()
 
-
-    def test_independent(self):
+    def test_independent(self, coin):
         self.log.info("Test multiple independent transactions in a package")
         node = self.nodes[0]
         # For independent transactions, order doesn't matter.
         self.assert_testres_equal(self.independent_txns_hex, self.independent_txns_testres)
 
         self.log.info("Test an otherwise valid package with an extra garbage tx appended")
-        garbage_tx = node.createrawtransaction([{"txid": "00" * 32, "vout": 5}], {self.address: 1})
+        address = node.get_deterministic_priv_key().address
+        garbage_tx = node.createrawtransaction([{"txid": "00" * 32, "vout": 5}], {address: 1})
         tx = tx_from_hex(garbage_tx)
-        # Only the txid is returned because validation is incomplete for the independent txns.
+        # Only the txid and wtxids are returned because validation is incomplete for the independent txns.
         # Package validation is atomic: if the node cannot find a UTXO for any single tx in the package,
         # it terminates immediately to avoid unnecessary, expensive signature verification.
         package_bad = self.independent_txns_hex + [garbage_tx]
-        testres_bad = self.independent_txns_testres_blank + [{"txid": tx.rehash(), "allowed": False, "reject-reason": "missing-inputs"}]
+        testres_bad = self.independent_txns_testres_blank + [{"txid": tx.rehash(), "wtxid": tx.getwtxid(), "allowed": False, "reject-reason": "missing-inputs"}]
         self.assert_testres_equal(package_bad, testres_bad)
 
         self.log.info("Check testmempoolaccept tells us when some transactions completed validation successfully")
-        coin = self.coins.pop()
         tx_bad_sig_hex = node.createrawtransaction([{"txid": coin["txid"], "vout": 0}],
-                                           {self.address : coin["amount"] - Decimal("0.0001")})
+                                           {address : coin["amount"] - Decimal("0.0001")})
         tx_bad_sig = tx_from_hex(tx_bad_sig_hex)
-        tx_bad_sig_hex = tx_bad_sig.serialize().hex()
         testres_bad_sig = node.testmempoolaccept(self.independent_txns_hex + [tx_bad_sig_hex])
         # By the time the signature for the last transaction is checked, all the other transactions
         # have been fully validated, which is why the node returns full validation results for all
         # transactions here but empty results in other cases.
         assert_equal(testres_bad_sig, self.independent_txns_testres + [{
             "txid": tx_bad_sig.rehash(),
-            "allowed": False,
+            "wtxid": tx_bad_sig.getwtxid(), "allowed": False,
             "reject-reason": "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)"
         }])
 
         self.log.info("Check testmempoolaccept reports txns in packages that exceed max feerate")
-        coin = self.coins.pop()
-        tx_high_fee_raw = node.createrawtransaction([{"txid": coin["txid"], "vout": 0}],
-                                           {self.address : coin["amount"] - Decimal("0.999")})
-        tx_high_fee_signed = node.signrawtransactionwithkey(hexstring=tx_high_fee_raw, privkeys=self.privkeys)
-        assert tx_high_fee_signed["complete"]
-        tx_high_fee = tx_from_hex(tx_high_fee_signed["hex"])
-        testres_high_fee = node.testmempoolaccept([tx_high_fee_signed["hex"]])
+        tx_high_fee = self.wallet.create_self_transfer(fee=Decimal("0.999"))
+        testres_high_fee = node.testmempoolaccept([tx_high_fee["hex"]])
         assert_equal(testres_high_fee, [
-            {"txid": tx_high_fee.rehash(), "allowed": False, "reject-reason": "max-fee-exceeded"}
+            {"txid": tx_high_fee["txid"], "wtxid": tx_high_fee["wtxid"], "allowed": False, "reject-reason": "max-fee-exceeded"}
         ])
-        package_high_fee = [tx_high_fee_signed["hex"]] + self.independent_txns_hex
+        package_high_fee = [tx_high_fee["hex"]] + self.independent_txns_hex
         testres_package_high_fee = node.testmempoolaccept(package_high_fee)
         assert_equal(testres_package_high_fee, testres_high_fee + self.independent_txns_testres_blank)
 
     def test_chain(self):
         node = self.nodes[0]
-        first_coin = self.coins.pop()
-        (chain_hex, chain_txns) = create_raw_chain(node, first_coin, self.address, self.privkeys)
+
+        chain = self.wallet.create_self_transfer_chain(chain_length=25)
+        chain_hex = [t["hex"] for t in chain]
+        chain_txns = [t["tx"] for t in chain]
+
         self.log.info("Check that testmempoolaccept requires packages to be sorted by dependency")
         assert_equal(node.testmempoolaccept(rawtxs=chain_hex[::-1]),
-                [{"txid": tx.rehash(), "package-error": "package-not-sorted"} for tx in chain_txns[::-1]])
+                [{"txid": tx.rehash(), "wtxid": tx.getwtxid(), "package-error": "package-not-sorted"} for tx in chain_txns[::-1]])
 
         self.log.info("Testmempoolaccept a chain of 25 transactions")
         testres_multiple = node.testmempoolaccept(rawtxs=chain_hex)
@@ -152,77 +152,57 @@ class RPCPackagesTest(BitcoinTestFramework):
 
     def test_multiple_children(self):
         node = self.nodes[0]
-
         self.log.info("Testmempoolaccept a package in which a transaction has two children within the package")
-        first_coin = self.coins.pop()
-        value = (first_coin["amount"] - Decimal("0.0002")) / 2 # Deduct reasonable fee and make 2 outputs
-        inputs = [{"txid": first_coin["txid"], "vout": 0}]
-        outputs = [{self.address : value}, {ADDRESS_BCRT1_P2SH_OP_TRUE : value}]
-        rawtx = node.createrawtransaction(inputs, outputs)
 
-        parent_signed = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=self.privkeys)
-        parent_tx = tx_from_hex(parent_signed["hex"])
-        assert parent_signed["complete"]
-        parent_txid = parent_tx.rehash()
-        assert node.testmempoolaccept([parent_signed["hex"]])[0]["allowed"]
-
-        parent_locking_script_a = parent_tx.vout[0].scriptPubKey.hex()
-        child_value = value - Decimal("0.0001")
+        parent_tx = self.wallet.create_self_transfer_multi(num_outputs=2)
+        assert node.testmempoolaccept([parent_tx["hex"]])[0]["allowed"]
 
         # Child A
-        (_, tx_child_a_hex, _, _) = make_chain(node, self.address, self.privkeys, parent_txid, child_value, 0, parent_locking_script_a)
-        assert not node.testmempoolaccept([tx_child_a_hex])[0]["allowed"]
+        child_a_tx = self.wallet.create_self_transfer(utxo_to_spend=parent_tx["new_utxos"][0])
+        assert not node.testmempoolaccept([child_a_tx["hex"]])[0]["allowed"]
 
         # Child B
-        rawtx_b = node.createrawtransaction([{"txid": parent_txid, "vout": 1}], {self.address : child_value})
-        tx_child_b = tx_from_hex(rawtx_b)
-        tx_child_b.vin[0].scriptSig = CScript([CScript([OP_TRUE])])
-        tx_child_b_hex = tx_child_b.serialize().hex()
-        assert not node.testmempoolaccept([tx_child_b_hex])[0]["allowed"]
+        child_b_tx = self.wallet.create_self_transfer(utxo_to_spend=parent_tx["new_utxos"][1])
+        assert not node.testmempoolaccept([child_b_tx["hex"]])[0]["allowed"]
 
         self.log.info("Testmempoolaccept with entire package, should work with children in either order")
-        testres_multiple_ab = node.testmempoolaccept(rawtxs=[parent_signed["hex"], tx_child_a_hex, tx_child_b_hex])
-        testres_multiple_ba = node.testmempoolaccept(rawtxs=[parent_signed["hex"], tx_child_b_hex, tx_child_a_hex])
+        testres_multiple_ab = node.testmempoolaccept(rawtxs=[parent_tx["hex"], child_a_tx["hex"], child_b_tx["hex"]])
+        testres_multiple_ba = node.testmempoolaccept(rawtxs=[parent_tx["hex"], child_b_tx["hex"], child_a_tx["hex"]])
         assert all([testres["allowed"] for testres in testres_multiple_ab + testres_multiple_ba])
 
         testres_single = []
         # Test accept and then submit each one individually, which should be identical to package testaccept
-        for rawtx in [parent_signed["hex"], tx_child_a_hex, tx_child_b_hex]:
+        for rawtx in [parent_tx["hex"], child_a_tx["hex"], child_b_tx["hex"]]:
             testres = node.testmempoolaccept([rawtx])
             testres_single.append(testres[0])
             # Submit the transaction now so its child should have no problem validating
             node.sendrawtransaction(rawtx)
         assert_equal(testres_single, testres_multiple_ab)
 
-
     def test_multiple_parents(self):
         node = self.nodes[0]
-
         self.log.info("Testmempoolaccept a package in which a transaction has multiple parents within the package")
+
         for num_parents in [2, 10, 24]:
             # Test a package with num_parents parents and 1 child transaction.
+            parent_coins = []
             package_hex = []
-            parents_tx = []
-            values = []
-            parent_locking_scripts = []
+
             for _ in range(num_parents):
-                parent_coin = self.coins.pop()
-                value = parent_coin["amount"]
-                (tx, txhex, value, parent_locking_script) = make_chain(node, self.address, self.privkeys, parent_coin["txid"], value)
-                package_hex.append(txhex)
-                parents_tx.append(tx)
-                values.append(value)
-                parent_locking_scripts.append(parent_locking_script)
-            child_hex = create_child_with_parents(node, self.address, self.privkeys, parents_tx, values, parent_locking_scripts)
-            # Package accept should work with the parents in any order (as long as parents come before child)
+                # Package accept should work with the parents in any order (as long as parents come before child)
+                parent_tx = self.wallet.create_self_transfer()
+                parent_coins.append(parent_tx["new_utxo"])
+                package_hex.append(parent_tx["hex"])
+
+            child_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_coins, fee_per_output=2000)
             for _ in range(10):
                 random.shuffle(package_hex)
-                testres_multiple = node.testmempoolaccept(rawtxs=package_hex + [child_hex])
+                testres_multiple = node.testmempoolaccept(rawtxs=package_hex + [child_tx['hex']])
                 assert all([testres["allowed"] for testres in testres_multiple])
 
             testres_single = []
             # Test accept and then submit each one individually, which should be identical to package testaccept
-            for rawtx in package_hex + [child_hex]:
+            for rawtx in package_hex + [child_tx["hex"]]:
                 testres_single.append(node.testmempoolaccept([rawtx])[0])
                 # Submit the transaction now so its child should have no problem validating
                 node.sendrawtransaction(rawtx)
@@ -230,38 +210,173 @@ class RPCPackagesTest(BitcoinTestFramework):
 
     def test_conflicting(self):
         node = self.nodes[0]
-        prevtx = self.coins.pop()
-        inputs = [{"txid": prevtx["txid"], "vout": 0}]
-        output1 = {node.get_deterministic_priv_key().address: 500 - 0.00125}
-        output2 = {ADDRESS_BCRT1_P2SH_OP_TRUE: 500 - 0.00125}
+        coin = self.wallet.get_utxo()
 
         # tx1 and tx2 share the same inputs
-        rawtx1 = node.createrawtransaction(inputs, output1)
-        rawtx2 = node.createrawtransaction(inputs, output2)
-        signedtx1 = node.signrawtransactionwithkey(hexstring=rawtx1, privkeys=self.privkeys)
-        signedtx2 = node.signrawtransactionwithkey(hexstring=rawtx2, privkeys=self.privkeys)
-        tx1 = tx_from_hex(signedtx1["hex"])
-        tx2 = tx_from_hex(signedtx2["hex"])
-        assert signedtx1["complete"]
-        assert signedtx2["complete"]
+        tx1 = self.wallet.create_self_transfer(utxo_to_spend=coin)
+        tx2 = self.wallet.create_self_transfer(utxo_to_spend=coin)
 
         # Ensure tx1 and tx2 are valid by themselves
-        assert node.testmempoolaccept([signedtx1["hex"]])[0]["allowed"]
-        assert node.testmempoolaccept([signedtx2["hex"]])[0]["allowed"]
+        assert node.testmempoolaccept([tx1["hex"]])[0]["allowed"]
+        assert node.testmempoolaccept([tx2["hex"]])[0]["allowed"]
 
         self.log.info("Test duplicate transactions in the same package")
-        testres = node.testmempoolaccept([signedtx1["hex"], signedtx1["hex"]])
+        testres = node.testmempoolaccept([tx1["hex"], tx1["hex"]])
         assert_equal(testres, [
-            {"txid": tx1.rehash(), "package-error": "conflict-in-package"},
-            {"txid": tx1.rehash(), "package-error": "conflict-in-package"}
+            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package-error": "conflict-in-package"},
+            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package-error": "conflict-in-package"}
         ])
 
         self.log.info("Test conflicting transactions in the same package")
-        testres = node.testmempoolaccept([signedtx1["hex"], signedtx2["hex"]])
+        testres = node.testmempoolaccept([tx1["hex"], tx2["hex"]])
         assert_equal(testres, [
-            {"txid": tx1.rehash(), "package-error": "conflict-in-package"},
-            {"txid": tx2.rehash(), "package-error": "conflict-in-package"}
+            {"txid": tx1["txid"], "wtxid": tx1["wtxid"], "package-error": "conflict-in-package"},
+            {"txid": tx2["txid"], "wtxid": tx2["wtxid"], "package-error": "conflict-in-package"}
         ])
+
+    def test_rbf(self):
+        node = self.nodes[0]
+
+        coin = self.wallet.get_utxo()
+        fee = Decimal("0.00125000")
+        replaceable_tx = self.wallet.create_self_transfer(utxo_to_spend=coin, sequence=MAX_BIP125_RBF_SEQUENCE, fee = fee)
+        testres_replaceable = node.testmempoolaccept([replaceable_tx["hex"]])[0]
+        assert_equal(testres_replaceable["txid"], replaceable_tx["txid"])
+        assert_equal(testres_replaceable["wtxid"], replaceable_tx["wtxid"])
+        assert testres_replaceable["allowed"]
+        assert_equal(testres_replaceable["vsize"], replaceable_tx["tx"].get_vsize())
+        assert_equal(testres_replaceable["fees"]["base"], fee)
+        assert_fee_amount(fee, replaceable_tx["tx"].get_vsize(), testres_replaceable["fees"]["effective-feerate"])
+        assert_equal(testres_replaceable["fees"]["effective-includes"], [replaceable_tx["wtxid"]])
+
+        # Replacement transaction is identical except has double the fee
+        replacement_tx = self.wallet.create_self_transfer(utxo_to_spend=coin, sequence=MAX_BIP125_RBF_SEQUENCE, fee = 2 * fee)
+        testres_rbf_conflicting = node.testmempoolaccept([replaceable_tx["hex"], replacement_tx["hex"]])
+        assert_equal(testres_rbf_conflicting, [
+            {"txid": replaceable_tx["txid"], "wtxid": replaceable_tx["wtxid"], "package-error": "conflict-in-package"},
+            {"txid": replacement_tx["txid"], "wtxid": replacement_tx["wtxid"], "package-error": "conflict-in-package"}
+        ])
+
+        self.log.info("Test that packages cannot conflict with mempool transactions, even if a valid BIP125 RBF")
+        # This transaction is a valid BIP125 replace-by-fee
+        self.wallet.sendrawtransaction(from_node=node, tx_hex=replaceable_tx["hex"])
+        testres_rbf_single = node.testmempoolaccept([replacement_tx["hex"]])
+        assert testres_rbf_single[0]["allowed"]
+        testres_rbf_package = self.independent_txns_testres_blank + [{
+            "txid": replacement_tx["txid"], "wtxid": replacement_tx["wtxid"], "allowed": False,
+            "reject-reason": "bip125-replacement-disallowed"
+        }]
+        self.assert_testres_equal(self.independent_txns_hex + [replacement_tx["hex"]], testres_rbf_package)
+
+    def assert_equal_package_results(self, node, testmempoolaccept_result, submitpackage_result):
+        """Assert that a successful submitpackage result is consistent with testmempoolaccept
+        results and getmempoolentry info. Note that the result structs are different and, due to
+        policy differences between testmempoolaccept and submitpackage (i.e. package feerate),
+        some information may be different.
+        """
+        for testres_tx in testmempoolaccept_result:
+            # Grab this result from the submitpackage_result
+            submitres_tx = submitpackage_result["tx-results"][testres_tx["wtxid"]]
+            assert_equal(submitres_tx["txid"], testres_tx["txid"])
+            # No "allowed" if the tx was already in the mempool
+            if "allowed" in testres_tx and testres_tx["allowed"]:
+                assert_equal(submitres_tx["vsize"], testres_tx["vsize"])
+                assert_equal(submitres_tx["fees"]["base"], testres_tx["fees"]["base"])
+            entry_info = node.getmempoolentry(submitres_tx["txid"])
+            assert_equal(submitres_tx["vsize"], entry_info["vsize"])
+            assert_equal(submitres_tx["fees"]["base"], entry_info["fees"]["base"])
+
+    def test_submit_child_with_parents(self, num_parents, partial_submit):
+        node = self.nodes[0]
+        peer = node.add_p2p_connection(P2PTxInvStore())
+
+        package_txns = []
+        presubmitted_wtxids = set()
+        for _ in range(num_parents):
+            parent_tx = self.wallet.create_self_transfer(fee=DEFAULT_FEE)
+            package_txns.append(parent_tx)
+            if partial_submit and random.choice([True, False]):
+                node.sendrawtransaction(parent_tx["hex"])
+                presubmitted_wtxids.add(parent_tx["wtxid"])
+        child_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=[tx["new_utxo"] for tx in package_txns], fee_per_output=10000) #DEFAULT_FEE
+        package_txns.append(child_tx)
+
+        testmempoolaccept_result = node.testmempoolaccept(rawtxs=[tx["hex"] for tx in package_txns])
+        submitpackage_result = node.submitpackage(package=[tx["hex"] for tx in package_txns])
+
+        # Check that each result is present, with the correct size and fees
+        for package_txn in package_txns:
+            tx = package_txn["tx"]
+            assert tx.getwtxid() in submitpackage_result["tx-results"]
+            wtxid = tx.getwtxid()
+            assert wtxid in submitpackage_result["tx-results"]
+            tx_result = submitpackage_result["tx-results"][wtxid]
+            assert_equal(tx_result["txid"], tx.rehash())
+            assert_equal(tx_result["vsize"], tx.get_vsize())
+            assert_equal(tx_result["fees"]["base"], DEFAULT_FEE)
+            if wtxid not in presubmitted_wtxids:
+                assert_fee_amount(DEFAULT_FEE, tx.get_vsize(), tx_result["fees"]["effective-feerate"])
+                assert_equal(tx_result["fees"]["effective-includes"], [wtxid])
+
+        # submitpackage result should be consistent with testmempoolaccept and getmempoolentry
+        self.assert_equal_package_results(node, testmempoolaccept_result, submitpackage_result)
+
+        # The node should announce each transaction. No guarantees for propagation.
+        peer.wait_for_broadcast([tx["tx"].getwtxid() for tx in package_txns])
+        self.generate(node, 1)
+
+    def test_submit_cpfp(self):
+        node = self.nodes[0]
+        peer = node.add_p2p_connection(P2PTxInvStore())
+
+        # Package with 2 parents and 1 child. One parent pays for itself using modified fees, and
+        # another has 0 fees but is bumped by child.
+        tx_poor = self.wallet.create_self_transfer(fee=0, fee_rate=0)
+        tx_rich = self.wallet.create_self_transfer(fee=0, fee_rate=0)
+        node.prioritisetransaction(tx_rich["txid"], 0, int(DEFAULT_FEE * COIN))
+        package_txns = [tx_rich, tx_poor]
+        coins = [tx["new_utxo"] for tx in package_txns]
+        tx_child = self.wallet.create_self_transfer_multi(utxos_to_spend=coins, fee_per_output=10000) #DEFAULT_FEE
+        package_txns.append(tx_child)
+
+        submitpackage_result = node.submitpackage([tx["hex"] for tx in package_txns])
+
+        rich_parent_result = submitpackage_result["tx-results"][tx_rich["wtxid"]]
+        poor_parent_result = submitpackage_result["tx-results"][tx_poor["wtxid"]]
+        child_result = submitpackage_result["tx-results"][tx_child["tx"].getwtxid()]
+        assert_equal(rich_parent_result["fees"]["base"], 0)
+        assert_equal(poor_parent_result["fees"]["base"], 0)
+        assert_equal(child_result["fees"]["base"], DEFAULT_FEE)
+        # The "rich" parent does not require CPFP so its effective feerate.
+        assert_fee_amount(DEFAULT_FEE, tx_rich["tx"].get_vsize(), rich_parent_result["fees"]["effective-feerate"])
+        assert_equal(rich_parent_result["fees"]["effective-includes"], [tx_rich["wtxid"]])
+        # The "poor" parent and child's effective feerates are the same, composed of the child's fee
+        # divided by their combined vsize.
+        assert_fee_amount(DEFAULT_FEE, tx_poor["tx"].get_vsize() + tx_child["tx"].get_vsize(), poor_parent_result["fees"]["effective-feerate"])
+        assert_fee_amount(DEFAULT_FEE, tx_poor["tx"].get_vsize() + tx_child["tx"].get_vsize(), child_result["fees"]["effective-feerate"])
+        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], poor_parent_result["fees"]["effective-includes"])
+        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], child_result["fees"]["effective-includes"])
+
+        # The node will broadcast each transaction, still abiding by its peer's fee filter
+        peer.wait_for_broadcast([tx["tx"].getwtxid() for tx in package_txns])
+        self.generate(node, 1)
+
+    def test_submitpackage(self):
+        node = self.nodes[0]
+
+        self.log.info("Submitpackage valid packages with 1 child and some number of parents")
+        for num_parents in [1, 2, 24]:
+            self.test_submit_child_with_parents(num_parents, False)
+            self.test_submit_child_with_parents(num_parents, True)
+
+        self.log.info("Submitpackage valid packages with CPFP")
+        self.test_submit_cpfp()
+
+        self.log.info("Submitpackage only allows packages of 1 child with its parents")
+        # Chain of 3 transactions has too many generations
+        chain_hex = [t["hex"] for t in self.wallet.create_self_transfer_chain(chain_length=25)]
+        assert_raises_rpc_error(-25, "not-child-with-parents", node.submitpackage, chain_hex)
+
 
 if __name__ == "__main__":
     RPCPackagesTest().main()

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -14,10 +14,15 @@ import random
 import unittest
 
 from test_framework.crypto import secp256k1
-from test_framework.util import random_bitflip
 
 # Order of the secp256k1 curve
 ORDER = secp256k1.GE.ORDER
+
+def random_bitflip(data):
+    """Flip a random bit in the provided data."""
+    data = list(data)
+    data[random.randrange(len(data))] ^= (1 << (random.randrange(8)))
+    return bytes(data)
 
 def TaggedHash(tag, data):
     ss = hashlib.sha256(tag.encode('utf-8')).digest()

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -14,15 +14,10 @@ import random
 import unittest
 
 from test_framework.crypto import secp256k1
+from test_framework.util import random_bitflip
 
 # Order of the secp256k1 curve
 ORDER = secp256k1.GE.ORDER
-
-def random_bitflip(data):
-    """Flip a random bit in the provided data."""
-    data = list(data)
-    data[random.randrange(len(data))] ^= (1 << (random.randrange(8)))
-    return bytes(data)
 
 def TaggedHash(tag, data):
     ss = hashlib.sha256(tag.encode('utf-8')).digest()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -348,6 +348,18 @@ def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 
+def get_chain_folder(datadir, chain):
+    # if try fails the directory doesn't exist
+    try:
+        for i in range(len(os.listdir(datadir))):
+            if chain in os.listdir(datadir)[i]:
+                chain = os.listdir(datadir)[i]
+                break
+    except:
+        pass
+    return chain
+
+
 def rpc_url(datadir, i, chain, rpchost):
     rpc_u, rpc_p = get_auth_cookie(datadir, chain)
     host = '127.0.0.1'

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -14,6 +14,7 @@ import logging
 import os
 import random
 import re
+import shutil
 import time
 import unittest
 
@@ -222,6 +223,56 @@ def count_bytes(hex_string):
 
 def str_to_b64str(string):
     return b64encode(string.encode('utf-8')).decode('ascii')
+
+
+def random_bitflip(data):
+    """Flip a random bit in the provided data."""
+    data = list(data)
+    data[random.randrange(len(data))] ^= (1 << (random.randrange(8)))
+    return bytes(data)
+
+
+def copy_datadir(from_node, to_node, dirname, chain):
+    """Copy datadir from one node to another."""
+    from_datadir = os.path.join(dirname, "node"+str(from_node), chain)
+    to_datadir = os.path.join(dirname, "node"+str(to_node), chain)
+
+    dirs = ["blocks", "chainstate", "evodb", "llmq"]
+    for d in dirs:
+        try:
+            src = os.path.join(from_datadir, d)
+            dst = os.path.join(to_datadir, d)
+            shutil.copytree(src, dst)
+        except:
+            pass
+
+
+def force_finish_mnsync(node):
+    """
+    Masternodes won't accept incoming connections while IsSynced is false.
+    Force them to switch to this state to speed things up.
+    """
+    while not node.mnsync("status")['IsSynced']:
+        node.mnsync("next")
+
+
+def get_chain_conf_names(chain):
+    """
+    Translate chain name to config names
+    """
+    if chain == 'testnet3':
+        arg = 'testnet'
+        value = '1'
+        section = 'test'
+    elif chain == 'devnet':
+        arg = 'devnet'
+        value = 'devnet1'
+        section = 'devnet'
+    else:
+        arg = chain
+        value = '1'
+        section = chain
+    return (arg, value, section)
 
 
 def ceildiv(a, b):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2014-2020 The Bitcoin Core developers
-# Copyright (c) 2014-2024 The Dash Core developers
+# Copyright (c) 2014-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Helpful routines for regression testing."""
@@ -14,9 +13,9 @@ import json
 import logging
 import os
 import random
-import shutil
 import re
 import time
+import unittest
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
@@ -30,41 +29,29 @@ logger = logging.getLogger("TestFramework.utils")
 
 def assert_approx(v, vexp, vspan=0.00001):
     """Assert that `v` is within `vspan` of `vexp`"""
+    if isinstance(v, Decimal) or isinstance(vexp, Decimal):
+        v=Decimal(v)
+        vexp=Decimal(vexp)
+        vspan=Decimal(vspan)
     if v < vexp - vspan:
         raise AssertionError("%s < [%s..%s]" % (str(v), str(vexp - vspan), str(vexp + vspan)))
     if v > vexp + vspan:
         raise AssertionError("%s > [%s..%s]" % (str(v), str(vexp - vspan), str(vexp + vspan)))
 
 
-def assert_fee_amount(fee, tx_size, feerate_DASH_kvB):
+def assert_fee_amount(fee, tx_size, feerate_BTC_kvB):
     """Assert the fee is in range."""
-    feerate_DASH_vB = feerate_DASH_kvB / 1000
-    target_fee = satoshi_round(tx_size * feerate_DASH_vB)
+    assert isinstance(tx_size, int)
+    target_fee = get_fee(tx_size, feerate_BTC_kvB)
     if fee < target_fee:
-        raise AssertionError("Fee of %s DASH too low! (Should be %s DASH)" % (str(fee), str(target_fee)))
+        raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
     # allow the wallet's estimation to be at most 2 bytes off
-    if fee > (tx_size + 2) * feerate_DASH_vB:
-        raise AssertionError("Fee of %s DASH too high! (Should be %s DASH)" % (str(fee), str(target_fee)))
+    high_fee = get_fee(tx_size + 2, feerate_BTC_kvB)
+    if fee > high_fee:
+        raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" % (str(fee), str(target_fee)))
 
-
-def summarise_dict_differences(thing1, thing2):
-    if not isinstance(thing1, dict) or not isinstance(thing2, dict):
-        return thing1, thing2
-    d1, d2 = {}, {}
-    for k in sorted(thing1.keys()):
-        if k not in thing2:
-            d1[k] = thing1[k]
-        elif thing1[k] != thing2[k]:
-            d1[k], d2[k] = summarise_dict_differences(thing1[k], thing2[k])
-    for k in sorted(thing2.keys()):
-        if k not in thing1:
-            d2[k] = thing2[k]
-    return d1, d2
 
 def assert_equal(thing1, thing2, *args):
-    if thing1 != thing2 and not args and isinstance(thing1, dict) and isinstance(thing2, dict):
-        d1,d2 = summarise_dict_differences(thing1, thing2)
-        raise AssertionError("not(%s == %s)\n  in particular not(%s == %s)" % (thing1, thing2, d1, d2))
     if thing1 != thing2 or any(thing1 != arg for arg in args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
 
@@ -237,17 +224,29 @@ def str_to_b64str(string):
     return b64encode(string.encode('utf-8')).decode('ascii')
 
 
-def random_bitflip(data):
-    data = list(data)
-    data[random.randrange(len(data))] ^= (1 << (random.randrange(8)))
-    return bytes(data)
+def ceildiv(a, b):
+    """
+    Divide 2 ints and round up to next int rather than round down
+    Implementation requires python integers, which have a // operator that does floor division.
+    Other types like decimal.Decimal whose // operator truncates towards 0 will not work.
+    """
+    assert isinstance(a, int)
+    assert isinstance(b, int)
+    return -(-a // b)
+
+
+def get_fee(tx_size, feerate_btc_kvb):
+    """Calculate the fee in BTC given a feerate is BTC/kvB. Reflects CFeeRate::GetFee"""
+    feerate_sat_kvb = int(feerate_btc_kvb * Decimal(1e8)) # Fee in sat/kvb as an int to avoid float precision errors
+    target_fee_sat = ceildiv(feerate_sat_kvb * tx_size, 1000) # Round calculated fee up to nearest sat
+    return target_fee_sat / Decimal(1e8) # Return result in  BTC
 
 
 def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
 
-def wait_until_helper(predicate, *, attempts=float('inf'), timeout=float('inf'), sleep=0.05, timeout_factor=1.0, lock=None, do_assert=True, allow_exception=False):
+def wait_until_helper(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None, timeout_factor=1.0):
     """Sleep until the predicate resolves to be True.
 
     Warning: Note that this method is not recommended to be used in tests as it is
@@ -263,31 +262,24 @@ def wait_until_helper(predicate, *, attempts=float('inf'), timeout=float('inf'),
     time_end = time.time() + timeout
 
     while attempt < attempts and time.time() < time_end:
-        try:
-            if lock:
-                with lock:
-                    if predicate():
-                        return True
-            else:
+        if lock:
+            with lock:
                 if predicate():
-                    return True
-        except:
-            if not allow_exception:
-                raise
+                    return
+        else:
+            if predicate():
+                return
         attempt += 1
-        time.sleep(sleep)
+        time.sleep(0.05)
 
-    if do_assert:
-        # Print the cause of the timeout
-        predicate_source = "''''\n" + inspect.getsource(predicate) + "'''"
-        logger.error("wait_until() failed. Predicate: {}".format(predicate_source))
-        if attempt >= attempts:
-            raise AssertionError("Predicate {} not true after {} attempts".format(predicate_source, attempts))
-        elif time.time() >= time_end:
-            raise AssertionError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
-        raise RuntimeError('Unreachable')
-    else:
-        return False
+    # Print the cause of the timeout
+    predicate_source = "''''\n" + inspect.getsource(predicate) + "'''"
+    logger.error("wait_until() failed. Predicate: {}".format(predicate_source))
+    if attempt >= attempts:
+        raise AssertionError("Predicate {} not true after {} attempts".format(predicate_source, attempts))
+    elif time.time() >= time_end:
+        raise AssertionError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
+    raise RuntimeError('Unreachable')
 
 
 def sha256sum_file(filename):
@@ -299,16 +291,18 @@ def sha256sum_file(filename):
             d = f.read(4096)
     return h.digest()
 
-# TODO: Remove and use random.randbytes(n) directly
+
+# TODO: Remove and use random.randbytes(n) instead, available in Python 3.9
 def random_bytes(n):
     """Return a random bytes object of length n."""
-    return random.randbytes(n)
+    return bytes(random.getrandbits(8) for i in range(n))
+
 
 # RPC/P2P connection constants and functions
 ############################################
 
 # The maximum number of nodes a single test can spawn
-MAX_NODES = 20
+MAX_NODES = 12
 # Don't assign rpc or p2p ports lower than this
 PORT_MIN = int(os.getenv('TEST_RUNNER_PORT_MIN', default=11000))
 # The number of ports to "reserve" for p2p and rpc, each
@@ -354,7 +348,7 @@ def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 
-def rpc_url(datadir, i, chain, rpchost=None):
+def rpc_url(datadir, i, chain, rpchost):
     rpc_u, rpc_p = get_auth_cookie(datadir, chain)
     host = '127.0.0.1'
     port = rpc_port(i)
@@ -371,26 +365,33 @@ def rpc_url(datadir, i, chain, rpchost=None):
 ################
 
 
-def initialize_datadir(dirname, n, chain):
+def initialize_datadir(dirname, n, chain, disable_autoconnect=True):
     datadir = get_datadir_path(dirname, n)
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
-    write_config(os.path.join(datadir, "dash.conf"), n=n, chain=chain)
+    write_config(os.path.join(datadir, "bitcoin.conf"), n=n, chain=chain, disable_autoconnect=disable_autoconnect)
     os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
     os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir
 
 
-def write_config(config_path, *, n, chain, extra_config=""):
-    (chain_name_conf_arg, chain_name_conf_arg_value, chain_name_conf_section) = get_chain_conf_names(chain)
+def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=True):
+    # Translate chain subdirectory name to config name
+    if chain == 'testnet3':
+        chain_name_conf_arg = 'testnet'
+        chain_name_conf_section = 'test'
+    else:
+        chain_name_conf_arg = chain
+        chain_name_conf_section = chain
     with open(config_path, 'w', encoding='utf8') as f:
         if chain_name_conf_arg:
-            f.write("{}={}\n".format(chain_name_conf_arg, chain_name_conf_arg_value))
+            f.write("{}=1\n".format(chain_name_conf_arg))
         if chain_name_conf_section:
             f.write("[{}]\n".format(chain_name_conf_section))
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
-        f.write("fallbackfee=0.00001\n")
+        f.write("rpcdoccheck=1\n")
+        f.write("fallbackfee=0.0002\n")
         f.write("server=1\n")
         f.write("keypool=1\n")
         f.write("discover=0\n")
@@ -408,6 +409,8 @@ def write_config(config_path, *, n, chain, extra_config=""):
         f.write("shrinkdebugfile=0\n")
         # To improve SQLite wallet performance so that the tests don't timeout, use -unsafesqlitesync
         f.write("unsafesqlitesync=1\n")
+        if disable_autoconnect:
+            f.write("connect=0\n")
         f.write(extra_config)
 
 
@@ -416,7 +419,7 @@ def get_datadir_path(dirname, n):
 
 
 def append_config(datadir, options):
-    with open(os.path.join(datadir, "dash.conf"), 'a', encoding='utf8') as f:
+    with open(os.path.join(datadir, "bitcoin.conf"), 'a', encoding='utf8') as f:
         for option in options:
             f.write(option + "\n")
 
@@ -424,8 +427,8 @@ def append_config(datadir, options):
 def get_auth_cookie(datadir, chain):
     user = None
     password = None
-    if os.path.isfile(os.path.join(datadir, "dash.conf")):
-        with open(os.path.join(datadir, "dash.conf"), 'r', encoding='utf8') as f:
+    if os.path.isfile(os.path.join(datadir, "bitcoin.conf")):
+        with open(os.path.join(datadir, "bitcoin.conf"), 'r', encoding='utf8') as f:
             for line in f:
                 if line.startswith("rpcuser="):
                     assert user is None  # Ensure that there is only one rpcuser line
@@ -433,7 +436,6 @@ def get_auth_cookie(datadir, chain):
                 if line.startswith("rpcpassword="):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
-    chain = get_chain_folder(datadir, chain)
     try:
         with open(os.path.join(datadir, chain, ".cookie"), 'r', encoding="ascii") as f:
             userpass = f.read()
@@ -447,88 +449,28 @@ def get_auth_cookie(datadir, chain):
     return user, password
 
 
-def copy_datadir(from_node, to_node, dirname, chain):
-    from_datadir = os.path.join(dirname, "node"+str(from_node), chain)
-    to_datadir = os.path.join(dirname, "node"+str(to_node), chain)
-
-    dirs = ["blocks", "chainstate", "evodb", "llmq"]
-    for d in dirs:
-        try:
-            src = os.path.join(from_datadir, d)
-            dst = os.path.join(to_datadir, d)
-            shutil.copytree(src, dst)
-        except:
-            pass
-
 # If a cookie file exists in the given datadir, delete it.
 def delete_cookie_file(datadir, chain):
-    chain = get_chain_folder(datadir, chain)
     if os.path.isfile(os.path.join(datadir, chain, ".cookie")):
         logger.debug("Deleting leftover cookie file")
         os.remove(os.path.join(datadir, chain, ".cookie"))
 
 
-"""
-since devnets can be named we won't always know what the folders name is unless we would pass it through all functions,
-which shouldn't be needed as if we are to test multiple different devnets we would just override setup_chain and make our own configs files.
-"""
-def get_chain_folder(datadir, chain):
-    # if try fails the directory doesn't exist
-    try:
-        for i in range(len(os.listdir(datadir))):
-            if chain in os.listdir(datadir)[i]:
-                chain = os.listdir(datadir)[i]
-                break
-    except:
-        pass
-    return chain
-
-def get_chain_conf_names(chain):
-    """
-    Translate chain name to config names
-    """
-    if chain == 'testnet3':
-        arg = 'testnet'
-        value = '1'
-        section = 'test'
-    elif chain == 'devnet':
-        arg = 'devnet'
-        value = 'devnet1'
-        section = 'devnet'
-    else:
-        arg = chain
-        value = '1'
-        section = chain
-    return (arg, value, section)
-
-def get_bip9_details(node, key):
-    """Return extra info about bip9 softfork"""
-    return node.getblockchaininfo()['softforks'][key]['bip9']
-
-
 def softfork_active(node, key):
     """Return whether a softfork is active."""
-    return node.getblockchaininfo()['softforks'][key]['active']
+    return node.getdeploymentinfo()['deployments'][key]['active']
 
 
 def set_node_times(nodes, t):
     for node in nodes:
-        node.mocktime = t
         node.setmocktime(t)
+
 
 def check_node_connections(*, node, num_in, num_out):
     info = node.getnetworkinfo()
     assert_equal(info["connections_in"], num_in)
     assert_equal(info["connections_out"], num_out)
 
-
-def force_finish_mnsync(node):
-    """
-    Masternodes won't accept incoming connections while IsSynced is false.
-    Force them to switch to this state to speed things up.
-    """
-    while not node.mnsync("status")['IsSynced']:
-        node.mnsync("next")
 
 # Transaction/Block functions
 #############################
@@ -546,61 +488,6 @@ def find_output(node, txid, amount, *, blockhash=None):
     raise RuntimeError("find_output txid %s : %s not found" % (txid, str(amount)))
 
 
-# Helper to create at least "count" utxos
-# Pass in a fee that is sufficient for relay and mining new transactions.
-def create_confirmed_utxos(test_framework, fee, node, count, **kwargs):
-    to_generate = int(0.5 * count) + 101
-    while to_generate > 0:
-        test_framework.generate(node, min(25, to_generate), **kwargs)
-        to_generate -= 25
-    utxos = node.listunspent()
-    iterations = count - len(utxos)
-    addr1 = node.getnewaddress()
-    addr2 = node.getnewaddress()
-    if iterations <= 0:
-        return utxos
-    for _ in range(iterations):
-        t = utxos.pop()
-        inputs = []
-        inputs.append({"txid": t["txid"], "vout": t["vout"]})
-        outputs = {}
-        send_value = t['amount'] - fee
-        outputs[addr1] = satoshi_round(send_value / 2)
-        outputs[addr2] = satoshi_round(send_value / 2)
-        raw_tx = node.createrawtransaction(inputs, outputs)
-        signed_tx = node.signrawtransactionwithwallet(raw_tx)["hex"]
-        node.sendrawtransaction(signed_tx)
-
-    while (node.getmempoolinfo()['size'] > 0):
-        test_framework.generate(node, 1, **kwargs)
-
-    utxos = node.listunspent()
-    assert len(utxos) >= count
-    return utxos
-
-
-def chain_transaction(node, parent_txids, vouts, value, fee, num_outputs):
-    """Build and send a transaction that spends the given inputs (specified
-    by lists of parent_txid:vout each), with the desired total value and fee,
-    equally divided up to the desired number of outputs.
-
-    Returns a tuple with the txid and the amount sent per output.
-    """
-    send_value = satoshi_round((value - fee)/num_outputs)
-    inputs = []
-    for (txid, vout) in zip(parent_txids, vouts):
-        inputs.append({'txid' : txid, 'vout' : vout})
-    outputs = {}
-    for _ in range(num_outputs):
-        outputs[node.getnewaddress()] = send_value
-    rawtx = node.createrawtransaction(inputs, outputs)
-    signedtx = node.signrawtransactionwithwallet(rawtx)
-    txid = node.sendrawtransaction(signedtx['hex'])
-    fulltx = node.getrawtransaction(txid, 1)
-    assert len(fulltx['vout']) == num_outputs  # make sure we didn't generate a change output
-    return (txid, send_value)
-
-
 # Create large OP_RETURN txouts that can be appended to a transaction
 # to make it large (helper for constructing large transactions). The
 # total serialized size of the txouts is about 66k vbytes.
@@ -615,16 +502,13 @@ def gen_return_txouts():
 # Create a spend of each passed-in utxo, splicing in "txouts" to each raw
 # transaction to make it large.  See gen_return_txouts() above.
 def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txouts, utxos=None):
-    from .messages import COIN
-    fee_sats = int(fee * COIN)
     txids = []
     use_internal_utxos = utxos is None
     for _ in range(tx_batch_size):
         tx = mini_wallet.create_self_transfer(
             utxo_to_spend=None if use_internal_utxos else utxos.pop(),
-            fee_rate=0,
-        )['tx']
-        tx.vout[0].nValue -= fee_sats
+            fee=fee,
+        )["tx"]
         tx.vout.extend(txouts)
         res = node.testmempoolaccept([tx.serialize().hex()])[0]
         assert_equal(res['fees']['base'], fee)
@@ -641,17 +525,6 @@ def mine_large_block(test_framework, mini_wallet, node):
     test_framework.generate(node, 1)
 
 
-def generate_to_height(test_framework, node, target_height):
-    """Generates blocks until a given target block height has been reached.
-       To prevent timeouts, only up to 200 blocks are generated per RPC call.
-       Can be used to activate certain soft-forks (e.g. CSV, CLTV)."""
-    current_height = node.getblockcount()
-    while current_height < target_height:
-        nblocks = min(200, target_height - current_height)
-        current_height += len(test_framework.generate(node, nblocks))
-    assert_equal(node.getblockcount(), target_height)
-
-
 def find_vout_for_address(node, txid, addr):
     """
     Locate the vout index of the given transaction sending to the
@@ -662,3 +535,33 @@ def find_vout_for_address(node, txid, addr):
         if addr == tx["vout"][i]["scriptPubKey"]["address"]:
             return i
     raise RuntimeError("Vout not found for address: txid=%s, addr=%s" % (txid, addr))
+
+def modinv(a, n):
+    """Compute the modular inverse of a modulo n using the extended Euclidean
+    Algorithm. See https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm#Modular_integers.
+    """
+    # TODO: Change to pow(a, -1, n) available in Python 3.8
+    t1, t2 = 0, 1
+    r1, r2 = n, a
+    while r2 != 0:
+        q = r1 // r2
+        t1, t2 = t2, t1 - q * t2
+        r1, r2 = r2, r1 - q * r2
+    if r1 > 1:
+        return None
+    if t1 < 0:
+        t1 += n
+    return t1
+
+class TestFrameworkUtil(unittest.TestCase):
+    def test_modinv(self):
+        test_vectors = [
+            [7, 11],
+            [11, 29],
+            [90, 13],
+            [1891, 3797],
+            [6003722857, 77695236973],
+        ]
+
+        for a, n in test_vectors:
+            self.assertEqual(modinv(a, n), pow(a, n-2, n))

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020 The Bitcoin Core developers
+# Copyright (c) 2020-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """A limited-functionality wallet, which may replace a real wallet in tests"""
@@ -7,7 +7,6 @@
 from copy import deepcopy
 from decimal import Decimal
 from enum import Enum
-from random import choice
 from typing import (
     Any,
     List,
@@ -15,29 +14,40 @@ from typing import (
 )
 from test_framework.address import (
     base58_to_byte,
+    create_deterministic_address_bcrt1_p2tr_op_true,
     key_to_p2pkh,
-    ADDRESS_BCRT1_P2SH_OP_TRUE,
+    key_to_p2sh_p2wpkh,
+    key_to_p2wpkh,
+    output_key_to_p2tr,
 )
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
+from test_framework.key import (
+    ECKey,
+    compute_xonly_pubkey,
+)
 from test_framework.messages import (
     COIN,
     COutPoint,
     CTransaction,
     CTxIn,
+    CTxInWitness,
     CTxOut,
-    tx_from_hex,
 )
 from test_framework.script import (
     CScript,
-    SignatureHash,
-    OP_TRUE,
+    LegacySignatureHash,
+    LEAF_VERSION_TAPSCRIPT,
     OP_NOP,
+    OP_RETURN,
+    OP_TRUE,
     SIGHASH_ALL,
+    taproot_construct,
 )
 from test_framework.script_util import (
     key_to_p2pk_script,
     key_to_p2pkh_script,
+    key_to_p2sh_p2wpkh_script,
+    key_to_p2wpkh_script,
     keyhash_to_p2pkh_script,
     scripthash_to_p2sh_script,
 )
@@ -53,7 +63,7 @@ class MiniWalletMode(Enum):
     """Determines the transaction type the MiniWallet is creating and spending.
 
     For most purposes, the default mode ADDRESS_OP_TRUE should be sufficient;
-    it simply uses a fixed P2SH address whose coins are spent with a
+    it simply uses a fixed bech32m P2TR address whose coins are spent with a
     witness stack of OP_TRUE, i.e. following an anyone-can-spend policy.
     However, if the transactions need to be modified by the user (e.g. prepending
     scriptSig for testing opcodes that are activated by a soft-fork), or the txs
@@ -63,7 +73,7 @@ class MiniWalletMode(Enum):
                     |      output       |           |  tx is   | can modify |  needs
          mode       |    description    |  address  | standard | scriptSig  | signing
     ----------------+-------------------+-----------+----------+------------+----------
-    ADDRESS_OP_TRUE | anyone-can-spend  |  bech32   |   yes    |    no      |   no
+    ADDRESS_OP_TRUE | anyone-can-spend  |  bech32m  |   yes    |    no      |   no
     RAW_OP_TRUE     | anyone-can-spend  |  - (raw)  |   no     |    yes     |   no
     RAW_P2PK        | pay-to-public-key |  - (raw)  |   yes    |    yes     |   yes
     """
@@ -88,11 +98,30 @@ class MiniWallet:
             pub_key = self._priv_key.get_pubkey()
             self._scriptPubKey = key_to_p2pk_script(pub_key.get_bytes())
         elif mode == MiniWalletMode.ADDRESS_OP_TRUE:
-            self._address = ADDRESS_BCRT1_P2SH_OP_TRUE
+            self._address, self._internal_key = create_deterministic_address_bcrt1_p2tr_op_true()
             self._scriptPubKey = bytes.fromhex(self._test_node.validateaddress(self._address)['scriptPubKey'])
+
+        # When the pre-mined test framework chain is used, it contains coinbase
+        # outputs to the MiniWallet's default address in blocks 76-100
+        # (see method BitcoinTestFramework._initialize_chain())
+        # The MiniWallet needs to rescan_utxos() in order to account
+        # for those mature UTXOs, so that all txs spend confirmed coins
+        self.rescan_utxos()
 
     def _create_utxo(self, *, txid, vout, value, height, coinbase, confirmations):
         return {"txid": txid, "vout": vout, "value": value, "height": height, "coinbase": coinbase, "confirmations": confirmations}
+
+    def _bulk_tx(self, tx, target_weight):
+        """Pad a transaction with extra outputs until it reaches a target weight (or higher).
+        returns the tx
+        """
+        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, b'a'])))
+        dummy_vbytes = (target_weight - tx.get_weight() + 3) // 4
+        tx.vout[-1].scriptPubKey = CScript([OP_RETURN, b'a' * dummy_vbytes])
+        # Lower bound should always be off by at most 3
+        assert_greater_than_or_equal(tx.get_weight(), target_weight)
+        # Higher bound should always be off by at most 3 + 12 weight (for encoding the length)
+        assert_greater_than_or_equal(target_weight + 15, tx.get_weight())
 
     def get_balance(self):
         return sum(u['value'] for u in self._utxos)
@@ -132,9 +161,13 @@ class MiniWallet:
             if out['scriptPubKey']['hex'] == self._scriptPubKey.hex():
                 self._utxos.append(self._create_utxo(txid=tx["txid"], vout=out["n"], value=out["value"], height=0, coinbase=False, confirmations=0))
 
+    def scan_txs(self, txs):
+        for tx in txs:
+            self.scan_tx(tx)
+
     def sign_tx(self, tx, fixed_length=True):
         if self._mode == MiniWalletMode.RAW_P2PK:
-            (sighash, err) = SignatureHash(CScript(self._scriptPubKey), tx, 0, SIGHASH_ALL)
+            (sighash, err) = LegacySignatureHash(CScript(self._scriptPubKey), tx, 0, SIGHASH_ALL)
             assert err is None
             # for exact fee calculation, create only signatures with fixed size by default (>49.89% probability):
             # 65 bytes: high-R val (33 bytes) + low-S val (32 bytes)
@@ -147,11 +180,12 @@ class MiniWallet:
             tx.vin[0].scriptSig = CScript([der_sig + bytes(bytearray([SIGHASH_ALL]))])
             tx.rehash()
         elif self._mode == MiniWalletMode.RAW_OP_TRUE:
-            for i in range(len(tx.vin)):
-                tx.vin[i].scriptSig = CScript([OP_NOP] * 24)  # pad to identical size
+            for i in tx.vin:
+                i.scriptSig = CScript([OP_NOP] * 43)  # pad to identical size
         elif self._mode == MiniWalletMode.ADDRESS_OP_TRUE:
-            for i in range(len(tx.vin)):
-                tx.vin[i].scriptSig = CScript([CScript([OP_TRUE])])
+            tx.wit.vtxinwit = [CTxInWitness()] * len(tx.vin)
+            for i in tx.wit.vtxinwit:
+                i.scriptWitness.stack = [CScript([OP_TRUE]), bytes([LEAF_VERSION_TAPSCRIPT]) + self._internal_key]
         else:
             assert False
 
@@ -249,6 +283,7 @@ class MiniWallet:
         locktime=0,
         sequence=0,
         fee_per_output=1000,
+        target_weight=0
     ):
         """
         Create and return a transaction that spends the given UTXOs and creates a
@@ -263,14 +298,20 @@ class MiniWallet:
         inputs_value_total = sum([int(COIN * utxo['value']) for utxo in utxos_to_spend])
         outputs_value_total = inputs_value_total - fee_per_output * num_outputs
         amount_per_output = amount_per_output or (outputs_value_total // num_outputs)
+        assert amount_per_output > 0
+        outputs_value_total = amount_per_output * num_outputs
+        fee = Decimal(inputs_value_total - outputs_value_total) / COIN
 
         # create tx
         tx = CTransaction()
-        tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']), nSequence=seq) for utxo_to_spend,seq in zip(utxos_to_spend, sequence)]
+        tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']), nSequence=seq) for utxo_to_spend, seq in zip(utxos_to_spend, sequence)]
         tx.vout = [CTxOut(amount_per_output, bytearray(self._scriptPubKey)) for _ in range(num_outputs)]
         tx.nLockTime = locktime
 
         self.sign_tx(tx)
+
+        if target_weight:
+            self._bulk_tx(tx, target_weight)
 
         txid = tx.rehash()
         return {
@@ -282,50 +323,90 @@ class MiniWallet:
                 coinbase=False,
                 confirmations=0,
             ) for i in range(len(tx.vout))],
+            "fee": fee,
             "txid": txid,
+            "wtxid": tx.getwtxid(),
             "hex": tx.serialize().hex(),
             "tx": tx,
         }
 
-    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), fee=Decimal("0"), utxo_to_spend=None, locktime=0, sequence=0):
+    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), fee=Decimal("0"), utxo_to_spend=None, locktime=0, sequence=0, target_weight=0):
         """Create and return a tx with the specified fee. If fee is 0, use fee_rate, where the resulting fee may be exact or at most one satoshi higher than needed."""
         utxo_to_spend = utxo_to_spend or self.get_utxo()
         assert fee_rate >= 0
         assert fee >= 0
         # calculate fee
         if self._mode in (MiniWalletMode.RAW_OP_TRUE, MiniWalletMode.ADDRESS_OP_TRUE):
-            vsize = Decimal(85)  # anyone-can-spend
+            vsize = Decimal(104)  # anyone-can-spend
         elif self._mode == MiniWalletMode.RAW_P2PK:
             vsize = Decimal(168)  # P2PK (73 bytes scriptSig + 35 bytes scriptPubKey + 60 bytes other)
         else:
             assert False
         send_value = utxo_to_spend["value"] - (fee or (fee_rate * vsize / 1000))
-        assert send_value > 0
 
         # create tx
-        tx = self.create_self_transfer_multi(utxos_to_spend=[utxo_to_spend], locktime=locktime, sequence=sequence, amount_per_output=int(COIN * send_value))
-        assert_equal(tx["tx"].get_vsize(), vsize)
+        tx = self.create_self_transfer_multi(utxos_to_spend=[utxo_to_spend], locktime=locktime, sequence=sequence, amount_per_output=int(COIN * send_value), target_weight=target_weight)
+        if not target_weight:
+            assert_equal(tx["tx"].get_vsize(), vsize)
+        tx["new_utxo"] = tx.pop("new_utxos")[0]
 
-        return {"txid": tx["txid"], "hex": tx["hex"], "tx": tx["tx"], "new_utxo": tx["new_utxos"][0]}
+        return tx
 
     def sendrawtransaction(self, *, from_node, tx_hex, maxfeerate=0, **kwargs):
         txid = from_node.sendrawtransaction(hexstring=tx_hex, maxfeerate=maxfeerate, **kwargs)
         self.scan_tx(from_node.decoderawtransaction(tx_hex))
         return txid
 
+    def create_self_transfer_chain(self, *, chain_length, utxo_to_spend=None):
+        """
+        Create a "chain" of chain_length transactions. The nth transaction in
+        the chain is a child of the n-1th transaction and parent of the n+1th transaction.
+        """
+        chaintip_utxo = utxo_to_spend or self.get_utxo()
+        chain = []
 
-def getnewdestination(address_type='legacy'):
+        for _ in range(chain_length):
+            tx = self.create_self_transfer(utxo_to_spend=chaintip_utxo)
+            chaintip_utxo = tx["new_utxo"]
+            chain.append(tx)
+
+        return chain
+
+    def send_self_transfer_chain(self, *, from_node, **kwargs):
+        """Create and send a "chain" of chain_length transactions. The nth transaction in
+        the chain is a child of the n-1th transaction and parent of the n+1th transaction.
+
+        Returns a list of objects for each tx (see create_self_transfer_multi).
+        """
+        chain = self.create_self_transfer_chain(**kwargs)
+        for t in chain:
+            self.sendrawtransaction(from_node=from_node, tx_hex=t["hex"])
+        return chain
+
+
+def getnewdestination(address_type='bech32m'):
     """Generate a random destination of the specified type and return the
        corresponding public key, scriptPubKey and address. Supported types are
-       'legacy'. Can be used when a random destination is needed, but no
-       compiled wallet is available (e.g. as replacement to the
-       getnewaddress/getaddressinfo RPCs)."""
+       'legacy', 'p2sh-segwit', 'bech32' and 'bech32m'. Can be used when a random
+       destination is needed, but no compiled wallet is available (e.g. as
+       replacement to the getnewaddress/getaddressinfo RPCs)."""
     key = ECKey()
     key.generate()
     pubkey = key.get_pubkey().get_bytes()
     if address_type == 'legacy':
         scriptpubkey = key_to_p2pkh_script(pubkey)
         address = key_to_p2pkh(pubkey)
+    elif address_type == 'p2sh-segwit':
+        scriptpubkey = key_to_p2sh_p2wpkh_script(pubkey)
+        address = key_to_p2sh_p2wpkh(pubkey)
+    elif address_type == 'bech32':
+        scriptpubkey = key_to_p2wpkh_script(pubkey)
+        address = key_to_p2wpkh(pubkey)
+    elif address_type == 'bech32m':
+        tap = taproot_construct(compute_xonly_pubkey(key.get_bytes())[0])
+        pubkey = tap.output_pubkey
+        scriptpubkey = tap.scriptPubKey
+        address = output_key_to_p2tr(pubkey)
     else:
         assert False
     return pubkey, scriptpubkey, address
@@ -334,82 +415,10 @@ def getnewdestination(address_type='legacy'):
 def address_to_scriptpubkey(address):
     """Converts a given address to the corresponding output script (scriptPubKey)."""
     payload, version = base58_to_byte(address)
-    if version == 140:  # testnet pubkey hash
+    if version == 111:  # testnet pubkey hash
         return keyhash_to_p2pkh_script(payload)
-    elif version == 19:  # testnet script hash
+    elif version == 196:  # testnet script hash
         return scripthash_to_p2sh_script(payload)
     # TODO: also support other address formats
     else:
         assert False
-
-
-def make_chain(node, address, privkeys, parent_txid, parent_value, n=0, parent_locking_script=None, fee=DEFAULT_FEE):
-    """Build a transaction that spends parent_txid.vout[n] and produces one output with
-    amount = parent_value with a fee deducted.
-    Return tuple (CTransaction object, raw hex, nValue, scriptPubKey of the output created).
-    """
-    inputs = [{"txid": parent_txid, "vout": n}]
-    my_value = parent_value - fee
-    outputs = {address : my_value}
-    rawtx = node.createrawtransaction(inputs, outputs)
-    prevtxs = [{
-        "txid": parent_txid,
-        "vout": n,
-        "scriptPubKey": parent_locking_script,
-        "amount": parent_value,
-    }] if parent_locking_script else None
-    signedtx = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=privkeys, prevtxs=prevtxs)
-    assert signedtx["complete"]
-    tx = tx_from_hex(signedtx["hex"])
-    return (tx, signedtx["hex"], my_value, tx.vout[0].scriptPubKey.hex())
-
-def create_child_with_parents(node, address, privkeys, parents_tx, values, locking_scripts, fee=DEFAULT_FEE):
-    """Creates a transaction that spends the first output of each parent in parents_tx."""
-    num_parents = len(parents_tx)
-    total_value = sum(values)
-    inputs = [{"txid": tx.rehash(), "vout": 0} for tx in parents_tx]
-    outputs = {address : total_value - fee}
-    rawtx_child = node.createrawtransaction(inputs, outputs)
-    prevtxs = []
-    for i in range(num_parents):
-        prevtxs.append({"txid": parents_tx[i].rehash(), "vout": 0, "scriptPubKey": locking_scripts[i], "amount": values[i]})
-    signedtx_child = node.signrawtransactionwithkey(hexstring=rawtx_child, privkeys=privkeys, prevtxs=prevtxs)
-    assert signedtx_child["complete"]
-    return signedtx_child["hex"]
-
-def create_raw_chain(node, first_coin, address, privkeys, chain_length=25):
-    """Helper function: create a "chain" of chain_length transactions. The nth transaction in the
-    chain is a child of the n-1th transaction and parent of the n+1th transaction.
-    """
-    parent_locking_script = None
-    txid = first_coin["txid"]
-    chain_hex = []
-    chain_txns = []
-    value = first_coin["amount"]
-
-    for _ in range(chain_length):
-        (tx, txhex, value, parent_locking_script) = make_chain(node, address, privkeys, txid, value, 0, parent_locking_script)
-        txid = tx.rehash()
-        chain_hex.append(txhex)
-        chain_txns.append(tx)
-
-    return (chain_hex, chain_txns)
-
-def bulk_transaction(tx, node, target_weight, privkeys, prevtxs=None):
-    """Pad a transaction with extra outputs until it reaches a target weight (or higher).
-    returns CTransaction object
-    """
-    tx_heavy = deepcopy(tx)
-    assert_greater_than_or_equal(target_weight, tx_heavy.get_weight())
-    while tx_heavy.get_weight() < target_weight:
-        random_spk = "6a4d0200"  # OP_RETURN OP_PUSH2 512 bytes
-        for _ in range(512*2):
-            random_spk += choice("0123456789ABCDEF")
-        tx_heavy.vout.append(CTxOut(0, bytes.fromhex(random_spk)))
-    # Re-sign the transaction
-    if privkeys:
-        signed = node.signrawtransactionwithkey(tx_heavy.serialize().hex(), privkeys, prevtxs)
-        return tx_from_hex(signed["hex"])
-    # OP_TRUE
-    tx_heavy.vin[0].scriptSig = CScript([CScript([OP_TRUE])])
-    return tx_heavy


### PR DESCRIPTION
Backports bitcoin/bitcoin#26625

Original commit: 89fb354f28273c16f8f8152bf112e5246ae40c50

Backported from Bitcoin Core v0.25

This is a test infrastructure modernization that converts test files to use MiniWallet instead of manual transaction creation, improving test reliability and removing dependency on compiled wallet.