### PR TITLE
Merge bitcoin/bitcoin#26699: wallet, gui: bugfix, getAvailableBalance skips selected coins

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -791,7 +791,7 @@ void SendCoinsDialog::on_buttonMinimizeFee_clicked()
 void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
 {
     // Include watch-only for wallets without private key
-    m_coin_control->fAllowWatchOnly = model->wallet().privateKeysDisabled();
+    m_coin_control->fAllowWatchOnly = model->wallet().privateKeysDisabled() && !model->wallet().hasExternalSigner();
 
     // Same behavior as send: if we have selected coins, only obtain their available balance.
     // Copy to avoid modifying the member's data.
@@ -799,7 +799,7 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
     coin_control.m_allow_other_inputs = !coin_control.HasSelected();
 
     // Calculate available amount to send.
-    CAmount amount = model->wallet().getAvailableBalance(coin_control);
+    CAmount amount = model->getAvailableBalance(&coin_control);
     for (int i = 0; i < ui->entries->count(); ++i) {
         SendCoinsEntry* e = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
         if (e && !e->isHidden() && e != entry) {

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -793,8 +793,13 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
     // Include watch-only for wallets without private key
     m_coin_control->fAllowWatchOnly = model->wallet().privateKeysDisabled();
 
+    // Same behavior as send: if we have selected coins, only obtain their available balance.
+    // Copy to avoid modifying the member's data.
+    CCoinControl coin_control = *m_coin_control;
+    coin_control.m_allow_other_inputs = !coin_control.HasSelected();
+
     // Calculate available amount to send.
-    CAmount amount = model->wallet().getAvailableBalance(*m_coin_control);
+    CAmount amount = model->wallet().getAvailableBalance(coin_control);
     for (int i = 0; i < ui->entries->count(); ++i) {
         SendCoinsEntry* e = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
         if (e && !e->isHidden() && e != entry) {

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -51,6 +51,9 @@ public:
     void pasteEntry(const SendCoinsRecipient &rv);
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);
 
+    // Only used for testing-purposes
+    wallet::CCoinControl* getCoinControl() { return m_coin_control.get(); }
+
 public Q_SLOTS:
     void clear();
     void reject() override;

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -5,6 +5,7 @@
 #include <qt/test/wallettests.h>
 #include <qt/test/util.h>
 
+#include <wallet/coincontrol.h>
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
 #include <qt/bitcoinamountfield.h>
@@ -98,6 +99,42 @@ QModelIndex FindTx(const QAbstractItemModel& model, const uint256& txid)
     return {};
 }
 
+// Verify the 'useAvailableBalance' functionality. With and without manually selected coins.
+// Case 1: No coin control selected coins.
+// 'useAvailableBalance' should fill the amount edit box with the total available balance
+// Case 2: With coin control selected coins.
+// 'useAvailableBalance' should fill the amount edit box with the sum of the selected coins values.
+void VerifyUseAvailableBalance(SendCoinsDialog& sendCoinsDialog, const WalletModel& walletModel)
+{
+    // Verify first entry amount and "useAvailableBalance" button
+    QVBoxLayout* entries = sendCoinsDialog.findChild<QVBoxLayout*>("entries");
+    QVERIFY(entries->count() == 1); // only one entry
+    SendCoinsEntry* send_entry = qobject_cast<SendCoinsEntry*>(entries->itemAt(0)->widget());
+    QVERIFY(send_entry->getValue().amount == 0);
+    // Now click "useAvailableBalance", check updated balance (the entire wallet balance should be set)
+    Q_EMIT send_entry->useAvailableBalance(send_entry);
+    QVERIFY(send_entry->getValue().amount == walletModel.getCachedBalance().balance);
+
+    // Now manually select two coins and click on "useAvailableBalance". Then check updated balance
+    // (only the sum of the selected coins should be set).
+    int COINS_TO_SELECT = 2;
+    auto coins = walletModel.wallet().listCoins();
+    CAmount sum_selected_coins = 0;
+    int selected = 0;
+    QVERIFY(coins.size() == 1); // context check, coins received only on one destination
+    for (const auto& [outpoint, tx_out] : coins.begin()->second) {
+        sendCoinsDialog.getCoinControl()->Select(outpoint);
+        sum_selected_coins += tx_out.txout.nValue;
+        if (++selected == COINS_TO_SELECT) break;
+    }
+    QVERIFY(selected == COINS_TO_SELECT);
+
+    // Now that we have 2 coins selected, "useAvailableBalance" should update the balance label only with
+    // the sum of them.
+    Q_EMIT send_entry->useAvailableBalance(send_entry);
+    QVERIFY(send_entry->getValue().amount == sum_selected_coins);
+}
+
 //! Simple qt wallet tests.
 //
 // Test widgets can be debugged interactively calling show() on them and
@@ -167,6 +204,9 @@ void TestGUI(interfaces::Node& node)
         QString balanceComparison = BitcoinUnits::formatWithUnit(unit, balance, false /*, BitcoinUnits::SeparatorStyle::ALWAYS*/);
         QCOMPARE(balanceText, balanceComparison);
     }
+
+    // Check 'UseAvailableBalance' functionality
+    VerifyUseAvailableBalance(sendCoinsDialog, walletModel);
 
     // Send two transactions, and verify they are added to transaction list.
     TransactionTableModel* transactionTableModel = walletModel.getTransactionTableModel();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -611,3 +611,20 @@ uint256 WalletModel::getLastBlockProcessed() const
 {
     return m_client_model ? m_client_model->getBestBlockHash() : uint256{};
 }
+
+CAmount WalletModel::getAvailableBalance(const CCoinControl* control)
+{
+    // No selected coins, return the cached balance
+    if (!control || !control->HasSelected()) {
+        const interfaces::WalletBalances& balances = getCachedBalance();
+        CAmount available_balance = balances.balance;
+        // if wallet private keys are disabled, this is a watch-only wallet
+        // so, let's include the watch-only balance.
+        if (balances.have_watch_only && m_wallet->privateKeysDisabled()) {
+            available_balance += balances.watch_only_balance;
+        }
+        return available_balance;
+    }
+    // Fetch balance from the wallet, taking into account the selected coins
+    return wallet().getAvailableBalance(*control);
+}

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -162,6 +162,8 @@ public:
 
     uint256 getLastBlockProcessed() const;
 
+    CAmount getAvailableBalance(const CCoinControl* control);
+
 private:
     std::unique_ptr<interfaces::Wallet> m_wallet;
     std::unique_ptr<interfaces::Handler> m_handler_unload;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -21,6 +21,7 @@
 #include <util/translation.h>
 #include <util/ui_change_type.h>
 #include <validation.h>
+#include <wallet/coincontrol.h>
 #include <wallet/coinjoin.h>
 #include <wallet/context.h>
 #include <wallet/fees.h>
@@ -445,7 +446,24 @@ public:
         if (coin_control.IsUsingCoinJoin()) {
             return GetBalanceAnonymized(*m_wallet, coin_control);
         } else {
-            return GetAvailableBalance(*m_wallet, &coin_control);
+            LOCK(m_wallet->cs_wallet);
+            CAmount total_amount = 0;
+            // Fetch selected coins total amount
+            if (coin_control.HasSelected()) {
+                FastRandomContext rng{};
+                CoinSelectionParams params(rng);
+                // Note: for now, swallow any error.
+                if (auto res = FetchSelectedInputs(*m_wallet, coin_control, params)) {
+                    total_amount += res->total_amount;
+                }
+            }
+
+            // And fetch the wallet available coins
+            if (coin_control.m_allow_other_inputs) {
+                total_amount += AvailableCoins(*m_wallet, &coin_control).GetTotalAmount();
+            }
+
+            return total_amount;
         }
     }
     wallet::isminetype txinIsMine(const CTxIn& txin) override

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -220,18 +220,6 @@ CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl*
     return AvailableCoins(wallet, coinControl, /*feerate=*/ std::nullopt, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, /*only_spendable=*/false);
 }
 
-CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl)
-{
-    LOCK(wallet.cs_wallet);
-    return AvailableCoins(wallet, coinControl,
-            /*feerate=*/ std::nullopt,
-            /*nMinimumAmount=*/ 1,
-            /*nMaximumAmount=*/ MAX_MONEY,
-            /*nMinimumSumAmount=*/ MAX_MONEY,
-            /*nMaximumCount=*/ 0
-    ).total_amount;
-}
-
 const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const CTransaction& tx, int output)
 {
     AssertLockHeld(wallet.cs_wallet);

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -50,8 +50,6 @@ CoinsResult AvailableCoins(const CWallet& wallet,
  */
 CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
-CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl = nullptr);
-
 /**
  * Find non-change parent output.
  */

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -597,7 +597,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 1U);
 
     // Check initial balance from one mature coinbase transaction.
-    BOOST_CHECK_EQUAL(500 * COIN, GetAvailableBalance(*wallet));
+    BOOST_CHECK_EQUAL(500 * COIN, WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).GetTotalAmount()));
 
     // Add a transaction creating a change address, and confirm ListCoins still
     // returns the coin associated with the change address underneath the
@@ -1431,7 +1431,7 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
 BOOST_FIXTURE_TEST_CASE(select_coins_grouped_by_addresses, ListCoinsTestingSetup)
 {
     // Check initial balance from one mature coinbase transaction.
-    BOOST_CHECK_EQUAL(GetAvailableBalance(*wallet), 500 * COIN);
+    BOOST_CHECK_EQUAL(WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).GetTotalAmount()), 500 * COIN);
 
     {
         std::vector<CompactTallyItem> vecTally = wallet->SelectCoinsGroupedByAddresses(/*fSkipDenominated=*/false,


### PR DESCRIPTION
## Summary
- Fixes getAvailableBalance to properly skip selected coins
- Updates GUI useAvailableBalance functionality 
- Adapts Bitcoin's coin control fixes to work with Dash's CoinJoin

## Test plan
- [ ] Verify GUI "use available balance" button works correctly with selected coins
- [ ] Run wallet tests: `test/functional/test_runner.py wallet_*`
- [ ] Manual testing of coin control in GUI

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to accurately use the available balance in the send coins dialog, reflecting either the total wallet balance or the sum of manually selected coins.
  * Introduced new methods to retrieve available balance with enhanced coin selection control.

* **Bug Fixes**
  * Improved calculation of available balance to better align with coin selection and wallet settings.

* **Tests**
  * Added GUI tests to verify correct behavior of the "use available balance" feature in various coin selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->