### PR TITLE
Merge bitcoin/bitcoin#27444: ci: use Debian Bookworm and Valgrind 3.19 in Valgrind jobs

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CI_IMAGE_NAME_TAG="debian:bookworm"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
 export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev valgrind"
 export NO_DEPENDS=1
@@ -14,6 +15,6 @@ export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export FUZZ_TESTS_CONFIG="--valgrind"
 export GOAL="install"
-# Temporarily pin dwarf 4, until valgrind can understand clang's dwarf 5
+# Temporarily pin dwarf 4, until using Valgrind 3.20 or later
 export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer CC=clang-18 CXX=clang++-18 CFLAGS='-gdwarf-4' CXXFLAGS='-gdwarf-4'"
 export CCACHE_SIZE=200M

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -6,10 +6,12 @@
 
 export LC_ALL=C.UTF-8
 
-export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
+export CI_IMAGE_NAME_TAG="debian:bookworm"
+export CONTAINER_NAME=ci_native_valgrind
+export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libsqlite3-dev"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
 export TEST_RUNNER_EXTRA="--exclude rpc_bind,feature_bind_extra --timeout-factor=4"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export GOAL="install"
-# Temporarily pin dwarf 4, until valgrind can understand clang's dwarf 5
+# Temporarily pin dwarf 4, until using Valgrind 3.20 or later
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang-18 CXX=clang++-18 CFLAGS='-gdwarf-4' CXXFLAGS='-gdwarf-4'"  # TODO enable GUI

--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -13,19 +13,8 @@
 #
 # Note that suppressions may depend on OS and/or library versions.
 # Tested on:
-# * aarch64 (Ubuntu 20.04 system libs, without gui)
-# * x86_64  (Ubuntu 18.04 system libs, without gui)
-{
-   Suppress libstdc++ warning - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65434
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   fun:malloc
-   obj:*/libstdc++.*
-   fun:call_init.part.0
-   fun:call_init
-   fun:_dl_init
-   obj:*/ld-*.so
-}
+# * aarch64 (Debian Bookworm system libs, clang, without gui)
+# * x86_64  (Debian Bookworm system libs, clang, without gui)
 {
    Suppress libdb warning - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=662917
    Memcheck:Cond
@@ -69,12 +58,6 @@
    Memcheck:Leak
    ...
    fun:_Z8ShutdownR11NodeContext
-}
-{
-   Ignore GUI warning
-   Memcheck:Leak
-   ...
-   obj:/usr/lib64/libgdk-3.so.0.2404.7
 }
 {
    Suppress leveldb leak


### PR DESCRIPTION
Backports bitcoin/bitcoin#27444

Original commit: cd603edee

Backported from Bitcoin Core v0.25