### PR TITLE
Merge bitcoin/bitcoin#27297: test: Remove unused Check* default constructors

### DIFF
--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -57,6 +57,7 @@ struct FakeCheckCheckCompletion {
 struct FailingCheck {
     bool fails;
     FailingCheck(bool _fails) : fails(_fails){};
+    FailingCheck() : fails(true){};
     bool operator()() const
     {
         return !fails;
@@ -72,6 +73,7 @@ struct UniqueCheck {
     static std::unordered_multiset<size_t> results GUARDED_BY(m);
     size_t check_id;
     UniqueCheck(size_t check_id_in) : check_id(check_id_in){};
+    UniqueCheck() : check_id(0){};
     bool operator()()
     {
         LOCK(m);
@@ -92,6 +94,7 @@ struct MemoryCheck {
     {
         return true;
     }
+    MemoryCheck(){};
     MemoryCheck(const MemoryCheck& x)
     {
         // We have to do this to make sure that destructor calls are paired

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -57,7 +57,6 @@ struct FakeCheckCheckCompletion {
 struct FailingCheck {
     bool fails;
     FailingCheck(bool _fails) : fails(_fails){};
-    FailingCheck() : fails(true){};
     bool operator()() const
     {
         return !fails;
@@ -73,7 +72,6 @@ struct UniqueCheck {
     static std::unordered_multiset<size_t> results GUARDED_BY(m);
     size_t check_id;
     UniqueCheck(size_t check_id_in) : check_id(check_id_in){};
-    UniqueCheck() : check_id(0){};
     bool operator()()
     {
         LOCK(m);
@@ -94,7 +92,6 @@ struct MemoryCheck {
     {
         return true;
     }
-    MemoryCheck(){};
     MemoryCheck(const MemoryCheck& x)
     {
         // We have to do this to make sure that destructor calls are paired
@@ -181,9 +178,7 @@ static void Correct_Queue_range(std::vector<size_t> range)
             control.Add(vChecks);
         }
         BOOST_REQUIRE(control.Wait());
-        if (FakeCheckCheckCompletion::n_calls != i) {
-            BOOST_REQUIRE_EQUAL(FakeCheckCheckCompletion::n_calls, i);
-        }
+        BOOST_REQUIRE_EQUAL(FakeCheckCheckCompletion::n_calls, i);
     }
     small_queue->StopWorkerThreads();
 }

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -57,7 +57,6 @@ struct FakeCheckCheckCompletion {
 struct FailingCheck {
     bool fails;
     FailingCheck(bool _fails) : fails(_fails){};
-    FailingCheck() : fails(true){};
     bool operator()() const
     {
         return !fails;
@@ -73,7 +72,6 @@ struct UniqueCheck {
     static std::unordered_multiset<size_t> results GUARDED_BY(m);
     size_t check_id;
     UniqueCheck(size_t check_id_in) : check_id(check_id_in){};
-    UniqueCheck() : check_id(0){};
     bool operator()()
     {
         LOCK(m);
@@ -94,7 +92,6 @@ struct MemoryCheck {
     {
         return true;
     }
-    MemoryCheck(){};
     MemoryCheck(const MemoryCheck& x)
     {
         // We have to do this to make sure that destructor calls are paired


### PR DESCRIPTION
Backports bitcoin/bitcoin#27297

Original commit: 4c6b7d330a4e80460dcce19b1a0a47d77a0b99ea

Backported from Bitcoin Core v0.25

Changes:
- Removed unused default constructor from MemoryCheck struct in test/checkqueue_tests.cpp
- The other default constructors removed in Bitcoin (FailingCheck and UniqueCheck) did not exist in Dash
- Validation shows 100% match with Bitcoin changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic for test assertions to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->