### PR TITLE
Merge bitcoin/bitcoin#23113: Add warnings to createmultisig and addmultisig if using uncompressed keys

### DIFF
--- a/doc/release-notes-23113.md
+++ b/doc/release-notes-23113.md
@@ -1,0 +1,9 @@
+Notable changes
+===============
+
+Updated RPCs
+------------
+
+- Both `createmultisig` and `addmultisigaddress` now include a `warnings`
+field in their output. This field is currently empty but provides a
+standardized way to communicate warnings to users in future updates.

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -305,6 +305,10 @@ static RPCHelpMan createmultisig()
                         {RPCResult::Type::STR, "address", "The value of the new multisig address."},
                         {RPCResult::Type::STR_HEX, "redeemScript", "The string value of the hex-encoded redemption script."},
                         {RPCResult::Type::STR, "descriptor", "The descriptor for this multisig."},
+                        {RPCResult::Type::ARR, "warnings", /* optional */ true, "Any warnings resulting from the creation of this multisig",
+                        {
+                            {RPCResult::Type::STR, "", ""},
+                        }},
                     }
                 },
                 RPCExamples{
@@ -340,6 +344,11 @@ static RPCHelpMan createmultisig()
     result.pushKV("address", EncodeDestination(dest));
     result.pushKV("redeemScript", HexStr(inner));
     result.pushKV("descriptor", descriptor->ToString());
+
+    // Dash doesn't support multiple address types, so we don't need to check for output type mismatches
+    UniValue warnings(UniValue::VARR);
+    // Add any warnings if needed in the future
+    if (warnings.size()) result.pushKV("warnings", warnings);
 
     return result;
 },

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -210,6 +210,10 @@ RPCHelpMan addmultisigaddress()
                 {RPCResult::Type::STR, "address", "The value of the new multisig address"},
                 {RPCResult::Type::STR_HEX, "redeemScript", "The string value of the hex-encoded redemption script"},
                 {RPCResult::Type::STR, "descriptor", "The descriptor for this multisig."},
+                {RPCResult::Type::ARR, "warnings", /* optional */ true, "Any warnings resulting from the creation of this multisig",
+                {
+                    {RPCResult::Type::STR, "", ""},
+                }},
             }
         },
         RPCExamples{
@@ -256,6 +260,12 @@ RPCHelpMan addmultisigaddress()
     result.pushKV("address", EncodeDestination(dest));
     result.pushKV("redeemScript", HexStr(inner));
     result.pushKV("descriptor", descriptor->ToString());
+
+    // Dash doesn't support multiple address types, so we don't need to check for output type mismatches
+    UniValue warnings(UniValue::VARR);
+    // Add any warnings if needed in the future
+    if (warnings.size()) result.pushKV("warnings", warnings);
+
     return result;
 },
     };

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -81,7 +81,10 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
             # Results should be the same as this legacy one
             legacy_addr = node0.createmultisig(2, keys)['address']
             if self.is_bdb_compiled():
-                assert_equal(legacy_addr, wmulti0.addmultisigaddress(2, keys, '')['address'])
+                result = wmulti0.addmultisigaddress(2, keys, '')
+                assert_equal(legacy_addr, result['address'])
+                # Check that warnings field exists but is empty for valid operations
+                assert 'warnings' not in result or result['warnings'] == []
 
         self.log.info('Testing sortedmulti descriptors with BIP 67 test vectors')
         with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/rpc_bip67.json'), encoding='utf-8') as f:


### PR DESCRIPTION
Backports bitcoin/bitcoin#23113

Original commit: ac92ab6da5

## Summary
This backport adds a `warnings` field to both `createmultisig` and `addmultisigaddress` RPC responses. In Bitcoin, this field warns when attempting to create non-legacy address types with uncompressed public keys. Since Dash only supports legacy addresses, the warnings field is added for consistency but remains empty.

## Changes
- Added `warnings` field to RPC result definitions for `createmultisig` and `addmultisigaddress`
- Updated release notes to document the new field
- Modified functional tests to verify the field exists

## Note
The Bitcoin implementation includes warnings for segwit address types which don't apply to Dash. The infrastructure is in place for future use if needed.

Backported from Bitcoin Core v0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "warnings" field to the results of the `createmultisig` and `addmultisigaddress` RPC commands. This field is currently empty but will be used to communicate warnings in future updates.

* **Documentation**
  * Updated help documentation for the affected RPC commands to describe the new "warnings" field.

* **Tests**
  * Enhanced tests to verify the presence and content of the new "warnings" field in RPC responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->