### PR TITLE
Merge bitcoin/bitcoin#24292: Revert "ci: Run fuzzer task for the master branch only"

### DIFF
--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export DOCKER_NAME_TAG="ubuntu:22.04"
 export CONTAINER_NAME=ci_native_fuzz
 export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev"
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"

--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export DOCKER_NAME_TAG="ubuntu:22.04"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
 export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev valgrind"
 export NO_DEPENDS=1


### PR DESCRIPTION
Backports bitcoin/bitcoin#24292

Original commit: 2ab4fbe375

This partial backport includes only the Ubuntu version bump for fuzzer CI scripts. The .cirrus.yml changes were intentionally excluded as Dash uses GitHub Actions instead of Cirrus CI.

Changes:
- Update fuzzer CI scripts to use Ubuntu 22.04 (jammy)

Backported from Bitcoin Core v0.24