### PR TITLE
Merge bitcoin/bitcoin#27473: bugfix: Properly handle "unknown" Address Type

### DIFF
--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -25,9 +25,6 @@ bool ParseOutputType(const std::string& type, OutputType& output_type)
     if (type == OUTPUT_TYPE_STRING_LEGACY) {
         output_type = OutputType::LEGACY;
         return true;
-    } else if (type == OUTPUT_TYPE_STRING_UNKNOWN) {
-        output_type = OutputType::UNKNOWN;
-        return true;
     }
     return false;
 }


### PR DESCRIPTION
$(cat <<'EOF'
Backports bitcoin/bitcoin#27473

Original commit: 4ad20a225

Backported from Bitcoin Core v0.25

This change removes the handling of OutputType::UNKNOWN from ParseOutputType function, which prevents potential issues when the parser encounters an "unknown" address type.

In Dash, the function signature differs from Bitcoin (returns bool with output parameter vs std::optional), but the equivalent change was applied by removing the handling of the UNKNOWN type case.
EOF
)