### PR TITLE
Merge bitcoin/bitcoin#26733: test: Add test for `sendmany` rpc that uses `subtractfeefrom` parameter

### DIFF
--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -16,7 +16,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     count_bytes,
     find_vout_for_address,
-    satoshi_round,
 )
 from test_framework.wallet_util import test_address
 
@@ -288,8 +287,8 @@ class WalletTest(BitcoinTestFramework):
         node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('10'), fee_per_byte, count_bytes(tx['hex']))
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
         expected_bal = Decimal('5') - (tx['fee'] / 2)
-        assert_equal(self.nodes[0].getreceivedbyaddress(a0), satoshi_round(expected_bal))
-        assert_equal(self.nodes[0].getreceivedbyaddress(a1), satoshi_round(expected_bal))
+        assert_equal(self.nodes[0].getreceivedbyaddress(a0), expected_bal)
+        assert_equal(self.nodes[0].getreceivedbyaddress(a1), expected_bal)
 
         self.log.info("Test sendmany with fee_rate param (explicit fee rate in duff/B)")
         fee_rate_sat_vb = 2

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -16,6 +16,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     count_bytes,
     find_vout_for_address,
+    satoshi_round,
 )
 from test_framework.wallet_util import test_address
 
@@ -275,6 +276,20 @@ class WalletTest(BitcoinTestFramework):
         node_2_bal -= Decimal('100')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
         node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('100'), fee_per_byte, count_bytes(self.nodes[2].gettransaction(txid)['hex']))
+
+        # Sendmany 5 DASH to two addresses with subtracting fee from both addresses
+        a0 = self.nodes[0].getnewaddress()
+        a1 = self.nodes[0].getnewaddress()
+        txid = self.nodes[2].sendmany(dummy='', amounts={a0: 5, a1: 5}, subtractfeefrom=[a0, a1])
+        self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
+        node_2_bal -= Decimal('10')
+        assert_equal(self.nodes[2].getbalance(), node_2_bal)
+        tx = self.nodes[2].gettransaction(txid)
+        node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('10'), fee_per_byte, count_bytes(tx['hex']))
+        assert_equal(self.nodes[0].getbalance(), node_0_bal)
+        expected_bal = Decimal('5') - (tx['fee'] / 2)
+        assert_equal(self.nodes[0].getreceivedbyaddress(a0), satoshi_round(expected_bal))
+        assert_equal(self.nodes[0].getreceivedbyaddress(a1), satoshi_round(expected_bal))
 
         self.log.info("Test sendmany with fee_rate param (explicit fee rate in duff/B)")
         fee_rate_sat_vb = 2


### PR DESCRIPTION
Backports bitcoin/bitcoin#26733

Original commit: 539452242e

This PR adds test that uses `sendmany` rpc to send DASH to multiple addresses using `subtractfeefrom` parameter, then checks receiver addresses balances to make sure fees are subtracted correctly.

Changes for Dash compatibility:
- Changed BTC to DASH in comment
- Used `count_bytes` instead of `self.get_vsize`
- Added `satoshi_round` for fee precision handling
- Fixed fee calculation (subtract instead of add)

Backported from Bitcoin Core v0.26