### PR TITLE
Merge bitcoin/bitcoin#24282: docs: Move explanation of hardened key syntax closer to KEY section

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -73,7 +73,8 @@ Descriptors consist of several types of expressions. The top level expression is
     - Followed by zero or more `/NUM` unhardened and `/NUM'` hardened BIP32 derivation steps.
     - Optionally followed by a single `/*` or `/*'` final step to denote all (direct) unhardened or hardened children.
     - The usage of hardened derivation steps requires providing the private key.
-- Anywhere a `'` suffix is permitted to denote hardened derivation, the suffix `h` can be used instead.
+
+(Anywhere a `'` suffix is permitted to denote hardened derivation, the suffix `h` can be used instead.)
 
 `ADDR` expressions are any type of supported address:
 - P2PKH addresses (base58, of the form `X...`). Note that P2PKH addresses in descriptors cannot be used for P2PK outputs (use the `pk` function instead).


### PR DESCRIPTION
Backports bitcoin/bitcoin#24282

Original commit: 8afcc89a8f

Backported from Bitcoin Core v0.23