### PR TITLE
Merge bitcoin/bitcoin#23677: build, qt: Use Android NDK r23 LTS

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -26,6 +26,7 @@ $(package)_patches += utc_from_string_no_optimize.patch
 $(package)_patches += windows_lto.patch
 $(package)_patches += darwin_no_libm.patch
 $(package)_patches += zlib-timebits64.patch
+$(package)_patches += use_android_ndk23.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=5b94d1a11b566908622fcca2f8b799744d2f8a68da20be4caa5953ed63b10489
@@ -259,6 +260,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/windows_lto.patch && \
   patch -p1 -i $($(package)_patch_dir)/darwin_no_libm.patch && \
   patch -p1 -i $($(package)_patch_dir)/zlib-timebits64.patch && \
+  patch -p1 -i $($(package)_patch_dir)/use_android_ndk23.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/use_android_ndk23.patch
+++ b/depends/patches/qt/use_android_ndk23.patch
@@ -1,0 +1,12 @@
+Use Android NDK r23 LTS
+
+--- old/qtbase/mkspecs/features/android/default_pre.prf
++++ new/qtbase/mkspecs/features/android/default_pre.prf
+@@ -73,7 +73,7 @@ else: equals(QT_ARCH, x86_64): CROSS_COMPILE = $$NDK_LLVM_PATH/bin/x86_64-linux-
+ else: equals(QT_ARCH, arm64-v8a): CROSS_COMPILE = $$NDK_LLVM_PATH/bin/aarch64-linux-android-
+ else: CROSS_COMPILE = $$NDK_LLVM_PATH/bin/arm-linux-androideabi-
+
+-QMAKE_RANLIB            = $${CROSS_COMPILE}ranlib
++QMAKE_RANLIB            = $$NDK_LLVM_PATH/bin/llvm-ranlib
+ QMAKE_LINK_SHLIB        = $$QMAKE_LINK
+ QMAKE_LFLAGS            =


### PR DESCRIPTION
Backports bitcoin/bitcoin#23677

Original commit: 6db7e43d42

This updates the Android NDK version to r23 LTS for Qt builds.

Note: Several files from the Bitcoin commit were skipped as they don't exist in Dash:
- .cirrus.yml (Dash doesn't use Cirrus CI)
- ci/test/00_setup_env_android.sh (deleted in Dash)
- doc/build-android.md (deleted in Dash)

The core changes to Qt's Android build configuration have been successfully applied.

Backported from Bitcoin Core v0.24