### PR TITLE
Merge bitcoin/bitcoin#23688: test: remove unneeded sync_all() calls in wallet_listtransactions.py

### DIFF
--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -3,13 +3,17 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the listtransactions API."""
+
 from decimal import Decimal
+import os
+import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_array_result,
     assert_equal,
 )
+
 
 class ListTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -5,8 +5,6 @@
 """Test the listtransactions API."""
 
 from decimal import Decimal
-import os
-import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -26,7 +26,6 @@ class ListTransactionsTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Test simple send from node0 to node1")
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
-        self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
                             {"txid": txid},
                             {"category": "send", "amount": Decimal("-0.1"), "confirmations": 0})
@@ -58,7 +57,6 @@ class ListTransactionsTest(BitcoinTestFramework):
                    self.nodes[0].getnewaddress(): 0.33,
                    self.nodes[1].getnewaddress(): 0.44}
         txid = self.nodes[1].sendmany("", send_to)
-        self.sync_all()
         assert_array_result(self.nodes[1].listtransactions(),
                             {"category": "send", "amount": Decimal("-0.11")},
                             {"txid": txid})


### PR DESCRIPTION
Backports bitcoin/bitcoin#23688

Original commit: 08dcc5912d

Note: In Dash, only the import reordering changes were applicable as we don't have the run_externally_generated_address_test function where the sync_all() removals would occur. The change reorganizes imports alphabetically and adds a blank line after imports.

Backported from Bitcoin Core v0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test efficiency by removing unnecessary synchronization steps after transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->