### PR TITLE
Merge bitcoin/bitcoin#26960: refactor: Remove c_str from util/check

### DIFF
--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -6,7 +6,11 @@
 
 #include <tinyformat.h>
 
-void assertion_fail(const char* file, int line, const char* func, const char* assertion)
+#include <cstdio>
+#include <cstdlib>
+#include <string_view>
+
+void assertion_fail(std::string_view file, int line, std::string_view func, std::string_view assertion)
 {
     auto str = strprintf("%s:%s %s: Assertion `%s' failed.\n", file, line, func, assertion);
     fwrite(str.data(), 1, str.size(), stderr);

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -14,6 +14,7 @@
 #include <tinyformat.h>
 
 #include <stdexcept>
+#include <string_view>
 
 class NonFatalCheckError : public std::runtime_error
 {
@@ -56,7 +57,7 @@ T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, co
 #endif
 
 /** Helper for Assert() */
-void assertion_fail(const char* file, int line, const char* func, const char* assertion);
+void assertion_fail(std::string_view file, int line, std::string_view func, std::string_view assertion);
 
 /** Helper for Assert()/Assume() */
 template <bool IS_ASSERT, typename T>


### PR DESCRIPTION
Backports bitcoin/bitcoin#26960

Original commit: d4c180ecc

Backported from Bitcoin Core v0.25

This refactoring modernizes function signatures in util/check to use std::string_view instead of const char*, making the API more convenient and consistent. The changes preserve the exact Bitcoin intent while adapting to Dash's architecture where applicable.