### PR TITLE
Merge bitcoin-core/gui#711: refactor: Disable unused special members functions in `UnlockContext`

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -578,8 +578,6 @@ WalletModel::UnlockContext::~UnlockContext()
     }
 }
 
-}
-
 bool WalletModel::isWalletEnabled()
 {
    return !gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -578,12 +578,6 @@ WalletModel::UnlockContext::~UnlockContext()
     }
 }
 
-void WalletModel::UnlockContext::CopyFrom(UnlockContext&& rhs)
-{
-    // Transfer context; old object no longer relocks wallet
-    *this = rhs;
-    rhs.was_locked = false;
-    rhs.was_mixing = false;
 }
 
 bool WalletModel::isWalletEnabled()

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -117,7 +117,7 @@ public:
     bool autoBackupWallet(QString& strBackupWarningRet, QString& strBackupErrorRet);
     int64_t getKeysLeftSinceAutoBackup() const;
 
-    // RAI object for unlocking wallet, returned by requestUnlock()
+    // RAII object for unlocking wallet, returned by requestUnlock()
     class UnlockContext
     {
     public:
@@ -126,19 +126,17 @@ public:
 
         bool isValid() const { return valid; }
 
-        // Copy constructor is disabled.
+        // Disable unused copy/move constructors/assignments explicitly.
         UnlockContext(const UnlockContext&) = delete;
-        // Move operator and constructor transfer the context
-        UnlockContext(UnlockContext&& obj) { CopyFrom(std::move(obj)); }
-        UnlockContext& operator=(UnlockContext&& rhs) { CopyFrom(std::move(rhs)); return *this; }
+        UnlockContext(UnlockContext&&) = delete;
+        UnlockContext& operator=(const UnlockContext&) = delete;
+        UnlockContext& operator=(UnlockContext&&) = delete;
+
     private:
         WalletModel *wallet;
-        bool valid;
-        mutable bool was_locked; // mutable, as it can be set to false by copying
-        mutable bool was_mixing; // mutable, as it can be set to false by copying
-
-        UnlockContext& operator=(const UnlockContext&) = default;
-        void CopyFrom(UnlockContext&& rhs);
+        const bool valid;
+        const bool was_locked;
+        const bool was_mixing;
     };
 
     UnlockContext requestUnlock(bool fForMixingOnly = false);


### PR DESCRIPTION
$(cat <<'EOF'
Backports bitcoin/bitcoin#711

Original commit: 54742532ce34114f893c119b25a3ef8630f85976

Backported from Bitcoin Core v0.25
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of wallet unlock context to ensure state immutability and prevent unintended transfers or modifications.
  * Enhanced code comments for clarity.

No visible changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->