### PR TITLE
Merge bitcoin/bitcoin#27674: ci: Fix "Number of CPUs" output

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -97,7 +97,7 @@ if [ "$CI_OS_NAME" == "macos" ]; then
   echo "Number of CPUs: $(sysctl -n hw.logicalcpu)"
 else
   CI_EXEC free -m -h
-  CI_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
+  CI_EXEC echo "Number of CPUs (nproc): $(nproc)"
   CI_EXEC echo "$(lscpu | grep Endian)"
 fi
 CI_EXEC echo "Free disk space:"


### PR DESCRIPTION
Backports bitcoin/bitcoin#27674

Original commit: 03a4e8dd4c

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display of CPU count in CI logs to show the actual number of CPUs instead of the command string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->