### PR TITLE
Merge bitcoin/bitcoin#24259: test: Remove unused valgrind suppressions

### DIFF
--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
-export TEST_RUNNER_EXTRA="--exclude rpc_bind,feature_bind_extra --timeout-factor=4"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
+export TEST_RUNNER_EXTRA="--exclude feature_init,rpc_bind,feature_bind_extra --timeout-factor=4"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export GOAL="install"
 # Temporarily pin dwarf 4, until valgrind can understand clang's dwarf 5
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang-18 CXX=clang++-18 CFLAGS='-gdwarf-4' CXXFLAGS='-gdwarf-4'"  # TODO enable GUI

--- a/ci/test/00_setup_env_s390x.sh
+++ b/ci/test/00_setup_env_s390x.sh
@@ -19,7 +19,7 @@ fi
 # Use debian to avoid 404 apt errors
 export CONTAINER_NAME=ci_s390x
 export RUN_UNIT_TESTS=true
-export TEST_RUNNER_EXTRA="--exclude rpc_bind,feature_bind_extra"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
+export TEST_RUNNER_EXTRA="--exclude feature_init,rpc_bind,feature_bind_extra"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export RUN_FUNCTIONAL_TESTS=true
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests --with-boost-process"  # GUI tests disabled for now, see https://github.com/bitcoin/bitcoin/issues/23730

--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -13,8 +13,8 @@
 #
 # Note that suppressions may depend on OS and/or library versions.
 # Tested on:
-# * aarch64 (Ubuntu 20.04 system libs, without gui)
-# * x86_64  (Ubuntu 18.04 system libs, without gui)
+# * aarch64 (Ubuntu 22.04 system libs, clang, without gui)
+# * x86_64  (Ubuntu 22.04 system libs, clang, without gui)
 {
    Suppress libstdc++ warning - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65434
    Memcheck:Leak
@@ -92,12 +92,6 @@
    fun:GetCoin
 }
 {
-   Suppress wcsnrtombs glibc SSE4 warning (could be related: https://stroika.atlassian.net/browse/STK-626)
-   Memcheck:Addr16
-   fun:__wcsnlen_sse4_1
-   fun:wcsnrtombs
-}
-{
    Suppress boost warning
    Memcheck:Leak
    fun:_Znwm
@@ -106,17 +100,6 @@
    fun:_ZN5boost9unit_test9framework3runEmb
    fun:_ZN5boost9unit_test14unit_test_mainEPFbvEiPPc
    fun:main
-}
-{
-   Suppress boost still reachable memory warning
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   fun:_Znwm
-   ...
-   fun:_M_construct_aux<char*>
-   fun:_M_construct<char*>
-   fun:basic_string
-   fun:path
 }
 {
    Suppress LogInstance still reachable memory warning


### PR DESCRIPTION
Backports bitcoin/bitcoin#24259

Original commit: 87b5b002ad

Backported from Bitcoin Core v0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to exclude additional test categories from certain test runs.
  * Revised Valgrind suppression rules to align with newer system libraries and compilers, and removed obsolete suppression entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->