### PR TITLE
Merge bitcoin/bitcoin#27461: verify-commits: error and exit cleanly when git is too old.

### DIFF
--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -159,7 +159,7 @@ def main():
                     print("git v2.38+ is required for this functionality.", file=sys.stderr)
                     sys.exit(1)
                 else:
-                    raise e
+                    raise
             if current_tree != recreated_tree:
                 print("Merge commit {} is not clean".format(current_commit), file=sys.stderr)
                 subprocess.call([GIT, 'diff', current_commit])

--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -148,15 +148,22 @@ def main():
         allow_unclean = current_commit in unclean_merge_allowed
         if len(parents) == 2 and check_merge and not allow_unclean:
             current_tree = subprocess.check_output([GIT, 'show', '--format=%T', current_commit]).decode('utf8').splitlines()[0]
-            subprocess.call([GIT, 'checkout', '--force', '--quiet', parents[0]])
-            subprocess.call([GIT, 'merge', '--no-ff', '--quiet', '--no-gpg-sign', parents[1]], stdout=subprocess.DEVNULL)
-            recreated_tree = subprocess.check_output([GIT, 'show', '--format=format:%T', 'HEAD']).decode('utf8').splitlines()[0]
+            # This merge-tree functionality requires git >= 2.38. The
+            # --write-tree option was added in order to opt-in to the new
+            # behavior. Older versions of git will not recognize the option and
+            # will instead exit with code 128.
+            try:
+                recreated_tree = subprocess.check_output([GIT, "merge-tree", "--write-tree", parents[0], parents[1]]).decode('utf8').splitlines()[0]
+            except subprocess.CalledProcessError as e:
+                if e.returncode == 128:
+                    print("git v2.38+ is required for this functionality.", file=sys.stderr)
+                    sys.exit(1)
+                else:
+                    raise e
             if current_tree != recreated_tree:
                 print("Merge commit {} is not clean".format(current_commit), file=sys.stderr)
                 subprocess.call([GIT, 'diff', current_commit])
-                subprocess.call([GIT, 'checkout', '--force', '--quiet', branch])
                 sys.exit(1)
-            subprocess.call([GIT, 'checkout', '--force', '--quiet', branch])
 
         prev_commit = current_commit
         current_commit = parents[0]


### PR DESCRIPTION
Backports bitcoin/bitcoin#27461

Original commit: 69460bd8b

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the method for verifying clean merge commits to use a more efficient approach that does not modify your working directory.
  * Enhanced error handling to notify users if their Git version is too old for this feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->