### PR TITLE
Merge bitcoin/bitcoin#18933: rpc: Add submit option to generateblock

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -35,6 +35,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "generatetodescriptor", 0, "num_blocks" },
     { "generatetodescriptor", 2, "maxtries" },
     { "generateblock", 1, "transactions" },
+    { "generateblock", 2, "submit" },
 #endif // ENABLE_MINER
     { "getnetworkhashps", 0, "nblocks" },
     { "getnetworkhashps", 1, "height" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -126,9 +126,9 @@ static RPCHelpMan getnetworkhashps()
 }
 
 #if ENABLE_MINER
-static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, uint256& block_hash)
+static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, std::shared_ptr<const CBlock>& block_out, bool process_new_block)
 {
-    block_hash.SetNull();
+    block_out.reset();
     block.hashMerkleRoot = BlockMerkleRoot(block);
 
     CChainParams chainparams(Params());
@@ -144,12 +144,14 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
         return true;
     }
 
-    std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    if (!chainman.ProcessNewBlock(chainparams, shared_pblock, true, nullptr)) {
+    block_out = std::make_shared<const CBlock>(block);
+
+    if (!process_new_block) return true;
+
+    if (!chainman.ProcessNewBlock(chainparams, block_out, true, nullptr)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
     }
 
-    block_hash = block.GetHash();
     return true;
 }
 
@@ -163,16 +165,15 @@ static UniValue generateBlocks(ChainstateManager& chainman, const NodeContext& n
         std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(chainman.ActiveChainstate(), node, &mempool, Params()).CreateNewBlock(coinbase_script));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
-        CBlock *pblock = &pblocktemplate->block;
 
-        uint256 block_hash;
-        if (!GenerateBlock(chainman, *pblock, nMaxTries, block_hash)) {
+        std::shared_ptr<const CBlock> block_out;
+        if (!GenerateBlock(chainman, pblocktemplate->block, nMaxTries, block_out, /*process_new_block=*/true)) {
             break;
         }
 
-        if (!block_hash.IsNull()) {
+        if (block_out) {
             --nGenerate;
-            blockHashes.push_back(block_hash.GetHex());
+            blockHashes.push_back(block_out->GetHash().GetHex());
         }
     }
     return blockHashes;
@@ -303,11 +304,13 @@ static RPCHelpMan generateblock()
                     {"rawtx/txid", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, ""},
                 },
             },
+            {"submit", RPCArg::Type::BOOL, RPCArg::Default{true}, "Whether to submit the block before the RPC call returns or to return it as hex."},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
                 {RPCResult::Type::STR_HEX, "hash", "hash of generated block"},
+                {RPCResult::Type::STR_HEX, "hex", /*optional=*/true, "hex of generated block, only present when submit=false"},
             }
         },
         RPCExamples{
@@ -356,6 +359,8 @@ static RPCHelpMan generateblock()
         }
     }
 
+    const bool process_new_block{request.params[2].isNull() ? true : request.params[2].get_bool()};
+
     CChainParams chainparams(Params());
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
 
@@ -389,15 +394,20 @@ static RPCHelpMan generateblock()
         }
     }
 
-    uint256 block_hash;
+    std::shared_ptr<const CBlock> block_out;
     uint64_t max_tries{DEFAULT_MAX_TRIES};
 
-    if (!GenerateBlock(chainman, block, max_tries, block_hash) || block_hash.IsNull()) {
+    if (!GenerateBlock(chainman, block, max_tries, block_out, process_new_block) || !block_out) {
         throw JSONRPCError(RPC_MISC_ERROR, "Failed to make block.");
     }
 
     UniValue obj(UniValue::VOBJ);
-    obj.pushKV("hash", block_hash.GetHex());
+    obj.pushKV("hash", block_out->GetHash().GetHex());
+    if (!process_new_block) {
+        CDataStream block_ser{SER_NETWORK, PROTOCOL_VERSION};
+        block_ser << *block_out;
+        obj.pushKV("hex", HexStr(block_ser));
+    }
     return obj;
 },
     };

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -22,7 +22,7 @@ class RPCGenerateTest(BitcoinTestFramework):
         self.test_generateblock()
 
     def test_generatetoaddress(self):
