### PR TITLE
Merge bitcoin/bitcoin#26875: Tests: Fill out dust limit unit test for known types except bare multisig

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -530,6 +530,65 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     fIsBareMultisigStd = false;
     CheckIsNotStandard(t, "bare-multisig");
     fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
+
+    // Check compressed P2PK outputs dust threshold (must have leading 02 or 03)
+    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG;
+    t.vout[0].nValue = 576;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 575;
+    CheckIsNotStandard(t, "dust");
+
+    // Check uncompressed P2PK outputs dust threshold (must have leading 04/06/07)
+    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(65, 0x04) << OP_CHECKSIG;
+    t.vout[0].nValue = 672;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 671;
+    CheckIsNotStandard(t, "dust");
+
+    // Check P2PKH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUALVERIFY << OP_CHECKSIG;
+    t.vout[0].nValue = 546;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 545;
+    CheckIsNotStandard(t, "dust");
+
+    // Check P2SH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUAL;
+    t.vout[0].nValue = 540;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 539;
+    CheckIsNotStandard(t, "dust");
+
+    // Check P2WPKH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(20, 0);
+    t.vout[0].nValue = 294;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 293;
+    CheckIsNotStandard(t, "dust");
+
+    // Check P2WSH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(32, 0);
+    t.vout[0].nValue = 330;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 329;
+    CheckIsNotStandard(t, "dust");
+
+    // Check P2TR outputs dust threshold (Invalid xonly key ok!)
+    t.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    t.vout[0].nValue = 330;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 329;
+    CheckIsNotStandard(t, "dust");
+
+    // Check future Witness Program versions dust threshold (non-32-byte pushes are undefined for version 1)
+    for (int op = OP_1; op <= OP_16; op += 1) {
+        t.vout[0].scriptPubKey = CScript() << (opcodetype)op << std::vector<unsigned char>(2, 0);
+        t.vout[0].nValue = 240;
+        CheckIsStandard(t);
+
+        t.vout[0].nValue = 239;
+        CheckIsNotStandard(t, "dust");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Backports bitcoin/bitcoin#26875

Original commit: aaa55971f6af3f19b22c28103630b856df266ebb

Backported from Bitcoin Core v0.25

This commit adds comprehensive dust limit unit tests for known script types except bare multisig. The tests verify dust thresholds for:
- Compressed P2PK outputs (576 satoshis)
- Uncompressed P2PK outputs (672 satoshis) 
- P2PKH outputs (546 satoshis)
- P2SH outputs (540 satoshis)
- P2WPKH outputs (294 satoshis)
- P2WSH outputs (330 satoshis)
- P2TR outputs (330 satoshis)
- Future witness program versions (240 satoshis)

The only conflict was adapting the variable name from Bitcoin's `g_bare_multi` to Dash's `fIsBareMultisigStd` in the test setup code.