### PR TITLE
Merge bitcoin/bitcoin#27238: refactor: Split logging utilities from system.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -355,6 +355,7 @@ BITCOIN_CORE_H = \
   util/enumerate.h \
   util/epochguard.h \
   util/error.h \
+  util/exception.h \
   util/expected.h \
   util/fastrange.h \
   util/fees.h \
@@ -875,6 +876,7 @@ libbitcoin_util_a_SOURCES = \
   util/check.cpp \
   util/edge.cpp \
   util/error.cpp \
+  util/exception.cpp \
   util/fees.cpp \
   util/hasher.cpp \
   util/getuniquepath.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -10,6 +10,7 @@
 #include <clientversion.h>
 #include <fs.h>
 #include <hash.h>
+#include <logging.h>
 #include <logging/timer.h>
 #include <netbase.h>
 #include <netgroup.h>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -20,6 +20,7 @@
 #include <stacktraces.h>
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/exception.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -12,14 +12,15 @@
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <core_io.h>
-#include <key_io.h>
 #include <fs.h>
+#include <key_io.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <univalue.h>
+#include <util/exception.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -15,6 +15,7 @@
 #include <key.h>
 #include <pubkey.h>
 #include <tinyformat.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <util/url.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -19,6 +19,7 @@
 #include <noui.h>
 #include <shutdown.h>
 #include <util/check.h>
+#include <util/exception.h>
 #include <util/syserror.h>
 #include <util/system.h>
 #include <util/strencodings.h>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -4,6 +4,8 @@
 
 #include <chainparams.h>
 #include <index/base.h>
+#include <interfaces/chain.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <node/interface_ui.h>
 #include <shutdown.h>

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -6,6 +6,7 @@
 #include <coins.h>
 #include <crypto/muhash.h>
 #include <index/coinstatsindex.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <serialize.h>
 #include <txdb.h>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -5,6 +5,7 @@
 #include <index/txindex.h>
 
 #include <index/disktxpos.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <util/system.h>
 #include <validation.h>

--- a/src/logging.h
+++ b/src/logging.h
@@ -299,4 +299,11 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
         }                                                 \
     } while (0)
 
+template <typename... Args>
+bool error(const char* fmt, const Args&... args)
+{
+    LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
+    return false;
+}
+
 #endif // BITCOIN_LOGGING_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -18,13 +18,14 @@
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
-#include <node/eviction.h>
 #include <fs.h>
 #include <i2p.h>
+#include <logging.h>
 #include <memusage.h>
 #include <net_permissions.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <node/eviction.h>
 #include <node/interface_ui.h>
 #include <protocol.h>
 #include <random.h>

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -10,12 +10,12 @@
 #include <netbase.h>
 
 #include <compat/compat.h>
+#include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <atomic>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -11,6 +11,7 @@
 #include <flatfile.h>
 #include <fs.h>
 #include <hash.h>
+#include <logging.h>
 #include <pow.h>
 #include <shutdown.h>
 #include <streams.h>

--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -9,11 +9,14 @@
 #include <crypto/muhash.h>
 #include <hash.h>
 #include <index/coinstatsindex.h>
+#include <logging.h>
+#include <node/blockstorage.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
 #include <serialize.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/overflow.h>
-#include <util/system.h>
 #include <validation.h>
 
 #include <map>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -32,6 +32,7 @@
 #include <qt/winshutdownmonitor.h>
 #include <stacktraces.h>
 #include <uint256.h>
+#include <util/exception.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/threadnames.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -23,6 +23,7 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <script/standard.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/time.h>
 

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -5,7 +5,7 @@
 #include <qt/initexecutor.h>
 
 #include <interfaces/node.h>
-#include <util/system.h>
+#include <util/exception.h>
 #include <util/threadnames.h>
 
 #include <exception>

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -7,7 +7,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 
-#include <util/system.h>
+#include <logging.h>
 
 const SigningProvider& DUMMY_SIGNING_PROVIDER = SigningProvider();
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -6,11 +6,11 @@
 #include <txdb.h>
 
 #include <chain.h>
