### PR TITLE
Merge bitcoin/bitcoin#23835: test: check for invalid listtransactions RPC parameters

### DIFF
--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -9,6 +9,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_array_result,
     assert_equal,
+    assert_raises_rpc_error,
 )
 
 class ListTransactionsTest(BitcoinTestFramework):
@@ -97,5 +98,13 @@ class ListTransactionsTest(BitcoinTestFramework):
                                 {"category": "receive", "amount": Decimal("0.1")},
                                 {"txid": txid, "label": "watchonly"})
 
+        self.run_invalid_parameters_test()
+
+    def run_invalid_parameters_test(self):
+        self.log.info("Test listtransactions RPC parameter validity")
+        assert_raises_rpc_error(-8, 'Label argument must be a valid label name or "*".', self.nodes[0].listtransactions, label="")
+        self.nodes[0].listtransactions(label="*")
+        assert_raises_rpc_error(-8, "Negative count", self.nodes[0].listtransactions, count=-1)
+        assert_raises_rpc_error(-8, "Negative from", self.nodes[0].listtransactions, skip=-1)
 if __name__ == '__main__':
     ListTransactionsTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#23835

Original commit: 369978686e156ad34df703f1e60bd90aeaa8f2d6

This PR adds missing test coverage for RPC errors that are thrown if invalid parameters are passed to `listtransactions`.

Backported from Bitcoin Core v0.23