### PR TITLE
Merge bitcoin/bitcoin#26184: test: p2p: check that headers message with invalid proof-of-work disconnects peer

### DIFF
--- a/src/wallet/coinjoin.h
+++ b/src/wallet/coinjoin.h
@@ -12,11 +12,11 @@
 
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.
-#define WalletCJLogPrint(wallet, ...)               \
-    do {                                            \
-        if (LogAcceptDebug(BCLog::COINJOIN)) {      \
-            wallet->WalletLogPrintf(__VA_ARGS__);   \
-        }                                           \
+#define WalletCJLogPrint(wallet, ...)             \
+    do {                                          \
+        if (LogAcceptDebug(BCLog::COINJOIN)) {    \
+            wallet->WalletLogPrintf(__VA_ARGS__); \
+        }                                         \
     } while (0)
 
 namespace wallet {
@@ -29,8 +29,7 @@ CAmount GetBalanceAnonymized(const CWallet& wallet, const CCoinControl& coinCont
 CAmount CachedTxGetAnonymizedCredit(const CWallet& wallet, const CWalletTx& wtx, const CCoinControl& coinControl)
     EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
-struct CoinJoinCredits
-{
+struct CoinJoinCredits {
     CAmount m_anonymized{0};
     CAmount m_denominated{0};
     bool is_unconfirmed{false};

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test node responses to invalid network messages."""
 
+import time
 
 from test_framework.messages import (
     CBlockHeader,
@@ -14,11 +15,12 @@ from test_framework.messages import (
     MAX_HEADERS_UNCOMPRESSED_RESULT,
     MAX_INV_SIZE,
     MAX_PROTOCOL_MESSAGE_LENGTH,
+    MSG_TX,
+    from_hex,
     msg_getdata,
     msg_headers,
     msg_headers2,
     msg_inv,
-    MSG_TX,
     msg_version,
 )
 from test_framework.p2p import (
@@ -61,6 +63,8 @@ class InvalidMessagesTest(BitcoinTestFramework):
         self.test_oversized_inv_msg()
         self.test_oversized_getdata_msg()
         self.test_oversized_headers_msg()
+        self.test_oversized_headers2_msg()
+        self.test_invalid_pow_headers_msg()
         self.test_resource_exhaustion()
 
     def test_buffer(self):
@@ -185,6 +189,36 @@ class InvalidMessagesTest(BitcoinTestFramework):
     def test_oversized_headers2_msg(self):
         size = MAX_HEADERS_COMPRESSED_RESULT + 1
         self.test_oversized_msg(msg_headers2([CBlockHeader()] * size), size)
+
+    def test_invalid_pow_headers_msg(self):
+        self.log.info("Test headers message with invalid proof-of-work is logged as misbehaving and disconnects peer")
+        blockheader_tip_hash = self.nodes[0].getbestblockhash()
+        blockheader_tip = from_hex(CBlockHeader(), self.nodes[0].getblockheader(blockheader_tip_hash, False))
+
+        # send valid headers message first
+        assert_equal(self.nodes[0].getblockchaininfo()['headers'], 0)
+        blockheader = CBlockHeader()
+        blockheader.hashPrevBlock = int(blockheader_tip_hash, 16)
+        blockheader.nTime = int(time.time())
+        blockheader.nBits = blockheader_tip.nBits
+        blockheader.rehash()
+        while not blockheader.hash.startswith('0'):
+            blockheader.nNonce += 1
+            blockheader.rehash()
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        peer.send_and_ping(msg_headers([blockheader]))
+        assert_equal(self.nodes[0].getblockchaininfo()['headers'], 1)
+        chaintips = self.nodes[0].getchaintips()
+        assert_equal(chaintips[0]['status'], 'headers-only')
+        assert_equal(chaintips[0]['hash'], blockheader.hash)
+
+        # invalidate PoW
+        while not blockheader.hash.startswith('f'):
+            blockheader.nNonce += 1
+            blockheader.rehash()
+        with self.nodes[0].assert_debug_log(['Misbehaving', 'header with invalid proof of work']):
+            peer.send_message(msg_headers([blockheader]))
+            peer.wait_for_disconnect()
 
     def test_resource_exhaustion(self):
         self.log.info("Test node stays up despite many large junk messages")

--- a/test/util/data/non-backported.txt
+++ b/test/util/data/non-backported.txt
@@ -50,5 +50,6 @@ src/util/ranges.h
 src/util/ranges_set.*
 src/util/wpipe.*
 src/wallet/bip39*
+src/wallet/coinjoin.*
 src/wallet/hdchain.*
 src/hash_x11.h


### PR DESCRIPTION
Backports bitcoin/bitcoin#26184

Original commit: 576e16e70

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and consistency in wallet CoinJoin components for better readability.
  * Reformatted macro and struct declarations for uniform style.

* **Tests**
  * Added new test cases to validate handling of oversized and invalid proof-of-work headers in P2P message processing.

* **Chores**
  * Updated internal lists to mark CoinJoin wallet files as non-backported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->