### PR TITLE
Merge bitcoin/bitcoin#24397: build: Fix Boost.Process check for Boost 1.73 and older

### DIFF
--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -16,5 +16,5 @@ export GOAL="deploy"
 # Prior to 11.0.0, the mingw-w64 headers were missing noreturn attributes, causing warnings when
 # cross-compiling for Windows. https://sourceforge.net/p/mingw-w64/bugs/306/
 # https://github.com/mingw-w64/mingw-w64/commit/1690994f515910a31b9fb7c7bd3a52d4ba987abe
-export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner --without-boost-process CXXFLAGS='-Wno-return-type -Wno-error=maybe-uninitialized -Wno-error=array-bounds'"
+export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner --disable-external-signer --without-boost-process CXXFLAGS='-Wno-return-type -Wno-error=maybe-uninitialized -Wno-error=array-bounds'"
 export DIRECT_WINE_EXEC_TESTS=true

--- a/configure.ac
+++ b/configure.ac
@@ -359,7 +359,7 @@ if test "$enable_debug" = "yes"; then
   dnl them, to prevent autoconfs "-g -O2" being added. Otherwise we'd end up
   dnl with "-O0 -g3 -g -O2".
   if test "$CXXFLAGS_overridden" = "no"; then
-	CXXFLAGS=""
+  CXXFLAGS=""
   fi
 
   dnl Disable all optimizations


### PR DESCRIPTION
Backports bitcoin/bitcoin#24397

Original commit: 25290071c4

Backported from Bitcoin Core v0.23

Note: This backport is smaller than the Bitcoin commit because:
1. Dash does not have external signer support, so the Boost.Process pthread fix doesn't apply
2. The file ci/test/06_script_a.sh doesn't exist in Dash
3. Only the applicable changes were backported: tab-to-space fix in configure.ac and adding --disable-external-signer flag to Windows CI config