### PR TITLE
Merge bitcoin/bitcoin#27465: doc: fix typo in developer-notes.md

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -110,6 +110,10 @@ code.
   - `nullptr` is preferred over `NULL` or `(void*)0`.
   - `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.
   - Align pointers and references to the left i.e. use `type& var` and not `type &var`.
+  - Use a named cast or functional cast, not a C-Style cast. When casting
+    between integer types, use functional casts such as `int(x)` or `int{x}`
+    instead of `(int) x`. When casting between more complex types, use `static_cast`.
+    Use `reinterpret_cast` and `const_cast` as appropriate.
 
 For function calls a namespace should be specified explicitly, unless such functions have been declared within it.
 Otherwise, [argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl), also known as ADL, could be


### PR DESCRIPTION
Backports bitcoin/bitcoin#27465

Original commit: b22c27558

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coding style guidelines to recommend using named or functional casts over C-style casts in C++ code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->