### PR TITLE
Merge bitcoin/bitcoin#27106: net: remove orphaned CSubNet::SanityCheck()

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -797,7 +797,7 @@ public:
         consensus.DIP0020Height = 1; // Always active unless overridden
         consensus.DIP0024Height = 1; // Always have dip0024 quorums unless overridden
         consensus.DIP0024QuorumsHeight = 1; // Always have dip0024 quorums unless overridden
-        consensus.V19Height = 1; // Always active unless overriden
+        consensus.V19Height = 1; // Always active unless overridden
         consensus.V20Height = consensus.DIP0003Height; // Active not earlier than dip0003. Functional tests (DashTestFramework) uses height 100 (same as coinbase maturity)
         consensus.MN_RRHeight = consensus.V20Height; // MN_RR does not really have effect before v20 activation
         consensus.WithdrawalsHeight = 600;

--- a/test/lint/lint-locale-dependence.py
+++ b/test/lint/lint-locale-dependence.py
@@ -34,9 +34,6 @@
 #
 # See https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings and
 # https://stackoverflow.com/a/34878283 for more details.
-#
-# TODO: Reduce KNOWN_VIOLATIONS by replacing uses of locale dependent stoul/strtol with locale
-#       independent ToIntegral<T>(...).
 
 import re
 import sys


### PR DESCRIPTION
Backports bitcoin/bitcoin#27106

Original commit: bc35c4f58c509093cbcf7fac7fdb0ca6c23d867d

Backported from Bitcoin Core v0.25

Note: For Dash, only the lint file TODO removal and chainparams.cpp typo fix apply. CSubNet::SanityCheck() doesn't exist in Dash, and the other typos in blockencodings.h and net.cpp weren't present in our codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in a comment for improved clarity.
  * Removed an outdated TODO comment regarding locale-dependent code.

* **Style**
  * Improved comment wording for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->