### PR TITLE
Merge bitcoin/bitcoin#15294: refactor: Extract RipeMd160

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -13,6 +13,7 @@
 #include <crypto/sha256.h>
 #include <prevector.h>
 #include <serialize.h>
+#include <span.h>
 #include <uint256.h>
 #include <version.h>
 
@@ -249,5 +250,13 @@ void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char he
  * then calling CHashWriter::GetSHA256().
  */
 CHashWriter TaggedHash(const std::string& tag);
+
+/** Compute the 160-bit RIPEMD-160 hash of an array. */
+inline uint160 RIPEMD160(Span<const unsigned char> data)
+{
+    uint160 result;
+    CRIPEMD160().Write(data.data(), data.size()).Finalize(result.begin());
+    return result;
+}
 
 #endif // BITCOIN_HASH_H

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -4,10 +4,12 @@
 
 #include <script/descriptor.h>
 
+#include <hash.h>
 #include <key_io.h>
 #include <pubkey.h>
 #include <script/script.h>
 #include <script/standard.h>
+#include <uint256.h>
 
 #include <span.h>
 #include <util/bip32.h>

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -107,7 +107,6 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
                      std::vector<valtype>& ret, TxoutType& whichTypeRet, SigVersion sigversion, SignatureData& sigdata)
 {
     CScript scriptRet;
-    uint160 h160;
     ret.clear();
     std::vector<unsigned char> sig;
 
@@ -135,8 +134,8 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
         ret.push_back(ToByteVector(pubkey));
         return true;
     }
-    case TxoutType::SCRIPTHASH:
-        h160 = uint160(vSolutions[0]);
+    case TxoutType::SCRIPTHASH: {
+        uint160 h160{vSolutions[0]};
         if (GetCScript(provider, sigdata, CScriptID{h160}, scriptRet)) {
             ret.push_back(std::vector<unsigned char>(scriptRet.begin(), scriptRet.end()));
             return true;
@@ -144,7 +143,7 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
         // Could not find redeemScript, add to missing
         sigdata.missing_redeem_script = h160;
         return false;
-
+    }
     case TxoutType::MULTISIG: {
         size_t required = vSolutions.front()[0];
         ret.push_back(valtype()); // workaround CHECKMULTISIG bug

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -11,6 +11,8 @@
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/keyorigin.h>
+#include <script/standard.h>
+#include <uint256.h>
 
 class CKey;
 class CKeyID;

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -7,6 +7,7 @@
 #include <clientversion.h>
 #include <core_io.h>
 #include <fs.h>
+#include <hash.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <merkleblock.h>
@@ -16,6 +17,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <sync.h>
+#include <uint256.h>
 #include <util/bip32.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <core_io.h>
+#include <hash.h>
 #include <key_io.h>
 #include <rpc/util.h>
 #include <util/moneystr.h>

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <hash.h>
 #include <key_io.h>
 #include <chainparams.h>
 #include <logging.h>


### PR DESCRIPTION
Backports bitcoin/bitcoin#15294

Original commit: 1c8b80f44

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new function to compute RIPEMD-160 hashes for byte arrays.

* **Refactor**
  * Improved variable scoping and initialization in script signing logic.

* **Chores**
  * Added missing header includes across multiple files to ensure proper access to hashing utilities and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->