### PR TITLE
Merge bitcoin/bitcoin#27035: test: simplify and speedup mempool_updatefromblock.py by using MiniWallet

### DIFF
--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -36,6 +36,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
         More details: https://en.wikipedia.org/wiki/Tournament_(graph_theory)
         """
         wallet = MiniWallet(self.nodes[0])
+        wallet.generate(1)  # Fund the wallet with initial UTXOs
         first_block_hash = ''
         tx_id = []
         tx_size = []

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -36,7 +36,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
         More details: https://en.wikipedia.org/wiki/Tournament_(graph_theory)
         """
         wallet = MiniWallet(self.nodes[0])
-        self.generatetoaddress(self.nodes[0], 1, wallet.get_address())  # Fund the wallet with initial UTXOs
+        wallet.generate(1)  # Fund the wallet with initial UTXOs
         first_block_hash = ''
         tx_id = []
         tx_size = []

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -7,11 +7,12 @@
 Test mempool update of transaction descendants/ancestors information (count, size)
 when transactions have been re-added from a disconnected block to the mempool.
 """
+from math import ceil
 import time
 
-from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
 
 
 class MempoolUpdateFromBlockTest(BitcoinTestFramework):
@@ -19,10 +20,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [['-limitdescendantsize=1000', '-limitancestorsize=1000', '-limitancestorcount=100']]
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
-    def transaction_graph_test(self, size, n_tx_to_mine=None, start_input_txid='', end_address='', fee=Decimal(0.00100000)):
+    def transaction_graph_test(self, size, n_tx_to_mine=None, fee=100_000):
         """Create an acyclic tournament (a type of directed graph) of transactions and use it for testing.
 
         Keyword arguments:
@@ -37,13 +35,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
 
         More details: https://en.wikipedia.org/wiki/Tournament_(graph_theory)
         """
-
-        if not start_input_txid:
-            start_input_txid = self.nodes[0].getblock(self.nodes[0].getblockhash(1))['tx'][0]
-
-        if not end_address:
-            end_address = self.nodes[0].getnewaddress()
-
+        wallet = MiniWallet(self.nodes[0])
         first_block_hash = ''
         tx_id = []
         tx_size = []
@@ -52,41 +44,31 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
             self.log.debug('Preparing transaction #{}...'.format(i))
             # Prepare inputs.
             if i == 0:
-                inputs = [{'txid': start_input_txid, 'vout': 0}]
-                inputs_value = self.nodes[0].gettxout(start_input_txid, 0)['value']
+                inputs = [wallet.get_utxo()]  # let MiniWallet provide a start UTXO
             else:
                 inputs = []
-                inputs_value = 0
                 for j, tx in enumerate(tx_id[0:i]):
                     # Transaction tx[K] is a child of each of previous transactions tx[0]..tx[K-1] at their output K-1.
                     vout = i - j - 1
-                    inputs.append({'txid': tx_id[j], 'vout': vout})
-                    inputs_value += self.nodes[0].gettxout(tx, vout)['value']
-
-            self.log.debug('inputs={}'.format(inputs))
-            self.log.debug('inputs_value={}'.format(inputs_value))
+                    inputs.append(wallet.get_utxo(txid=tx_id[j], vout=vout))
 
             # Prepare outputs.
             tx_count = i + 1
             if tx_count < size:
                 # Transaction tx[K] is an ancestor of each of subsequent transactions tx[K+1]..tx[N-1].
                 n_outputs = size - tx_count
-                output_value = ((inputs_value - fee) / Decimal(n_outputs)).quantize(Decimal('0.00000001'))
-                outputs = {}
-                for _ in range(n_outputs):
-                    outputs[self.nodes[0].getnewaddress()] = output_value
             else:
-                output_value = (inputs_value - fee).quantize(Decimal('0.00000001'))
-                outputs = {end_address: output_value}
-
-            self.log.debug('output_value={}'.format(output_value))
-            self.log.debug('outputs={}'.format(outputs))
+                n_outputs = 1
 
             # Create a new transaction.
-            unsigned_raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
-            signed_raw_tx = self.nodes[0].signrawtransactionwithwallet(unsigned_raw_tx)
-            tx_id.append(self.nodes[0].sendrawtransaction(signed_raw_tx['hex']))
-            tx_size.append(self.nodes[0].getmempoolentry(tx_id[-1])['vsize'])
+            new_tx = wallet.send_self_transfer_multi(
+                from_node=self.nodes[0],
+                utxos_to_spend=inputs,
+                num_outputs=n_outputs,
+                fee_per_output=ceil(fee / n_outputs)
+            )
+            tx_id.append(new_tx['txid'])
+            tx_size.append(new_tx['tx'].get_vsize())
 
             if tx_count in n_tx_to_mine:
                 # The created transactions are mined into blocks by batches.

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -36,7 +36,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
         More details: https://en.wikipedia.org/wiki/Tournament_(graph_theory)
         """
         wallet = MiniWallet(self.nodes[0])
-        wallet.generate(1)  # Fund the wallet with initial UTXOs
+        self.generatetoaddress(self.nodes[0], 1, wallet.get_address())  # Fund the wallet with initial UTXOs
         first_block_hash = ''
         tx_id = []
         tx_size = []


### PR DESCRIPTION
Backports bitcoin/bitcoin#27035

Original commit: a65d2259f

Backported from Bitcoin Core v0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified transaction creation in tests by using an automated wallet utility, reducing manual steps and streamlining fee handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->