### PR TITLE
Merge bitcoin/bitcoin#27363: ci: use LLVM/clang-16 in native_fuzz (ASAN) job

### DIFF
--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_fuzz
-export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev"
+export PACKAGES="clang-18 llvm-18 libclang-rt-18-dev python3 libevent-dev bsdmainutils libboost-dev"
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"
 export CPPFLAGS="-DDEBUG_LOCKORDER -DARENA_DEBUG"
 export PYZMQ=true
@@ -16,3 +16,4 @@ export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address,undefined,integer CC='clang-18 -ftrivial-auto-var-init=pattern' CXX='clang++-18 -ftrivial-auto-var-init=pattern' --with-boost-process"
+export CCACHE_SIZE=200M


### PR DESCRIPTION
Backports bitcoin/bitcoin#27363

Original commit: 84f4ac39f

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment setup for native fuzz testing to use specific versions of Clang and LLVM.
  * Configured compiler commands to use versioned Clang binaries with improved initialization flags.
  * Set a default cache size for ccache to enhance build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->