### PR TITLE
Merge bitcoin/bitcoin#26612: refactor: RPC: pass named argument value as string_view

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -9,7 +9,6 @@
 #include <util/system.h>
 
 #include <set>
-#include <stdint.h>
 #include <string>
 #include <string_view>
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -5,9 +5,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rpc/client.h>
+#include <tinyformat.h>
 #include <util/system.h>
 
 #include <set>
+#include <stdint.h>
+#include <string>
+#include <string_view>
 
 class CRPCConvertParam
 {
@@ -262,15 +266,15 @@ public:
     CRPCConvertTable();
 
     /** Return arg_value as UniValue, and first parse it if it is a non-string parameter */
-    UniValue ArgToUniValue(const std::string& arg_value, const std::string& method, int param_idx)
+    UniValue ArgToUniValue(std::string_view arg_value, const std::string& method, int param_idx)
     {
-        return members.count(std::make_pair(method, param_idx)) > 0 ? ParseNonRFCJSONValue(arg_value) : arg_value;
+        return members.count({method, param_idx}) > 0 ? ParseNonRFCJSONValue(arg_value) : UniValue(std::string(arg_value));
     }
 
     /** Return arg_value as UniValue, and first parse it if it is a non-string parameter */
-    UniValue ArgToUniValue(const std::string& arg_value, const std::string& method, const std::string& param_name)
+    UniValue ArgToUniValue(std::string_view arg_value, const std::string& method, const std::string& param_name)
     {
-        return membersByName.count(std::make_pair(method, param_name)) > 0 ? ParseNonRFCJSONValue(arg_value) : arg_value;
+        return membersByName.count({method, param_name}) > 0 ? ParseNonRFCJSONValue(arg_value) : UniValue(std::string(arg_value));
     }
 };
 
@@ -287,13 +291,11 @@ static CRPCConvertTable rpcCvtTable;
 /** Non-RFC4627 JSON parser, accepts internal values (such as numbers, true, false, null)
  * as well as objects and arrays.
  */
-UniValue ParseNonRFCJSONValue(const std::string& strVal)
+UniValue ParseNonRFCJSONValue(std::string_view raw)
 {
-    UniValue jVal;
-    if (!jVal.read(std::string("[")+strVal+std::string("]")) ||
-        !jVal.isArray() || jVal.size()!=1)
-        throw std::runtime_error(std::string("Error parsing JSON: ") + strVal);
-    return jVal[0];
+    UniValue parsed;
+    if (!parsed.read(raw)) throw std::runtime_error(tfm::format("Error parsing JSON: %s", raw));
+    return parsed;
 }
 
 UniValue RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams)
@@ -301,8 +303,8 @@ UniValue RPCConvertValues(const std::string &strMethod, const std::vector<std::s
     UniValue params(UniValue::VARR);
 
     for (unsigned int idx = 0; idx < strParams.size(); idx++) {
-        const std::string& strVal = strParams[idx];
-        params.push_back(rpcCvtTable.ArgToUniValue(strVal, strMethod, idx));
+        std::string_view value{strParams[idx]};
+        params.push_back(rpcCvtTable.ArgToUniValue(value, strMethod, idx));
     }
 
     return params;
@@ -313,15 +315,15 @@ UniValue RPCConvertNamedValues(const std::string &strMethod, const std::vector<s
     UniValue params(UniValue::VOBJ);
     UniValue positional_args{UniValue::VARR};
 
-    for (const std::string &s: strParams) {
+    for (std::string_view s: strParams) {
         size_t pos = s.find('=');
         if (pos == std::string::npos) {
             positional_args.push_back(rpcCvtTable.ArgToUniValue(s, strMethod, positional_args.size()));
             continue;
         }
 
-        std::string name = s.substr(0, pos);
-        std::string value = s.substr(pos+1);
+        std::string name{s.substr(0, pos)};
+        std::string_view value{s.substr(pos+1)};
 
         // Intentionally overwrite earlier named values with later ones as a
         // convenience for scripts and command line users that want to merge

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -6,6 +6,9 @@
 #ifndef BITCOIN_RPC_CLIENT_H
 #define BITCOIN_RPC_CLIENT_H
 
+#include <string>
+#include <string_view>
+
 #include <univalue.h>
 
 /** Convert positional arguments to command-specific RPC representation */
@@ -17,6 +20,6 @@ UniValue RPCConvertNamedValues(const std::string& strMethod, const std::vector<s
 /** Non-RFC4627 JSON parser, accepts internal values (such as numbers, true, false, null)
  * as well as objects and arrays.
  */
-UniValue ParseNonRFCJSONValue(const std::string& strVal);
+UniValue ParseNonRFCJSONValue(std::string_view raw);
 
 #endif // BITCOIN_RPC_CLIENT_H

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -296,6 +296,10 @@ BOOST_AUTO_TEST_CASE(json_parse_errors)
 {
     // Valid
     BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0").get_real(), 1.0);
+    BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("true").get_bool(), true);
+    BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("[false]")[0].get_bool(), false);
+    BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("{\"a\": true}")["a"].get_bool(), true);
+    BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("{\"1\": \"true\"}")["1"].get_str(), "true");
     // Valid, with leading or trailing whitespace
     BOOST_CHECK_EQUAL(ParseNonRFCJSONValue(" 1.0").get_real(), 1.0);
     BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0 ").get_real(), 1.0);
@@ -308,6 +312,11 @@ BOOST_AUTO_TEST_CASE(json_parse_errors)
     // Invalid, trailing garbage
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("1.0sds"), std::runtime_error);
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("1.0]"), std::runtime_error);
+    // Invalid, keys have to be names
+    BOOST_CHECK_THROW(ParseNonRFCJSONValue("{1: \"true\"}"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseNonRFCJSONValue("{true: 1}"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseNonRFCJSONValue("{[1]: 1}"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseNonRFCJSONValue("{{\"a\": \"a\"}: 1}"), std::runtime_error);
     // BTC addresses should fail parsing
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W"), std::runtime_error);
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNL"), std::runtime_error);

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -10,6 +10,8 @@
 #include <string.h>
 
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <vector>
 #include <map>
 #include <cassert>
@@ -151,9 +153,7 @@ public:
 
     bool read(const char *raw, size_t len);
     bool read(const char *raw) { return read(raw, strlen(raw)); }
-    bool read(const std::string& rawStr) {
-        return read(rawStr.data(), rawStr.size());
-    }
+    bool read(std::string_view raw) { return read(raw.data(), raw.size()); }
 
 private:
     UniValue::VType typ;

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <vector>
 #include <map>
 #include <cassert>


### PR DESCRIPTION
Backports bitcoin/bitcoin#26612

Original commit: 3b88c8502

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced efficiency in RPC parameter and JSON parsing by reducing unnecessary string copying.
  * Improved handling of string data using modern string views for faster processing.

* **Bug Fixes**
  * Expanded test coverage to ensure correct parsing of boolean values and error handling for invalid JSON keys.

* **Documentation**
  * Updated public method signatures in the user-facing API to reflect the use of string views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->