### PR TITLE
Merge bitcoin/bitcoin#27657: doc: Remove unused NO_BLOOM_VERSION constant

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -135,7 +135,8 @@ extern const char* GETADDR;
 /**
  * The mempool message requests the TXIDs of transactions that the receiving
  * node has verified as valid but which have not yet appeared in a block.
- * @since protocol version 60002.
+ * @since protocol version 60002 as described by BIP35.
+ *   Only available with service bit NODE_BLOOM, see also BIP111.
  */
 extern const char* MEMPOOL;
 /**
@@ -315,8 +316,6 @@ enum ServiceFlags : uint64_t {
     // set by all Dash Core non pruned nodes, and is unset by SPV clients or other light clients.
     NODE_NETWORK = (1 << 0),
     // NODE_BLOOM means the node is capable and willing to handle bloom-filtered connections.
-    // Dash Core nodes used to support this by default, without advertising this bit,
-    // but no longer do as of protocol version 70201 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
     // NODE_COMPACT_FILTERS means the node will service basic block filter requests.
     // See BIP157 and BIP158 for details on how this is implemented.


### PR DESCRIPTION
Backports bitcoin/bitcoin#27657

Original commit: 30d6c7d8c0

Backported from Bitcoin Core v0.26

**Note**: This backport only includes changes to `src/protocol.h`. The `src/version.h` changes from Bitcoin are not applicable to Dash as the `NO_BLOOM_VERSION` constant does not exist in Dash's version.h file. Dash uses `70201` directly in the comment within protocol.h instead of referencing a constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for the `MEMPOOL` message type, clarifying its protocol version availability and service requirements.
  * Updated comments to reflect current support for bloom filtering and removed outdated explanations regarding the `NODE_BLOOM` service flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->