### PR TITLE
Merge bitcoin/bitcoin#27013: ci: avoid using `-Werror` for older compilers

### DIFF
--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -14,5 +14,6 @@ export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude fe
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"
+export NO_WERROR=1
 export PREVIOUS_RELEASES_TO_DOWNLOAD="v0.12.1.5 v0.15.0.0 v0.16.1.1 v0.17.0.3 v18.2.2 v19.3.0 v20.0.1"
 export BITCOIN_CONFIG="--enable-zmq --with-libs=no --enable-reduce-exports --disable-fuzz-binary LDFLAGS=-static-libstdc++ --with-boost-process"


### PR DESCRIPTION
Backports bitcoin/bitcoin#27013

Original commit: 102645280

Backported from Bitcoin Core v0.25

Cherry-picked CI configuration change to avoid using `-Werror` for older compilers. The change adds `export NO_WERROR=1` to the native Qt5 CI environment configuration. Two other CI files were not included as they don't exist in Dash's CI setup.