### PR TITLE
Merge bitcoin/bitcoin#27712: test: p2p: check misbehavior for non-continuous headers messages

### DIFF
--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test node responses to invalid network messages."""
 
+import random
 
 from test_framework.messages import (
     CBlockHeader,
@@ -20,6 +21,7 @@ from test_framework.messages import (
     msg_inv,
     MSG_TX,
     msg_version,
+    from_hex,
 )
 from test_framework.p2p import (
     P2PDataStore, P2PInterface
@@ -61,6 +63,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         self.test_oversized_inv_msg()
         self.test_oversized_getdata_msg()
         self.test_oversized_headers_msg()
+        self.test_noncontinuous_headers_msg()
         self.test_resource_exhaustion()
 
     def test_buffer(self):
@@ -185,6 +188,25 @@ class InvalidMessagesTest(BitcoinTestFramework):
     def test_oversized_headers2_msg(self):
         size = MAX_HEADERS_COMPRESSED_RESULT + 1
         self.test_oversized_msg(msg_headers2([CBlockHeader()] * size), size)
+
+    def test_noncontinuous_headers_msg(self):
+        self.log.info("Test headers message with non-continuous headers sequence is logged as misbehaving")
+        block_hashes = self.generate(self.nodes[0], 10)
+        block_headers = []
+        for block_hash in block_hashes:
+            block_headers.append(from_hex(CBlockHeader(), self.nodes[0].getblockheader(block_hash, False)))
+
+        # continuous headers sequence should be fine
+        MISBEHAVING_NONCONTINUOUS_HEADERS_MSGS = ['Misbehaving', 'non-continuous headers sequence']
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        with self.nodes[0].assert_debug_log([], unexpected_msgs=MISBEHAVING_NONCONTINUOUS_HEADERS_MSGS):
+            peer.send_and_ping(msg_headers(block_headers))
+
+        # delete arbitrary block header somewhere in the middle to break link
+        del block_headers[random.randrange(1, len(block_headers)-1)]
+        with self.nodes[0].assert_debug_log(expected_msgs=MISBEHAVING_NONCONTINUOUS_HEADERS_MSGS):
+            peer.send_and_ping(msg_headers(block_headers))
+        self.nodes[0].disconnect_p2ps()
 
     def test_resource_exhaustion(self):
         self.log.info("Test node stays up despite many large junk messages")


### PR DESCRIPTION
Backports bitcoin/bitcoin#27712

Original commit: b3db18a012

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify that the application correctly logs misbehavior when receiving a headers message with a non-continuous sequence of block headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->