### PR TITLE
Merge bitcoin/bitcoin#27269: test: Support decoding segwit address in address_to_scriptpubkey()

### DIFF
--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -8,6 +8,7 @@ import itertools
 import json
 import os
 
+from test_framework.address import address_to_scriptpubkey
 from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create, drop_origins
 from test_framework.key import ECPubKey, ECKey
@@ -158,7 +159,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
             assert mredeemw == mredeem
             wmulti.unloadwallet()
 
-        spk = bytes.fromhex(node0.validateaddress(madd)["scriptPubKey"])
+        spk = address_to_scriptpubkey(madd)
         txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=spk, amount=2000)
         tx = node0.getrawtransaction(txid, True)
         vout = [v["n"] for v in tx["vout"] if madd == v["scriptPubKey"]["address"]]

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -13,12 +13,17 @@ import unittest
 
 from .script import hash160, hash256, CScript
 from .util import assert_equal
+from test_framework.script_util import (
+    keyhash_to_p2pkh_script,
+    program_to_witness_script,
+    scripthash_to_p2sh_script,
+)
 from test_framework.segwit_addr import (
     decode_segwit_address,
     encode_segwit_address,
 )
 
-# Note unlike in bitcoin, this address isn't bech32 since we don't (at this time) support bech32.
+# Note: This is a legacy address format. Bech32 addresses are now supported via bech32_to_bytes().
 ADDRESS_BCRT1_UNSPENDABLE = 'yVg3NBUHNEhgDceqwVUjsZHreC5PBHnUo9'
 ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR = 'addr(yVg3NBUHNEhgDceqwVUjsZHreC5PBHnUo9)#e5kt0jtk'
 ADDRESS_BCRT1_P2SH_OP_TRUE = '8zJctvfrzGZ5s1zQ3kagwyW1DsPYSQ4V2P'
@@ -112,6 +117,21 @@ def bech32_to_bytes(address):
     if version is None:
         return (None, None)
     return version, bytearray(payload)
+
+
+def address_to_scriptpubkey(address):
+    """Converts a given address to the corresponding output script (scriptPubKey)."""
+    version, payload = bech32_to_bytes(address)
+    if version is not None:
+        return program_to_witness_script(version, payload) # testnet segwit scriptpubkey
+    payload, version = base58_to_byte(address)
+    if version == 140:  # testnet pubkey hash
+        return keyhash_to_p2pkh_script(payload)
+    elif version == 19:  # testnet script hash
+        return scripthash_to_p2sh_script(payload)
+    # TODO: also support other address formats
+    else:
+        assert False
 
 
 class TestFrameworkScript(unittest.TestCase):

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -13,6 +13,10 @@ import unittest
 
 from .script import hash160, hash256, CScript
 from .util import assert_equal
+from test_framework.segwit_addr import (
+    decode_segwit_address,
+    encode_segwit_address,
+)
 
 # Note unlike in bitcoin, this address isn't bech32 since we don't (at this time) support bech32.
 ADDRESS_BCRT1_UNSPENDABLE = 'yVg3NBUHNEhgDceqwVUjsZHreC5PBHnUo9'
@@ -100,6 +104,16 @@ def check_script(script):
     assert False
 
 
+def bech32_to_bytes(address):
+    hrp = address.split('1')[0]
+    if hrp not in ['bc', 'tb', 'bcrt']:
+        return (None, None)
+    version, payload = decode_segwit_address(hrp, address)
+    if version is None:
+        return (None, None)
+    return version, bytearray(payload)
+
+
 class TestFrameworkScript(unittest.TestCase):
     def test_base58encodedecode(self):
         def check_base58(data, version):
@@ -117,3 +131,18 @@ class TestFrameworkScript(unittest.TestCase):
         check_base58(bytes.fromhex('0041c1eaf111802559bad61b60d62b1f897c63928a'), 0)
         check_base58(bytes.fromhex('000041c1eaf111802559bad61b60d62b1f897c63928a'), 0)
         check_base58(bytes.fromhex('00000041c1eaf111802559bad61b60d62b1f897c63928a'), 0)
