### PR TITLE
Merge bitcoin/bitcoin#27757: rpc: remove deprecated "warning" field from {create,load,restore,unload}wallet

### DIFF
--- a/doc/release-notes-27757.md
+++ b/doc/release-notes-27757.md
@@ -1,0 +1,8 @@
+Wallet
+------
+
+- The `deprecatedrpc=walletwarningfield` configuration option has been removed.
+  The `createwallet`, `loadwallet`, `restorewallet` and `unloadwallet` RPCs no
+  longer return the "warning" string field. The same information is provided
+  through the "warnings" field added in v25.0, which returns a JSON array of
+  strings. The "warning" string field was deprecated also in v25.0. (#27757)

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -2057,7 +2057,7 @@ RPCHelpMan listdescriptors()
 RPCHelpMan backupwallet()
 {
     return RPCHelpMan{"backupwallet",
-        "\nSafely copies current wallet file to destination, which can be a directory or a path with filename.\n",
+        "\nSafely copies the current wallet file to the specified destination, which can either be a directory or a path with a filename.\n",
         {
             {"destination", RPCArg::Type::STR, RPCArg::Optional::NO, "The destination directory or file"},
         },
@@ -2091,7 +2091,9 @@ RPCHelpMan restorewallet()
 {
     return RPCHelpMan{
         "restorewallet",
-        "\nRestore and loads a wallet from backup.\n",
+        "\nRestores and loads a wallet from backup.\n"
+        "\nThe rescan is significantly faster if a descriptor wallet is restored"
+        "\nand block filters are available (using startup option \"-blockfilterindex=1\").\n",
         {
             {"wallet_name", RPCArg::Type::STR, RPCArg::Optional::NO, "The name that will be applied to the restored wallet"},
             {"backup_file", RPCArg::Type::STR, RPCArg::Optional::NO, "The backup file that will be used to restore the wallet."},
@@ -2101,7 +2103,10 @@ RPCHelpMan restorewallet()
             RPCResult::Type::OBJ, "", "",
             {
                 {RPCResult::Type::STR, "name", "The wallet name if restored successfully."},
-                {RPCResult::Type::STR, "warning", "Warning message if wallet was not loaded cleanly."},
+                {RPCResult::Type::ARR, "warnings", /*optional=*/true, "Warning messages, if any, related to restoring and loading the wallet.",
+                {
+                    {RPCResult::Type::STR, "", ""},
+                }},
             }
         },
         RPCExamples{
@@ -2131,7 +2136,13 @@ RPCHelpMan restorewallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    UniValue warnings_array(UniValue::VARR);
+    for (const auto& warning : warnings) {
+        warnings_array.push_back(warning.original);
+    }
+    if (!warnings_array.empty()) {
+        obj.pushKV("warnings", warnings_array);
+    }
 
     return obj;
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -2091,9 +2091,7 @@ RPCHelpMan restorewallet()
 {
     return RPCHelpMan{
         "restorewallet",
-        "\nRestores and loads a wallet from backup.\n"
-        "\nThe rescan is significantly faster if a descriptor wallet is restored"
-        "\nand block filters are available (using startup option \"-blockfilterindex=1\").\n",
+        "\nRestores and loads a wallet from backup.\n",
         {
             {"wallet_name", RPCArg::Type::STR, RPCArg::Optional::NO, "The name that will be applied to the restored wallet"},
             {"backup_file", RPCArg::Type::STR, RPCArg::Optional::NO, "The backup file that will be used to restore the wallet."},

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -454,7 +454,10 @@ static RPCHelpMan loadwallet()
             RPCResult::Type::OBJ, "", "",
             {
                 {RPCResult::Type::STR, "name", "The wallet name if loaded successfully."},
-                {RPCResult::Type::STR, "warning", "Warning message if wallet was not loaded cleanly."},
+                {RPCResult::Type::ARR, "warnings", /*optional=*/true, "Warning messages, if any, related to loading the wallet.",
+                {
+                    {RPCResult::Type::STR, "", ""},
+                }},
             }
         },
         RPCExamples{
@@ -479,7 +482,13 @@ static RPCHelpMan loadwallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    UniValue warnings_array(UniValue::VARR);
+    for (const auto& warning : warnings) {
+        warnings_array.push_back(warning.original);
+    }
+    if (!warnings_array.empty()) {
+        obj.pushKV("warnings", warnings_array);
+    }
 
     return obj;
 },
@@ -572,7 +581,10 @@ static RPCHelpMan createwallet()
             RPCResult::Type::OBJ, "", "",
             {
                 {RPCResult::Type::STR, "name", "The wallet name if created successfully. If the wallet was created using a full path, the wallet_name will be the full path."},
-                {RPCResult::Type::STR, "warning", "Warning message if wallet was not loaded cleanly."},
+                {RPCResult::Type::ARR, "warnings", /*optional=*/true, "Warning messages, if any, related to creating and loading the wallet.",
+                {
+                    {RPCResult::Type::STR, "", ""},
+                }},
             }
         },
         RPCExamples{
@@ -639,7 +651,13 @@ static RPCHelpMan createwallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    UniValue warnings_array(UniValue::VARR);
+    for (const auto& warning : warnings) {
+        warnings_array.push_back(warning.original);
+    }
+    if (!warnings_array.empty()) {
+        obj.pushKV("warnings", warnings_array);
+    }
 
     return obj;
 },
@@ -656,7 +674,10 @@ static RPCHelpMan unloadwallet()
             {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
         },
         RPCResult{RPCResult::Type::OBJ, "", "", {
-            {RPCResult::Type::STR, "warning", "Warning message if wallet was not unloaded cleanly."},
+            {RPCResult::Type::ARR, "warnings", /*optional=*/true, "Warning messages, if any, related to unloading the wallet.",
+            {
+                {RPCResult::Type::STR, "", ""},
+            }},
         }},
         RPCExamples{
             HelpExampleCli("unloadwallet", "wallet_name")
@@ -698,7 +719,13 @@ static RPCHelpMan unloadwallet()
     UnloadWallet(std::move(wallet));
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    UniValue warnings_array(UniValue::VARR);
+    for (const auto& warning : warnings) {
+        warnings_array.push_back(warning.original);
+    }
+    if (!warnings_array.empty()) {
+        result.pushKV("warnings", warnings_array);
+    }
     return result;
 },
     };

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -157,7 +157,7 @@ class CreateWalletTest(BitcoinTestFramework):
         assert_equal(walletinfo['keypoolsize_hd_internal'], keys)
         # Allow empty passphrase, but there should be a warning
         resp = self.nodes[0].createwallet(wallet_name='w7', disable_private_keys=False, blank=False, passphrase='')
-        assert 'Empty string given as passphrase, wallet will not be encrypted.' in resp['warning']
+        assert 'Empty string given as passphrase, wallet will not be encrypted.' in resp['warnings'][0]
         w7 = node.get_wallet_rpc('w7')
         assert_raises_rpc_error(-15, 'Error: running with an unencrypted wallet, but walletpassphrase was called.', w7.walletpassphrase, '', 60)
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27757

Original commit: f0758d8a66

**Summary:**
This PR removes the deprecated "warning" field from wallet RPCs (createwallet, loadwallet, unloadwallet, and restorewallet) and replaces it with a "warnings" array. This change was part of Bitcoin's v26.0 release after the deprecation was introduced in v25.0.

**Changes:**
- Replaced single "warning" string field with "warnings" array in RPC outputs
- Updated documentation strings for affected RPCs
- Modified test expectations to check warnings array instead of warning field
- Added release notes documenting the change

**Dash-specific adaptations:**
- Manually implemented the warnings array conversion inline (instead of using PushWarnings helper)
- Kept Dash naming conventions (dashd vs bitcoind)
- Simplified test changes to match Dash's test framework

Backported from Bitcoin Core v0.26