### PR TITLE
Merge bitcoin/bitcoin#27016: mapport: require miniupnpc API version 17 or later

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1439,14 +1439,15 @@ if test "$use_upnp" != "no"; then
     [AC_CHECK_LIB([miniupnpc], [upnpDiscover], [MINIUPNPC_LIBS="$MINIUPNPC_LIBS -lminiupnpc"], [have_miniupnpc=no], [$MINIUPNPC_LIBS])],
     [have_miniupnpc=no]
   )
-  dnl The minimum supported miniUPnPc API version is set to 10. This keeps compatibility
-  dnl with Ubuntu 16.04 LTS and Debian 8 libminiupnpc-dev packages.
+
+  dnl The minimum supported miniUPnPc API version is set to 17. This excludes
+  dnl versions with known vulnerabilities.
   if test "$have_miniupnpc" != "no"; then
     AC_MSG_CHECKING([whether miniUPnPc API version is supported])
     AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
         @%:@include <miniupnpc/miniupnpc.h>
       ]], [[
-        #if MINIUPNPC_API_VERSION >= 10
+        #if MINIUPNPC_API_VERSION >= 17
         // Everything is okay
         #else
         #  error miniUPnPc API version is too old
@@ -1455,7 +1456,7 @@ if test "$use_upnp" != "no"; then
         AC_MSG_RESULT([yes])
       ],[
       AC_MSG_RESULT([no])
-      AC_MSG_WARN([miniUPnPc API version < 10 is unsupported, disabling UPnP support.])
+      AC_MSG_WARN([miniUPnPc API version < 17 is unsupported, disabling UPnP support.])
       have_miniupnpc=no
     ])
   fi

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -39,7 +39,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 | Dependency | Version used | Minimum required | Runtime |
 | --- | --- | --- | --- |
 | [libnatpmp](https://github.com/miniupnp/libnatpmp/) | commit [07004b9...](https://github.com/miniupnp/libnatpmp/tree/07004b97cf691774efebe70404cf22201e4d330d) | | No |
-| [MiniUPnPc](https://miniupnp.tuxfamily.org/) | 2.2.2 | 1.9 | No |
+| [MiniUPnPc](https://miniupnp.tuxfamily.org/) | 2.2.2 | 2.1 | No |
 
 ### Notifications
 | Dependency | Version used | Minimum required | Runtime |

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -26,9 +26,9 @@
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>
-// The minimum supported miniUPnPc API version is set to 10. This keeps compatibility
-// with Ubuntu 16.04 LTS and Debian 8 libminiupnpc-dev packages.
-static_assert(MINIUPNPC_API_VERSION >= 10, "miniUPnPc API version >= 10 assumed");
+// The minimum supported miniUPnPc API version is set to 17. This excludes
+// versions with known vulnerabilities.
+static_assert(MINIUPNPC_API_VERSION >= 17, "miniUPnPc API version >= 17 assumed");
 #endif // USE_UPNP
 
 #include <atomic>
@@ -158,11 +158,7 @@ static bool ProcessUpnp()
     char lanaddr[64];
 
     int error = 0;
-#if MINIUPNPC_API_VERSION < 14
-    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
-#else
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
-#endif
 
     struct UPNPUrls urls;
     struct IGDdatas data;


### PR DESCRIPTION
Backports bitcoin/bitcoin#27016

Original commit: 1ad0711d7c

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the minimum required version of MiniUPnPc to enhance security and compatibility, excluding older versions with known vulnerabilities.

* **Documentation**
  * Revised dependency documentation to reflect the new minimum required version of MiniUPnPc.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->