### PR TITLE
Merge bitcoin/bitcoin#26705: clang-tidy: Fix `modernize-use-default-member-init` in headers and force to check all headers

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,13 +1,19 @@
 Checks: '
 -*,
 bugprone-argument-comment,
+modernize-use-default-member-init,
 modernize-use-nullptr,
 readability-redundant-declaration,
 readability-redundant-string-init,
 '
 WarningsAsErrors: '
 bugprone-argument-comment,
+modernize-use-default-member-init,
 modernize-use-nullptr,
 readability-redundant-declaration,
 readability-redundant-string-init,
 '
+CheckOptions:
+ - key: performance-move-const-arg.CheckTriviallyCopyableMove
+   value: false
+HeaderFilterRegex: '.'

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -239,7 +239,7 @@ void Transform(uint32_t* s, const unsigned char* chunk)
 
 ////// RIPEMD160
 
-CRIPEMD160::CRIPEMD160() : bytes(0)
+CRIPEMD160::CRIPEMD160()
 {
     ripemd160::Initialize(s);
 }

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -14,7 +14,7 @@ class CRIPEMD160
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    uint64_t bytes;
+    uint64_t bytes{0};
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -146,7 +146,7 @@ void Transform(uint32_t* s, const unsigned char* chunk)
 
 ////// SHA1
 
-CSHA1::CSHA1() : bytes(0)
+CSHA1::CSHA1()
 {
     sha1::Initialize(s);
 }

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -14,7 +14,7 @@ class CSHA1
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    uint64_t bytes;
+    uint64_t bytes{0};
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -673,7 +673,7 @@ std::string SHA256AutoDetect()
 
 ////// SHA-256
 
-CSHA256::CSHA256() : bytes(0)
+CSHA256::CSHA256()
 {
     sha256::Initialize(s);
 }

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -15,7 +15,7 @@ class CSHA256
 private:
     uint32_t s[8];
     unsigned char buf[64];
-    uint64_t bytes;
+    uint64_t bytes{0};
 
 public:
     static const size_t OUTPUT_SIZE = 32;

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -151,7 +151,7 @@ void Transform(uint64_t* s, const unsigned char* chunk)
 
 ////// SHA-512
 
-CSHA512::CSHA512() : bytes(0)
+CSHA512::CSHA512()
 {
     sha512::Initialize(s);
 }

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -14,7 +14,7 @@ class CSHA512
 private:
     uint64_t s[8];
     unsigned char buf[128];
-    uint64_t bytes;
+    uint64_t bytes{0};
 
 public:
     static constexpr size_t OUTPUT_SIZE = 64;

--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -164,7 +164,7 @@ private:
     std::vector<Element> table;
 
     /** size stores the total available slots in the hash table */
-    uint32_t size;
+    uint32_t size{0};
 
     /** The bit_packed_atomic_flags array is marked mutable because we want
      * garbage collection to be allowed to occur from const methods */
@@ -181,7 +181,7 @@ private:
      * decremented on insert and reset to the new number of inserts which would
      * cause the epoch to reach epoch_size when it reaches zero.
      */
-    uint32_t epoch_heuristic_counter;
+    uint32_t epoch_heuristic_counter{0};
 
     /** epoch_size is set to be the number of elements supposed to be in a
      * epoch. When the number of non-erased elements in an epoch
@@ -191,12 +191,12 @@ private:
      * one "dead" which has been erased, one "dying" which has been marked to be
      * erased next, and one "living" which new inserts add to.
      */
-    uint32_t epoch_size;
+    uint32_t epoch_size{0};
 
     /** depth_limit determines how many elements insert should try to replace.
      * Should be set to log2(n).
      */
-    uint8_t depth_limit;
+    uint8_t depth_limit{0};
 
     /** hash_function is a const instance of the hash function. It cannot be
      * static or initialized at call time as it may have internal state (such as
@@ -320,8 +320,7 @@ public:
     /** You must always construct a cache with some elements via a subsequent
      * call to setup or setup_bytes, otherwise operations may segfault.
      */
