### PR TITLE
Merge bitcoin/bitcoin#27800: streams: Drop confusing DataStream::Serialize method and << operator

### DIFF
--- a/linux64_build_logs.txt
+++ b/linux64_build_logs.txt
@@ -1,0 +1,1881 @@
+﻿2025-07-26T11:56:52.8004364Z Current runner version: '2.326.0'
+2025-07-26T11:56:52.8026668Z ##[group]Runner Image Provisioner
+2025-07-26T11:56:52.8027461Z Hosted Compute Agent
+2025-07-26T11:56:52.8027967Z Version: 20250711.363
+2025-07-26T11:56:52.8028680Z Commit: 6785254374ce925a23743850c1cb91912ce5c14c
+2025-07-26T11:56:52.8029413Z Build Date: 2025-07-11T20:04:25Z
+2025-07-26T11:56:52.8030008Z ##[endgroup]
+2025-07-26T11:56:52.8030577Z ##[group]Operating System
+2025-07-26T11:56:52.8031152Z Ubuntu
+2025-07-26T11:56:52.8031596Z 24.04.2
+2025-07-26T11:56:52.8032122Z LTS
+2025-07-26T11:56:52.8032610Z ##[endgroup]
+2025-07-26T11:56:52.8033059Z ##[group]Runner Image
+2025-07-26T11:56:52.8033650Z Image: ubuntu-24.04
+2025-07-26T11:56:52.8034112Z Version: 20250720.1.0
+2025-07-26T11:56:52.8035419Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250720.1/images/ubuntu/Ubuntu2404-Readme.md
+2025-07-26T11:56:52.8037108Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250720.1
+2025-07-26T11:56:52.8038069Z ##[endgroup]
+2025-07-26T11:56:52.8039195Z ##[group]GITHUB_TOKEN Permissions
+2025-07-26T11:56:52.8040973Z Contents: read
+2025-07-26T11:56:52.8041600Z Metadata: read
+2025-07-26T11:56:52.8042101Z Packages: write
+2025-07-26T11:56:52.8042606Z ##[endgroup]
+2025-07-26T11:56:52.8044905Z Secret source: Actions
+2025-07-26T11:56:52.8045789Z Prepare workflow directory
+2025-07-26T11:56:52.8555583Z Prepare all required actions
+2025-07-26T11:56:52.8591683Z Getting action download info
+2025-07-26T11:56:53.1733911Z ##[group]Download immutable action package 'actions/checkout@v4'
+2025-07-26T11:56:53.1734881Z Version: 4.2.2
+2025-07-26T11:56:53.1736084Z Digest: sha256:ccb2698953eaebd21c7bf6268a94f9c26518a7e38e27e0b83c1fe1ad049819b1
+2025-07-26T11:56:53.1737325Z Source commit SHA: 11bd71901bbe5b1630ceea73d27597364c9af683
+2025-07-26T11:56:53.1738017Z ##[endgroup]
+2025-07-26T11:56:53.2672635Z ##[group]Download immutable action package 'actions/cache@v4'
+2025-07-26T11:56:53.2673461Z Version: 4.2.3
+2025-07-26T11:56:53.2674275Z Digest: sha256:c8a3bb963e1f1826d8fcc8d1354f0dd29d8ac1db1d4f6f20247055ae11b81ed9
+2025-07-26T11:56:53.2675533Z Source commit SHA: 5a3ec84eff668545956fd18022155c47e93e2684
+2025-07-26T11:56:53.2676312Z ##[endgroup]
+2025-07-26T11:56:53.4367209Z ##[group]Download immutable action package 'actions/upload-artifact@v4'
+2025-07-26T11:56:53.4368062Z Version: 4.6.2
+2025-07-26T11:56:53.4368890Z Digest: sha256:290722aa3281d5caf23d0acdc3dbeb3424786a1a01a9cc97e72f147225e37c38
+2025-07-26T11:56:53.4369902Z Source commit SHA: ea165f8d65b6e75b540449e92b4886f43607fa02
+2025-07-26T11:56:53.4370644Z ##[endgroup]
+2025-07-26T11:56:53.6401095Z Uses: DashCoreAutoGuix/dash/.github/workflows/build-src.yml@refs/heads/backport-0.23-batch-427-pr-27800 (045209774fbdd38b4d17181cfce309869819fdab)
+2025-07-26T11:56:53.6406064Z ##[group] Inputs
+2025-07-26T11:56:53.6406615Z   build-target: linux64
+2025-07-26T11:56:53.6407572Z   container-path: ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.23-batch-427-pr-27800
+2025-07-26T11:56:53.6410324Z   depends-key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-26T11:56:53.6412635Z ##[endgroup]
+2025-07-26T11:56:53.6413122Z Complete job name: linux64-build / Build source
+2025-07-26T11:56:53.6866564Z ##[group]Checking docker version
+2025-07-26T11:56:53.6879424Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2025-07-26T11:56:53.7289281Z '1.48'
+2025-07-26T11:56:53.7301193Z Docker daemon API version: '1.48'
+2025-07-26T11:56:53.7302000Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2025-07-26T11:56:53.7449526Z '1.48'
+2025-07-26T11:56:53.7462438Z Docker client API version: '1.48'
+2025-07-26T11:56:53.7468807Z ##[endgroup]
+2025-07-26T11:56:53.7473858Z ##[group]Clean up resources from previous jobs
+2025-07-26T11:56:53.7479815Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=8d73ed"
+2025-07-26T11:56:53.7615305Z ##[command]/usr/bin/docker network prune --force --filter "label=8d73ed"
+2025-07-26T11:56:53.7743593Z ##[endgroup]
+2025-07-26T11:56:53.7744428Z ##[group]Create local container network
+2025-07-26T11:56:53.7757833Z ##[command]/usr/bin/docker network create --label 8d73ed github_network_659f293b501b4a82825737f4f8099758
+2025-07-26T11:56:53.8301855Z 55d70fbde135ce4fb809c1c97db7ff2e24658dd88068ba26e261bca205749484
+2025-07-26T11:56:53.8325804Z ##[endgroup]
+2025-07-26T11:56:53.8350901Z ##[group]Starting job container
+2025-07-26T11:56:53.8373152Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_cafe998c-f4c6-4b66-83b3-9322374462e5 login ghcr.io -u DashCoreAutoGuix --password-stdin
+2025-07-26T11:56:53.9759085Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_cafe998c-f4c6-4b66-83b3-9322374462e5 pull ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.23-batch-427-pr-27800
+2025-07-26T11:56:54.1700581Z backport-0.23-batch-427-pr-27800: Pulling from dashcoreautoguix/dash/dashcore-ci-runner
+2025-07-26T11:56:54.2092503Z 32f112e3802c: Pulling fs layer
+2025-07-26T11:56:54.2095212Z 3c418bbf5534: Pulling fs layer
+2025-07-26T11:56:54.2096455Z 824b5144f7af: Pulling fs layer
+2025-07-26T11:56:54.2097365Z bb9f5c709011: Pulling fs layer
+2025-07-26T11:56:54.2098243Z c31b5eed60b6: Pulling fs layer
+2025-07-26T11:56:54.2099090Z da96180e845f: Pulling fs layer
+2025-07-26T11:56:54.2099944Z f28d6a4cf5de: Pulling fs layer
+2025-07-26T11:56:54.2100779Z 49cbdb9e902d: Pulling fs layer
+2025-07-26T11:56:54.2101624Z 247fd41058fa: Pulling fs layer
+2025-07-26T11:56:54.2102459Z d6a01b6e446c: Pulling fs layer
+2025-07-26T11:56:54.2103289Z 4f4fb700ef54: Pulling fs layer
+2025-07-26T11:56:54.2104102Z c31b5eed60b6: Waiting
+2025-07-26T11:56:54.2104853Z da96180e845f: Waiting
+2025-07-26T11:56:54.2105835Z f28d6a4cf5de: Waiting
+2025-07-26T11:56:54.2106634Z 49cbdb9e902d: Waiting
+2025-07-26T11:56:54.2107442Z 247fd41058fa: Waiting
+2025-07-26T11:56:54.2108239Z 1382f2390a1c: Pulling fs layer
+2025-07-26T11:56:54.2109162Z be38403a389e: Pulling fs layer
+2025-07-26T11:56:54.2110088Z 409781d99354: Pulling fs layer
+2025-07-26T11:56:54.2111008Z c418b82685d0: Pulling fs layer
+2025-07-26T11:56:54.2112674Z d6a01b6e446c: Waiting
+2025-07-26T11:56:54.2114151Z be38403a389e: Waiting
+2025-07-26T11:56:54.2115490Z 409781d99354: Waiting
+2025-07-26T11:56:54.2116490Z 4f4fb700ef54: Waiting
+2025-07-26T11:56:54.2117324Z c418b82685d0: Waiting
+2025-07-26T11:56:54.2118296Z 1382f2390a1c: Waiting
+2025-07-26T11:56:54.2119343Z bb9f5c709011: Waiting
+2025-07-26T11:56:54.2547602Z 824b5144f7af: Verifying Checksum
+2025-07-26T11:56:54.2549250Z 824b5144f7af: Download complete
+2025-07-26T11:56:54.2771169Z 3c418bbf5534: Verifying Checksum
+2025-07-26T11:56:54.2772772Z 3c418bbf5534: Download complete
+2025-07-26T11:56:54.3430611Z 32f112e3802c: Verifying Checksum
+2025-07-26T11:56:54.3433101Z 32f112e3802c: Download complete
+2025-07-26T11:56:54.5324027Z da96180e845f: Verifying Checksum
+2025-07-26T11:56:54.5328229Z da96180e845f: Download complete
+2025-07-26T11:56:54.5825660Z c31b5eed60b6: Verifying Checksum
+2025-07-26T11:56:54.5833104Z c31b5eed60b6: Download complete
+2025-07-26T11:56:54.5879826Z f28d6a4cf5de: Verifying Checksum
+2025-07-26T11:56:54.5883338Z f28d6a4cf5de: Download complete
+2025-07-26T11:56:54.6514920Z 49cbdb9e902d: Verifying Checksum
+2025-07-26T11:56:54.6517672Z 49cbdb9e902d: Download complete
+2025-07-26T11:56:54.7023877Z d6a01b6e446c: Verifying Checksum
+2025-07-26T11:56:54.7029206Z d6a01b6e446c: Download complete
+2025-07-26T11:56:54.7487707Z 4f4fb700ef54: Verifying Checksum
+2025-07-26T11:56:54.7489640Z 4f4fb700ef54: Download complete
+2025-07-26T11:56:54.7564704Z bb9f5c709011: Verifying Checksum
+2025-07-26T11:56:54.7566693Z bb9f5c709011: Download complete
+2025-07-26T11:56:55.3645520Z be38403a389e: Verifying Checksum
+2025-07-26T11:56:55.3649846Z be38403a389e: Download complete
+2025-07-26T11:56:55.4245886Z 409781d99354: Verifying Checksum
+2025-07-26T11:56:55.4250292Z 409781d99354: Download complete
+2025-07-26T11:56:55.4846364Z c418b82685d0: Verifying Checksum
+2025-07-26T11:56:55.4848790Z c418b82685d0: Download complete
+2025-07-26T11:56:55.6843462Z 247fd41058fa: Verifying Checksum
+2025-07-26T11:56:55.6845455Z 247fd41058fa: Download complete
+2025-07-26T11:56:56.0701213Z 32f112e3802c: Pull complete
+2025-07-26T11:56:57.2875391Z 1382f2390a1c: Verifying Checksum
+2025-07-26T11:56:57.2876393Z 1382f2390a1c: Download complete
+2025-07-26T11:56:59.0913567Z 3c418bbf5534: Pull complete
+2025-07-26T11:56:59.2431616Z 824b5144f7af: Pull complete
+2025-07-26T11:57:03.2861589Z bb9f5c709011: Pull complete
+2025-07-26T11:57:06.7626083Z c31b5eed60b6: Pull complete
+2025-07-26T11:57:07.7666031Z da96180e845f: Pull complete
+2025-07-26T11:57:07.8176985Z f28d6a4cf5de: Pull complete
+2025-07-26T11:57:07.8588824Z 49cbdb9e902d: Pull complete
+2025-07-26T11:57:13.8428638Z 247fd41058fa: Pull complete
+2025-07-26T11:57:13.8589233Z d6a01b6e446c: Pull complete
+2025-07-26T11:57:13.8713262Z 4f4fb700ef54: Pull complete
+2025-07-26T11:57:28.5586130Z 1382f2390a1c: Pull complete
+2025-07-26T11:57:32.3929207Z be38403a389e: Pull complete
+2025-07-26T11:57:32.4892329Z 409781d99354: Pull complete
+2025-07-26T11:57:32.4992656Z c418b82685d0: Pull complete
+2025-07-26T11:57:32.5030263Z Digest: sha256:0209e3aa1f18c757f1f9c88663b041cefc859689d32cdb7a5cc1f3d6956ed5ff
+2025-07-26T11:57:32.5040976Z Status: Downloaded newer image for ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.23-batch-427-pr-27800
+2025-07-26T11:57:32.5051424Z ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.23-batch-427-pr-27800
+2025-07-26T11:57:32.5139261Z ##[command]/usr/bin/docker create --name 15b9befcc4604905bf485cda1dfbafe9_ghcriodashcoreautoguixdashdashcorecirunnerbackport023batch427pr27800_9d13c6 --label 8d73ed --workdir /__w/dash/dash --network github_network_659f293b501b4a82825737f4f8099758 --user root -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" -v "/home/runner/actions-runner/cached/externals":"/__e":ro -v "/home/runner/work/_temp":"/__w/_temp" -v "/home/runner/work/_actions":"/__w/_actions" -v "/opt/hostedtoolcache":"/__t" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.23-batch-427-pr-27800 "-f" "/dev/null"
+2025-07-26T11:57:32.5413706Z 4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7
+2025-07-26T11:57:32.5438709Z ##[command]/usr/bin/docker start 4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7
+2025-07-26T11:57:32.7027155Z 4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7
+2025-07-26T11:57:32.7048529Z ##[command]/usr/bin/docker ps --all --filter id=4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7 --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2025-07-26T11:57:32.7173121Z 4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7 Up Less than a second
+2025-07-26T11:57:32.7192436Z ##[command]/usr/bin/docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" 4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7
+2025-07-26T11:57:32.7311995Z HOME=/github/home
+2025-07-26T11:57:32.7312388Z GITHUB_ACTIONS=true
+2025-07-26T11:57:32.7312737Z CI=true
+2025-07-26T11:57:32.7314158Z PATH=/opt/shellcheck:/usr/local/pyenv/shims:/usr/local/pyenv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+2025-07-26T11:57:32.7315571Z DEBIAN_FRONTEND=noninteractive
+2025-07-26T11:57:32.7316023Z TZ=Europe/London
+2025-07-26T11:57:32.7316548Z APT_ARGS=-y --no-install-recommends --no-upgrade
+2025-07-26T11:57:32.7317120Z PYENV_ROOT=/usr/local/pyenv
+2025-07-26T11:57:32.7317530Z LD_LIBRARY_PATH=/usr/lib/llvm-18/lib
+2025-07-26T11:57:32.7333793Z ##[endgroup]
+2025-07-26T11:57:32.7343077Z ##[group]Waiting for all services to be ready
+2025-07-26T11:57:32.7344823Z ##[endgroup]
+2025-07-26T11:57:32.7584093Z ##[group]Run actions/checkout@v4
+2025-07-26T11:57:32.7584626Z with:
+2025-07-26T11:57:32.7585207Z   fetch-depth: 50
+2025-07-26T11:57:32.7585517Z   repository: DashCoreAutoGuix/dash
+2025-07-26T11:57:32.7585962Z   token: ***
+2025-07-26T11:57:32.7586137Z   ssh-strict: true
+2025-07-26T11:57:32.7586317Z   ssh-user: git
+2025-07-26T11:57:32.7586497Z   persist-credentials: true
+2025-07-26T11:57:32.7586704Z   clean: true
+2025-07-26T11:57:32.7586898Z   sparse-checkout-cone-mode: true
+2025-07-26T11:57:32.7587118Z   fetch-tags: false
+2025-07-26T11:57:32.7587297Z   show-progress: true
+2025-07-26T11:57:32.7587472Z   lfs: false
+2025-07-26T11:57:32.7587633Z   submodules: false
+2025-07-26T11:57:32.7587807Z   set-safe-directory: true
+2025-07-26T11:57:32.7588294Z ##[endgroup]
+2025-07-26T11:57:32.7711443Z ##[command]/usr/bin/docker exec  4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-26T11:57:32.9879858Z Syncing repository: DashCoreAutoGuix/dash
+2025-07-26T11:57:32.9881088Z ##[group]Getting Git version info
+2025-07-26T11:57:32.9881402Z Working directory is '/__w/dash/dash'
+2025-07-26T11:57:32.9881867Z [command]/usr/bin/git version
+2025-07-26T11:57:32.9882091Z git version 2.43.0
+2025-07-26T11:57:32.9903541Z ##[endgroup]
+2025-07-26T11:57:32.9920094Z Temporarily overriding HOME='/__w/_temp/4be73025-bb13-488f-88a4-031f805ac1ed' before making global git config changes
+2025-07-26T11:57:32.9921285Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-26T11:57:32.9926897Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-26T11:57:32.9959290Z Deleting the contents of '/__w/dash/dash'
+2025-07-26T11:57:32.9963304Z ##[group]Initializing the repository
+2025-07-26T11:57:32.9974579Z [command]/usr/bin/git init /__w/dash/dash
+2025-07-26T11:57:33.0006966Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-07-26T11:57:33.0007535Z hint: is subject to change. To configure the initial branch name to use in all
+2025-07-26T11:57:33.0008015Z hint: of your new repositories, which will suppress this warning, call:
+2025-07-26T11:57:33.0008349Z hint: 
+2025-07-26T11:57:33.0008600Z hint: 	git config --global init.defaultBranch <name>
+2025-07-26T11:57:33.0008888Z hint: 
+2025-07-26T11:57:33.0009155Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-07-26T11:57:33.0009607Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-07-26T11:57:33.0010125Z hint: 
+2025-07-26T11:57:33.0010316Z hint: 	git branch -m <name>
+2025-07-26T11:57:33.0016047Z Initialized empty Git repository in /__w/dash/dash/.git/
+2025-07-26T11:57:33.0027553Z [command]/usr/bin/git remote add origin https://github.com/DashCoreAutoGuix/dash
+2025-07-26T11:57:33.0056652Z ##[endgroup]
+2025-07-26T11:57:33.0057290Z ##[group]Disabling automatic garbage collection
+2025-07-26T11:57:33.0061378Z [command]/usr/bin/git config --local gc.auto 0
+2025-07-26T11:57:33.0089023Z ##[endgroup]
+2025-07-26T11:57:33.0089640Z ##[group]Setting up auth
+2025-07-26T11:57:33.0096185Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-26T11:57:33.0125737Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-26T11:57:33.0337200Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-26T11:57:33.0366294Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-26T11:57:33.0570616Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-07-26T11:57:33.0604005Z ##[endgroup]
+2025-07-26T11:57:33.0604549Z ##[group]Fetching the repository
+2025-07-26T11:57:33.0612948Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=50 origin +045209774fbdd38b4d17181cfce309869819fdab:refs/remotes/origin/backport-0.23-batch-427-pr-27800
+2025-07-26T11:57:34.9912264Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-26T11:57:34.9913172Z  * [new ref]         045209774fbdd38b4d17181cfce309869819fdab -> origin/backport-0.23-batch-427-pr-27800
+2025-07-26T11:57:34.9935468Z ##[endgroup]
+2025-07-26T11:57:34.9936036Z ##[group]Determining the checkout info
+2025-07-26T11:57:34.9938866Z ##[endgroup]
+2025-07-26T11:57:34.9943843Z [command]/usr/bin/git sparse-checkout disable
+2025-07-26T11:57:34.9979677Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-07-26T11:57:35.0005808Z ##[group]Checking out the ref
+2025-07-26T11:57:35.0010136Z [command]/usr/bin/git checkout --progress --force -B backport-0.23-batch-427-pr-27800 refs/remotes/origin/backport-0.23-batch-427-pr-27800
+2025-07-26T11:57:35.3932666Z Switched to a new branch 'backport-0.23-batch-427-pr-27800'
+2025-07-26T11:57:35.3933778Z branch 'backport-0.23-batch-427-pr-27800' set up to track 'origin/backport-0.23-batch-427-pr-27800'.
+2025-07-26T11:57:35.3959180Z ##[endgroup]
+2025-07-26T11:57:35.3997366Z [command]/usr/bin/git log -1 --format=%H
+2025-07-26T11:57:35.4020567Z 045209774fbdd38b4d17181cfce309869819fdab
+2025-07-26T11:57:35.4232300Z ##[group]Run git config --global --add safe.directory "$PWD"
+2025-07-26T11:57:35.4232746Z [36;1mgit config --global --add safe.directory "$PWD"[0m
+2025-07-26T11:57:35.4233080Z [36;1mgit fetch -fu origin develop:develop[0m
+2025-07-26T11:57:35.4233346Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-26T11:57:35.4233583Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-26T11:57:35.4233830Z [36;1mecho "HOST=${HOST}" >> $GITHUB_OUTPUT[0m
+2025-07-26T11:57:35.4234098Z [36;1mecho "PR_BASE_SHA=" >> $GITHUB_OUTPUT[0m
+2025-07-26T11:57:35.4238130Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-26T11:57:35.4238408Z ##[endgroup]
+2025-07-26T11:57:35.6287934Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-26T11:57:35.6288594Z  * [new branch]      develop    -> develop
+2025-07-26T11:57:35.6289162Z  * [new branch]      develop    -> origin/develop
+2025-07-26T11:57:35.6363673Z Setting specific values in env
+2025-07-26T11:57:35.6364298Z Fallback to default values in env (if not yet set)
+2025-07-26T11:57:35.6859338Z ##[group]Run actions/cache/restore@v4
+2025-07-26T11:57:35.6859593Z with:
+2025-07-26T11:57:35.6859812Z   path: depends/built
+depends/x86_64-pc-linux-gnu
+
+2025-07-26T11:57:35.6860802Z   key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-26T11:57:35.6861760Z   fail-on-cache-miss: true
+2025-07-26T11:57:35.6861978Z   enableCrossOsArchive: false
+2025-07-26T11:57:35.6862184Z   lookup-only: false
+2025-07-26T11:57:35.6862366Z ##[endgroup]
+2025-07-26T11:57:35.6865871Z ##[command]/usr/bin/docker exec  4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-26T11:57:35.9921804Z Cache hit for: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-26T11:57:36.5652815Z Received 90045347 of 90045347 (100.0%), 168.7 MBs/sec
+2025-07-26T11:57:36.5653445Z Cache Size: ~86 MB (90045347 B)
+2025-07-26T11:57:36.5679477Z [command]/usr/bin/tar -xf /__w/_temp/90009866-0f59-4eac-afcd-b1c4224772aa/cache.tzst -P -C /__w/dash/dash --use-compress-program unzstd
+2025-07-26T11:57:37.7521012Z Cache restored successfully
+2025-07-26T11:57:37.7844945Z Cache restored from key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-26T11:57:37.9659537Z ##[group]Run actions/cache@v4
+2025-07-26T11:57:37.9659854Z with:
+2025-07-26T11:57:37.9660310Z   path: /cache
+
+2025-07-26T11:57:37.9661017Z   key: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-045209774fbdd38b4d17181cfce309869819fdab
+2025-07-26T11:57:37.9662075Z   restore-keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-
+
+2025-07-26T11:57:37.9662680Z   enableCrossOsArchive: false
+2025-07-26T11:57:37.9662974Z   fail-on-cache-miss: false
+2025-07-26T11:57:37.9663250Z   lookup-only: false
+2025-07-26T11:57:37.9663500Z   save-always: false
+2025-07-26T11:57:37.9663731Z ##[endgroup]
+2025-07-26T11:57:37.9668609Z ##[command]/usr/bin/docker exec  4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-26T11:57:38.2723789Z Cache not found for input keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-045209774fbdd38b4d17181cfce309869819fdab, ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-
+2025-07-26T11:57:38.2818387Z ##[group]Run CCACHE_SIZE="400M"
+2025-07-26T11:57:38.2818693Z [36;1mCCACHE_SIZE="400M"[0m
+2025-07-26T11:57:38.2818926Z [36;1mCACHE_DIR="/cache"[0m
+2025-07-26T11:57:38.2819151Z [36;1mmkdir /output[0m
+2025-07-26T11:57:38.2819377Z [36;1mBASE_OUTDIR="/output"[0m
+2025-07-26T11:57:38.2819626Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-26T11:57:38.2819885Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-26T11:57:38.2820144Z [36;1m./ci/dash/build_src.sh[0m
+2025-07-26T11:57:38.2820393Z [36;1mccache -X 9[0m
+2025-07-26T11:57:38.2820600Z [36;1mccache -c[0m
+2025-07-26T11:57:38.2820952Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-26T11:57:38.2821262Z ##[endgroup]
+2025-07-26T11:57:38.3444283Z Setting specific values in env
+2025-07-26T11:57:38.3444726Z Fallback to default values in env (if not yet set)
+2025-07-26T11:57:38.3829040Z Setting specific values in env
+2025-07-26T11:57:38.3829965Z Fallback to default values in env (if not yet set)
+2025-07-26T11:57:38.4594680Z Statistics zeroed
+2025-07-26T11:57:38.4595322Z Set cache size limit to 400.0 MB
+2025-07-26T11:57:43.4205678Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-26T11:57:43.4206543Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-26T11:57:43.4449531Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-26T11:57:43.4450116Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-26T11:57:43.4727686Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-26T11:57:43.5015963Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-26T11:57:43.5309332Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-26T11:57:43.5593253Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-26T11:57:45.5974310Z configure.ac:38: installing 'build-aux/compile'
+2025-07-26T11:57:45.5993147Z configure.ac:12: installing 'build-aux/config.guess'
+2025-07-26T11:57:45.6011114Z configure.ac:12: installing 'build-aux/config.sub'
+2025-07-26T11:57:45.6028950Z configure.ac:17: installing 'build-aux/install-sh'
+2025-07-26T11:57:45.6047676Z configure.ac:17: installing 'build-aux/missing'
+2025-07-26T11:57:45.6723313Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-26T11:57:48.0141728Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-26T11:57:48.0143081Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-26T11:57:48.0385853Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-26T11:57:48.0386813Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-26T11:57:48.0607664Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-26T11:57:48.0832272Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-26T11:57:48.1057679Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-26T11:57:48.1274288Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-26T11:57:49.5871841Z configure.ac:39: installing 'build-aux/ar-lib'
+2025-07-26T11:57:49.5888988Z configure.ac:37: installing 'build-aux/compile'
+2025-07-26T11:57:49.5907651Z configure.ac:24: installing 'build-aux/config.guess'
+2025-07-26T11:57:49.5926322Z configure.ac:24: installing 'build-aux/config.sub'
+2025-07-26T11:57:49.5945561Z configure.ac:27: installing 'build-aux/install-sh'
+2025-07-26T11:57:49.5964585Z configure.ac:27: installing 'build-aux/missing'
+2025-07-26T11:57:49.6288693Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-26T11:57:49.6605815Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-26T11:57:49.7555244Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-26T11:57:49.7556504Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-26T11:57:49.7814455Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-26T11:57:49.7815326Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-26T11:57:49.8242811Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-26T11:57:49.8685270Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-26T11:57:49.9143976Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-26T11:57:49.9583590Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-26T11:57:52.5556204Z configure.ac:105: installing 'build-aux/compile'
+2025-07-26T11:57:52.5573189Z configure.ac:48: installing 'build-aux/config.guess'
+2025-07-26T11:57:52.5591022Z configure.ac:48: installing 'build-aux/config.sub'
+2025-07-26T11:57:52.5607928Z configure.ac:55: installing 'build-aux/install-sh'
+2025-07-26T11:57:52.5626308Z configure.ac:55: installing 'build-aux/missing'
+2025-07-26T11:57:52.8086586Z src/Makefile.am: installing 'build-aux/depcomp'
+2025-07-26T11:57:55.3056466Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-26T11:57:55.4844290Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-26T11:57:55.4925833Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-26T11:57:55.4940224Z checking pkg-config is at least version 0.9.0... yes
+2025-07-26T11:57:55.5394531Z checking build system type... x86_64-pc-linux-gnu
+2025-07-26T11:57:55.5443901Z checking host system type... x86_64-pc-linux-gnu
+2025-07-26T11:57:55.5524422Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-26T11:57:55.5553324Z checking whether build environment is sane... yes
+2025-07-26T11:57:55.5614260Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-26T11:57:55.5635439Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-26T11:57:55.5640194Z checking for gawk... gawk
+2025-07-26T11:57:55.5703855Z checking whether make sets $(MAKE)... yes
+2025-07-26T11:57:55.5758174Z checking whether make supports nested variables... yes
+2025-07-26T11:57:55.5802027Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-26T11:57:55.5804375Z checking whether make supports nested variables... (cached) yes
+2025-07-26T11:57:55.6379978Z checking whether the C++ compiler works... yes
+2025-07-26T11:57:55.6380748Z checking for C++ compiler default output file name... a.out
+2025-07-26T11:57:55.6717047Z checking for suffix of executables... 
+2025-07-26T11:57:55.7169990Z checking whether we are cross compiling... no
+2025-07-26T11:57:55.7337878Z checking for suffix of object files... o
+2025-07-26T11:57:55.7480576Z checking whether the compiler supports GNU C++... yes
+2025-07-26T11:57:55.7634779Z checking whether g++ -m64 accepts -g... yes
+2025-07-26T11:57:56.0427327Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-26T11:57:56.0909611Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-26T11:57:56.0984265Z checking whether make supports the include directive... yes (GNU style)
+2025-07-26T11:57:56.0988010Z checking dependency style of g++ -m64... none
+2025-07-26T11:57:56.1787823Z checking whether g++ -m64 supports C++20 features with -std=c++20... yes
+2025-07-26T11:57:56.1792345Z checking for x86_64-pc-linux-gnu-g++... g++ -m64 -std=c++20
+2025-07-26T11:57:56.2098049Z checking whether the compiler supports GNU Objective C++... no
+2025-07-26T11:57:56.2371844Z checking whether g++ -m64 -std=c++20 accepts -g... no
+2025-07-26T11:57:56.2375744Z checking dependency style of g++ -m64 -std=c++20... none
+2025-07-26T11:57:56.2401770Z checking how to print strings... printf
+2025-07-26T11:57:56.2404257Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-26T11:57:56.2792089Z checking whether the compiler supports GNU C... yes
+2025-07-26T11:57:56.2953507Z checking whether gcc -m64 accepts -g... yes
+2025-07-26T11:57:56.3311084Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-26T11:57:56.3589202Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-26T11:57:56.3591791Z checking dependency style of gcc -m64... none
+2025-07-26T11:57:56.3632292Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-26T11:57:56.3664912Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-26T11:57:56.3681446Z checking for egrep... /usr/bin/grep -E
+2025-07-26T11:57:56.3697552Z checking for fgrep... /usr/bin/grep -F
+2025-07-26T11:57:56.3746268Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-26T11:57:56.3773958Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-26T11:57:56.3777404Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-26T11:57:56.4082478Z checking the name lister (nm) interface... BSD nm
+2025-07-26T11:57:56.4083223Z checking whether ln -s works... yes
+2025-07-26T11:57:56.4129150Z checking the maximum length of command line arguments... 3145728
+2025-07-26T11:57:56.4157363Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-26T11:57:56.4158944Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-26T11:57:56.4161366Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-26T11:57:56.4166886Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-26T11:57:56.4171931Z checking for file... file
+2025-07-26T11:57:56.4177284Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:57:56.4182153Z checking for objdump... objdump
+2025-07-26T11:57:56.4215806Z checking how to recognize dependent libraries... pass_all
+2025-07-26T11:57:56.4216483Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-26T11:57:56.4216962Z checking for dlltool... no
+2025-07-26T11:57:56.4217466Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-26T11:57:56.4218061Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:57:56.4558791Z checking for archiver @FILE support... @
+2025-07-26T11:57:56.4559741Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-26T11:57:56.4562395Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-26T11:57:56.5256372Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-26T11:57:56.5273644Z checking for sysroot... no
+2025-07-26T11:57:56.5317396Z checking for a working dd... /usr/bin/dd
+2025-07-26T11:57:56.5356736Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-26T11:57:56.5467963Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-26T11:57:56.5472552Z checking for mt... no
+2025-07-26T11:57:56.5504368Z checking if : is a manifest tool... no
+2025-07-26T11:57:56.5654333Z checking for stdio.h... yes
+2025-07-26T11:57:56.5814153Z checking for stdlib.h... yes
+2025-07-26T11:57:56.5982342Z checking for string.h... yes
+2025-07-26T11:57:56.6153076Z checking for inttypes.h... yes
+2025-07-26T11:57:56.6323242Z checking for stdint.h... yes
+2025-07-26T11:57:56.6495603Z checking for strings.h... yes
+2025-07-26T11:57:56.6672318Z checking for sys/stat.h... yes
+2025-07-26T11:57:56.6855541Z checking for sys/types.h... yes
+2025-07-26T11:57:56.7055835Z checking for unistd.h... yes
+2025-07-26T11:57:56.7261011Z checking for dlfcn.h... yes
+2025-07-26T11:57:56.7302874Z checking for objdir... .libs
+2025-07-26T11:57:56.7896861Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-26T11:57:56.7897920Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:57:56.8036002Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:57:56.8612196Z checking if gcc -m64 static flag -static works... yes
+2025-07-26T11:57:56.8837320Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-26T11:57:56.8838588Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-26T11:57:56.8934372Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:57:56.9149842Z checking whether -lc should be explicitly linked in... no
+2025-07-26T11:57:56.9649748Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-26T11:57:56.9650728Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:57:56.9668666Z checking whether stripping libraries is possible... yes
+2025-07-26T11:57:56.9669685Z checking if libtool supports shared libraries... yes
+2025-07-26T11:57:56.9670434Z checking whether to build shared libraries... yes
+2025-07-26T11:57:56.9675158Z checking whether to build static libraries... yes
+2025-07-26T11:57:56.9941827Z checking how to run the C++ preprocessor... g++ -m64 -std=c++20 -E
+2025-07-26T11:57:57.0686709Z checking for ld used by g++ -m64 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-26T11:57:57.0710818Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-26T11:57:57.0782146Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:57:57.1388524Z checking for g++ -m64 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:57:57.1543198Z checking if g++ -m64 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:57:57.2151488Z checking if g++ -m64 -std=c++20 static flag -static works... yes
+2025-07-26T11:57:57.2382069Z checking if g++ -m64 -std=c++20 supports -c -o file.o... yes
+2025-07-26T11:57:57.2384246Z checking if g++ -m64 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-26T11:57:57.2386242Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:57:57.2432808Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-26T11:57:57.2434726Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:57:57.2441347Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-26T11:57:57.2448096Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-26T11:57:57.2453504Z checking for gcov... /usr/bin/gcov
+2025-07-26T11:57:57.2458616Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-26T11:57:57.2463909Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-26T11:57:57.2469008Z checking for lcov... no
+2025-07-26T11:57:57.2472859Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-26T11:57:57.2477584Z checking for genhtml... no
+2025-07-26T11:57:57.2481278Z checking for git... /usr/bin/git
+2025-07-26T11:57:57.2485460Z checking for ccache... /usr/bin/ccache
+2025-07-26T11:57:57.2489976Z checking for xgettext... /usr/bin/xgettext
+2025-07-26T11:57:57.2494434Z checking for hexdump... /usr/bin/hexdump
+2025-07-26T11:57:57.2499939Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-26T11:57:57.2504788Z checking for objcopy... /usr/bin/objcopy
+2025-07-26T11:57:57.2508933Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:57:57.2512898Z checking for objdump... /usr/bin/objdump
+2025-07-26T11:57:57.2518263Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-26T11:57:57.2523124Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-26T11:57:57.2528250Z checking for doxygen... no
+2025-07-26T11:57:57.2683047Z checking whether C++ compiler accepts -Werror... yes
+2025-07-26T11:57:57.3051213Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-26T11:57:57.3514862Z checking for execinfo.h... yes
+2025-07-26T11:57:57.3913731Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-26T11:57:57.4128093Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-26T11:57:57.4321155Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-26T11:57:57.4505553Z checking whether C++ compiler accepts -Wdangling-reference... yes
+2025-07-26T11:57:57.4690034Z checking whether C++ compiler accepts -Wattributes... yes
+2025-07-26T11:57:57.4878742Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-26T11:57:57.5080255Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-26T11:57:57.5285577Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-26T11:57:57.5485517Z checking whether C++ compiler accepts -Wall... yes
+2025-07-26T11:57:57.5680765Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-26T11:57:57.5831853Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-26T11:57:57.6026206Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-26T11:57:57.6218799Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-26T11:57:57.6413340Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-26T11:57:57.6603927Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-26T11:57:57.6822106Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-26T11:57:57.7034261Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-26T11:57:57.7234015Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-26T11:57:57.7502132Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-26T11:57:57.7703947Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-26T11:57:57.7985531Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-26T11:57:57.8176576Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-26T11:57:57.8373053Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-26T11:57:57.8569342Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-26T11:57:57.8758622Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-26T11:57:57.8949328Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-26T11:57:57.9142004Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-26T11:57:57.9341874Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-26T11:57:57.9559458Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-26T11:57:57.9742479Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-26T11:57:57.9927653Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-26T11:57:58.0118404Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-26T11:57:58.0275808Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-26T11:57:58.0469072Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-26T11:57:58.0657796Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-26T11:57:58.0851654Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-26T11:57:58.1041745Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-26T11:57:58.5957834Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-26T11:57:58.6426107Z checking for SSE4.2 intrinsics... yes
+2025-07-26T11:57:59.0861448Z checking for SSE4.1 intrinsics... yes
+2025-07-26T11:57:59.5177344Z checking for AVX2 intrinsics... yes
+2025-07-26T11:57:59.9553206Z checking for x86 SHA-NI intrinsics... yes
+2025-07-26T11:57:59.9728724Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-26T11:57:59.9887601Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-26T11:58:00.0030692Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-26T11:58:00.0178513Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-26T11:58:00.1013784Z checking whether byte ordering is bigendian... no
+2025-07-26T11:58:00.1244811Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-26T11:58:00.1558848Z checking whether gcc -m64 is Clang... no
+2025-07-26T11:58:00.2040390Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-26T11:58:00.2422524Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-26T11:58:00.2423477Z checking whether more special flags are required for pthreads... no
+2025-07-26T11:58:00.2778055Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-26T11:58:01.0891159Z checking whether std::atomic can be used without link library... yes
+2025-07-26T11:58:01.0898565Z checking for special C compiler options needed for large files... no
+2025-07-26T11:58:01.1106103Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-26T11:58:01.1436585Z checking for g++ -m64 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-26T11:58:01.1934167Z checking whether strerror_r is declared... yes
+2025-07-26T11:58:01.2158847Z checking whether strerror_r returns char *... yes
+2025-07-26T11:58:01.2309213Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-26T11:58:01.2463742Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-26T11:58:01.2614642Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-26T11:58:01.2762387Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-26T11:58:01.2930689Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-26T11:58:01.3017201Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-26T11:58:01.3104560Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-26T11:58:01.3373710Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-26T11:58:01.3631330Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-26T11:58:01.3878684Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-26T11:58:01.4127785Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-26T11:58:01.4535904Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-26T11:58:01.4918042Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-26T11:58:01.5289987Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-26T11:58:01.5668228Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-26T11:58:01.6093251Z checking for sys/select.h... yes
+2025-07-26T11:58:01.6512609Z checking for sys/prctl.h... yes
+2025-07-26T11:58:01.6848627Z checking for vm/vm_param.h... no
+2025-07-26T11:58:01.7180297Z checking for sys/vmmeter.h... no
+2025-07-26T11:58:01.7496493Z checking for sys/resources.h... no
+2025-07-26T11:58:01.7774234Z checking whether getifaddrs is declared... yes
+2025-07-26T11:58:01.8225612Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-26T11:58:01.8517285Z checking whether freeifaddrs is declared... yes
+2025-07-26T11:58:01.8965634Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-26T11:58:01.9487315Z checking whether fork is declared... yes
+2025-07-26T11:58:01.9995365Z checking whether setsid is declared... yes
+2025-07-26T11:58:02.0501376Z checking whether pipe2 is declared... yes
+2025-07-26T11:58:02.0749732Z checking for mallopt M_ARENA_MAX... yes
+2025-07-26T11:58:02.1006474Z checking for getmemoryinfo... yes
+2025-07-26T11:58:02.1215388Z checking for posix_fallocate... yes
+2025-07-26T11:58:02.1368837Z checking for default visibility attribute... yes
+2025-07-26T11:58:02.1523519Z checking for dllexport attribute... no
+2025-07-26T11:58:02.6356620Z checking for thread_local support... yes
+2025-07-26T11:58:02.6640826Z checking for Linux getrandom syscall... yes
+2025-07-26T11:58:02.6958655Z checking for getentropy via random.h... yes
+2025-07-26T11:58:02.7156912Z checking for sysctl... no
+2025-07-26T11:58:02.7352564Z checking for sysctl KERN_ARND... no
+2025-07-26T11:58:02.7735228Z checking for library containing backtrace... none required
+2025-07-26T11:58:02.7990012Z checking for fdatasync... yes
+2025-07-26T11:58:02.8200700Z checking for F_FULLFSYNC... no
+2025-07-26T11:58:02.8411443Z checking for O_CLOEXEC... yes
+2025-07-26T11:58:02.8571302Z checking for __builtin_prefetch... yes
+2025-07-26T11:58:02.8986465Z checking for _mm_prefetch... yes
+2025-07-26T11:58:02.9198431Z checking for strong getauxval support in the system headers... yes
+2025-07-26T11:58:02.9465882Z checking for sockaddr_un... yes
+2025-07-26T11:58:02.9956900Z checking for std::system... yes
+2025-07-26T11:58:03.0257329Z checking for ::_wsystem... no
+2025-07-26T11:58:03.0427766Z checking for Qt5Core >= 5.11.3... yes
+2025-07-26T11:58:03.0537702Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-26T11:58:03.0650538Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-26T11:58:03.0758651Z checking for Qt5Network >= 5.11.3... yes
+2025-07-26T11:58:03.0867366Z checking for Qt5Test >= 5.11.3... yes
+2025-07-26T11:58:03.0976146Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-26T11:58:03.3104803Z checking for static Qt... yes
+2025-07-26T11:58:03.3228607Z checking for Qt5AccessibilitySupport... yes
+2025-07-26T11:58:03.3343323Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-26T11:58:03.3455620Z checking for Qt5EdidSupport... yes
+2025-07-26T11:58:03.3571791Z checking for Qt5EventDispatcherSupport... yes
+2025-07-26T11:58:03.3699011Z checking for Qt5FbSupport... yes
+2025-07-26T11:58:03.3820344Z checking for Qt5FontDatabaseSupport... yes
+2025-07-26T11:58:03.3938411Z checking for Qt5ThemeSupport... yes
+2025-07-26T11:58:03.4053258Z checking for Qt5InputSupport... yes
+2025-07-26T11:58:03.4168821Z checking for Qt5ServiceSupport... yes
+2025-07-26T11:58:03.4304147Z checking for Qt5XcbQpa... yes
+2025-07-26T11:58:03.4421707Z checking for Qt5XkbCommonSupport... yes
+2025-07-26T11:58:05.4420527Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-26T11:58:07.5216357Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-26T11:58:07.7340542Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-26T11:58:07.7353494Z checking for moc-qt5... no
+2025-07-26T11:58:07.7355504Z checking for moc5... no
+2025-07-26T11:58:07.7356176Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-26T11:58:07.7357786Z checking for uic-qt5... no
+2025-07-26T11:58:07.7359417Z checking for uic5... no
+2025-07-26T11:58:07.7361465Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-26T11:58:07.7362738Z checking for rcc-qt5... no
+2025-07-26T11:58:07.7364259Z checking for rcc5... no
+2025-07-26T11:58:07.7365964Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-26T11:58:07.7367835Z checking for lrelease-qt5... no
+2025-07-26T11:58:07.7369486Z checking for lrelease5... no
+2025-07-26T11:58:07.7370418Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-26T11:58:07.7371649Z checking for lupdate-qt5... no
+2025-07-26T11:58:07.7373438Z checking for lupdate5... no
+2025-07-26T11:58:07.7374811Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-26T11:58:07.7376401Z checking for lconvert-qt5... no
+2025-07-26T11:58:07.7377604Z checking for lconvert5... no
+2025-07-26T11:58:07.7379538Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-26T11:58:07.7410776Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-26T11:58:07.7411701Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-26T11:58:08.6211207Z checking for Berkeley DB C++ headers... default
+2025-07-26T11:58:08.6633237Z checking for main in -ldb_cxx-4.8... yes
+2025-07-26T11:58:08.6787812Z checking for sqlite3 >= 3.7.17... yes
+2025-07-26T11:58:08.6789581Z checking whether to build wallet with support for sqlite... yes
+2025-07-26T11:58:08.6982903Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-26T11:58:08.7468749Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-26T11:58:08.7903046Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-26T11:58:08.8382009Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-26T11:58:08.8424426Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-26T11:58:08.8890062Z checking for miniupnpc/upnperrors.h... yes
+2025-07-26T11:58:08.8933750Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-26T11:58:08.9018551Z checking whether miniUPnPc API version is supported... yes
+2025-07-26T11:58:08.9513607Z checking for natpmp.h... yes
+2025-07-26T11:58:08.9905581Z checking for initnatpmp in -lnatpmp... yes
+2025-07-26T11:58:08.9988709Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-26T11:58:08.9991224Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-26T11:58:08.9992583Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-26T11:58:08.9993946Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-26T11:58:08.9994981Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-26T11:58:09.0142102Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-26T11:58:09.0436403Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-26T11:58:11.9072591Z checking for Boost Process... yes
+2025-07-26T11:58:11.9292859Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-26T11:58:11.9685838Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-26T11:58:11.9963709Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-26T11:58:12.0088777Z checking for libevent >= 2.1.8... yes
+2025-07-26T11:58:12.0204941Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-26T11:58:12.0544278Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-26T11:58:12.0672409Z checking for libqrencode... yes
+2025-07-26T11:58:12.0790369Z checking for libzmq >= 4... yes
+2025-07-26T11:58:12.1385999Z checking for gmp.h... yes
+2025-07-26T11:58:12.1761654Z checking for __gmpz_init in -lgmp... yes
+2025-07-26T11:58:12.1877044Z checking for libmultiprocess... no
+2025-07-26T11:58:12.1958973Z checking whether to build dashd... yes
+2025-07-26T11:58:12.1959778Z checking whether to build dash-cli... yes
+2025-07-26T11:58:12.1961587Z checking whether to build dash-tx... yes
+2025-07-26T11:58:12.1962220Z checking whether to build dash-wallet... yes
+2025-07-26T11:58:12.1962852Z checking whether to build libraries... no
+2025-07-26T11:58:12.1965494Z checking if ccache should be used... yes
+2025-07-26T11:58:12.2250498Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-26T11:58:12.2366699Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-26T11:58:12.2368845Z checking if wallet should be enabled... yes
+2025-07-26T11:58:12.2372164Z checking whether to build with support for UPnP... yes
+2025-07-26T11:58:12.2373096Z checking whether to build with support for NAT-PMP... yes
+2025-07-26T11:58:12.2375709Z checking whether to build GUI with support for D-Bus... yes
+2025-07-26T11:58:12.2378036Z checking whether to build GUI with support for QR codes... yes
+2025-07-26T11:58:12.2378753Z checking whether to build test_dash-qt... yes
+2025-07-26T11:58:12.2380238Z checking whether to build test_dash... yes
+2025-07-26T11:58:12.2380762Z checking whether to reduce exports... yes
+2025-07-26T11:58:12.2519961Z checking whether dsymutil needs -flat... yes
+2025-07-26T11:58:12.2520420Z 
+2025-07-26T11:58:12.2975233Z checking that generated files are newer than configure... done
+2025-07-26T11:58:12.2981276Z configure: creating ./config.status
+2025-07-26T11:58:12.9484649Z config.status: creating Makefile
+2025-07-26T11:58:12.9612322Z config.status: creating src/Makefile
+2025-07-26T11:58:13.0201565Z config.status: creating doc/man/Makefile
+2025-07-26T11:58:13.0369567Z config.status: creating share/setup.nsi
+2025-07-26T11:58:13.0539055Z config.status: creating share/qt/Info.plist
+2025-07-26T11:58:13.0708313Z config.status: creating test/config.ini
+2025-07-26T11:58:13.0876496Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-26T11:58:13.1051391Z config.status: creating src/config/bitcoin-config.h
+2025-07-26T11:58:13.1237365Z config.status: linking ../contrib/filter-lcov.py to contrib/filter-lcov.py
+2025-07-26T11:58:13.1304960Z config.status: linking ../src/.bear-tidy-config to src/.bear-tidy-config
+2025-07-26T11:58:13.1370832Z config.status: linking ../src/.clang-tidy to src/.clang-tidy
+2025-07-26T11:58:13.1448258Z config.status: linking ../test/functional/test_runner.py to test/functional/test_runner.py
+2025-07-26T11:58:13.1525894Z config.status: linking ../test/fuzz/test_runner.py to test/fuzz/test_runner.py
+2025-07-26T11:58:13.1600859Z config.status: linking ../test/util/test_runner.py to test/util/test_runner.py
+2025-07-26T11:58:13.1667677Z config.status: linking ../test/util/rpcauth-test.py to test/util/rpcauth-test.py
+2025-07-26T11:58:13.1702112Z config.status: executing depfiles commands
+2025-07-26T11:58:13.1718027Z config.status: executing libtool commands
+2025-07-26T11:58:13.1850436Z === configuring in src/dashbls (/__w/dash/dash/build-ci/src/dashbls)
+2025-07-26T11:58:13.1914714Z configure: running /bin/bash ../../../src/dashbls/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/dashbls
+2025-07-26T11:58:13.3115299Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-26T11:58:13.3620016Z checking build system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:13.3671249Z checking host system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:13.3751599Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-26T11:58:13.3781780Z checking whether build environment is sane... yes
+2025-07-26T11:58:13.3846986Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-26T11:58:13.3870619Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-26T11:58:13.3874409Z checking for gawk... gawk
+2025-07-26T11:58:13.3941867Z checking whether make sets $(MAKE)... yes
+2025-07-26T11:58:13.3996359Z checking whether make supports nested variables... yes
+2025-07-26T11:58:13.4040604Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-26T11:58:13.4042900Z checking whether make supports nested variables... (cached) yes
+2025-07-26T11:58:13.4046485Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-26T11:58:13.4628328Z checking whether the C compiler works... yes
+2025-07-26T11:58:13.4629404Z checking for C compiler default output file name... a.out
+2025-07-26T11:58:13.4923242Z checking for suffix of executables... 
+2025-07-26T11:58:13.5299806Z checking whether we are cross compiling... no
+2025-07-26T11:58:13.5468241Z checking for suffix of object files... o
+2025-07-26T11:58:13.5613079Z checking whether the compiler supports GNU C... yes
+2025-07-26T11:58:13.5775840Z checking whether gcc -m64 accepts -g... yes
+2025-07-26T11:58:13.6147755Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-26T11:58:13.6428394Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-26T11:58:13.6501355Z checking whether make supports the include directive... yes (GNU style)
+2025-07-26T11:58:13.6505769Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:13.6857053Z checking whether the compiler supports GNU C++... yes
+2025-07-26T11:58:13.7028126Z checking whether g++ -m64 accepts -g... yes
+2025-07-26T11:58:13.9938455Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-26T11:58:14.0430276Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-26T11:58:14.0433969Z checking dependency style of g++ -m64... none
+2025-07-26T11:58:14.0821372Z checking whether g++ -m64 supports C++14 features with -std=c++14... yes
+2025-07-26T11:58:14.0846834Z checking how to print strings... printf
+2025-07-26T11:58:14.0885537Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-26T11:58:14.0917854Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-26T11:58:14.0933157Z checking for egrep... /usr/bin/grep -E
+2025-07-26T11:58:14.0949150Z checking for fgrep... /usr/bin/grep -F
+2025-07-26T11:58:14.0997880Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-26T11:58:14.1022291Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-26T11:58:14.1024704Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-26T11:58:14.1331945Z checking the name lister (nm) interface... BSD nm
+2025-07-26T11:58:14.1333193Z checking whether ln -s works... yes
+2025-07-26T11:58:14.1376943Z checking the maximum length of command line arguments... 3145728
+2025-07-26T11:58:14.1404776Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-26T11:58:14.1408394Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-26T11:58:14.1410105Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-26T11:58:14.1414474Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-26T11:58:14.1419032Z checking for file... file
+2025-07-26T11:58:14.1423445Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:58:14.1428053Z checking for objdump... objdump
+2025-07-26T11:58:14.1432288Z checking how to recognize dependent libraries... pass_all
+2025-07-26T11:58:14.1437202Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-26T11:58:14.1441224Z checking for dlltool... no
+2025-07-26T11:58:14.1442983Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-26T11:58:14.1444746Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:58:14.1785659Z checking for archiver @FILE support... @
+2025-07-26T11:58:14.1787994Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-26T11:58:14.1790999Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-26T11:58:14.2458451Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-26T11:58:14.2476464Z checking for sysroot... no
+2025-07-26T11:58:14.2519185Z checking for a working dd... /usr/bin/dd
+2025-07-26T11:58:14.2559344Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-26T11:58:14.2664646Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-26T11:58:14.2670305Z checking for mt... no
+2025-07-26T11:58:14.2702406Z checking if : is a manifest tool... no
+2025-07-26T11:58:14.2850263Z checking for stdio.h... yes
+2025-07-26T11:58:14.3009116Z checking for stdlib.h... yes
+2025-07-26T11:58:14.3184579Z checking for string.h... yes
+2025-07-26T11:58:14.3359696Z checking for inttypes.h... yes
+2025-07-26T11:58:14.3537090Z checking for stdint.h... yes
+2025-07-26T11:58:14.3715377Z checking for strings.h... yes
+2025-07-26T11:58:14.3904252Z checking for sys/stat.h... yes
+2025-07-26T11:58:14.4091882Z checking for sys/types.h... yes
+2025-07-26T11:58:14.4302445Z checking for unistd.h... yes
+2025-07-26T11:58:14.4513085Z checking for dlfcn.h... yes
+2025-07-26T11:58:14.4550847Z checking for objdir... .libs
+2025-07-26T11:58:14.5172818Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-26T11:58:14.5175481Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:14.5312021Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:14.5893606Z checking if gcc -m64 static flag -static works... yes
+2025-07-26T11:58:14.6109828Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-26T11:58:14.6110726Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:14.6204121Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:14.6682685Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-26T11:58:14.6684564Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:14.6700897Z checking whether stripping libraries is possible... yes
+2025-07-26T11:58:14.6701582Z checking if libtool supports shared libraries... yes
+2025-07-26T11:58:14.6702237Z checking whether to build shared libraries... no
+2025-07-26T11:58:14.6703202Z checking whether to build static libraries... yes
+2025-07-26T11:58:14.6963726Z checking how to run the C++ preprocessor... g++ -m64 -std=c++14 -E
+2025-07-26T11:58:14.7723899Z checking for ld used by g++ -m64 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-26T11:58:14.7749192Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-26T11:58:14.7820019Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:14.8419756Z checking for g++ -m64 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:14.8571668Z checking if g++ -m64 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:14.9159910Z checking if g++ -m64 -std=c++14 static flag -static works... yes
+2025-07-26T11:58:14.9387186Z checking if g++ -m64 -std=c++14 supports -c -o file.o... yes
+2025-07-26T11:58:14.9388602Z checking if g++ -m64 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:14.9390042Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:14.9438288Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-26T11:58:14.9439057Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:14.9445189Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-26T11:58:14.9451873Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-26T11:58:14.9454195Z checking for ranlib... (cached) ranlib
+2025-07-26T11:58:14.9459085Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-26T11:58:14.9461011Z checking for strip... (cached) strip
+2025-07-26T11:58:14.9464849Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:14.9609595Z checking whether C compiler accepts -Werror... yes
+2025-07-26T11:58:14.9859876Z checking for gmp.h... yes
+2025-07-26T11:58:15.0202997Z checking for __gmpz_init in -lgmp... yes
+2025-07-26T11:58:15.0377323Z checking gmp version >= 6.2... yes
+2025-07-26T11:58:15.0407062Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-26T11:58:15.0418272Z checking pkg-config is at least version 0.9.0... yes
+2025-07-26T11:58:15.0504699Z checking if gcc -m64 supports -pipe... yes
+2025-07-26T11:58:15.0601783Z checking if gcc -m64 supports -fomit-frame-pointer... yes
+2025-07-26T11:58:15.0858963Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-26T11:58:15.1171998Z checking whether gcc -m64 is Clang... no
+2025-07-26T11:58:15.1622368Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-26T11:58:15.1986587Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-26T11:58:15.1987465Z checking whether more special flags are required for pthreads... no
+2025-07-26T11:58:15.2344090Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-26T11:58:15.2677820Z checking for library containing clock_gettime... none required
+2025-07-26T11:58:15.2860091Z checking whether C compiler accepts -fPIC... yes
+2025-07-26T11:58:15.3037684Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-26T11:58:15.3186540Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-26T11:58:15.3356998Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-26T11:58:15.3524630Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-26T11:58:15.3694422Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-26T11:58:15.3933418Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-26T11:58:15.4174308Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-26T11:58:15.4407634Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-26T11:58:15.4630746Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-26T11:58:15.4944561Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-26T11:58:15.5278071Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-26T11:58:15.5595390Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-26T11:58:15.5909293Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-26T11:58:15.6094867Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-26T11:58:15.6097138Z checking whether to build runtest... yes
+2025-07-26T11:58:15.6098847Z checking whether to build runbench... yes
+2025-07-26T11:58:15.6338098Z checking that generated files are newer than configure... done
+2025-07-26T11:58:15.6343055Z configure: creating ./config.status
+2025-07-26T11:58:16.1723384Z config.status: creating Makefile
+2025-07-26T11:58:16.1937745Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-26T11:58:16.2081614Z config.status: executing depfiles commands
+2025-07-26T11:58:16.2096649Z config.status: executing libtool commands
+2025-07-26T11:58:16.2231453Z 
+2025-07-26T11:58:16.2232003Z Options used to compile and link:
+2025-07-26T11:58:16.2232930Z   target os           = linux
+2025-07-26T11:58:16.2233290Z   backend             = gmp
+2025-07-26T11:58:16.2234557Z   build bench         = yes
+2025-07-26T11:58:16.2234916Z   build test          = yes
+2025-07-26T11:58:16.2235478Z   use debug           = no
+2025-07-26T11:58:16.2235843Z   use hardening       = yes
+2025-07-26T11:58:16.2236177Z   use optimizations   = yes
+2025-07-26T11:58:16.2236413Z 
+2025-07-26T11:58:16.2236686Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-26T11:58:16.2237940Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-26T11:58:16.2239044Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-26T11:58:16.2240080Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-26T11:58:16.2240780Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-26T11:58:16.2240966Z 
+2025-07-26T11:58:16.2592703Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/src/secp256k1)
+2025-07-26T11:58:16.2651314Z configure: running /bin/bash ../../../src/secp256k1/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/secp256k1
+2025-07-26T11:58:16.3875219Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-26T11:58:16.4390951Z checking build system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:16.4438432Z checking host system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:16.4515705Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-26T11:58:16.4544639Z checking whether build environment is sane... yes
+2025-07-26T11:58:16.4604812Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-26T11:58:16.4626300Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-26T11:58:16.4630353Z checking for gawk... gawk
+2025-07-26T11:58:16.4691523Z checking whether make sets $(MAKE)... yes
+2025-07-26T11:58:16.4745402Z checking whether make supports nested variables... yes
+2025-07-26T11:58:16.4789080Z checking whether make supports nested variables... (cached) yes
+2025-07-26T11:58:16.4791293Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-26T11:58:16.5347615Z checking whether the C compiler works... yes
+2025-07-26T11:58:16.5348416Z checking for C compiler default output file name... a.out
+2025-07-26T11:58:16.5631794Z checking for suffix of executables... 
+2025-07-26T11:58:16.5984104Z checking whether we are cross compiling... no
+2025-07-26T11:58:16.6138602Z checking for suffix of object files... o
+2025-07-26T11:58:16.6271392Z checking whether the compiler supports GNU C... yes
+2025-07-26T11:58:16.6420714Z checking whether gcc -m64 accepts -g... yes
+2025-07-26T11:58:16.6764971Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-26T11:58:16.7030057Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-26T11:58:16.7103746Z checking whether make supports the include directive... yes (GNU style)
+2025-07-26T11:58:16.7107812Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:16.7112309Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:16.7114243Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:58:16.7384025Z checking the archiver (ar) interface... ar
+2025-07-26T11:58:16.7407657Z checking how to print strings... printf
+2025-07-26T11:58:16.7447327Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-26T11:58:16.7477117Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-26T11:58:16.7492891Z checking for egrep... /usr/bin/grep -E
+2025-07-26T11:58:16.7509237Z checking for fgrep... /usr/bin/grep -F
+2025-07-26T11:58:16.7556245Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-26T11:58:16.7581870Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-26T11:58:16.7584326Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-26T11:58:16.7888682Z checking the name lister (nm) interface... BSD nm
+2025-07-26T11:58:16.7889541Z checking whether ln -s works... yes
+2025-07-26T11:58:16.7936169Z checking the maximum length of command line arguments... 3145728
+2025-07-26T11:58:16.7964272Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-26T11:58:16.7966310Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-26T11:58:16.7967550Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-26T11:58:16.7973593Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-26T11:58:16.7978548Z checking for file... file
+2025-07-26T11:58:16.7982953Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:58:16.7987906Z checking for objdump... objdump
+2025-07-26T11:58:16.7991560Z checking how to recognize dependent libraries... pass_all
+2025-07-26T11:58:16.7996219Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-26T11:58:16.8001164Z checking for dlltool... no
+2025-07-26T11:58:16.8002482Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-26T11:58:16.8004819Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:58:16.8333079Z checking for archiver @FILE support... @
+2025-07-26T11:58:16.8334368Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-26T11:58:16.8337924Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-26T11:58:16.9000689Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-26T11:58:16.9018077Z checking for sysroot... no
+2025-07-26T11:58:16.9060008Z checking for a working dd... /usr/bin/dd
+2025-07-26T11:58:16.9099774Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-26T11:58:16.9201341Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-26T11:58:16.9206884Z checking for mt... no
+2025-07-26T11:58:16.9237467Z checking if : is a manifest tool... no
+2025-07-26T11:58:16.9382763Z checking for stdio.h... yes
+2025-07-26T11:58:16.9535743Z checking for stdlib.h... yes
+2025-07-26T11:58:16.9701328Z checking for string.h... yes
+2025-07-26T11:58:16.9873848Z checking for inttypes.h... yes
+2025-07-26T11:58:17.0043900Z checking for stdint.h... yes
+2025-07-26T11:58:17.0215717Z checking for strings.h... yes
+2025-07-26T11:58:17.0389222Z checking for sys/stat.h... yes
+2025-07-26T11:58:17.0569380Z checking for sys/types.h... yes
+2025-07-26T11:58:17.0768180Z checking for unistd.h... yes
+2025-07-26T11:58:17.0972790Z checking for dlfcn.h... yes
+2025-07-26T11:58:17.1015397Z checking for objdir... .libs
+2025-07-26T11:58:17.1601075Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-26T11:58:17.1601915Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:17.1735194Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:17.2303691Z checking if gcc -m64 static flag -static works... yes
+2025-07-26T11:58:17.2512601Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-26T11:58:17.2513377Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:17.2606110Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:17.3079730Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-26T11:58:17.3080456Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:17.3097858Z checking whether stripping libraries is possible... yes
+2025-07-26T11:58:17.3098817Z checking if libtool supports shared libraries... yes
+2025-07-26T11:58:17.3099386Z checking whether to build shared libraries... no
+2025-07-26T11:58:17.3100110Z checking whether to build static libraries... yes
+2025-07-26T11:58:17.3203887Z checking if gcc -m64 supports -Werror... yes
+2025-07-26T11:58:17.3296165Z checking if gcc -m64 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-26T11:58:17.3388636Z checking if gcc -m64 supports -Wno-overlength-strings... yes
+2025-07-26T11:58:17.3480567Z checking if gcc -m64 supports -Wall... yes
+2025-07-26T11:58:17.3572520Z checking if gcc -m64 supports -Wno-unused-function... yes
+2025-07-26T11:58:17.3666827Z checking if gcc -m64 supports -Wextra... yes
+2025-07-26T11:58:17.3760604Z checking if gcc -m64 supports -Wcast-align... yes
+2025-07-26T11:58:17.3853314Z checking if gcc -m64 supports -Wcast-align=strict... yes
+2025-07-26T11:58:17.4107878Z checking if gcc -m64 supports -Wconditional-uninitialized... no
+2025-07-26T11:58:17.4311802Z checking if gcc -m64 supports -Wreserved-identifier... no
+2025-07-26T11:58:17.4402975Z checking if gcc -m64 supports -fvisibility=hidden... yes
+2025-07-26T11:58:17.4546438Z checking for valgrind support... 
+2025-07-26T11:58:17.4882319Z checking for x86_64 assembly availability... yes
+2025-07-26T11:58:17.5114612Z checking that generated files are newer than configure... done
+2025-07-26T11:58:17.5118870Z configure: creating ./config.status
+2025-07-26T11:58:17.9107237Z config.status: creating Makefile
+2025-07-26T11:58:17.9237530Z config.status: creating libsecp256k1.pc
+2025-07-26T11:58:17.9342874Z config.status: executing depfiles commands
+2025-07-26T11:58:17.9356977Z config.status: executing libtool commands
+2025-07-26T11:58:17.9442770Z 
+2025-07-26T11:58:17.9443352Z Build Options:
+2025-07-26T11:58:17.9443755Z   with external callbacks = no
+2025-07-26T11:58:17.9444341Z   with benchmarks         = no
+2025-07-26T11:58:17.9444784Z   with tests              = yes
+2025-07-26T11:58:17.9445429Z   with ctime tests        = no
+2025-07-26T11:58:17.9445889Z   with coverage           = no
+2025-07-26T11:58:17.9446294Z   with examples           = no
+2025-07-26T11:58:17.9446714Z   module ecdh             = no
+2025-07-26T11:58:17.9447137Z   module recovery         = yes
+2025-07-26T11:58:17.9447542Z   module extrakeys        = yes
+2025-07-26T11:58:17.9447946Z   module schnorrsig       = yes
+2025-07-26T11:58:17.9448349Z   module ellswift         = yes
+2025-07-26T11:58:17.9448607Z 
+2025-07-26T11:58:17.9449505Z   asm                     = x86_64
+2025-07-26T11:58:17.9449935Z   ecmult window size      = 15
+2025-07-26T11:58:17.9450340Z   ecmult gen prec. bits   = 4
+2025-07-26T11:58:17.9450543Z 
+2025-07-26T11:58:17.9450880Z   valgrind                = no
+2025-07-26T11:58:17.9451148Z   CC                      = gcc -m64
+2025-07-26T11:58:17.9451540Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-26T11:58:17.9452693Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-26T11:58:17.9453750Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-26T11:58:17.9454128Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-26T11:58:17.9761153Z 
+2025-07-26T11:58:17.9761393Z Options used to compile and link:
+2025-07-26T11:58:17.9761848Z   boost process       = yes
+2025-07-26T11:58:17.9762240Z   multiprocess        = no
+2025-07-26T11:58:17.9762583Z   with libs           = no
+2025-07-26T11:58:17.9762922Z   with wallet         = yes
+2025-07-26T11:58:17.9763571Z     with sqlite       = yes
+2025-07-26T11:58:17.9763976Z     with bdb          = yes
+2025-07-26T11:58:17.9764355Z   with gui / qt       = yes
+2025-07-26T11:58:17.9764734Z     with qr           = yes
+2025-07-26T11:58:17.9765348Z   with zmq            = yes
+2025-07-26T11:58:17.9765572Z   with test           = yes
+2025-07-26T11:58:17.9765810Z   with fuzz binary    = no
+2025-07-26T11:58:17.9766039Z   with bench          = yes
+2025-07-26T11:58:17.9766257Z   with upnp           = yes
+2025-07-26T11:58:17.9766476Z   with natpmp         = yes
+2025-07-26T11:58:17.9766697Z   USDT tracing        = yes
+2025-07-26T11:58:17.9766912Z   sanitizers          = 
+2025-07-26T11:58:17.9767138Z   debug enabled       = no
+2025-07-26T11:58:17.9767367Z   stacktraces enabled = yes
+2025-07-26T11:58:17.9767592Z   crash hooks enabled = no
+2025-07-26T11:58:17.9767818Z   miner enabled       = yes
+2025-07-26T11:58:17.9768178Z   gprof enabled       = no
+2025-07-26T11:58:17.9768522Z   werror              = yes
+2025-07-26T11:58:17.9768763Z 
+2025-07-26T11:58:17.9768911Z   target os           = linux-gnu
+2025-07-26T11:58:17.9769304Z   build os            = linux-gnu
+2025-07-26T11:58:17.9769564Z 
+2025-07-26T11:58:17.9769740Z   CC                  = /usr/bin/ccache gcc -m64
+2025-07-26T11:58:17.9770392Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-26T11:58:17.9771582Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-26T11:58:17.9772349Z   CXX                 = /usr/bin/ccache g++ -m64 -std=c++20
+2025-07-26T11:58:17.9774837Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-26T11:58:17.9779140Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-26T11:58:17.9780037Z   AR                  = ar
+2025-07-26T11:58:17.9780382Z   ARFLAGS             = cr
+2025-07-26T11:58:17.9780613Z 
+2025-07-26T11:58:18.0366537Z make  distdir-am
+2025-07-26T11:58:18.0421560Z make[1]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-26T11:58:18.0422854Z if test -d "dashcore-linux64"; then find "dashcore-linux64" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "dashcore-linux64" || { sleep 5 && rm -rf "dashcore-linux64"; }; else :; fi
+2025-07-26T11:58:18.0440552Z test -d "dashcore-linux64" || mkdir "dashcore-linux64"
+2025-07-26T11:58:18.2532535Z  (cd src && make  top_distdir=../dashcore-linux64 distdir=../dashcore-linux64/src \
+2025-07-26T11:58:18.2533242Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-26T11:58:18.2784274Z make[2]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-26T11:58:18.2785378Z make  distdir-am
+2025-07-26T11:58:18.4082753Z make[3]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-26T11:58:18.4914139Z Generated bench/data/block813851.raw.h
+2025-07-26T11:58:18.5134234Z Generated test/data/blockfilters.json.h
+2025-07-26T11:58:18.5215180Z Generated test/data/base58_encode_decode.json.h
+2025-07-26T11:58:18.5309431Z Generated test/data/bip39_vectors.json.h
+2025-07-26T11:58:18.5401538Z Generated test/data/key_io_valid.json.h
+2025-07-26T11:58:18.5485370Z Generated test/data/key_io_invalid.json.h
+2025-07-26T11:58:18.5564885Z Generated test/data/proposals_valid.json.h
+2025-07-26T11:58:18.5650014Z Generated test/data/proposals_invalid.json.h
+2025-07-26T11:58:18.6001326Z Generated test/data/script_tests.json.h
+2025-07-26T11:58:18.6305604Z Generated test/data/sighash.json.h
+2025-07-26T11:58:18.6399348Z Generated test/data/trivially_invalid.json.h
+2025-07-26T11:58:18.6501621Z Generated test/data/trivially_valid.json.h
+2025-07-26T11:58:18.6617744Z Generated test/data/tx_invalid.json.h
+2025-07-26T11:58:18.6740197Z Generated test/data/tx_valid.json.h
+2025-07-26T11:58:18.6819386Z Generated test/data/asmap.raw.h
+2025-07-26T11:58:21.2312766Z  (cd secp256k1 && make  top_distdir=../../dashcore-linux64 distdir=../../dashcore-linux64/src/secp256k1 \
+2025-07-26T11:58:21.2313683Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-26T11:58:21.2350552Z make[4]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-26T11:58:21.2351311Z make  distdir-am
+2025-07-26T11:58:21.2466422Z make[5]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-26T11:58:21.2467178Z :
+2025-07-26T11:58:21.2467761Z test -d "../../dashcore-linux64/src/secp256k1" || mkdir "../../dashcore-linux64/src/secp256k1"
+2025-07-26T11:58:21.4660204Z test -n ":" \
+2025-07-26T11:58:21.4661041Z || find "../../dashcore-linux64/src/secp256k1" -type d ! -perm -755 \
+2025-07-26T11:58:21.4661778Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-26T11:58:21.4662312Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-26T11:58:21.4662879Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-26T11:58:21.4663712Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/src/secp256k1/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-26T11:58:21.4664562Z || chmod -R a+r "../../dashcore-linux64/src/secp256k1"
+2025-07-26T11:58:21.4675222Z make[5]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-26T11:58:21.4679712Z make[4]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-26T11:58:21.4685905Z make[3]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-26T11:58:21.4694932Z make[2]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-26T11:58:21.4966192Z  (cd doc/man && make  top_distdir=../../dashcore-linux64 distdir=../../dashcore-linux64/doc/man \
+2025-07-26T11:58:21.4967406Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-26T11:58:21.4989858Z make[2]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-26T11:58:21.4990731Z make  distdir-am
+2025-07-26T11:58:21.5023060Z make[3]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-26T11:58:21.5195548Z make[3]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-26T11:58:21.5197518Z make[2]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-26T11:58:21.5202286Z make  \
+2025-07-26T11:58:21.5202776Z   top_distdir="dashcore-linux64" distdir="dashcore-linux64" \
+2025-07-26T11:58:21.5203401Z   dist-hook
+2025-07-26T11:58:21.5236869Z make[2]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-26T11:58:21.5238535Z /usr/bin/git archive --format=tar HEAD -- src/clientversion.cpp | ${TAR-tar} -C dashcore-linux64 -xf -
+2025-07-26T11:58:21.5266836Z fatal: pathspec 'src/clientversion.cpp' did not match any files
+2025-07-26T11:58:21.5270213Z tar: This does not look like a tar archive
+2025-07-26T11:58:21.5270969Z tar: Exiting with failure status due to previous errors
+2025-07-26T11:58:21.5274437Z make[2]: [Makefile:1226: dist-hook] Error 2 (ignored)
+2025-07-26T11:58:21.5275326Z make[2]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-26T11:58:21.5276611Z test -n "" \
+2025-07-26T11:58:21.5277274Z || find "dashcore-linux64" -type d ! -perm -755 \
+2025-07-26T11:58:21.5277771Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-26T11:58:21.5278233Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-26T11:58:21.5278715Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-26T11:58:21.5279334Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-26T11:58:21.5280191Z || chmod -R a+r "dashcore-linux64"
+2025-07-26T11:58:21.5496459Z make[1]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-26T11:58:21.6587686Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-26T11:58:21.6662596Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-26T11:58:21.6675270Z checking pkg-config is at least version 0.9.0... yes
+2025-07-26T11:58:21.7126665Z checking build system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:21.7174953Z checking host system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:21.7252711Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-26T11:58:21.7281450Z checking whether build environment is sane... yes
+2025-07-26T11:58:21.7343085Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-26T11:58:21.7365369Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-26T11:58:21.7369572Z checking for gawk... gawk
+2025-07-26T11:58:21.7433906Z checking whether make sets $(MAKE)... yes
+2025-07-26T11:58:21.7491457Z checking whether make supports nested variables... yes
+2025-07-26T11:58:21.7537401Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-26T11:58:21.7540047Z checking whether make supports nested variables... (cached) yes
+2025-07-26T11:58:21.8101929Z checking whether the C++ compiler works... yes
+2025-07-26T11:58:21.8102869Z checking for C++ compiler default output file name... a.out
+2025-07-26T11:58:21.8427378Z checking for suffix of executables... 
+2025-07-26T11:58:21.8875882Z checking whether we are cross compiling... no
+2025-07-26T11:58:21.9047161Z checking for suffix of object files... o
+2025-07-26T11:58:21.9193286Z checking whether the compiler supports GNU C++... yes
+2025-07-26T11:58:21.9349878Z checking whether g++ -m64 accepts -g... yes
+2025-07-26T11:58:22.2140411Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-26T11:58:22.2612103Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-26T11:58:22.2687815Z checking whether make supports the include directive... yes (GNU style)
+2025-07-26T11:58:22.2691454Z checking dependency style of g++ -m64... none
+2025-07-26T11:58:22.3481643Z checking whether g++ -m64 supports C++20 features with -std=c++20... yes
+2025-07-26T11:58:22.3485631Z checking for x86_64-pc-linux-gnu-g++... g++ -m64 -std=c++20
+2025-07-26T11:58:22.3775679Z checking whether the compiler supports GNU Objective C++... no
+2025-07-26T11:58:22.4055461Z checking whether g++ -m64 -std=c++20 accepts -g... no
+2025-07-26T11:58:22.4059847Z checking dependency style of g++ -m64 -std=c++20... none
+2025-07-26T11:58:22.4084633Z checking how to print strings... printf
+2025-07-26T11:58:22.4087245Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-26T11:58:22.4477132Z checking whether the compiler supports GNU C... yes
+2025-07-26T11:58:22.4628130Z checking whether gcc -m64 accepts -g... yes
+2025-07-26T11:58:22.4975543Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-26T11:58:22.5249970Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-26T11:58:22.5253992Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:22.5292713Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-26T11:58:22.5323198Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-26T11:58:22.5339279Z checking for egrep... /usr/bin/grep -E
+2025-07-26T11:58:22.5354076Z checking for fgrep... /usr/bin/grep -F
+2025-07-26T11:58:22.5401424Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-26T11:58:22.5425631Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-26T11:58:22.5427875Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-26T11:58:22.5707129Z checking the name lister (nm) interface... BSD nm
+2025-07-26T11:58:22.5707726Z checking whether ln -s works... yes
+2025-07-26T11:58:22.5749767Z checking the maximum length of command line arguments... 3145728
+2025-07-26T11:58:22.5777119Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-26T11:58:22.5780102Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-26T11:58:22.5781601Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-26T11:58:22.5786037Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-26T11:58:22.5790886Z checking for file... file
+2025-07-26T11:58:22.5795545Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:58:22.5799608Z checking for objdump... objdump
+2025-07-26T11:58:22.5803566Z checking how to recognize dependent libraries... pass_all
+2025-07-26T11:58:22.5808215Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-26T11:58:22.5812194Z checking for dlltool... no
+2025-07-26T11:58:22.5813918Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-26T11:58:22.5815848Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:58:22.6149256Z checking for archiver @FILE support... @
+2025-07-26T11:58:22.6150152Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-26T11:58:22.6153698Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-26T11:58:22.6811742Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-26T11:58:22.6828283Z checking for sysroot... no
+2025-07-26T11:58:22.6869979Z checking for a working dd... /usr/bin/dd
+2025-07-26T11:58:22.6907587Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-26T11:58:22.7008492Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-26T11:58:22.7013465Z checking for mt... no
+2025-07-26T11:58:22.7044334Z checking if : is a manifest tool... no
+2025-07-26T11:58:22.7190908Z checking for stdio.h... yes
+2025-07-26T11:58:22.7349807Z checking for stdlib.h... yes
+2025-07-26T11:58:22.7512728Z checking for string.h... yes
+2025-07-26T11:58:22.7680986Z checking for inttypes.h... yes
+2025-07-26T11:58:22.7848691Z checking for stdint.h... yes
+2025-07-26T11:58:22.8020509Z checking for strings.h... yes
+2025-07-26T11:58:22.8194286Z checking for sys/stat.h... yes
+2025-07-26T11:58:22.8370385Z checking for sys/types.h... yes
+2025-07-26T11:58:22.8569464Z checking for unistd.h... yes
+2025-07-26T11:58:22.8770799Z checking for dlfcn.h... yes
+2025-07-26T11:58:22.8810651Z checking for objdir... .libs
+2025-07-26T11:58:22.9405668Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-26T11:58:22.9406924Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:22.9541809Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:23.0110120Z checking if gcc -m64 static flag -static works... yes
+2025-07-26T11:58:23.0323793Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-26T11:58:23.0325524Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:23.0418767Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:23.0623686Z checking whether -lc should be explicitly linked in... no
+2025-07-26T11:58:23.1113324Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-26T11:58:23.1114327Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:23.1132322Z checking whether stripping libraries is possible... yes
+2025-07-26T11:58:23.1133022Z checking if libtool supports shared libraries... yes
+2025-07-26T11:58:23.1133886Z checking whether to build shared libraries... yes
+2025-07-26T11:58:23.1134658Z checking whether to build static libraries... yes
+2025-07-26T11:58:23.1389953Z checking how to run the C++ preprocessor... g++ -m64 -std=c++20 -E
+2025-07-26T11:58:23.2116075Z checking for ld used by g++ -m64 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-26T11:58:23.2140141Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-26T11:58:23.2210137Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:23.2822750Z checking for g++ -m64 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:23.2974066Z checking if g++ -m64 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:23.3575372Z checking if g++ -m64 -std=c++20 static flag -static works... yes
+2025-07-26T11:58:23.3804061Z checking if g++ -m64 -std=c++20 supports -c -o file.o... yes
+2025-07-26T11:58:23.3805324Z checking if g++ -m64 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:23.3806753Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:23.3854242Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-26T11:58:23.3857615Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:23.3863278Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-26T11:58:23.3868883Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-26T11:58:23.3873176Z checking for gcov... /usr/bin/gcov
+2025-07-26T11:58:23.3878142Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-26T11:58:23.3882350Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-26T11:58:23.3886688Z checking for lcov... no
+2025-07-26T11:58:23.3890208Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-26T11:58:23.3894383Z checking for genhtml... no
+2025-07-26T11:58:23.3898639Z checking for git... /usr/bin/git
+2025-07-26T11:58:23.3902381Z checking for ccache... /usr/bin/ccache
+2025-07-26T11:58:23.3908110Z checking for xgettext... /usr/bin/xgettext
+2025-07-26T11:58:23.3911559Z checking for hexdump... /usr/bin/hexdump
+2025-07-26T11:58:23.3915784Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-26T11:58:23.3920404Z checking for objcopy... /usr/bin/objcopy
+2025-07-26T11:58:23.3926074Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:58:23.3931243Z checking for objdump... /usr/bin/objdump
+2025-07-26T11:58:23.3936798Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-26T11:58:23.3942317Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-26T11:58:23.3947397Z checking for doxygen... no
+2025-07-26T11:58:23.4106393Z checking whether C++ compiler accepts -Werror... yes
+2025-07-26T11:58:23.4467721Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-26T11:58:23.4892661Z checking for execinfo.h... yes
+2025-07-26T11:58:23.5258628Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-26T11:58:23.5450485Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-26T11:58:23.5623598Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-26T11:58:23.5790258Z checking whether C++ compiler accepts -Wdangling-reference... yes
+2025-07-26T11:58:23.5957613Z checking whether C++ compiler accepts -Wattributes... yes
+2025-07-26T11:58:23.6136431Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-26T11:58:23.6311664Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-26T11:58:23.6485440Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-26T11:58:23.6665344Z checking whether C++ compiler accepts -Wall... yes
+2025-07-26T11:58:23.6839048Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-26T11:58:23.6977418Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-26T11:58:23.7148950Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-26T11:58:23.7319621Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-26T11:58:23.7490694Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-26T11:58:23.7663362Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-26T11:58:23.7860727Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-26T11:58:23.8056213Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-26T11:58:23.8234708Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-26T11:58:23.8491347Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-26T11:58:23.8670289Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-26T11:58:23.8937645Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-26T11:58:23.9109024Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-26T11:58:23.9280163Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-26T11:58:23.9451062Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-26T11:58:23.9621666Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-26T11:58:23.9792258Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-26T11:58:23.9962061Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-26T11:58:24.0134644Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-26T11:58:24.0342055Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-26T11:58:24.0517829Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-26T11:58:24.0691006Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-26T11:58:24.0871811Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-26T11:58:24.1017450Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-26T11:58:24.1189012Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-26T11:58:24.1358731Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-26T11:58:24.1533919Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-26T11:58:24.1707779Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-26T11:58:24.6265385Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-26T11:58:24.6707121Z checking for SSE4.2 intrinsics... yes
+2025-07-26T11:58:25.0992076Z checking for SSE4.1 intrinsics... yes
+2025-07-26T11:58:25.5207722Z checking for AVX2 intrinsics... yes
+2025-07-26T11:58:25.9540152Z checking for x86 SHA-NI intrinsics... yes
+2025-07-26T11:58:25.9708800Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-26T11:58:25.9860857Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-26T11:58:26.0001572Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-26T11:58:26.0151879Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-26T11:58:26.0976166Z checking whether byte ordering is bigendian... no
+2025-07-26T11:58:26.1192507Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-26T11:58:26.1497777Z checking whether gcc -m64 is Clang... no
+2025-07-26T11:58:26.1937842Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-26T11:58:26.2288983Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-26T11:58:26.2290248Z checking whether more special flags are required for pthreads... no
+2025-07-26T11:58:26.2662842Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-26T11:58:27.0863606Z checking whether std::atomic can be used without link library... yes
+2025-07-26T11:58:27.0878840Z checking for special C compiler options needed for large files... no
+2025-07-26T11:58:27.1091023Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-26T11:58:27.1413050Z checking for g++ -m64 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-26T11:58:27.1920702Z checking whether strerror_r is declared... yes
+2025-07-26T11:58:27.2141615Z checking whether strerror_r returns char *... yes
+2025-07-26T11:58:27.2293938Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-26T11:58:27.2451017Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-26T11:58:27.2603428Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-26T11:58:27.2750505Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-26T11:58:27.2920430Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-26T11:58:27.3006311Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-26T11:58:27.3090597Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-26T11:58:27.3341670Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-26T11:58:27.3608150Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-26T11:58:27.3882539Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-26T11:58:27.4146255Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-26T11:58:27.4529117Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-26T11:58:27.4895518Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-26T11:58:27.5268682Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-26T11:58:27.5640039Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-26T11:58:27.6061541Z checking for sys/select.h... yes
+2025-07-26T11:58:27.6473264Z checking for sys/prctl.h... yes
+2025-07-26T11:58:27.6792707Z checking for vm/vm_param.h... no
+2025-07-26T11:58:27.7107607Z checking for sys/vmmeter.h... no
+2025-07-26T11:58:27.7429059Z checking for sys/resources.h... no
+2025-07-26T11:58:27.7709060Z checking whether getifaddrs is declared... yes
+2025-07-26T11:58:27.8175740Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-26T11:58:27.8465519Z checking whether freeifaddrs is declared... yes
+2025-07-26T11:58:27.8907266Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-26T11:58:27.9428953Z checking whether fork is declared... yes
+2025-07-26T11:58:27.9929098Z checking whether setsid is declared... yes
+2025-07-26T11:58:28.0440648Z checking whether pipe2 is declared... yes
+2025-07-26T11:58:28.0672552Z checking for mallopt M_ARENA_MAX... yes
+2025-07-26T11:58:28.0912592Z checking for getmemoryinfo... yes
+2025-07-26T11:58:28.1107360Z checking for posix_fallocate... yes
+2025-07-26T11:58:28.1250058Z checking for default visibility attribute... yes
+2025-07-26T11:58:28.1397894Z checking for dllexport attribute... no
+2025-07-26T11:58:28.6245363Z checking for thread_local support... yes
+2025-07-26T11:58:28.6543939Z checking for Linux getrandom syscall... yes
+2025-07-26T11:58:28.6861707Z checking for getentropy via random.h... yes
+2025-07-26T11:58:28.7055526Z checking for sysctl... no
+2025-07-26T11:58:28.7245597Z checking for sysctl KERN_ARND... no
+2025-07-26T11:58:28.7622676Z checking for library containing backtrace... none required
+2025-07-26T11:58:28.7866403Z checking for fdatasync... yes
+2025-07-26T11:58:28.8070069Z checking for F_FULLFSYNC... no
+2025-07-26T11:58:28.8280703Z checking for O_CLOEXEC... yes
+2025-07-26T11:58:28.8438060Z checking for __builtin_prefetch... yes
+2025-07-26T11:58:28.8842259Z checking for _mm_prefetch... yes
+2025-07-26T11:58:28.9041614Z checking for strong getauxval support in the system headers... yes
+2025-07-26T11:58:28.9308803Z checking for sockaddr_un... yes
+2025-07-26T11:58:28.9779351Z checking for std::system... yes
+2025-07-26T11:58:29.0067975Z checking for ::_wsystem... no
+2025-07-26T11:58:29.0246816Z checking for Qt5Core >= 5.11.3... yes
+2025-07-26T11:58:29.0360476Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-26T11:58:29.0475984Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-26T11:58:29.0590858Z checking for Qt5Network >= 5.11.3... yes
+2025-07-26T11:58:29.0703554Z checking for Qt5Test >= 5.11.3... yes
+2025-07-26T11:58:29.0814122Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-26T11:58:29.2900272Z checking for static Qt... yes
+2025-07-26T11:58:29.3016451Z checking for Qt5AccessibilitySupport... yes
+2025-07-26T11:58:29.3131359Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-26T11:58:29.3243133Z checking for Qt5EdidSupport... yes
+2025-07-26T11:58:29.3357410Z checking for Qt5EventDispatcherSupport... yes
+2025-07-26T11:58:29.3470370Z checking for Qt5FbSupport... yes
+2025-07-26T11:58:29.3586635Z checking for Qt5FontDatabaseSupport... yes
+2025-07-26T11:58:29.3704256Z checking for Qt5ThemeSupport... yes
+2025-07-26T11:58:29.3822265Z checking for Qt5InputSupport... yes
+2025-07-26T11:58:29.3939199Z checking for Qt5ServiceSupport... yes
+2025-07-26T11:58:29.4070704Z checking for Qt5XcbQpa... yes
+2025-07-26T11:58:29.4184393Z checking for Qt5XkbCommonSupport... yes
+2025-07-26T11:58:31.4017260Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-26T11:58:33.5235511Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-26T11:58:33.7333184Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-26T11:58:33.7345819Z checking for moc-qt5... no
+2025-07-26T11:58:33.7347394Z checking for moc5... no
+2025-07-26T11:58:33.7349254Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-26T11:58:33.7351218Z checking for uic-qt5... no
+2025-07-26T11:58:33.7351962Z checking for uic5... no
+2025-07-26T11:58:33.7354738Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-26T11:58:33.7357057Z checking for rcc-qt5... no
+2025-07-26T11:58:33.7358853Z checking for rcc5... no
+2025-07-26T11:58:33.7359864Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-26T11:58:33.7361975Z checking for lrelease-qt5... no
+2025-07-26T11:58:33.7362714Z checking for lrelease5... no
+2025-07-26T11:58:33.7365431Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-26T11:58:33.7366221Z checking for lupdate-qt5... no
+2025-07-26T11:58:33.7368445Z checking for lupdate5... no
+2025-07-26T11:58:33.7370363Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-26T11:58:33.7371551Z checking for lconvert-qt5... no
+2025-07-26T11:58:33.7372302Z checking for lconvert5... no
+2025-07-26T11:58:33.7374298Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-26T11:58:33.7406560Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-26T11:58:33.7407612Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-26T11:58:34.5946744Z checking for Berkeley DB C++ headers... default
+2025-07-26T11:58:34.6366194Z checking for main in -ldb_cxx-4.8... yes
+2025-07-26T11:58:34.6506712Z checking for sqlite3 >= 3.7.17... yes
+2025-07-26T11:58:34.6508451Z checking whether to build wallet with support for sqlite... yes
+2025-07-26T11:58:34.6697832Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-26T11:58:34.7165407Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-26T11:58:34.7592830Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-26T11:58:34.8050952Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-26T11:58:34.8091134Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-26T11:58:34.8537713Z checking for miniupnpc/upnperrors.h... yes
+2025-07-26T11:58:34.8579422Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-26T11:58:34.8664431Z checking whether miniUPnPc API version is supported... yes
+2025-07-26T11:58:34.9148709Z checking for natpmp.h... yes
+2025-07-26T11:58:34.9513466Z checking for initnatpmp in -lnatpmp... yes
+2025-07-26T11:58:34.9592531Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-26T11:58:34.9595366Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-26T11:58:34.9597492Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-26T11:58:34.9599725Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-26T11:58:34.9601551Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-26T11:58:34.9739786Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-26T11:58:35.0027293Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-26T11:58:37.7739934Z checking for Boost Process... yes
+2025-07-26T11:58:37.7955618Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-26T11:58:37.8334112Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-26T11:58:37.8601696Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-26T11:58:37.8724633Z checking for libevent >= 2.1.8... yes
+2025-07-26T11:58:37.8846649Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-26T11:58:37.9186145Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-26T11:58:37.9314935Z checking for libqrencode... yes
+2025-07-26T11:58:37.9435797Z checking for libzmq >= 4... yes
+2025-07-26T11:58:38.0014313Z checking for gmp.h... yes
+2025-07-26T11:58:38.0401473Z checking for __gmpz_init in -lgmp... yes
+2025-07-26T11:58:38.0524010Z checking for libmultiprocess... no
+2025-07-26T11:58:38.0604617Z checking whether to build dashd... yes
+2025-07-26T11:58:38.0606792Z checking whether to build dash-cli... yes
+2025-07-26T11:58:38.0607694Z checking whether to build dash-tx... yes
+2025-07-26T11:58:38.0608577Z checking whether to build dash-wallet... yes
+2025-07-26T11:58:38.0609419Z checking whether to build libraries... no
+2025-07-26T11:58:38.0612412Z checking if ccache should be used... yes
+2025-07-26T11:58:38.0711707Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-26T11:58:38.0829655Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-26T11:58:38.0831722Z checking if wallet should be enabled... yes
+2025-07-26T11:58:38.0834343Z checking whether to build with support for UPnP... yes
+2025-07-26T11:58:38.0836422Z checking whether to build with support for NAT-PMP... yes
+2025-07-26T11:58:38.0839267Z checking whether to build GUI with support for D-Bus... yes
+2025-07-26T11:58:38.0840502Z checking whether to build GUI with support for QR codes... yes
+2025-07-26T11:58:38.0842708Z checking whether to build test_dash-qt... yes
+2025-07-26T11:58:38.0843185Z checking whether to build test_dash... yes
+2025-07-26T11:58:38.0844366Z checking whether to reduce exports... yes
+2025-07-26T11:58:38.0976539Z checking whether dsymutil needs -flat... yes
+2025-07-26T11:58:38.0977497Z 
+2025-07-26T11:58:38.1424442Z checking that generated files are newer than configure... done
+2025-07-26T11:58:38.1431005Z configure: creating ./config.status
+2025-07-26T11:58:38.8015824Z config.status: creating Makefile
+2025-07-26T11:58:38.8139116Z config.status: creating src/Makefile
+2025-07-26T11:58:38.8708164Z config.status: creating doc/man/Makefile
+2025-07-26T11:58:38.8858527Z config.status: creating share/setup.nsi
+2025-07-26T11:58:38.9018901Z config.status: creating share/qt/Info.plist
+2025-07-26T11:58:38.9176066Z config.status: creating test/config.ini
+2025-07-26T11:58:38.9330554Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-26T11:58:38.9490981Z config.status: creating src/config/bitcoin-config.h
+2025-07-26T11:58:38.9964331Z config.status: executing depfiles commands
+2025-07-26T11:58:38.9981633Z config.status: executing libtool commands
+2025-07-26T11:58:39.0120786Z === configuring in src/dashbls (/__w/dash/dash/build-ci/dashcore-linux64/src/dashbls)
+2025-07-26T11:58:39.0168945Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-26T11:58:39.1367653Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-26T11:58:39.1864415Z checking build system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:39.1913528Z checking host system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:39.1991978Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-26T11:58:39.2021944Z checking whether build environment is sane... yes
+2025-07-26T11:58:39.2082413Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-26T11:58:39.2103849Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-26T11:58:39.2108308Z checking for gawk... gawk
+2025-07-26T11:58:39.2170762Z checking whether make sets $(MAKE)... yes
+2025-07-26T11:58:39.2223233Z checking whether make supports nested variables... yes
+2025-07-26T11:58:39.2263884Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-26T11:58:39.2266271Z checking whether make supports nested variables... (cached) yes
+2025-07-26T11:58:39.2267857Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-26T11:58:39.2824715Z checking whether the C compiler works... yes
+2025-07-26T11:58:39.2825778Z checking for C compiler default output file name... a.out
+2025-07-26T11:58:39.3114639Z checking for suffix of executables... 
+2025-07-26T11:58:39.3483247Z checking whether we are cross compiling... no
+2025-07-26T11:58:39.3641293Z checking for suffix of object files... o
+2025-07-26T11:58:39.3777817Z checking whether the compiler supports GNU C... yes
+2025-07-26T11:58:39.3927791Z checking whether gcc -m64 accepts -g... yes
+2025-07-26T11:58:39.4274675Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-26T11:58:39.4544235Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-26T11:58:39.4620226Z checking whether make supports the include directive... yes (GNU style)
+2025-07-26T11:58:39.4624620Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:39.4964586Z checking whether the compiler supports GNU C++... yes
+2025-07-26T11:58:39.5120442Z checking whether g++ -m64 accepts -g... yes
+2025-07-26T11:58:39.7904736Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-26T11:58:39.8377833Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-26T11:58:39.8380989Z checking dependency style of g++ -m64... none
+2025-07-26T11:58:39.8772080Z checking whether g++ -m64 supports C++14 features with -std=c++14... yes
+2025-07-26T11:58:39.8796951Z checking how to print strings... printf
+2025-07-26T11:58:39.8834567Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-26T11:58:39.8864653Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-26T11:58:39.8881206Z checking for egrep... /usr/bin/grep -E
+2025-07-26T11:58:39.8897078Z checking for fgrep... /usr/bin/grep -F
+2025-07-26T11:58:39.8944008Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-26T11:58:39.8969222Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-26T11:58:39.8971602Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-26T11:58:39.9256408Z checking the name lister (nm) interface... BSD nm
+2025-07-26T11:58:39.9257325Z checking whether ln -s works... yes
+2025-07-26T11:58:39.9299753Z checking the maximum length of command line arguments... 3145728
+2025-07-26T11:58:39.9327184Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-26T11:58:39.9329662Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-26T11:58:39.9331450Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-26T11:58:39.9336276Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-26T11:58:39.9341020Z checking for file... file
+2025-07-26T11:58:39.9345532Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:58:39.9349853Z checking for objdump... objdump
+2025-07-26T11:58:39.9353934Z checking how to recognize dependent libraries... pass_all
+2025-07-26T11:58:39.9358634Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-26T11:58:39.9363344Z checking for dlltool... no
+2025-07-26T11:58:39.9364776Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-26T11:58:39.9366584Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:58:39.9696987Z checking for archiver @FILE support... @
+2025-07-26T11:58:39.9698695Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-26T11:58:39.9701445Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-26T11:58:40.0371876Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-26T11:58:40.0388636Z checking for sysroot... no
+2025-07-26T11:58:40.0430517Z checking for a working dd... /usr/bin/dd
+2025-07-26T11:58:40.0468842Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-26T11:58:40.0571712Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-26T11:58:40.0577323Z checking for mt... no
+2025-07-26T11:58:40.0608659Z checking if : is a manifest tool... no
+2025-07-26T11:58:40.0759153Z checking for stdio.h... yes
+2025-07-26T11:58:40.0920693Z checking for stdlib.h... yes
+2025-07-26T11:58:40.1086685Z checking for string.h... yes
+2025-07-26T11:58:40.1257217Z checking for inttypes.h... yes
+2025-07-26T11:58:40.1424818Z checking for stdint.h... yes
+2025-07-26T11:58:40.1599488Z checking for strings.h... yes
+2025-07-26T11:58:40.1776857Z checking for sys/stat.h... yes
+2025-07-26T11:58:40.1959537Z checking for sys/types.h... yes
+2025-07-26T11:58:40.2162330Z checking for unistd.h... yes
+2025-07-26T11:58:40.2364115Z checking for dlfcn.h... yes
+2025-07-26T11:58:40.2398809Z checking for objdir... .libs
+2025-07-26T11:58:40.3004345Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-26T11:58:40.3005437Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:40.3144239Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:40.3737182Z checking if gcc -m64 static flag -static works... yes
+2025-07-26T11:58:40.3966504Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-26T11:58:40.3967462Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:40.4065819Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:40.4550338Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-26T11:58:40.4552181Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:40.4566961Z checking whether stripping libraries is possible... yes
+2025-07-26T11:58:40.4567990Z checking if libtool supports shared libraries... yes
+2025-07-26T11:58:40.4568645Z checking whether to build shared libraries... no
+2025-07-26T11:58:40.4569949Z checking whether to build static libraries... yes
+2025-07-26T11:58:40.4836049Z checking how to run the C++ preprocessor... g++ -m64 -std=c++14 -E
+2025-07-26T11:58:40.5590874Z checking for ld used by g++ -m64 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-26T11:58:40.5614936Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-26T11:58:40.5685839Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:40.6289726Z checking for g++ -m64 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:40.6437918Z checking if g++ -m64 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:40.7030698Z checking if g++ -m64 -std=c++14 static flag -static works... yes
+2025-07-26T11:58:40.7267090Z checking if g++ -m64 -std=c++14 supports -c -o file.o... yes
+2025-07-26T11:58:40.7268644Z checking if g++ -m64 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:40.7270358Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:40.7320060Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-26T11:58:40.7321700Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:40.7329379Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-26T11:58:40.7334497Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-26T11:58:40.7336989Z checking for ranlib... (cached) ranlib
+2025-07-26T11:58:40.7341388Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-26T11:58:40.7343242Z checking for strip... (cached) strip
+2025-07-26T11:58:40.7347562Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:40.7495303Z checking whether C compiler accepts -Werror... yes
+2025-07-26T11:58:40.7746307Z checking for gmp.h... yes
+2025-07-26T11:58:40.8082325Z checking for __gmpz_init in -lgmp... yes
+2025-07-26T11:58:40.8272093Z checking gmp version >= 6.2... yes
+2025-07-26T11:58:40.8302466Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-26T11:58:40.8314171Z checking pkg-config is at least version 0.9.0... yes
+2025-07-26T11:58:40.8407210Z checking if gcc -m64 supports -pipe... yes
+2025-07-26T11:58:40.8504057Z checking if gcc -m64 supports -fomit-frame-pointer... yes
+2025-07-26T11:58:40.8758946Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-26T11:58:40.9075231Z checking whether gcc -m64 is Clang... no
+2025-07-26T11:58:40.9534158Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-26T11:58:40.9904895Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-26T11:58:40.9906044Z checking whether more special flags are required for pthreads... no
+2025-07-26T11:58:41.0287855Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-26T11:58:41.0637812Z checking for library containing clock_gettime... none required
+2025-07-26T11:58:41.0824006Z checking whether C compiler accepts -fPIC... yes
+2025-07-26T11:58:41.1006253Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-26T11:58:41.1166311Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-26T11:58:41.1343998Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-26T11:58:41.1509330Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-26T11:58:41.1671831Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-26T11:58:41.1897036Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-26T11:58:41.2127298Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-26T11:58:41.2355203Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-26T11:58:41.2598539Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-26T11:58:41.2941742Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-26T11:58:41.3265729Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-26T11:58:41.3580819Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-26T11:58:41.3897417Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-26T11:58:41.4079924Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-26T11:58:41.4081092Z checking whether to build runtest... yes
+2025-07-26T11:58:41.4081985Z checking whether to build runbench... yes
+2025-07-26T11:58:41.4313481Z checking that generated files are newer than configure... done
+2025-07-26T11:58:41.4319158Z configure: creating ./config.status
+2025-07-26T11:58:41.9642921Z config.status: creating Makefile
+2025-07-26T11:58:41.9857102Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-26T11:58:41.9988380Z config.status: executing depfiles commands
+2025-07-26T11:58:42.0001914Z config.status: executing libtool commands
+2025-07-26T11:58:42.0135471Z 
+2025-07-26T11:58:42.0136647Z Options used to compile and link:
+2025-07-26T11:58:42.0137566Z   target os           = linux
+2025-07-26T11:58:42.0138203Z   backend             = gmp
+2025-07-26T11:58:42.0138834Z   build bench         = yes
+2025-07-26T11:58:42.0139407Z   build test          = yes
+2025-07-26T11:58:42.0139984Z   use debug           = no
+2025-07-26T11:58:42.0140581Z   use hardening       = yes
+2025-07-26T11:58:42.0141162Z   use optimizations   = yes
+2025-07-26T11:58:42.0141527Z 
+2025-07-26T11:58:42.0141964Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-26T11:58:42.0143401Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-26T11:58:42.0144464Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-26T11:58:42.0145735Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-26T11:58:42.0146631Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-26T11:58:42.0146868Z 
+2025-07-26T11:58:42.0504969Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/dashcore-linux64/src/secp256k1)
+2025-07-26T11:58:42.0553394Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-26T11:58:42.1741324Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-26T11:58:42.2259809Z checking build system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:42.2309460Z checking host system type... x86_64-pc-linux-gnu
+2025-07-26T11:58:42.2386706Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-26T11:58:42.2415641Z checking whether build environment is sane... yes
+2025-07-26T11:58:42.2476820Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-26T11:58:42.2496814Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-26T11:58:42.2501512Z checking for gawk... gawk
+2025-07-26T11:58:42.2563743Z checking whether make sets $(MAKE)... yes
+2025-07-26T11:58:42.2617201Z checking whether make supports nested variables... yes
+2025-07-26T11:58:42.2660114Z checking whether make supports nested variables... (cached) yes
+2025-07-26T11:58:42.2662433Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-26T11:58:42.3242142Z checking whether the C compiler works... yes
+2025-07-26T11:58:42.3243204Z checking for C compiler default output file name... a.out
+2025-07-26T11:58:42.3545863Z checking for suffix of executables... 
+2025-07-26T11:58:42.3912151Z checking whether we are cross compiling... no
+2025-07-26T11:58:42.4080876Z checking for suffix of object files... o
+2025-07-26T11:58:42.4229174Z checking whether the compiler supports GNU C... yes
+2025-07-26T11:58:42.4379806Z checking whether gcc -m64 accepts -g... yes
+2025-07-26T11:58:42.4724104Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-26T11:58:42.4999051Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-26T11:58:42.5074459Z checking whether make supports the include directive... yes (GNU style)
+2025-07-26T11:58:42.5079088Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:42.5083409Z checking dependency style of gcc -m64... none
+2025-07-26T11:58:42.5085765Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:58:42.5354659Z checking the archiver (ar) interface... ar
+2025-07-26T11:58:42.5377906Z checking how to print strings... printf
+2025-07-26T11:58:42.5416677Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-26T11:58:42.5447133Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-26T11:58:42.5463746Z checking for egrep... /usr/bin/grep -E
+2025-07-26T11:58:42.5478991Z checking for fgrep... /usr/bin/grep -F
+2025-07-26T11:58:42.5524971Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-26T11:58:42.5548976Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-26T11:58:42.5551224Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-26T11:58:42.5826456Z checking the name lister (nm) interface... BSD nm
+2025-07-26T11:58:42.5827231Z checking whether ln -s works... yes
+2025-07-26T11:58:42.5868784Z checking the maximum length of command line arguments... 3145728
+2025-07-26T11:58:42.5894250Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-26T11:58:42.5896773Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-26T11:58:42.5898067Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-26T11:58:42.5901718Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-26T11:58:42.5906625Z checking for file... file
+2025-07-26T11:58:42.5911341Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-26T11:58:42.5915894Z checking for objdump... objdump
+2025-07-26T11:58:42.5919981Z checking how to recognize dependent libraries... pass_all
+2025-07-26T11:58:42.5924209Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-26T11:58:42.5929294Z checking for dlltool... no
+2025-07-26T11:58:42.5931340Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-26T11:58:42.5933364Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-26T11:58:42.6259373Z checking for archiver @FILE support... @
+2025-07-26T11:58:42.6260895Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-26T11:58:42.6264127Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-26T11:58:42.6915587Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-26T11:58:42.6932828Z checking for sysroot... no
+2025-07-26T11:58:42.6974499Z checking for a working dd... /usr/bin/dd
+2025-07-26T11:58:42.7012730Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-26T11:58:42.7112479Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-26T11:58:42.7117471Z checking for mt... no
+2025-07-26T11:58:42.7147488Z checking if : is a manifest tool... no
+2025-07-26T11:58:42.7294756Z checking for stdio.h... yes
+2025-07-26T11:58:42.7451972Z checking for stdlib.h... yes
+2025-07-26T11:58:42.7619209Z checking for string.h... yes
+2025-07-26T11:58:42.7788934Z checking for inttypes.h... yes
+2025-07-26T11:58:42.7958285Z checking for stdint.h... yes
+2025-07-26T11:58:42.8132205Z checking for strings.h... yes
+2025-07-26T11:58:42.8311059Z checking for sys/stat.h... yes
+2025-07-26T11:58:42.8497696Z checking for sys/types.h... yes
+2025-07-26T11:58:42.8707709Z checking for unistd.h... yes
+2025-07-26T11:58:42.8914673Z checking for dlfcn.h... yes
+2025-07-26T11:58:42.8955468Z checking for objdir... .libs
+2025-07-26T11:58:42.9546373Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-26T11:58:42.9547260Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-26T11:58:42.9686630Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-26T11:58:43.0281644Z checking if gcc -m64 static flag -static works... yes
+2025-07-26T11:58:43.0495420Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-26T11:58:43.0496690Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-26T11:58:43.0590300Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-26T11:58:43.1070604Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-26T11:58:43.1071464Z checking how to hardcode library paths into programs... immediate
+2025-07-26T11:58:43.1090117Z checking whether stripping libraries is possible... yes
+2025-07-26T11:58:43.1090998Z checking if libtool supports shared libraries... yes
+2025-07-26T11:58:43.1091972Z checking whether to build shared libraries... no
+2025-07-26T11:58:43.1092594Z checking whether to build static libraries... yes
+2025-07-26T11:58:43.1200355Z checking if gcc -m64 supports -Werror... yes
+2025-07-26T11:58:43.1299706Z checking if gcc -m64 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-26T11:58:43.1398938Z checking if gcc -m64 supports -Wno-overlength-strings... yes
+2025-07-26T11:58:43.1494985Z checking if gcc -m64 supports -Wall... yes
+2025-07-26T11:58:43.1593323Z checking if gcc -m64 supports -Wno-unused-function... yes
+2025-07-26T11:58:43.1686978Z checking if gcc -m64 supports -Wextra... yes
+2025-07-26T11:58:43.1779851Z checking if gcc -m64 supports -Wcast-align... yes
+2025-07-26T11:58:43.1873169Z checking if gcc -m64 supports -Wcast-align=strict... yes
+2025-07-26T11:58:43.2120437Z checking if gcc -m64 supports -Wconditional-uninitialized... no
+2025-07-26T11:58:43.2331050Z checking if gcc -m64 supports -Wreserved-identifier... no
+2025-07-26T11:58:43.2428627Z checking if gcc -m64 supports -fvisibility=hidden... yes
+2025-07-26T11:58:43.2584284Z checking for valgrind support... 
+2025-07-26T11:58:43.2938907Z checking for x86_64 assembly availability... yes
+2025-07-26T11:58:43.3172237Z checking that generated files are newer than configure... done
+2025-07-26T11:58:43.3175180Z configure: creating ./config.status
+2025-07-26T11:58:43.7114522Z config.status: creating Makefile
+2025-07-26T11:58:43.7242103Z config.status: creating libsecp256k1.pc
+2025-07-26T11:58:43.7351114Z config.status: executing depfiles commands
+2025-07-26T11:58:43.7365150Z config.status: executing libtool commands
+2025-07-26T11:58:43.7457511Z 
+2025-07-26T11:58:43.7457768Z Build Options:
+2025-07-26T11:58:43.7458662Z   with external callbacks = no
+2025-07-26T11:58:43.7459317Z   with benchmarks         = no
+2025-07-26T11:58:43.7459833Z   with tests              = yes
+2025-07-26T11:58:43.7460335Z   with ctime tests        = no
+2025-07-26T11:58:43.7460869Z   with coverage           = no
+2025-07-26T11:58:43.7461357Z   with examples           = no
+2025-07-26T11:58:43.7461811Z   module ecdh             = no
+2025-07-26T11:58:43.7462218Z   module recovery         = yes
+2025-07-26T11:58:43.7462684Z   module extrakeys        = yes
+2025-07-26T11:58:43.7463162Z   module schnorrsig       = yes
+2025-07-26T11:58:43.7463656Z   module ellswift         = yes
+2025-07-26T11:58:43.7463976Z 
+2025-07-26T11:58:43.7464149Z   asm                     = x86_64
+2025-07-26T11:58:43.7464473Z   ecmult window size      = 15
+2025-07-26T11:58:43.7464787Z   ecmult gen prec. bits   = 4
+2025-07-26T11:58:43.7465163Z 
+2025-07-26T11:58:43.7465335Z   valgrind                = no
+2025-07-26T11:58:43.7465650Z   CC                      = gcc -m64
+2025-07-26T11:58:43.7466111Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-26T11:58:43.7467946Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-26T11:58:43.7469650Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-26T11:58:43.7470366Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-26T11:58:43.7790890Z 
+2025-07-26T11:58:43.7791692Z Options used to compile and link:
+2025-07-26T11:58:43.7793373Z   boost process       = yes
+2025-07-26T11:58:43.7794204Z   multiprocess        = no
+2025-07-26T11:58:43.7794694Z   with libs           = no
+2025-07-26T11:58:43.7795468Z   with wallet         = yes
+2025-07-26T11:58:43.7795942Z     with sqlite       = yes
+2025-07-26T11:58:43.7796656Z     with bdb          = yes
+2025-07-26T11:58:43.7797337Z   with gui / qt       = yes
+2025-07-26T11:58:43.7797767Z     with qr           = yes
+2025-07-26T11:58:43.7798079Z   with zmq            = yes
+2025-07-26T11:58:43.7798386Z   with test           = yes
+2025-07-26T11:58:43.7798728Z   with fuzz binary    = no
+2025-07-26T11:58:43.7799318Z   with bench          = yes
+2025-07-26T11:58:43.7799630Z   with upnp           = yes
+2025-07-26T11:58:43.7799947Z   with natpmp         = yes
+2025-07-26T11:58:43.7800264Z   USDT tracing        = yes
+2025-07-26T11:58:43.7800581Z   sanitizers          = 
+2025-07-26T11:58:43.7800905Z   debug enabled       = no
+2025-07-26T11:58:43.7801231Z   stacktraces enabled = yes
+2025-07-26T11:58:43.7801557Z   crash hooks enabled = no
+2025-07-26T11:58:43.7801871Z   miner enabled       = yes
+2025-07-26T11:58:43.7802189Z   gprof enabled       = no
+2025-07-26T11:58:43.7802500Z   werror              = yes
+2025-07-26T11:58:43.7802699Z 
+2025-07-26T11:58:43.7802822Z   target os           = linux-gnu
+2025-07-26T11:58:43.7803177Z   build os            = linux-gnu
+2025-07-26T11:58:43.7803407Z 
+2025-07-26T11:58:43.7803568Z   CC                  = /usr/bin/ccache gcc -m64
+2025-07-26T11:58:43.7804132Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-26T11:58:43.7805822Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-26T11:58:43.7807602Z   CXX                 = /usr/bin/ccache g++ -m64 -std=c++20
+2025-07-26T11:58:43.7811742Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-26T11:58:43.7816553Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-26T11:58:43.7817513Z   AR                  = ar
+2025-07-26T11:58:43.7818018Z   ARFLAGS             = cr
+2025-07-26T11:58:43.7818257Z 
+2025-07-26T11:58:43.8461849Z Making install in src
+2025-07-26T11:58:43.8694929Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T11:58:43.8960382Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T11:58:43.8987885Z   CXX      dashd-bitcoind.o
+2025-07-26T11:58:43.8988371Z   CXX      libbitcoin_node_a-addrdb.o
+2025-07-26T11:58:43.9029163Z   CXX      libbitcoin_node_a-addressindex.o
+2025-07-26T11:58:43.9043111Z   CXX      libbitcoin_node_a-addrman.o
+2025-07-26T11:58:45.9776356Z   CXX      libbitcoin_node_a-banman.o
+2025-07-26T11:58:47.4034275Z   CXX      libbitcoin_node_a-batchedlogger.o
+2025-07-26T11:58:48.9044698Z   CXX      libbitcoin_node_a-bip324.o
+2025-07-26T11:58:49.6602760Z   CXX      libbitcoin_node_a-blockencodings.o
+2025-07-26T11:58:49.7625938Z   CXX      libbitcoin_node_a-blockfilter.o
+2025-07-26T11:58:51.5062239Z   CXX      libbitcoin_node_a-chain.o
+2025-07-26T11:58:51.9540235Z   CXX      libbitcoin_node_a-dbwrapper.o
+2025-07-26T11:58:52.4286355Z   CXX      libbitcoin_node_a-deploymentstatus.o
+2025-07-26T11:58:54.2064093Z   CXX      libbitcoin_node_a-dsnotificationinterface.o
+2025-07-26T11:58:54.6138102Z   CXX      libbitcoin_node_a-flatfile.o
+2025-07-26T11:58:56.0142682Z   CXX      libbitcoin_node_a-httprpc.o
+2025-07-26T11:58:56.1390805Z   CXX      libbitcoin_node_a-httpserver.o
+2025-07-26T11:58:57.9570533Z   CXX      libbitcoin_node_a-i2p.o
+2025-07-26T11:59:01.6334911Z   CXX      libbitcoin_node_a-init.o
+2025-07-26T11:59:01.7848226Z   CXX      libbitcoin_node_a-mapport.o
+2025-07-26T11:59:03.1670330Z   CXX      libbitcoin_node_a-net.o
+2025-07-26T11:59:04.2102942Z   CXX      libbitcoin_node_a-netfulfilledman.o
+2025-07-26T11:59:05.9054876Z   CXX      libbitcoin_node_a-netgroup.o
+2025-07-26T11:59:08.2598470Z   CXX      libbitcoin_node_a-net_processing.o
+2025-07-26T11:59:09.3147187Z   CXX      libbitcoin_node_a-noui.o
+2025-07-26T11:59:13.1576696Z   CXX      libbitcoin_node_a-pow.o
+2025-07-26T11:59:15.2531780Z   CXX      libbitcoin_node_a-rest.o
+2025-07-26T11:59:21.8838184Z In file included from ./hash.h:15,
+2025-07-26T11:59:21.8839105Z                  from ./pubkey.h:10,
+2025-07-26T11:59:21.8843020Z                  from ./key.h:10,
+2025-07-26T11:59:21.8843423Z                  from ./bip324.h:14,
+2025-07-26T11:59:21.8843845Z                  from ./net.h:9,
+2025-07-26T11:59:21.8844237Z                  from ./net_processing.h:9,
+2025-07-26T11:59:21.8844649Z                  from net_processing.cpp:6:
+2025-07-26T11:59:21.8850246Z ./serialize.h: In instantiation of ‘void Serialize(Stream&, const T&) [with Stream = CVectorWriter; T = CDataStream; typename std::enable_if<std::is_class<T>::value>::type* <anonymous> = 0]’:
+2025-07-26T11:59:21.8852491Z ./serialize.h:1384:17:   required from ‘void SerializeMany(Stream&, const Args& ...) [with Stream = CVectorWriter; Args = {CDataStream}]’
+2025-07-26T11:59:21.8854508Z ./streams.h:96:24:   required from ‘CVectorWriter::CVectorWriter(int, int, std::vector<unsigned char>&, size_t, Args&& ...) [with Args = {CDataStream&}; size_t = long unsigned int]’
+2025-07-26T11:59:21.8956605Z ./netmessagemaker.h:23:9:   required from ‘CSerializedNetMsg CNetMsgMaker::Make(int, std::string, Args&& ...) const [with Args = {CDataStream&}; std::string = std::__cxx11::basic_string<char>]’
+2025-07-26T11:59:21.8958962Z ./netmessagemaker.h:31:20:   required from ‘CSerializedNetMsg CNetMsgMaker::Make(std::string, Args&& ...) const [with Args = {CDataStream&}; std::string = std::__cxx11::basic_string<char>]’
+2025-07-26T11:59:21.8960091Z net_processing.cpp:2791:60:   required from here
+2025-07-26T11:59:21.8961014Z ./serialize.h:895:7: error: ‘const class CDataStream’ has no member named ‘Serialize’
+2025-07-26T11:59:21.8961637Z   895 |     a.Serialize(os);
+2025-07-26T11:59:21.8962008Z       |     ~~^~~~~~~~~
+2025-07-26T11:59:21.8970151Z make[2]: *** [Makefile:11243: libbitcoin_node_a-net_processing.o] Error 1
+2025-07-26T11:59:21.8975200Z make[2]: *** Waiting for unfinished jobs....
+2025-07-26T11:59:24.0792782Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T11:59:24.0800379Z make[1]: *** [Makefile:20677: install-recursive] Error 1
+2025-07-26T11:59:24.0802421Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T11:59:24.0810075Z make: *** [Makefile:789: install-recursive] Error 1
+2025-07-26T11:59:24.0815519Z Build failure. Verbose build follows.
+2025-07-26T11:59:24.0878283Z Making install in src
+2025-07-26T11:59:24.1107470Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T11:59:24.1379333Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T11:59:24.1389018Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o init/dashd-bitcoind.o `test -f 'init/bitcoind.cpp' || echo './'`init/bitcoind.cpp
+2025-07-26T11:59:26.5091723Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-coinjoin.o `test -f 'coinjoin/coinjoin.cpp' || echo './'`coinjoin/coinjoin.cpp
+2025-07-26T11:59:32.0601459Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-context.o `test -f 'coinjoin/context.cpp' || echo './'`coinjoin/context.cpp
+2025-07-26T11:59:36.4841536Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-server.o `test -f 'coinjoin/server.cpp' || echo './'`coinjoin/server.cpp
+2025-07-26T11:59:44.0121693Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o consensus/libbitcoin_node_a-tx_verify.o `test -f 'consensus/tx_verify.cpp' || echo './'`consensus/tx_verify.cpp
+2025-07-26T11:59:45.8863558Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-assetlocktx.o `test -f 'evo/assetlocktx.cpp' || echo './'`evo/assetlocktx.cpp
+2025-07-26T11:59:49.6715600Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-cbtx.o `test -f 'evo/cbtx.cpp' || echo './'`evo/cbtx.cpp
+2025-07-26T11:59:54.0376990Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-creditpool.o `test -f 'evo/creditpool.cpp' || echo './'`evo/creditpool.cpp
+2025-07-26T11:59:59.6711198Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-chainhelper.o `test -f 'evo/chainhelper.cpp' || echo './'`evo/chainhelper.cpp
+2025-07-26T12:00:02.1940979Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-deterministicmns.o `test -f 'evo/deterministicmns.cpp' || echo './'`evo/deterministicmns.cpp
+2025-07-26T12:00:11.6490991Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-dmnstate.o `test -f 'evo/dmnstate.cpp' || echo './'`evo/dmnstate.cpp
+2025-07-26T12:00:13.8935765Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-evodb.o `test -f 'evo/evodb.cpp' || echo './'`evo/evodb.cpp
+2025-07-26T12:00:16.3982103Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-mnauth.o `test -f 'evo/mnauth.cpp' || echo './'`evo/mnauth.cpp
+2025-07-26T12:00:20.3160935Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-mnhftx.o `test -f 'evo/mnhftx.cpp' || echo './'`evo/mnhftx.cpp
+2025-07-26T12:00:26.2950224Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-providertx.o `test -f 'evo/providertx.cpp' || echo './'`evo/providertx.cpp
+2025-07-26T12:00:29.1063046Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-simplifiedmns.o `test -f 'evo/simplifiedmns.cpp' || echo './'`evo/simplifiedmns.cpp
+2025-07-26T12:00:31.9545833Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-smldiff.o `test -f 'evo/smldiff.cpp' || echo './'`evo/smldiff.cpp
+2025-07-26T12:00:37.7022891Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-specialtx.o `test -f 'evo/specialtx.cpp' || echo './'`evo/specialtx.cpp
+2025-07-26T12:00:38.5766956Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-specialtxman.o `test -f 'evo/specialtxman.cpp' || echo './'`evo/specialtxman.cpp
+2025-07-26T12:00:45.9145571Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-classes.o `test -f 'governance/classes.cpp' || echo './'`governance/classes.cpp
+2025-07-26T12:00:50.4329481Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-exceptions.o `test -f 'governance/exceptions.cpp' || echo './'`governance/exceptions.cpp
+2025-07-26T12:00:51.1677301Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-governance.o `test -f 'governance/governance.cpp' || echo './'`governance/governance.cpp
+2025-07-26T12:01:02.3568498Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-object.o `test -f 'governance/object.cpp' || echo './'`governance/object.cpp
+2025-07-26T12:01:08.4098865Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-validators.o `test -f 'governance/validators.cpp' || echo './'`governance/validators.cpp
+2025-07-26T12:01:10.5392330Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-vote.o `test -f 'governance/vote.cpp' || echo './'`governance/vote.cpp
+2025-07-26T12:01:14.8797273Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-votedb.o `test -f 'governance/votedb.cpp' || echo './'`governance/votedb.cpp
+2025-07-26T12:01:16.1991834Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o gsl/libbitcoin_node_a-assert.o `test -f 'gsl/assert.cpp' || echo './'`gsl/assert.cpp
+2025-07-26T12:01:17.3966410Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-base.o `test -f 'index/base.cpp' || echo './'`index/base.cpp
+2025-07-26T12:01:21.7968089Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-blockfilterindex.o `test -f 'index/blockfilterindex.cpp' || echo './'`index/blockfilterindex.cpp
+2025-07-26T12:01:25.6338615Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-coinstatsindex.o `test -f 'index/coinstatsindex.cpp' || echo './'`index/coinstatsindex.cpp
+2025-07-26T12:01:29.9588939Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-txindex.o `test -f 'index/txindex.cpp' || echo './'`index/txindex.cpp
+2025-07-26T12:01:33.8969150Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-db.o `test -f 'instantsend/db.cpp' || echo './'`instantsend/db.cpp
+2025-07-26T12:01:38.1409064Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-instantsend.o `test -f 'instantsend/instantsend.cpp' || echo './'`instantsend/instantsend.cpp
+2025-07-26T12:01:45.8539117Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-lock.o `test -f 'instantsend/lock.cpp' || echo './'`instantsend/lock.cpp
+2025-07-26T12:01:47.0511097Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-signing.o `test -f 'instantsend/signing.cpp' || echo './'`instantsend/signing.cpp
+2025-07-26T12:01:52.9491967Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-blockprocessor.o `test -f 'llmq/blockprocessor.cpp' || echo './'`llmq/blockprocessor.cpp
+2025-07-26T12:02:00.6708440Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-chainlocks.o `test -f 'llmq/chainlocks.cpp' || echo './'`llmq/chainlocks.cpp
+2025-07-26T12:02:06.6262720Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-clsig.o `test -f 'llmq/clsig.cpp' || echo './'`llmq/clsig.cpp
+2025-07-26T12:02:08.0019002Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-commitment.o `test -f 'llmq/commitment.cpp' || echo './'`llmq/commitment.cpp
+2025-07-26T12:02:13.0658626Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-context.o `test -f 'llmq/context.cpp' || echo './'`llmq/context.cpp
+2025-07-26T12:02:17.8343701Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-debug.o `test -f 'llmq/debug.cpp' || echo './'`llmq/debug.cpp
+2025-07-26T12:02:21.7568852Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsession.o `test -f 'llmq/dkgsession.cpp' || echo './'`llmq/dkgsession.cpp
+2025-07-26T12:02:29.4064977Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsessionhandler.o `test -f 'llmq/dkgsessionhandler.cpp' || echo './'`llmq/dkgsessionhandler.cpp
+2025-07-26T12:02:37.4753571Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsessionmgr.o `test -f 'llmq/dkgsessionmgr.cpp' || echo './'`llmq/dkgsessionmgr.cpp
+2025-07-26T12:02:41.9966820Z In file included from ./hash.h:15,
+2025-07-26T12:02:41.9967351Z                  from ./bls/bls.h:8,
+2025-07-26T12:02:41.9967695Z                  from ./llmq/dkgsessionmgr.h:8,
+2025-07-26T12:02:41.9968021Z                  from llmq/dkgsessionmgr.cpp:5:
+2025-07-26T12:02:41.9969702Z ./serialize.h: In instantiation of ‘void Serialize(Stream&, const T&) [with Stream = CDataStream; T = CDataStream; typename std::enable_if<std::is_class<T>::value>::type* <anonymous> = 0]’:
+2025-07-26T12:02:41.9971274Z ./streams.h:373:20:   required from ‘CDataStream& CDataStream::operator<<(const T&) [with T = CDataStream]’
+2025-07-26T12:02:41.9973916Z ./dbwrapper.h:91:17:   required from ‘void CDBBatch::Write(const CDataStream&, const V&) [with V = CDataStream]’
+2025-07-26T12:02:41.9976163Z ./dbwrapper.h:81:14:   required from ‘void CDBBatch::Write(const K&, const V&) [with K = std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Consensus::LLMQType, uint256, uint256>; V = CDataStream]’
+2025-07-26T12:02:41.9978667Z ./dbwrapper.h:304:20:   required from ‘bool CDBWrapper::Write(const K&, const V&, bool) [with K = std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Consensus::LLMQType, uint256, uint256>; V = CDataStream]’
+2025-07-26T12:02:41.9980479Z llmq/dkgsessionmgr.cpp:286:14:   required from here
+2025-07-26T12:02:41.9981299Z ./serialize.h:895:7: error: ‘const class CDataStream’ has no member named ‘Serialize’
+2025-07-26T12:02:41.9981758Z   895 |     a.Serialize(os);
+2025-07-26T12:02:41.9982010Z       |     ~~^~~~~~~~~
+2025-07-26T12:02:41.9991575Z make[2]: *** [Makefile:11005: llmq/libbitcoin_node_a-dkgsessionmgr.o] Error 1
+2025-07-26T12:02:41.9993013Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T12:02:42.0001215Z make[1]: *** [Makefile:20677: install-recursive] Error 1
+2025-07-26T12:02:42.0002513Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-26T12:02:42.0009607Z make: *** [Makefile:789: install-recursive] Error 1
+2025-07-26T12:02:42.0067299Z ##[error]Process completed with exit code 2.
+2025-07-26T12:02:42.0154374Z Post job cleanup.
+2025-07-26T12:02:42.0158409Z ##[command]/usr/bin/docker exec  4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-26T12:02:42.2154035Z [command]/usr/bin/git version
+2025-07-26T12:02:42.2194266Z git version 2.43.0
+2025-07-26T12:02:42.2235641Z Copying '/github/home/.gitconfig' to '/__w/_temp/b7832a3c-de9a-44b1-8cda-70eb3cb972cc/.gitconfig'
+2025-07-26T12:02:42.2247922Z Temporarily overriding HOME='/__w/_temp/b7832a3c-de9a-44b1-8cda-70eb3cb972cc' before making global git config changes
+2025-07-26T12:02:42.2249215Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-26T12:02:42.2253699Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-26T12:02:42.2288679Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-26T12:02:42.2331801Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-26T12:02:42.2560325Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-26T12:02:42.2582982Z http.https://github.com/.extraheader
+2025-07-26T12:02:42.2595542Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-07-26T12:02:42.2627801Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-26T12:02:42.2976442Z Stop and remove container: 15b9befcc4604905bf485cda1dfbafe9_ghcriodashcoreautoguixdashdashcorecirunnerbackport023batch427pr27800_9d13c6
+2025-07-26T12:02:42.2981484Z ##[command]/usr/bin/docker rm --force 4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7
+2025-07-26T12:02:42.4129908Z 4b68280281f28c5a705f848e5d12cbcb77bfb20b751e1d0fcd9214fdfdaf5bc7
+2025-07-26T12:02:42.4166929Z Remove container network: github_network_659f293b501b4a82825737f4f8099758
+2025-07-26T12:02:42.4171900Z ##[command]/usr/bin/docker network rm github_network_659f293b501b4a82825737f4f8099758
+2025-07-26T12:02:42.5329833Z github_network_659f293b501b4a82825737f4f8099758
+2025-07-26T12:02:42.5392245Z Evaluate and set job outputs
+2025-07-26T12:02:42.5398881Z Cleaning up orphan processes

--- a/src/flat-database.h
+++ b/src/flat-database.h
@@ -58,7 +58,7 @@ private:
 
         // Write and commit header, data
         try {
-            fileout << ssObj;
+            fileout.write(MakeByteSpan(ssObj));
         }
         catch (std::exception &e) {
             return error("%s: Serialize or I/O error - %s", __func__, e.what());

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -283,7 +283,7 @@ void CDKGSessionManager::WriteVerifiedVvecContribution(Consensus::LLMQType llmqT
     for (auto& pubkey : *vvec) {
         s << CBLSPublicKeyVersionWrapper(pubkey, false);
     }
-    db->Write(std::make_tuple(DB_VVEC, llmqType, pQuorumBaseBlockIndex->GetBlockHash(), proTxHash), s);
+    db->Write(std::make_tuple(DB_VVEC, llmqType, pQuorumBaseBlockIndex->GetBlockHash(), proTxHash), MakeUCharSpan(s));
 }
 
 void CDKGSessionManager::WriteVerifiedSkContribution(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex, const uint256& proTxHash, const CBLSSecretKey& skContribution)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3760,6 +3760,12 @@ void PeerManagerImpl::ProcessMessage(
             AddTimeData(pfrom.addr, nTimeOffset);
         }
 
+        // If the peer is old enough to have the old alert system, send it the final alert.
+        if (greatest_common_version <= 70012) {
+            const auto finalAlert{ParseHex("60010000000000000000000000ffffff7f00000000ffffff7ffeffff7f01ffffff7f00000000ffffff7f00ffffff7f002f555247454e543a20416c657274206b657920636f6d70726f6d697365642c2075706772616465207265717569726564004630440220653febd6410f470f6bae11cad19c48413becb1ac2c17f908fd0fd53bdc3abd5202206d0e9c96fe88d4a0f01ed9dedae2b6f9e00da94cad0fecaae66ecf689bf71b50")};
+            m_connman.PushMessage(&pfrom, CNetMsgMaker(greatest_common_version).Make("alert", Span{finalAlert}));
+        }
+
         // Feeler connections exist only to verify if address is online.
         if (pfrom.IsFeelerConn()) {
             LogPrint(BCLog::NET_NETCONN, "feeler connection completed peer=%d; disconnecting\n", pfrom.GetId());

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2788,7 +2788,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
                 }
             }
             if (topush) {
-                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECT, ss));
+                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECT, MakeUCharSpan(ss)));
                 push = true;
             }
         }
@@ -2803,7 +2803,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
                 }
             }
             if (topush) {
-                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECTVOTE, ss));
+                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECTVOTE, MakeUCharSpan(ss)));
                 push = true;
             }
         }

--- a/src/streams.h
+++ b/src/streams.h
@@ -297,14 +297,6 @@ public:
         vch.insert(vch.end(), src.begin(), src.end());
     }
 
-    template<typename Stream>
-    void Serialize(Stream& s) const
-    {
-        // Special case: stream << stream concatenates like stream += stream
-        if (!vch.empty())
-            s.write(MakeByteSpan(vch));
-    }
-
     template<typename T>
     DataStream& operator<<(const T& obj)
     {

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -253,11 +253,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
 
             std::vector<unsigned char> k = ParseHex(key);
             std::vector<unsigned char> v = ParseHex(value);
-
-            CDataStream ss_key(k, SER_DISK, CLIENT_VERSION);
-            CDataStream ss_value(v, SER_DISK, CLIENT_VERSION);
-
-            if (!batch->Write(ss_key, ss_value)) {
+            if (!batch->Write(Span{k}, Span{v})) {
                 error = strprintf(_("Error: Unable to write record to new wallet"));
                 ret = false;
                 break;


### PR DESCRIPTION
Backports bitcoin/bitcoin#27800

Original commit: 83c7269965c330ae1f4d85b1ba652717c9080914

Backported from Bitcoin Core v0.26

## Summary
Removes the confusing DataStream::Serialize method and << operator that had surprising behavior.

### Dash Adaptations
- Updated `flat-database.h` to use `fileout.write(MakeByteSpan(ssObj))` instead of `fileout << ssObj`
- Removed CDataStream usage in `wallet/dump.cpp`, using Span directly
- MigrateToSQLite function from Bitcoin does not exist in Dash, so those changes were not applicable

## Test Plan
- [ ] Verify serialization still works correctly with the adapted code
- [ ] Test flat database operations
- [ ] Test wallet dump functionality