### PR TITLE
Merge bitcoin/bitcoin#26924: refactor: Add missing includes to fix gcc-13 compile error

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
 #ifdef ARENA_DEBUG
 #include <iomanip>

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_SUPPORT_LOCKEDPOOL_H
 #define BITCOIN_SUPPORT_LOCKEDPOOL_H
 
-#include <stdint.h>
+#include <cstddef>
 #include <list>
 #include <map>
-#include <mutex>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 /**


### PR DESCRIPTION
Backports bitcoin/bitcoin#26924

Original commit: 392dc68e37be9fc7adb32496b13d9b50262e317d

Backported from Bitcoin Core v0.25

This adds missing includes to fix gcc-13 compile errors:
- Added `#include <limits>` to src/support/lockedpool.cpp
- Reordered includes in src/support/lockedpool.h (changed `<stdint.h>` to `<cstddef>` and reordered `<mutex>`)

The changes ensure compatibility with gcc-13 which has stricter include requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal header file includes to improve compatibility and organization. No changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->