### PR TITLE
Merge bitcoin/bitcoin#27921: fuzz: Avoid OOM in transaction fuzz target

### DIFF
--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -93,10 +93,14 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
     const CCoinsViewCache coins_view_cache(&coins_view);
     (void)AreInputsStandard(tx, coins_view_cache);
 
-    UniValue u(UniValue::VOBJ);
-    TxToUniv(tx, /*block_hash=*/uint256::ZERO, /*entry=*/u);
-    TxToUniv(tx, /*block_hash=*/uint256::ONE, /*entry=*/u);
-
-//    TxToUniv(tx, /*block_hash=*/uint256::ZERO, /*include_addresses=*/true, u);
-//    TxToUniv(tx, /*block_hash=*/uint256::ONE, /*include_addresses=*/false, u);
+    if (tx.GetTotalSize() < 250'000) { // Avoid high memory usage (with msan) due to json encoding
+        {
+            UniValue u{UniValue::VOBJ};
+            TxToUniv(tx, /*block_hash=*/uint256::ZERO, /*entry=*/u);
+        }
+        {
+            UniValue u{UniValue::VOBJ};
+            TxToUniv(tx, /*block_hash=*/uint256::ONE, /*entry=*/u);
+        }
+    }
 }


### PR DESCRIPTION
Backports bitcoin/bitcoin#27921

Original commit: f1b4975461

This backport adds a size check in the transaction fuzz target to avoid out-of-memory issues when encoding large transactions to JSON. The change limits processing to transactions under 250KB.

Backported from Bitcoin Core v0.23