### PR TITLE
Merge bitcoin/bitcoin#26642: clang-tidy: Add more `performance-*` checks and related fixes

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -2,6 +2,12 @@ Checks: '
 -*,
 bugprone-argument-comment,
 modernize-use-nullptr,
+performance-*,
+-performance-inefficient-string-concatenation,
+-performance-no-int-to-ptr,
+-performance-noexcept-move-constructor,
+-performance-unnecessary-value-param,
+readability-const-return-type,
 readability-redundant-declaration,
 readability-redundant-string-init,
 '

--- a/src/bench/lockedpool.cpp
+++ b/src/bench/lockedpool.cpp
@@ -17,9 +17,7 @@ static void BenchLockedPool(benchmark::Bench& bench)
     const size_t synth_size = 1024*1024;
     Arena b(synth_base, synth_size, 16);
 
-    std::vector<void*> addr;
-    for (int x=0; x<ASIZE; ++x)
-        addr.push_back(nullptr);
+    std::vector<void*> addr{ASIZE, nullptr};
     uint32_t s = 0x12345678;
     bench.run([&] {
         int idx = s & (addr.size() - 1);

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -1050,6 +1050,7 @@ static void ParseGetInfoResult(UniValue& result)
     }
 
     std::vector<std::string> formatted_proxies;
+    formatted_proxies.reserve(ordered_proxies.size());
     for (const std::string& proxy : ordered_proxies) {
         formatted_proxies.emplace_back(strprintf("%s (%s)", proxy, Join(proxy_networks.find(proxy)->second, ", ")));
     }

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -94,8 +94,8 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     painter.drawLine(XMARGIN, YMARGIN + h, width() - XMARGIN, YMARGIN + h);
 
     // decide what order of magnitude we are
-    int base = floor(log10(fMax));
-    float val = pow(10.0f, base);
+    int base = std::floor(std::log10(fMax));
+    float val = std::pow(10.0f, base);
     float val2 = val;
 
     const QString units = tr("kB/s");

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -85,6 +85,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
     std::string category;
     std::set<intptr_t> setDone;
     std::vector<std::pair<std::string, const CRPCCommand*> > vCommands;
+    vCommands.reserve(mapCommands.size());
 
     for (const auto& entry : mapCommands)
         vCommands.push_back(make_pair(entry.second.front()->category + entry.first, entry.second.front()));
@@ -547,6 +548,7 @@ static bool ExecuteCommand(const CRPCCommand& command, const JSONRPCRequest& req
 std::vector<std::string> CRPCTable::listCommands() const
 {
     std::vector<std::string> commandList;
+    commandList.reserve(mapCommands.size());
     for (const auto& i : mapCommands) commandList.emplace_back(i.first);
     return commandList;
 }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -555,6 +555,7 @@ bool RPCHelpMan::IsValidNumArgs(size_t num_args) const
 std::vector<std::string> RPCHelpMan::GetArgNames() const
 {
     std::vector<std::string> ret;
+    ret.reserve(m_args.size());
     for (const auto& arg : m_args) {
         ret.emplace_back(arg.m_names);
     }
@@ -633,12 +634,12 @@ UniValue RPCHelpMan::GetArgMap() const
 
 std::string RPCArg::GetFirstName() const
 {
-    return m_names.substr(0, m_names.find("|"));
+    return m_names.substr(0, m_names.find('|'));
 }
 
 std::string RPCArg::GetName() const
 {
-    CHECK_NONFATAL(std::string::npos == m_names.find("|"));
+    CHECK_NONFATAL(std::string::npos == m_names.find('|'));
     return m_names;
 }
 

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -16,6 +16,7 @@
 #include <util/system.h>
 #include <util/vector.h>
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -76,6 +76,7 @@ BOOST_AUTO_TEST_CASE(arena_tests)
     b.walk();
 #endif
     // Sweeping allocate all memory
+    addr.reserve(2048);
     for (int x=0; x<1024; ++x)
         addr.push_back(b.alloc(1024));
     BOOST_CHECK(b.stats().free == 0);

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -306,6 +306,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
     SetMempoolConstraints(*node.args, fuzzed_data_provider);
 
     std::vector<uint256> txids;
+    txids.reserve(g_outpoints_coinbase_init_mature.size());
     for (const auto& outpoint : g_outpoints_coinbase_init_mature) {
         txids.push_back(outpoint.hash);
     }

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -29,6 +29,7 @@ void ResetArgs(ArgsManager& local_args, const std::string& strArg)
 
     // Convert to char*:
     std::vector<const char*> vecChar;
+    vecChar.reserve(vecArg.size());
     for (const std::string& s : vecArg)
         vecChar.push_back(s.c_str());
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -23,6 +23,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     CAmount basefee(2000);
     CAmount deltaFee(100);
     std::vector<CAmount> feeV;
+    feeV.reserve(10);
 
     // Populate vectors of increasing fees
     for (int j = 0; j < 10; j++) {

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -71,6 +71,7 @@ BOOST_AUTO_TEST_CASE(manythreads)
 
     // As soon as these are created they will start running and servicing the queue
     std::vector<std::thread> microThreads;
+    microThreads.reserve(10);
     for (int i = 0; i < 5; i++)
         microThreads.emplace_back(std::bind(&CScheduler::serviceQueue, &microTasks));
 
@@ -136,6 +137,7 @@ BOOST_AUTO_TEST_CASE(singlethreadedscheduler_ordered)
     // the extra threads should effectively be doing nothing
     // if they don't we'll get out of order behaviour
     std::vector<std::thread> threads;
+    threads.reserve(5);
     for (int i = 0; i < 5; ++i) {
         threads.emplace_back([&] { scheduler.serviceQueue(); });
     }

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -154,6 +154,7 @@ BOOST_AUTO_TEST_CASE(set)
     FillableSigningProvider keystore;
     CKey key[4];
     std::vector<CPubKey> keys;
+    keys.reserve(4);
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
@@ -268,12 +269,13 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     CCoinsViewCache coins(&coinsDummy);
     FillableSigningProvider keystore;
     CKey key[6];
-    std::vector<CPubKey> keys;
     for (int i = 0; i < 6; i++)
     {
         key[i].MakeNewKey(true);
         BOOST_CHECK(keystore.AddKey(key[i]));
     }
+    std::vector<CPubKey> keys;
+    keys.reserve(3);
     for (int i = 0; i < 3; i++)
         keys.push_back(key[i].GetPubKey());
 

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -116,6 +116,7 @@ CNode* ConnmanTestMsg::ConnectNodePublic(PeerManager& peerman, const char* pszDe
 std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candidates, FastRandomContext& random_context)
 {
     std::vector<NodeEvictionCandidate> candidates;
+    candidates.reserve(n_candidates);
     for (int id = 0; id < n_candidates; ++id) {
         candidates.push_back({
             /*id=*/id,

--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -38,6 +38,7 @@ std::set<std::string> RenameEnMasse(int num_threads)
         names.insert(util::ThreadGetInternalName());
     };
 
+    threads.reserve(num_threads);
     for (int i = 0; i < num_threads; ++i) {
         threads.push_back(std::thread(RenameThisThread, i));
     }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -172,6 +172,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
     // this will create parallelism and randomness inside validation - the ValidationInterface
     // will subscribe to events generated during block validation and assert on ordering invariance
     std::vector<std::thread> threads;
+    threads.reserve(10);
     for (int i = 0; i < 10; i++) {
         threads.emplace_back([&]() {
             bool ignored;

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -26,7 +26,7 @@ bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypa
         }
         // Finds whether it is hardened
         uint32_t path = 0;
-        size_t pos = item.find("'");
+        size_t pos = item.find('\'');
         if (pos != std::string::npos) {
             // The hardened tick can only be in the last index of the string
             if (pos != item.size() - 1) {

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -443,7 +443,8 @@ void BerkeleyEnvironment::ReloadDbEnv()
     });
 
     std::vector<fs::path> filenames;
-    for (auto it : m_databases) {
+    filenames.reserve(m_databases.size());
+    for (const auto& it : m_databases) {
         filenames.push_back(it.first);
     }
     // Close the individual Db's

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -987,6 +987,7 @@ RPCHelpMan dumpwallet()
 
     // sort time/key pairs
     std::vector<std::pair<int64_t, CKeyID> > vKeyBirth;
+    vKeyBirth.reserve(mapKeyBirth.size());
     for (const auto& entry : mapKeyBirth) {
         vKeyBirth.push_back(std::make_pair(entry.second, entry.first));
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2327,9 +2327,8 @@ TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction&
             *keys = Merge(*keys, *script_keys);
         } else {
             // Maybe there are pubkeys listed that we can sign for
-            script_keys = std::make_unique<FlatSigningProvider>();
             std::vector<CPubKey> pubkeys;
-            pubkeys.reserve(input.hd_keypaths.size());
+            pubkeys.reserve(input.hd_keypaths.size() + 2);
 
             // ECDSA Pubkeys
             for (const auto& pk_pair : input.hd_keypaths) {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1645,6 +1645,7 @@ std::vector<CKeyID> GetAffectedKeys(const CScript& spk, const SigningProvider& p
     FlatSigningProvider out;
     InferDescriptor(spk, provider)->Expand(0, DUMMY_SIGNING_PROVIDER, dummy, out);
     std::vector<CKeyID> ret;
+    ret.reserve(out.pubkeys.size());
     for (const auto& entry : out.pubkeys) {
         ret.push_back(entry.first);
     }
@@ -2326,9 +2327,15 @@ TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction&
             *keys = Merge(*keys, *script_keys);
         } else {
             // Maybe there are pubkeys listed that we can sign for
-            script_keys = std::make_unique<FlatSigningProvider>();
+            std::vector<CPubKey> pubkeys;
+            pubkeys.reserve(input.hd_keypaths.size());
+
+            // ECDSA Pubkeys
             for (const auto& pk_pair : input.hd_keypaths) {
-                const CPubKey& pubkey = pk_pair.first;
+                pubkeys.push_back(pk_pair.first);
+            }
+
+            for (const auto& pubkey : pubkeys) {
                 std::unique_ptr<FlatSigningProvider> pk_keys = GetSigningProvider(pubkey);
                 if (pk_keys) {
                     *keys = Merge(*keys, *pk_keys);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2327,6 +2327,7 @@ TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction&
             *keys = Merge(*keys, *script_keys);
         } else {
             // Maybe there are pubkeys listed that we can sign for
+            script_keys = std::make_unique<FlatSigningProvider>();
             std::vector<CPubKey> pubkeys;
             pubkeys.reserve(input.hd_keypaths.size());
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2327,6 +2327,7 @@ TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction&
             *keys = Merge(*keys, *script_keys);
         } else {
             // Maybe there are pubkeys listed that we can sign for
+            script_keys = std::make_unique<FlatSigningProvider>();
             std::vector<CPubKey> pubkeys;
             pubkeys.reserve(input.hd_keypaths.size() + 2);
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -97,7 +97,7 @@ static bool IsZMQAddressIPV6(const std::string &zmq_address)
 {
     const std::string tcp_prefix = "tcp://";
     const size_t tcp_index = zmq_address.rfind(tcp_prefix);
-    const size_t colon_index = zmq_address.rfind(":");
+    const size_t colon_index = zmq_address.rfind(':');
     if (tcp_index == 0 && colon_index != std::string::npos) {
         const std::string ip = zmq_address.substr(tcp_prefix.length(), colon_index - tcp_prefix.length());
         const std::optional<CNetAddr> addr{LookupHost(ip, false)};


### PR DESCRIPTION
Backports bitcoin/bitcoin#26642

Original commit: 396306755

Backported from Bitcoin Core v0.25

This PR adds more performance-related clang-tidy checks and applies the related fixes:
- Adds `performance-*` checks to .clang-tidy
- Adds `reserve()` calls to vectors before loops that fill them
- Uses std:: prefix for math functions (floor, log10, pow)
- Changes string character searches to use character literals instead of strings

Note: Some files from the original Bitcoin commit don't exist in Dash:
- src/bench/wallet_create_tx.cpp
- src/bitcoin-util.cpp  
- src/test/txrequest_tests.cpp
- External signer functionality in src/node/interfaces.cpp
- Taproot descriptors in src/script/descriptor.cpp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced memory allocation efficiency by preallocating vector capacity in multiple components, reducing potential slowdowns from repeated reallocations.
  * Updated static analysis configuration to include additional performance and readability checks.

* **Bug Fixes**
  * Improved handling of signing providers when filling partially signed transactions, ensuring more robust key collection in specific wallet operations.

* **Style**
  * Standardized usage of character literals and namespace-qualified mathematical functions for improved code consistency and readability.

* **Tests**
  * Optimized test performance by preallocating memory for vectors and threads in various test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->