### PR TITLE
Merge bitcoin/bitcoin#26471: Reduce default mempool size in -blocksonly mode

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -16,7 +16,7 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
   - The minimum value for `-maxmempool` is 5.
   - A lower maximum mempool size means that transactions will be evicted sooner. This will affect any uses of `dashd` that process unconfirmed transactions.
 
-- To disable most of the mempool functionality there is the `-blocksonly` option. This will reduce the default memory usage to 5MB and make the client opt out of receiving (and thus relaying) transactions, except from whitelisted peers and as part of blocks.
+- To disable most of the mempool functionality there is the `-blocksonly` option. This will reduce the default memory usage to 5MB and make the client opt out of receiving (and thus relaying) transactions, except from peers who have the `relay` permission set (e.g. whitelisted peers), and as part of blocks.
 
   - Do not use this when using the client to broadcast transactions as any transaction sent will stick out like a sore thumb, affecting privacy. When used with the wallet it should be combined with `-walletbroadcast=0` and `-spendzeroconfchange=0`. Another mechanism for broadcasting outgoing transactions (if any) should be used.
 

--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -16,7 +16,7 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
   - The minimum value for `-maxmempool` is 5.
   - A lower maximum mempool size means that transactions will be evicted sooner. This will affect any uses of `dashd` that process unconfirmed transactions.
 
-- To completely disable mempool functionality there is the option `-blocksonly`. This will make the client opt out of receiving (and thus relaying) transactions completely, except as part of blocks.
+- To disable most of the mempool functionality there is the `-blocksonly` option. This will reduce the default memory usage to 5MB and make the client opt out of receiving (and thus relaying) transactions, except from whitelisted peers and as part of blocks.
 
   - Do not use this when using the client to broadcast transactions as any transaction sent will stick out like a sore thumb, affecting privacy. When used with the wallet it should be combined with `-walletbroadcast=0` and `-spendzeroconfchange=0`. Another mechanism for broadcasting outgoing transactions (if any) should be used.
 

--- a/doc/release-notes-26471.md
+++ b/doc/release-notes-26471.md
@@ -1,5 +1,4 @@
-Updated settings
-----------------
+# Updated settings
 
 - Setting `-blocksonly` will now reduce the maximum mempool memory
   to 5MB (users may still use `-maxmempool` to override). Previously,

--- a/doc/release-notes-26471.md
+++ b/doc/release-notes-26471.md
@@ -1,0 +1,12 @@
+Updated settings
+----------------
+
+- Setting `-blocksonly` will now reduce the maximum mempool memory
+  to 5MB (users may still use `-maxmempool` to override). Previously,
+  the default 300MB would be used, leading to unexpected memory usage
+  for users running with `-blocksonly` expecting it to eliminate
+  mempool memory usage.
+
+  As unused mempool memory is shared with dbcache, this also reduces
+  the dbcache size for users running with `-blocksonly`, potentially
+  impacting performance.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -973,10 +973,13 @@ void InitParameterInteraction(ArgsManager& args)
             LogPrintf("%s: parameter interaction: -externalip set -> setting -discover=0\n", __func__);
     }
 
-    // disable whitelistrelay in blocksonly mode
     if (args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)) {
+        // disable whitelistrelay in blocksonly mode
         if (args.SoftSetBoolArg("-whitelistrelay", false))
             LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -whitelistrelay=0\n", __func__);
+        // Reduce default mempool size in blocksonly mode to avoid unexpected resource usage
+        if (args.SoftSetArg("-maxmempool", ToString(DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB)))
+            LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -maxmempool=%d\n", __func__, DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB);
     }
 
     // Forcing relay from whitelisted hosts implies we will accept relays from them in the first place.

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -33,6 +33,8 @@ static constexpr unsigned int MAX_P2SH_SIGOPS{15};
 static constexpr unsigned int MAX_STANDARD_TX_SIGOPS{4000};
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE{300};
+/** Default for -maxmempool when blocksonly is set */
+static constexpr unsigned int DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB{5};
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 /** Default for -bytespersigop */


### PR DESCRIPTION
Backports bitcoin/bitcoin#26471

Original commit: ad09b76275

Backported from Bitcoin Core v0.25

This change reduces the default mempool size from 300MB to 5MB when `-blocksonly` mode is enabled. This prevents unexpected resource usage for users who expect `-blocksonly` to minimize memory usage.

**Note**: Adapted for Dash architecture by placing the new constant in `src/policy/policy.h` instead of the non-existent `src/kernel/mempool_options.h`.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that enabling `-blocksonly` reduces default mempool memory usage to 5MB and only disables most, not all, mempool functionality.
  * Added release notes describing the new default mempool size and its impact on memory sharing with the database cache when using `-blocksonly`.

* **New Features**
  * The default mempool size is now automatically reduced to 5MB when `-blocksonly` is enabled, unless overridden by the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->