### PR TITLE
Merge bitcoin/bitcoin#27996: ci: filter all subtrees from tidy output

### DIFF
--- a/src/.bear-tidy-config
+++ b/src/.bear-tidy-config
@@ -5,14 +5,16 @@
       "paths_to_include": [],
       "paths_to_exclude": [
         "src/crc32",
+        "src/crc32c",
+        "src/crypto/ctaes",
         "src/crypto/x11",
         "src/dashbls",
         "src/gsl",
         "src/immer",
         "src/leveldb",
         "src/minisketch",
-        "src/univalue",
-        "src/secp256k1"
+        "src/secp256k1",
+        "src/univalue"
       ]
     },
     "format": {


### PR DESCRIPTION
Backports bitcoin/bitcoin#27996

Original commit: c6287faae4

Backported from Bitcoin Core v0.26

Note: Only applied changes to `src/.bear-tidy-config` as the CI script changes were not applicable to Dash (the secp256k1 filter that Bitcoin removed doesn't exist in Dash's CI scripts).