### PR TITLE
Merge bitcoin/bitcoin#27073: Convert ArgsManager::GetDataDir to a read-only function

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -171,6 +171,7 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
 
 static bool InitSettings()
 {
+    gArgs.EnsureDataDir();
     if (!gArgs.GetSettingsPath()) {
         return true; // Do nothing if settings file disabled.
     }

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -257,6 +257,11 @@ protected:
     void SelectConfigNetwork(const std::string& network);
 
     [[nodiscard]] bool ParseParameters(int argc, const char* const argv[], std::string& error);
+
+    /**
+     * Return config file path (read-only)
+     */
+    fs::path GetConfigFilePath() const;
     [[nodiscard]] bool ReadConfigFiles(std::string& error, bool ignore_invalid_keys = false);
 
     /**
@@ -495,13 +500,18 @@ protected:
      */
     void LogArgs() const;
 
+    /**
+     * If datadir does not exist, create it along with wallets/
+     * subdirectory(s).
+     */
+    void EnsureDataDir() const;
+
 private:
     /**
      * Get data directory path
      *
      * @param net_specific Append network identifier to the returned path
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
-     * @post Returned directory path is created unless it is empty
      */
     fs::path GetDataDir(bool net_specific) const;
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27073

Original commit: 1258af40c0d396dd922cc8dc1b4c1719b39a4026

This PR converts ArgsManager::GetDataDir to a read-only function by splitting out the directory creation logic into a separate EnsureDataDir() method. This prevents bitcoin-cli from creating directories unnecessarily.

Key changes:
- GetDataDir() no longer creates directories
- New EnsureDataDir() method handles directory creation
- EnsureDataDir() is called in bitcoind and bitcoin-qt init, but not bitcoin-cli
- GetConfigFilePath() helper added for cleaner config file path handling

Backported from Bitcoin Core v0.25