+#include <logging.h>
 #include <pow.h>
 #include <random.h>
 #include <shutdown.h>
 #include <uint256.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <util/vector.h>
 

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/exception.h>
+
+#include <logging.h>
+#include <stacktraces.h>
+#include <tinyformat.h>
+
+#include <exception>
+#include <iostream>
+#include <string>
+#include <typeinfo>
+
+#ifdef WIN32
+#include <windows.h>
+#endif // WIN32
+
+static std::string FormatException(const std::exception* pex, std::string_view thread_name)
+{
+#ifdef WIN32
+    char pszModule[MAX_PATH] = "";
+    GetModuleFileNameA(nullptr, pszModule, sizeof(pszModule));
+#else
+    const char* pszModule = "dash";
+#endif
+    if (pex)
+        return strprintf(
+            "EXCEPTION: %s       \n%s       \n%s in %s       \n", typeid(*pex).name(), pex->what(), pszModule, thread_name);
+    else
+        return strprintf(
+            "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, thread_name);
+}
+
+void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name)
+{
+    std::string message = FormatException(pex, thread_name);
+    LogPrintf("\n\n************************\n%s\n", message);
+    tfm::format(std::cerr, "\n\n************************\n%s\n", message);
+}
+
+void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin)
+{
+    std::string message = strprintf("\"%s\" raised an exception\n%s", pszExceptionOrigin, GetPrettyExceptionStr(pex));
+    LogPrintf("\n\n************************\n%s\n", message);
+    tfm::format(std::cerr, "\n\n************************\n%s\n", message);
+}

--- a/src/util/exception.h
+++ b/src/util/exception.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_EXCEPTION_H
+#define BITCOIN_UTIL_EXCEPTION_H
+
+#include <exception>
+#include <string_view>
+
+void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name);
+void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin);
+
+#endif // BITCOIN_UTIL_EXCEPTION_H

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -827,13 +827,6 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n\n");
 }
 
-void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin)
-{
-    std::string message = strprintf("\"%s\" raised an exception\n%s", pszExceptionOrigin, GetPrettyExceptionStr(pex));
-    LogPrintf("\n\n************************\n%s\n", message);
-    tfm::format(std::cerr, "\n\n************************\n%s\n", message);
-}
-
 fs::path GetDefaultDataDir()
 {
     // Windows: C:\Users\Username\AppData\Roaming\DashCore

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -25,7 +25,6 @@
 #include <util/settings.h>
 #include <util/time.h>
 
-#include <exception>
 #include <map>
 #include <optional>
 #include <set>
@@ -50,15 +49,6 @@ extern const char * const BITCOIN_SETTINGS_FILENAME;
 
 void SetupEnvironment();
 bool SetupNetworking();
-
-template<typename... Args>
-bool error(const char* fmt, const Args&... args)
-{
-    LogPrintf("ERROR: %s\n", SafeStringFormat(fmt, args...));
-    return false;
-}
-
-void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin);
 
 /**
  * Ensure file contents are fully committed to disk, using a platform-specific

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -5,7 +5,7 @@
 #include <util/thread.h>
 
 #include <logging.h>
-#include <util/system.h>
+#include <util/exception.h>
 #include <util/threadnames.h>
 
 #include <exception>


### PR DESCRIPTION
Backports bitcoin/bitcoin#27238

Original commit: b175bdb9b

Backported from Bitcoin Core v0.25

This PR is part of the libbitcoinkernel project to decouple utilities from system.h. It:
- Moves PrintExceptionContinue from util/system.h to a new util/exception.h/cpp
- Moves error() template from util/system.h to logging.h
- Adds necessary logging.h includes to files that were relying on it through system.h

Dash-specific adaptations:
- Preserved both signatures of PrintExceptionContinue for compatibility with Dash's exception handling
- Used GetPrettyExceptionStr from stacktraces.h for the old signature
- Changed "bitcoin" to "dash" in error messages
- Excluded files that don't exist in Dash (bitcoin-util.cpp, ci/test/06_script_b.sh)
- Adapted kernel/coinstats.cpp changes to node/coinstats.cpp (Dash structure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new utility functions for improved exception handling and reporting.

* **Bug Fixes**
  * Enhanced logging capabilities with a new error logging function.

* **Refactor**
  * Updated and reorganized header inclusions across multiple files to use new exception and logging utilities.
  * Moved exception handling logic to dedicated utility files for better maintainability.
  * Removed deprecated error and exception handling code from system utility files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->