### PR TITLE
Merge bitcoin/bitcoin#27889: test: Kill `BOOST_ASSERT` and update the linter

### DIFF
--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -478,7 +478,7 @@ void FuncDIP3Protx(TestChainSetup& setup)
     // check MN reward payments
     for (size_t i = 0; i < 20; i++) {
         auto dmnExpectedPayee = dmnman.GetListAtChainTip().GetMNPayee(chainman.ActiveChain().Tip());
-        BOOST_ASSERT(dmnExpectedPayee);
+        BOOST_CHECK(dmnExpectedPayee);
 
         CBlock block = setup.CreateAndProcessBlock({}, setup.coinbaseKey);
         dmnman.UpdatedBlockTip(chainman.ActiveChain().Tip());
@@ -587,7 +587,7 @@ void FuncDIP3Protx(TestChainSetup& setup)
     bool foundRevived = false;
     for (size_t i = 0; i < 20; i++) {
         auto dmnExpectedPayee = dmnman.GetListAtChainTip().GetMNPayee(chainman.ActiveChain().Tip());
-        BOOST_ASSERT(dmnExpectedPayee);
+        BOOST_CHECK(dmnExpectedPayee);
         if (dmnExpectedPayee->proTxHash == dmnHashes[0]) {
             foundRevived = true;
         }

--- a/test/lint/lint-assertions.py
+++ b/test/lint/lint-assertions.py
@@ -35,6 +35,16 @@ def main():
         ":(exclude)src/rpc/server.cpp",
     ], "CHECK_NONFATAL(condition) or NONFATAL_UNREACHABLE should be used instead of assert for RPC code.")
 
+    # The `BOOST_ASSERT` macro requires to `#include boost/assert.hpp`,
+    # which is an unnecessary Boost dependency.
+    exit_code |= git_grep([
+        "-E",
+        r"BOOST_ASSERT *\(.*\);",
+        "--",
+        "*.cpp",
+        "*.h",
+    ], "BOOST_ASSERT must be replaced with Assert, BOOST_REQUIRE, or BOOST_CHECK.")
+
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27889

Original commit: 2880bb588a

This PR kills the BOOST_ASSERT macros in Dash code and adds a linter rule to prevent their reintroduction. In Dash, the BOOST_ASSERT macros were found in src/test/evo_deterministicmns_tests.cpp rather than src/wallet/test/db_tests.cpp (which doesn't have the affected tests in Dash yet).

Changes:
- Replace BOOST_ASSERT with BOOST_CHECK in evo_deterministicmns_tests.cpp
- Add linter rule to prevent future BOOST_ASSERT usage

Backported from Bitcoin Core v0.23