### PR TITLE
Merge bitcoin/bitcoin#26913: doc: Clarify debian copyright comment

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -7,10 +7,10 @@ Files: *
 Copyright: 2009-2025, Bitcoin Core Developers,
            2019-2025, Dash Core Developers
 License: Expat
-Comment: The Bitcoin Core Developers encompasses the current developers listed on bitcoin.org,
-         as well as the numerous contributors to the project. The Dash Core Developers
-         encompasses the current developers listed on https://www.dash.org/team/, as well as
-         the numerous contributors to the project.
+Comment: The Bitcoin Core Developers encompasses all contributors to the
+         project, listed in the release notes or the git log. The Dash Core
+         Developers encompasses all contributors to the project, listed in the
+         release notes or the git log.
 
 Files: debian/*
 Copyright: 2010-2011, Jonas Smedegaard <dr@jones.dk>


### PR DESCRIPTION
Backports bitcoin/bitcoin#26913

Original commit: 8741cd88b

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor acknowledgments to reference release notes and version control history, clarifying the scope of recognized contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->