### PR TITLE
Merge bitcoin/bitcoin#24538: miner: bug fix? update for ancestor inclusion using modified fees, not base

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -193,7 +193,6 @@ $(package)_config_opts_android += -android-sdk $(ANDROID_SDK)
 $(package)_config_opts_android += -android-ndk $(ANDROID_NDK)
 $(package)_config_opts_android += -android-ndk-platform android-$(ANDROID_API_LEVEL)
 $(package)_config_opts_android += -egl
-$(package)_config_opts_android += -qpa xcb
 $(package)_config_opts_android += -no-dbus
 $(package)_config_opts_android += -opengl es2
 $(package)_config_opts_android += -qt-freetype


### PR DESCRIPTION
Backports bitcoin/bitcoin#24538

Original commit: b2e7811c62

This backport includes only the core bug fix (7a8d60676b) from Bitcoin PR#24538. The test reorganization commits were not included as they would require significant adaptation due to Dash's different test structure.

The bug fix changes `update_for_parent_inclusion` to use `GetModifiedFee()` instead of `GetFee()` when updating ancestor fee calculations in the mining code, ensuring that prioritized transactions are handled correctly.

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed support for 224-, 256-, and 384-bit variants of several cryptographic hash functions, retaining only 512-bit variants for BLAKE, BMW, CubeHash, ECHO, Groestl, JH, Keccak, Luffa, SHAvite, SIMD, and Skein.
  * Simplified AES helper code by removing big-endian support.
  * Adjusted fee calculation logic for ancestor transactions in mining.

* **Tests**
  * Added comprehensive new test suites for LLMQ components, including chainlocks, commitments, hash functions, parameters, snapshots, and utilities.
  * Introduced a test for mining prioritization and updated test utilities for LLMQ.

* **Chores**
  * Updated non-backported test file patterns to include new LLMQ-related test files.

* **Documentation**
  * Removed extensive internal documentation and legacy code from cryptographic type headers.

End-users may notice the removal of less common hash variants and improved test coverage for consensus and mining features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->