### PR TITLE
Merge bitcoin/bitcoin#27378: test: Remove python3.5 workaround

### DIFF
--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -51,9 +51,11 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         self.supports_cli = False
 
         # Set -maxmempool=0 to turn off mempool memory sharing with dbcache
-        # Set -rpcservertimeout=900 to reduce socket disconnects in this
-        # long-running test
-        self.base_args = ["-limitdescendantsize=0", "-maxmempool=0", "-rpcservertimeout=900", "-dbbatchsize=200000"]
+        self.base_args = [
+            "-limitdescendantsize=0",
+            "-maxmempool=0",
+            "-dbbatchsize=200000",
+        ]
 
         # Set different crash ratios and cache sizes.  Note that not all of
         # -dbcache goes to the in-memory coins cache.

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -39,6 +39,7 @@ from http import HTTPStatus
 import http.client
 import json
 import logging
+import os
 import socket
 import time
 import urllib.parse
@@ -100,6 +101,11 @@ class AuthServiceProxy():
                    'User-Agent': USER_AGENT,
                    'Authorization': self.__auth_header,
                    'Content-type': 'application/json'}
+        if os.name == 'nt':
+            # Windows somehow does not like to re-use connections
+            # TODO: Find out why the connection would disconnect occasionally and make it reusable on Windows
+            # Avoid "ConnectionAbortedError: [WinError 10053] An established connection was aborted by the software in your host machine"
+            self._set_conn()
         self.__conn.request(method, path, postdata, headers)
         return self._get_response()
 

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -94,31 +94,19 @@ class AuthServiceProxy():
 
     def _request(self, method, path, postdata):
         '''
-        Do a HTTP request, with retry if we get disconnected (e.g. due to a timeout).
-        This is a workaround for https://bugs.python.org/issue3566 which is fixed in Python 3.5.
+        Do a HTTP request.
         '''
         headers = {'Host': self.__url.hostname,
                    'User-Agent': USER_AGENT,
                    'Authorization': self.__auth_header,
                    'Content-type': 'application/json'}
-        try:
-            self.__conn.request(method, path, postdata, headers)
-            return self._get_response()
-        except (BrokenPipeError, ConnectionResetError):
-            # Python 3.5+ raises BrokenPipeError when the connection was reset
-            # ConnectionResetError happens on FreeBSD
-            self.__conn.close()
-            self.__conn.request(method, path, postdata, headers)
-            return self._get_response()
-        except OSError as e:
-            # Workaround for a bug on macOS. See https://bugs.python.org/issue33450
-            retry = '[Errno 41] Protocol wrong type for socket' in str(e)
-            if retry:
-                self.__conn.close()
-                self.__conn.request(method, path, postdata, headers)
-                return self._get_response()
-            else:
-                raise
+        if os.name == 'nt':
+            # Windows somehow does not like to re-use connections
+            # TODO: Find out why the connection would disconnect occasionally and make it reusable on Windows
+            # Avoid "ConnectionAbortedError: [WinError 10053] An established connection was aborted by the software in your host machine"
+            self._set_conn()
+        self.__conn.request(method, path, postdata, headers)
+        return self._get_response()
 
     def get_request(self, *args, **argsn):
         AuthServiceProxy.__id_count += 1

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -39,7 +39,6 @@ from http import HTTPStatus
 import http.client
 import json
 import logging
-import os
 import socket
 import time
 import urllib.parse
@@ -101,11 +100,6 @@ class AuthServiceProxy():
                    'User-Agent': USER_AGENT,
                    'Authorization': self.__auth_header,
                    'Content-type': 'application/json'}
-        if os.name == 'nt':
-            # Windows somehow does not like to re-use connections
-            # TODO: Find out why the connection would disconnect occasionally and make it reusable on Windows
-            # Avoid "ConnectionAbortedError: [WinError 10053] An established connection was aborted by the software in your host machine"
-            self._set_conn()
         self.__conn.request(method, path, postdata, headers)
         return self._get_response()
 

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -39,6 +39,7 @@ from http import HTTPStatus
 import http.client
 import json
 import logging
+import os
 import socket
 import time
 import urllib.parse

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -396,6 +396,9 @@ def write_config(config_path, *, n, chain, extra_config=""):
             f.write("[{}]\n".format(chain_name_conf_section))
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
+        # Disable server-side timeouts to avoid intermittent issues
+        f.write("rpcservertimeout=99000\n")
+        f.write("rpcdoccheck=1\n")
         f.write("fallbackfee=0.00001\n")
         f.write("server=1\n")
         f.write("keypool=1\n")


### PR DESCRIPTION
Backports bitcoin/bitcoin#27378

Original commit: 88134fcee

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to set a higher RPC server timeout and enable RPC documentation checks.
  * Removed retry logic from HTTP requests in the test framework for simplified behavior.
  * Adjusted test parameters by removing a specific RPC server timeout argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->