### PR TITLE
Merge bitcoin/bitcoin#24359: doc: Fix typos

### DIFF
--- a/src/crypto/sha256_arm_shani.cpp
+++ b/src/crypto/sha256_arm_shani.cpp
@@ -62,7 +62,7 @@ void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
         MSG3 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(chunk + 48)));
         chunk += 64;
 
-        // Original implemenation preloaded message and constant addition which was 1-3% slower.
+        // Original implementation preloaded message and constant addition which was 1-3% slower.
         // Now included as first step in quad round code saving one Q Neon register
         // "TMP0 = vaddq_u32(MSG0, vld1q_u32(&K[0]));"
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_CASE(LoadReceiveRequests)
 
 // Test some watch-only LegacyScriptPubKeyMan methods by the procedure of loading (LoadWatchOnly),
 // checking (HaveWatchOnly), getting (GetWatchPubKey) and removing (RemoveWatchOnly) a
-// given PubKey, resp. its corresponding P2PK Script. Results of the the impact on
+// given PubKey, resp. its corresponding P2PK Script. Results of the impact on
 // the address -> PubKey map is dependent on whether the PubKey is a point on the curve
 static void TestWatchOnlyPubKey(LegacyScriptPubKeyMan* spk_man, const CPubKey& add_pubkey)
 {


### PR DESCRIPTION
Backports bitcoin/bitcoin#24359

Original commit: b304b65782

This PR fixes typos in the codebase:
- Fixed "implemenation" to "implementation" in src/crypto/sha256_arm_shani.cpp
- Fixed "the the" to "the" in src/wallet/test/wallet_tests.cpp

Note: The third typo fix from the Bitcoin commit (in src/node/blockstorage.cpp) was not applied because the affected code section related to assumed-valid blocks does not exist in Dash.

Backported from Bitcoin Core v0.24