### PR TITLE
Merge bitcoin/bitcoin#27453: test: added coverage to rpc_scantxoutset.py

### DIFF
--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -127,8 +127,8 @@ class ScantxoutsetTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, "scanobjects argument is required for the start action", self.nodes[0].scantxoutset, "start")
 
         # Check that invalid command give error
-        assert_raises_rpc_error(-8, "Invalid command", self.nodes[0].scantxoutset, "invalid_command")
+        assert_raises_rpc_error(-8, "Invalid action 'invalid_command'", self.nodes[0].scantxoutset, "invalid_command")
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     ScantxoutsetTest().main()

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -127,7 +127,7 @@ class ScantxoutsetTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, "scanobjects argument is required for the start action", self.nodes[0].scantxoutset, "start")
 
         # Check that invalid command give error
-        assert_raises_rpc_error(-8, "Invalid action 'invalid_command'", self.nodes[0].scantxoutset, "invalid_command")
+        assert_raises_rpc_error(-8, "Invalid command", self.nodes[0].scantxoutset, "invalid_command")
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -126,5 +126,9 @@ class ScantxoutsetTest(BitcoinTestFramework):
         # Check that second arg is needed for start
         assert_raises_rpc_error(-1, "scanobjects argument is required for the start action", self.nodes[0].scantxoutset, "start")
 
-if __name__ == '__main__':
+        # Check that invalid command give error
+        assert_raises_rpc_error(-8, "Invalid command", self.nodes[0].scantxoutset, "invalid_command")
+
+
+if __name__ == "__main__":
     ScantxoutsetTest().main()

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -129,6 +129,5 @@ class ScantxoutsetTest(BitcoinTestFramework):
         # Check that invalid command give error
         assert_raises_rpc_error(-8, "Invalid command", self.nodes[0].scantxoutset, "invalid_command")
 
-
 if __name__ == '__main__':
     ScantxoutsetTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#27453

Original commit: d654c762c8

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to verify that an appropriate error is returned when an invalid command is used with the `scantxoutset` RPC call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->