-    cache() : table(), size(), collection_flags(0), epoch_flags(),
-    epoch_heuristic_counter(), epoch_size(), depth_limit(0), hash_function()
+    cache() : table(), collection_flags(0), epoch_flags(), hash_function()
     {
     }
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -59,13 +59,13 @@ private:
     CDataStream ssKey;
     CDataStream ssValue;
 
-    size_t size_estimate;
+    size_t size_estimate{0};
 
 public:
     /**
      * @param[in] _parent    CDBWrapper that this batch is to be submitted to
      */
-    explicit CDBBatch(const CDBWrapper &_parent) : parent(_parent), ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION), size_estimate(0) { };
+    explicit CDBBatch(const CDBWrapper &_parent) : parent(_parent), ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION) { };
 
     void Clear()
     {

--- a/src/key.h
+++ b/src/key.h
@@ -48,10 +48,10 @@ public:
 private:
     //! Whether this private key is valid. We check for correctness when modifying the key
     //! data, so fValid should always correspond to the actual state.
-    bool fValid;
+    bool fValid{false};
 
     //! Whether the public key corresponding to this private key is (to be) compressed.
-    bool fCompressed;
+    bool fCompressed{false};
 
     //! The actual byte data
     std::vector<unsigned char, secure_allocator<unsigned char> > keydata;
@@ -61,7 +61,7 @@ private:
 
 public:
     //! Construct an invalid private key.
-    CKey() : fValid(false), fCompressed(false)
+    CKey()
     {
         // Important: vch must be 32 bytes in length to not break serialization
         keydata.resize(32);

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -543,7 +543,6 @@ bool CBlockPolicyEstimator::_removeTx(const uint256& hash, bool inBlock)
 }
 
 CBlockPolicyEstimator::CBlockPolicyEstimator()
-    : nBestSeenHeight(0), firstRecordedHeight(0), historicalFirst(0), historicalBest(0), trackedTxs(0), untrackedTxs(0)
 {
     static_assert(MIN_BUCKET_FEERATE > 0, "Min feerate must be nonzero");
     size_t bucketIndex = 0;

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -240,16 +240,16 @@ public:
 private:
     mutable Mutex m_cs_fee_estimator;
 
-    unsigned int nBestSeenHeight GUARDED_BY(m_cs_fee_estimator);
-    unsigned int firstRecordedHeight GUARDED_BY(m_cs_fee_estimator);
-    unsigned int historicalFirst GUARDED_BY(m_cs_fee_estimator);
-    unsigned int historicalBest GUARDED_BY(m_cs_fee_estimator);
+    unsigned int nBestSeenHeight GUARDED_BY(m_cs_fee_estimator){0};
+    unsigned int firstRecordedHeight GUARDED_BY(m_cs_fee_estimator){0};
+    unsigned int historicalFirst GUARDED_BY(m_cs_fee_estimator){0};
+    unsigned int historicalBest GUARDED_BY(m_cs_fee_estimator){0};
 
     struct TxStatsInfo
     {
-        unsigned int blockHeight;
-        unsigned int bucketIndex;
-        TxStatsInfo() : blockHeight(0), bucketIndex(0) {}
+        unsigned int blockHeight{0};
+        unsigned int bucketIndex{0};
+        TxStatsInfo() {}
     };
 
     // map of txids to information about that transaction
@@ -260,8 +260,8 @@ private:
     std::unique_ptr<TxConfirmStats> shortStats PT_GUARDED_BY(m_cs_fee_estimator);
     std::unique_ptr<TxConfirmStats> longStats PT_GUARDED_BY(m_cs_fee_estimator);
 
-    unsigned int trackedTxs GUARDED_BY(m_cs_fee_estimator);
-    unsigned int untrackedTxs GUARDED_BY(m_cs_fee_estimator);
+    unsigned int trackedTxs GUARDED_BY(m_cs_fee_estimator){0};
+    unsigned int untrackedTxs GUARDED_BY(m_cs_fee_estimator){0};
 
     std::vector<double> buckets GUARDED_BY(m_cs_fee_estimator); // The upper-bound of the range for the bucket (inclusive)
     std::map<double, unsigned int> bucketMap GUARDED_BY(m_cs_fee_estimator); // Map of bucket upper-bound to index into all vectors by bucket

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1346,11 +1346,11 @@ struct CSerActionUnserialize
 class CSizeComputer
 {
 protected:
-    size_t nSize;
+    size_t nSize{0};
 
     const int nVersion;
 public:
-    explicit CSizeComputer(int nVersionIn) : nSize(0), nVersion(nVersionIn) {}
+    explicit CSizeComputer(int nVersionIn) : nVersion(nVersionIn) {}
 
     void write(Span<const std::byte> src)
     {

--- a/src/span.h
+++ b/src/span.h
@@ -96,7 +96,7 @@ template<typename C>
 class Span
 {
     C* m_data;
-    std::size_t m_size;
+    std::size_t m_size{0};
 
     template <class T>
     struct is_Span_int : public std::false_type {};
@@ -107,7 +107,7 @@ class Span
 
 
 public:
-    constexpr Span() noexcept : m_data(nullptr), m_size(0) {}
+    constexpr Span() noexcept : m_data(nullptr) {}
 
     /** Construct a span from a begin pointer and a size.
      *

--- a/src/streams.h
+++ b/src/streams.h
@@ -616,8 +616,8 @@ private:
     const int nVersion;
 
     FILE *src;            //!< source file
-    uint64_t nSrcPos;     //!< how many bytes have been read from source
-    uint64_t m_read_pos;    //!< how many bytes have been read from this
+    uint64_t nSrcPos{0};  //!< how many bytes have been read from source
+    uint64_t m_read_pos{0}; //!< how many bytes have been read from this
     uint64_t nReadLimit;  //!< up to which position we're allowed to read
     uint64_t nRewind;     //!< how many bytes we guarantee to rewind
     std::vector<std::byte> vchBuf; //!< the buffer
@@ -663,7 +663,7 @@ private:
 
 public:
     CBufferedFile(FILE* fileIn, uint64_t nBufSize, uint64_t nRewindIn, int nTypeIn, int nVersionIn)
-        : nType(nTypeIn), nVersion(nVersionIn), nSrcPos(0), m_read_pos(0), nReadLimit(std::numeric_limits<uint64_t>::max()), nRewind(nRewindIn), vchBuf(nBufSize, std::byte{0})
+        : nType(nTypeIn), nVersion(nVersionIn), nReadLimit(std::numeric_limits<uint64_t>::max()), nRewind(nRewindIn), vchBuf(nBufSize, std::byte{0})
     {
         if (nRewindIn >= nBufSize)
             throw std::ios_base::failure("Rewind limit must be less than buffer size");

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -280,8 +280,8 @@ size_t PosixLockedPageAllocator::GetLimit()
 /*******************************************************************************/
 // Implementation: LockedPool
 
-LockedPool::LockedPool(std::unique_ptr<LockedPageAllocator> allocator_in, LockingFailed_Callback lf_cb_in):
-    allocator(std::move(allocator_in)), lf_cb(lf_cb_in), cumulative_bytes_locked(0)
+LockedPool::LockedPool(std::unique_ptr<LockedPageAllocator> allocator_in, LockingFailed_Callback lf_cb_in)
+    : allocator(std::move(allocator_in)), lf_cb(lf_cb_in)
 {
 }
 

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -198,7 +198,7 @@ private:
 
     std::list<LockedPageArena> arenas;
     LockingFailed_Callback lf_cb;
-    size_t cumulative_bytes_locked;
+    size_t cumulative_bytes_locked{0};
     /** Mutex protects access to this pool's data structures, including arenas.
      */
     mutable std::mutex mutex;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -133,7 +133,7 @@ constexpr auto ALL_NETWORKS = std::array{
 class StaticContentsSock : public Sock
 {
 public:
-    explicit StaticContentsSock(const std::string& contents) : m_contents{contents}, m_consumed{0}
+    explicit StaticContentsSock(const std::string& contents) : m_contents{contents}
     {
         // Just a dummy number that is not INVALID_SOCKET.
         m_socket = INVALID_SOCKET - 1;
@@ -224,7 +224,7 @@ public:
 
 private:
     const std::string m_contents;
-    mutable size_t m_consumed;
+    mutable size_t m_consumed{0};
 };
 
 std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candidates, FastRandomContext& random_context);

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -508,9 +508,6 @@ class FormatArg
 {
     public:
         FormatArg()
-            : m_value(nullptr),
-            m_formatImpl(nullptr),
-            m_toIntImpl(nullptr)
         { }
 
         template<typename T>
@@ -549,10 +546,10 @@ class FormatArg
             return convertToInt<T>::invoke(*static_cast<const T*>(value));
         }
 
-        const void* m_value;
+        const void* m_value{nullptr};
         void (*m_formatImpl)(std::ostream& out, const char* fmtBegin,
-                             const char* fmtEnd, int ntrunc, const void* value);
-        int (*m_toIntImpl)(const void* value);
+                             const char* fmtEnd, int ntrunc, const void* value){nullptr};
+        int (*m_toIntImpl)(const void* value){nullptr};
 };
 
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -63,8 +63,8 @@ static const uint16_t DEFAULT_TOR_SOCKS_PORT = 9050;
 
 /****** Low-level TorControlConnection ********/
 
-TorControlConnection::TorControlConnection(struct event_base *_base):
-    base(_base), b_conn(nullptr)
+TorControlConnection::TorControlConnection(struct event_base* _base)
+    : base(_base)
 {
 }
 

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -86,7 +86,7 @@ private:
     /** Libevent event base */
     struct event_base *base;
     /** Connection to control socket */
-    struct bufferevent *b_conn;
+    struct bufferevent* b_conn{nullptr};
     /** Message being received */
     TorControlReply message;
     /** Response handlers */

--- a/src/univalue/lib/univalue_utffilter.h
+++ b/src/univalue/lib/univalue_utffilter.h
@@ -9,8 +9,8 @@
 class JSONUTF8StringFilter
 {
 public:
-    explicit JSONUTF8StringFilter(std::string &s):
-        str(s), is_valid(true), codepoint(0), state(0), surpair(0)
+    explicit JSONUTF8StringFilter(std::string& s)
+        : str(s)
     {
     }
     // Write single 8-bit char (may be part of UTF-8 sequence)
@@ -76,11 +76,13 @@ public:
     }
 private:
     std::string &str;
-    bool is_valid;
+    bool is_valid{true};
     // Current UTF-8 decoding state
-    unsigned int codepoint;
-    int state; // Top bit to be filled in for next UTF-8 byte, or 0
-    // Keep track of this state to handle the following section of RFC4627:
+    unsigned int codepoint{0};
+    int state{0}; // Top bit to be filled in for next UTF-8 byte, or 0
+
+    // Keep track of the following state to handle the following section of
+    // RFC4627:
     //
     //    To escape an extended character that is not in the Basic Multilingual
     //    Plane, the character is represented as a twelve-character sequence,
@@ -89,7 +91,7 @@ private:
     //    "\uD834\uDD1E".
     //
     //  Two subsequent \u.... may have to be replaced with one actual codepoint.
-    unsigned int surpair; // First of UTF-16 surrogate pair
+    unsigned int surpair{0}; // First half of open UTF-16 surrogate pair, or 0
 
     void append_codepoint(unsigned int codepoint_)
     {

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -284,9 +284,9 @@ public:
      * Auxiliary requested/occurred events to wait for in `WaitMany()`.
      */
     struct Events {
-        explicit Events(Event req, Event ocr = 0) : requested{req}, occurred{ocr} {}
+        explicit Events(Event req) : requested{req} {}
         Event requested;
-        Event occurred;
+        Event occurred{0};
     };
 
     /**

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -318,7 +318,7 @@ BerkeleyDatabase::~BerkeleyDatabase()
     }
 }
 
-BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const bool read_only, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr), m_cursor(nullptr), m_database(database)
+BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const bool read_only, bool fFlushOnCloseIn) : m_database(database)
 {
     database.AddRef();
     database.Open();

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -196,10 +196,10 @@ private:
     bool HasKey(CDataStream&& key) override;
 
 protected:
-    Db* pdb;
+    Db* pdb{nullptr};
     std::string strFile;
-    DbTxn* activeTxn;
-    Dbc* m_cursor;
+    DbTxn* activeTxn{nullptr};
+    Dbc* m_cursor{nullptr};
     bool fReadOnly;
     bool fFlushOnClose;
     BerkeleyEnvironment *env;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -106,7 +106,7 @@ class WalletDatabase
 {
 public:
     /** Create dummy DB handle */
-    WalletDatabase() : nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0) {}
+    WalletDatabase() : nUpdateCounter(0) {}
     virtual ~WalletDatabase() {};
 
     /** Open the database if it is not already opened. */
@@ -148,9 +148,9 @@ public:
     virtual std::string Format() = 0;
 
     std::atomic<unsigned int> nUpdateCounter;
-    unsigned int nLastSeen;
-    unsigned int nLastFlushed;
-    int64_t nLastWalletUpdate;
+    unsigned int nLastSeen{0};
+    unsigned int nLastFlushed{0};
+    int64_t nLastWalletUpdate{0};
 
     /** Make a DatabaseBatch connected to this database */
     virtual std::unique_ptr<DatabaseBatch> MakeBatch(bool flush_on_close = true) = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1064,9 +1064,9 @@ class WalletRescanReserver
 {
 private:
     CWallet& m_wallet;
-    bool m_could_reserve;
+    bool m_could_reserve{false};
 public:
-    explicit WalletRescanReserver(CWallet& w) : m_wallet(w), m_could_reserve(false) {}
+    explicit WalletRescanReserver(CWallet& w) : m_wallet(w) {}
 
     bool reserve()
     {

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -35,7 +35,7 @@ class CZMQAbstractNotifier
 public:
     static const int DEFAULT_ZMQ_SNDHWM {1000};
 
-    CZMQAbstractNotifier() : psocket(nullptr), outbound_message_high_water_mark(DEFAULT_ZMQ_SNDHWM) { }
+    CZMQAbstractNotifier() : outbound_message_high_water_mark(DEFAULT_ZMQ_SNDHWM) {}
     virtual ~CZMQAbstractNotifier();
 
     template <typename T>
@@ -78,7 +78,7 @@ public:
     virtual bool NotifyRecoveredSig(const std::shared_ptr<const llmq::CRecoveredSig>& sig);
 
 protected:
-    void *psocket;
+    void* psocket{nullptr};
     std::string type;
     std::string address;
     int outbound_message_high_water_mark; // aka SNDHWM

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -12,7 +12,7 @@
 
 #include <zmq.h>
 
-CZMQNotificationInterface::CZMQNotificationInterface() : pcontext(nullptr)
+CZMQNotificationInterface::CZMQNotificationInterface()
 {
 }
 

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -41,7 +41,7 @@ protected:
 private:
     CZMQNotificationInterface();
 
-    void *pcontext;
+    void* pcontext{nullptr};
     std::list<std::unique_ptr<CZMQAbstractNotifier>> notifiers;
 };
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#26705

Original commit: e1bf5470f

Backported from Bitcoin Core v0.25