+
+
+    def test_bech32_decode(self):
+        def check_bech32_decode(payload, version):
+            hrp = "tb"
+            self.assertEqual(bech32_to_bytes(encode_segwit_address(hrp, version, payload)), (version, payload))
+
+        check_bech32_decode(bytes.fromhex('36e3e2a33f328de12e4b43c515a75fba2632ecc3'), 0)
+        check_bech32_decode(bytes.fromhex('823e9790fc1d1782321140d4f4aa61aabd5e045b'), 0)
+        check_bech32_decode(bytes.fromhex('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'), 1)
+        check_bech32_decode(bytes.fromhex('39cf8ebd95134f431c39db0220770bd127f5dd3cc103c988b7dcd577ae34e354'), 1)
+        check_bech32_decode(bytes.fromhex('708244006d27c757f6f1fc6f853b6ec26268b727866f7ce632886e34eb5839a3'), 1)
+        check_bech32_decode(bytes.fromhex('616211ab00dffe0adcb6ce258d6d3fd8cbd901e2'), 0)
+        check_bech32_decode(bytes.fromhex('b6a7c98b482d7fb21c9fa8e65692a0890410ff22'), 0)
+        check_bech32_decode(bytes.fromhex('f0c2109cb1008cfa7b5a09cc56f7267cd8e50929'), 0)

--- a/test/functional/test_framework/script_util.py
+++ b/test/functional/test_framework/script_util.py
@@ -80,6 +80,15 @@ def check_key(key):
     assert False
 
 
+def program_to_witness_script(version, program):
+    """Convert a segwit program to a witness script."""
+    if version == 0:
+        assert len(program) in [20, 32]
+        return CScript([version, program])
+    else:
+        return CScript([version, program])
+
+
 def check_script(script):
     if isinstance(script, str):
         script = bytes.fromhex(script)  # Assuming this is hex string

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -91,7 +91,7 @@ class MiniWallet:
             self._scriptPubKey = key_to_p2pk_script(pub_key.get_bytes())
         elif mode == MiniWalletMode.ADDRESS_OP_TRUE:
             self._address = ADDRESS_BCRT1_P2SH_OP_TRUE
-            self._scriptPubKey = bytes.fromhex(self._test_node.validateaddress(self._address)['scriptPubKey'])
+            self._scriptPubKey = address_to_scriptpubkey(self._address)
 
     def _create_utxo(self, *, txid, vout, value, height, coinbase, confirmations):
         return {"txid": txid, "vout": vout, "value": value, "height": height, "coinbase": coinbase, "confirmations": confirmations}

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -15,6 +15,7 @@ from typing import (
 )
 from test_framework.address import (
     base58_to_byte,
+    bech32_to_bytes,
     key_to_p2pkh,
     ADDRESS_BCRT1_P2SH_OP_TRUE,
 )
@@ -39,6 +40,7 @@ from test_framework.script_util import (
     key_to_p2pk_script,
     key_to_p2pkh_script,
     keyhash_to_p2pkh_script,
+    program_to_witness_script,
     scripthash_to_p2sh_script,
 )
 from test_framework.util import (
@@ -333,6 +335,9 @@ def getnewdestination(address_type='legacy'):
 
 def address_to_scriptpubkey(address):
     """Converts a given address to the corresponding output script (scriptPubKey)."""
+    version, payload = bech32_to_bytes(address)
+    if version is not None:
+        return program_to_witness_script(version, payload) # testnet segwit scriptpubkey
     payload, version = base58_to_byte(address)
     if version == 140:  # testnet pubkey hash
         return keyhash_to_p2pkh_script(payload)


### PR DESCRIPTION
Backports bitcoin/bitcoin#27269

Original commit: 873a5062d

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding and handling Bech32 (SegWit) addresses, enabling conversion to scriptPubKey.
  * Introduced tests to validate Bech32 address encoding and decoding.

* **Refactor**
  * Updated address handling logic to use a unified utility for scriptPubKey extraction, improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->