### PR TITLE
Merge bitcoin/bitcoin#27069: net: add `Ensure{any}Banman`

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -740,7 +740,7 @@ static RPCHelpMan setban()
     if (strCommand != "add" && strCommand != "remove") {
         throw std::runtime_error(help.ToString());
     }
-    NodeContext& node = EnsureAnyNodeContext(request.context);
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
     BanMan& banman = EnsureBanman(node);
 
     CSubNet subNet;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -740,10 +740,8 @@ static RPCHelpMan setban()
     if (strCommand != "add" && strCommand != "remove") {
         throw std::runtime_error(help.ToString());
     }
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    if (!node.banman) {
-        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
-    }
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    BanMan& banman = EnsureBanman(node);
 
     CSubNet subNet;
     CNetAddr netAddr;
@@ -766,7 +764,7 @@ static RPCHelpMan setban()
 
     if (strCommand == "add")
     {
-        if (isSubnet ? node.banman->IsBanned(subNet) : node.banman->IsBanned(netAddr)) {
+        if (isSubnet ? banman.IsBanned(subNet) : banman.IsBanned(netAddr)) {
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: IP/Subnet already banned");
         }
 
@@ -779,12 +777,12 @@ static RPCHelpMan setban()
             absolute = true;
 
         if (isSubnet) {
-            node.banman->Ban(subNet, banTime, absolute);
+            banman.Ban(subNet, banTime, absolute);
             if (node.connman) {
                 node.connman->DisconnectNode(subNet);
             }
         } else {
-            node.banman->Ban(netAddr, banTime, absolute);
+            banman.Ban(netAddr, banTime, absolute);
             if (node.connman) {
                 node.connman->DisconnectNode(netAddr);
             }
@@ -792,7 +790,7 @@ static RPCHelpMan setban()
     }
     else if(strCommand == "remove")
     {
-        if (!( isSubnet ? node.banman->Unban(subNet) : node.banman->Unban(netAddr) )) {
+        if (!( isSubnet ? banman.Unban(subNet) : banman.Unban(netAddr) )) {
             throw JSONRPCError(RPC_CLIENT_INVALID_IP_OR_SUBNET, "Error: Unban failed. Requested address/subnet was not previously manually banned.");
         }
     }
@@ -823,14 +821,10 @@ static RPCHelpMan listbanned()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    if(!node.banman) {
-        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
-    }
+    BanMan& banman = EnsureAnyBanman(request.context);
 
     banmap_t banMap;
-    node.banman->GetBanned(banMap);
+    banman.GetBanned(banMap);
     const int64_t current_time{GetTime()};
 
     UniValue bannedAddresses(UniValue::VARR);
@@ -864,12 +858,9 @@ static RPCHelpMan clearbanned()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    if (!node.banman) {
-        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
-    }
+    BanMan& banman = EnsureAnyBanman(request.context);
 
-    node.banman->ClearBanned();
+    banman.ClearBanned();
 
     return NullUniValue;
 },
@@ -888,12 +879,9 @@ static RPCHelpMan cleardiscouraged()
                },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    if (!node.banman) {
-        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
-    }
+    BanMan& banman = EnsureAnyBanman(request.context);
 
-    node.banman->ClearDiscouraged();
+    banman.ClearDiscouraged();
 
     return NullUniValue;
 },

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -56,6 +56,20 @@ CTxMemPool& EnsureAnyMemPool(const CoreContext& context)
     return EnsureMemPool(EnsureAnyNodeContext(context));
 }
 
+
+BanMan& EnsureBanman(const NodeContext& node)
+{
+    if (!node.banman) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
+    }
+    return *node.banman;
+}
+
+BanMan& EnsureAnyBanman(const CoreContext& context)
+{
+    return EnsureBanman(EnsureAnyNodeContext(context));
+}
+
 ArgsManager& EnsureArgsman(const NodeContext& node)
 {
     if (!node.args) {

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -13,6 +13,7 @@ class CConnman;
 class CTxMemPool;
 class ChainstateManager;
 class PeerManager;
+class BanMan;
 struct LLMQContext;
 namespace node {
 struct NodeContext;
@@ -21,6 +22,8 @@ struct NodeContext;
 node::NodeContext& EnsureAnyNodeContext(const CoreContext& context);
 CTxMemPool& EnsureMemPool(const node::NodeContext& node);
 CTxMemPool& EnsureAnyMemPool(const CoreContext& context);
+BanMan& EnsureBanman(const node::NodeContext& node);
+BanMan& EnsureAnyBanman(const CoreContext& context);
 ArgsManager& EnsureArgsman(const node::NodeContext& node);
 ArgsManager& EnsureAnyArgsman(const CoreContext& context);
 ChainstateManager& EnsureChainman(const node::NodeContext& node);


### PR DESCRIPTION
Backports bitcoin/bitcoin#27069

Original commit: e0d8378f2d7222a5b5ee711f97393ef256c1eec5

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of ban management in RPC commands for banning, listing, and clearing bans, resulting in more consistent error handling and streamlined code. No changes to user-facing features or command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->