### PR TITLE
Merge bitcoin/bitcoin#27739: ci: Add missing set -e to 01_base_install.sh

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -21,12 +21,6 @@ requires `docker` to be installed. To install all requirements on Ubuntu, run
 sudo apt install docker.io bash
 ```
 
-To run the default test stage,
-
-```
-./ci/test_run_all.sh
-```
-
 To run the test stage with a specific configuration,
 
 ```

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
+set -ex
+
 # The root dir.
 # The ci system copies this folder.
 # This is where the depends build is done.
@@ -46,8 +48,6 @@ export RUN_SECURITY_TESTS=${RUN_SECURITY_TESTS:-false}
 export TEST_RUNNER_TIMEOUT_FACTOR=${TEST_RUNNER_TIMEOUT_FACTOR:-4}
 export RUN_FUZZ_TESTS=${RUN_FUZZ_TESTS:-false}
 
-export CONTAINER_NAME=${CONTAINER_NAME:-ci_unnamed}
-export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:20.04}
 # Randomize test order.
 # See https://www.boost.org/doc/libs/1_71_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/random.html
 export BOOST_TEST_RANDOM=${BOOST_TEST_RANDOM:-1}

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
+set -ex
+
 if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
   export LC_ALL=C
 fi
@@ -33,7 +35,10 @@ export P_CI_DIR="$PWD"
 export BINS_SCRATCH_DIR="${BASE_SCRATCH_DIR}/bins/"
 
 if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
-  echo "Creating $DOCKER_NAME_TAG container to run in"
+  # Export all env vars to avoid missing some.
+  # Though, exclude those with newlines to avoid parsing problems.
+  python3 -c 'import os; [print(f"{key}={value}") for key, value in os.environ.items() if "\n" not in value and "HOME" not in key]' | tee /tmp/env
+  echo "Creating container to run in"
   LOCAL_UID=$(id -u)
   LOCAL_GID=$(id -g)
 

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
+set -ex
+
 # Make sure default datadir does not exist and is never read by creating a dummy file
 if [ "$CI_OS_NAME" == "macos" ]; then
   echo > "${HOME}/Library/Application Support/DashCore"


### PR DESCRIPTION
Backports bitcoin/bitcoin#27739

Original commit: b5ed656c3b

Backported from Bitcoin Core v0.26

## Changes:
- Added `set -e` to CI scripts (04_install.sh, 05_before_script.sh) 
- Applied Bitcoin's environment variable export improvements (excluding HOME)
- Removed deprecated CONTAINER_NAME and DOCKER_NAME_TAG variables

Note: Bitcoin's changes to `ci/test/01_base_install.sh` were skipped as this file doesn't exist in Dash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions in the README for running the default test stage.

* **Chores**
  * Enabled shell debugging and error tracing in several CI scripts for improved transparency and reliability.
  * Updated environment variable handling and messaging in container setup scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->