-        self.generatetoaddress(self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
+        self.generatetoaddress(self.nodes[0], 1, 'yjQ5gLvGRtmq1cwc4kePLCrzQ8GVCh9Gaz')
         assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, self.nodes[0], 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
 
     def test_generateblock(self):
@@ -57,7 +57,7 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info('Generate an empty block to a combo descriptor with uncompressed pubkey')
         combo_key = '0408ef68c46d20596cc3f6ddf7c8794f71913add807f1dc55949fa805d764d191c0b7ce6894c126fce0babc6663042f3dde9b0cf76467ea315514e5a6731149c67'
-        combo_address = 'mkc9STceoCcjoXEXe6cm66iJbmjM6zR9B2'
+        combo_address = 'yWziQMcwmKjRdzi7eWjwiQX8EjWcd6dSg6'
         hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
         block = node.getblock(hash, 2)
         assert_equal(len(block['tx']), 1)

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -49,7 +49,7 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info('Generate an empty block to a combo descriptor with compressed pubkey')
         combo_key = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
-        combo_address = 'yVg3NBUHNEhgDceqwVUjsZHreC5PBHnUo9'
+        combo_address = 'yWziQMcwmKjRdzi7eWjwiQX8EjWcd6dSg6'
         hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
         block = node.getblock(hash, 2)
         assert_equal(len(block['tx']), 1)
@@ -57,7 +57,7 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info('Generate an empty block to a combo descriptor with uncompressed pubkey')
         combo_key = '0408ef68c46d20596cc3f6ddf7c8794f71913add807f1dc55949fa805d764d191c0b7ce6894c126fce0babc6663042f3dde9b0cf76467ea315514e5a6731149c67'
-        combo_address = 'yWziQMcwmKjRdzi7eWjwiQX8EjWcd6dSg6'
+        combo_address = 'yVg3NBUHNEhgDceqwVUjsZHreC5PBHnUo9'
         hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
         block = node.getblock(hash, 2)
         assert_equal(len(block['tx']), 1)

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -9,6 +9,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
+from test_framework.wallet import MiniWallet
 
 
 class RPCGenerateTest(BitcoinTestFramework):
@@ -16,6 +17,97 @@ class RPCGenerateTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def run_test(self):
+        self.test_generatetoaddress()
+        self.test_generate()
+        self.test_generateblock()
+
+    def test_generatetoaddress(self):
+        self.generatetoaddress(self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
+        assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, self.nodes[0], 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
+
+    def test_generateblock(self):
+        node = self.nodes[0]
+        miniwallet = MiniWallet(node)
+
+        self.log.info('Mine an empty block to address and return the hex')
+        address = miniwallet.get_address()
+        generated_block = self.generateblock(node, output=address, transactions=[], submit=False)
+        node.submitblock(hexdata=generated_block['hex'])
+        assert_equal(generated_block['hash'], node.getbestblockhash())
+
+        self.log.info('Generate an empty block to address')
+        hash = self.generateblock(node, output=address, transactions=[])['hash']
+        block = node.getblock(blockhash=hash, verbose=2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
+
+        self.log.info('Generate an empty block to a descriptor')
+        hash = self.generateblock(node, 'addr(' + address + ')', [])['hash']
+        block = node.getblock(blockhash=hash, verbosity=2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
+
+        self.log.info('Generate an empty block to a combo descriptor with compressed pubkey')
+        combo_key = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+        combo_address = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080'
+        hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
+        block = node.getblock(hash, 2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], combo_address)
+
+        self.log.info('Generate an empty block to a combo descriptor with uncompressed pubkey')
+        combo_key = '0408ef68c46d20596cc3f6ddf7c8794f71913add807f1dc55949fa805d764d191c0b7ce6894c126fce0babc6663042f3dde9b0cf76467ea315514e5a6731149c67'
+        combo_address = 'mkc9STceoCcjoXEXe6cm66iJbmjM6zR9B2'
+        hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
+        block = node.getblock(hash, 2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], combo_address)
+
+        # Generate some extra blocks to spend
+        self.generatetoaddress(node, 110, combo_address)
+
+        # Generate block with txid
+        txid1 = miniwallet.send_self_transfer(from_node=node)['txid']
+        hash = self.generateblock(node, address, [txid1])['hash']
+        block = node.getblock(hash, 1)
+        assert_equal(len(block['tx']), 2)
+        assert_equal(block['tx'][1], txid1)
+
+        self.log.info('Generate block with raw tx')
+        rawtx = miniwallet.create_self_transfer()['hex']
+        hash = self.generateblock(node, address, [rawtx])['hash']
+
+        block = node.getblock(hash, 1)
+        assert_equal(len(block['tx']), 2)
+        txid = block['tx'][1]
+        assert_equal(node.getrawtransaction(txid=txid, verbose=False, blockhash=hash), rawtx)
+
+        self.log.info('Fail to generate block with out of order txs')
+        txid1 = miniwallet.send_self_transfer(from_node=node)['txid']
+        utxo1 = miniwallet.get_utxo(txid=txid1)
+        rawtx2 = miniwallet.create_self_transfer(utxo_to_spend=utxo1)['hex']
+        assert_raises_rpc_error(-25, 'TestBlockValidity failed: bad-txns-inputs-missingorspent', self.generateblock, node, address, [rawtx2, txid1])
+
+        self.log.info('Fail to generate block with txid not in mempool')
+        missing_txid = '0000000000000000000000000000000000000000000000000000000000000000'
+        assert_raises_rpc_error(-5, 'Transaction ' + missing_txid + ' not in mempool.', self.generateblock, node, address, [missing_txid])
+
+        self.log.info('Fail to generate block with invalid raw tx')
+        invalid_raw_tx = '0000'
+        assert_raises_rpc_error(-22, 'Transaction decode failed for ' + invalid_raw_tx, self.generateblock, node, address, [invalid_raw_tx])
+
+        self.log.info('Fail to generate block with invalid address/descriptor')
+        assert_raises_rpc_error(-5, 'Invalid address or descriptor', self.generateblock, node, '1234', [])
+
+        self.log.info('Fail to generate block with a ranged descriptor')
+        ranged_descriptor = 'pkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/*)'
+        assert_raises_rpc_error(-8, 'Ranged descriptor not accepted. Maybe pass through deriveaddresses first?', self.generateblock, node, ranged_descriptor, [])
+
+        self.log.info('Fail to generate block with a descriptor missing a private key')
+        child_descriptor = 'pkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0\'/0)'
+        assert_raises_rpc_error(-5, 'Cannot derive script without private keys', self.generateblock, node, child_descriptor, [])
+
+    def test_generate(self):
         message = (
             "generate\n\n"
             "has been replaced by the -generate "

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -49,7 +49,7 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info('Generate an empty block to a combo descriptor with compressed pubkey')
         combo_key = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
-        combo_address = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080'
+        combo_address = 'yVg3NBUHNEhgDceqwVUjsZHreC5PBHnUo9'
         hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
         block = node.getblock(hash, 2)
         assert_equal(len(block['tx']), 1)


### PR DESCRIPTION
Backports bitcoin/bitcoin#18933

Original commit: 8acfb1f8e0

This PR adds a `submit` parameter to the `generateblock` RPC command that allows generating a block without submitting it to the network. When `submit=false`, the block is returned as hex for further testing purposes.

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The block generation RPC now supports an optional "submit" parameter, allowing users to generate a block without immediately submitting it to the network. When "submit" is false, the block data is returned in hex format.

* **Bug Fixes**
  * Improved error handling and messaging for invalid addresses, descriptors, and transactions in block generation RPC calls.

* **Tests**
  * Expanded test coverage for block generation, including new scenarios for address and descriptor handling, transaction inclusion, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->