### PR TITLE
Merge bitcoin/bitcoin#27846: [coinselection] Increase SRD target by change_fee

### DIFF
--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -165,7 +165,7 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
     return result;
 }
 
-std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng)
+std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, CAmount change_fee, FastRandomContext& rng)
 {
     if (utxo_pool.empty()) return std::nullopt;
 

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -319,9 +319,10 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
  *
  * @param[in]  utxo_pool    The positive effective value OutputGroups eligible for selection
  * @param[in]  target_value The target value to select for
+ * @param[in]  change_fee   The fee for creating a change output
  * @returns If successful, a SelectionResult, otherwise, std::nullopt
  */
-std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng);
+std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, CAmount change_fee, FastRandomContext& rng);
 
 // Original coin selection algorithm as a fallback
 std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue,

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -421,7 +421,7 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
     // generated one, since SRD will result in a random change amount anyway; avoid making the
     // target needlessly large.
     const CAmount srd_target = target_with_change + CHANGE_LOWER;
-    if (auto srd_result{SelectCoinsSRD(positive_groups, srd_target, coin_selection_params.rng_fast)}) {
+    if (auto srd_result{SelectCoinsSRD(positive_groups, srd_target, coin_selection_params.m_change_fee, coin_selection_params.rng_fast)}) {
         srd_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
         results.push_back(*srd_result);
     }

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -83,8 +83,11 @@ FUZZ_TARGET(coinselection)
     // Run coinselection algorithms
     const auto result_bnb = SelectCoinsBnB(group_pos, target, cost_of_change);
 
-    auto result_srd = SelectCoinsSRD(group_pos, target, fast_random_context);
-    if (result_srd) result_srd->ComputeAndSetWaste(cost_of_change);
+    auto result_srd = SelectCoinsSRD(group_pos, target, coin_params.m_change_fee, fast_random_context);
+    if (result_srd) {
+        assert(result_srd->GetChange(CHANGE_LOWER, coin_params.m_change_fee) > 0); // Demonstrate that SRD creates change of at least CHANGE_LOWER
+        result_srd->ComputeAndSetWaste(cost_of_change);
+    }
 
     CAmount change_target{GenerateChangeTarget(target, fast_random_context)};
     auto result_knapsack = KnapsackSolver(group_all, target, change_target, fast_random_context,


### PR DESCRIPTION
Backports bitcoin/bitcoin#27846

Original commit: 8e0cf4f90c0408a394d177f6d389090cd749d505

This backport addresses an issue where at extremely high feerates SRD may find input sets that lead to transactions without change outputs. This is an unintended outcome since SRD is meant to always produce a transaction with a change output.

The fix increases the change budget by `change_fee` to ensure SRD behaves as expected at any feerates.

Note: The Bitcoin test additions in `src/wallet/test/coinselector_tests.cpp` were not included as they are entirely new tests that don't exist in Dash's test suite.

Backported from Bitcoin Core v0.23