### PR TITLE
Merge bitcoin/bitcoin#26194: rpc, wallet: use the same `next_index` key in `listdescriptors` and `importdescriptors`

### DIFF
--- a/doc/release-note-26194.md
+++ b/doc/release-note-26194.md
@@ -1,0 +1,4 @@
+Add `next_index` in `listdescriptors` RPC
+-----------------
+
+- Added a new `next_index` field in the response in `listdescriptors` to have the same format as `importdescriptors`

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1980,7 +1980,8 @@ RPCHelpMan listdescriptors()
                         {RPCResult::Type::NUM, "", "Range start inclusive"},
                         {RPCResult::Type::NUM, "", "Range end inclusive"},
                     }},
-                    {RPCResult::Type::NUM, "next", /*optional=*/true, "The next index to generate addresses from; defined only for ranged descriptors"},
+                    {RPCResult::Type::NUM, "next", /*optional=*/true, "Same as next_index field. Kept for compatibility reason."},
+                    {RPCResult::Type::NUM, "next_index", /*optional=*/true, "The next index to generate addresses from; defined only for ranged descriptors"},
                 }},
             }}
         }},
@@ -2041,6 +2042,7 @@ RPCHelpMan listdescriptors()
             range.push_back(wallet_descriptor.range_end - 1);
             spk.pushKV("range", range);
             spk.pushKV("next", wallet_descriptor.next_index);
+            spk.pushKV("next_index", wallet_descriptor.next_index);
         }
         descriptors.push_back(spk);
     }

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -51,7 +51,7 @@ class ListDescriptorsTest(BitcoinTestFramework):
         assert_equal(1, len([d for d in result['descriptors'] if d['internal']]))
         for item in result['descriptors']:
             assert item['desc'] != ''
-            assert item['next'] == 0
+            assert item['next_index'] == 0
             assert item['range'] == [0, 0]
             assert item['timestamp'] is not None
 
@@ -71,7 +71,8 @@ class ListDescriptorsTest(BitcoinTestFramework):
                  'timestamp': TIME_GENESIS_BLOCK,
                  'active': False,
                  'range': [0, 0],
-                 'next': 0},
+                 'next': 0,
+                 'next_index': 0},
             ],
         }
         assert_equal(expected, wallet.listdescriptors())
@@ -85,7 +86,8 @@ class ListDescriptorsTest(BitcoinTestFramework):
                  'timestamp': TIME_GENESIS_BLOCK,
                  'active': False,
                  'range': [0, 0],
-                 'next': 0},
+                 'next': 0,
+                 'next_index': 0},
             ],
         }
         assert_equal(expected_private, wallet.listdescriptors(True))


### PR DESCRIPTION
Backports bitcoin/bitcoin#26194

Original commit: 1ff135ca7

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The response for the `listdescriptors` RPC now includes a new field, `next_index`, providing clearer information for ranged descriptors.

* **Documentation**
  * Updated help text and release notes to reflect the addition of the `next_index` field and clarify its relationship with the existing `next` field.

* **Tests**
  * Adjusted tests to validate the presence and correctness of both `next` and `next_index` fields in the RPC response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->