### PR TITLE
Merge bitcoin/bitcoin#27530: Remove now-unnecessary poll, fcntl includes from net(base).cpp

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -48,8 +48,6 @@
 
 #ifdef WIN32
 #include <string.h>
-#else
-#include <fcntl.h>
 #endif
 
 #if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -28,14 +28,6 @@
 #include <sys/un.h>
 #endif
 
-#ifndef WIN32
-#include <fcntl.h>
-#endif
-
-#ifdef USE_POLL
-#include <poll.h>
-#endif
-
 // Settings
 static Mutex g_proxyinfo_mutex;
 static Proxy proxyInfo[NET_MAX] GUARDED_BY(g_proxyinfo_mutex);


### PR DESCRIPTION
Backports bitcoin/bitcoin#27530

Original commit: e0cd7458e6

Backported from Bitcoin Core v0.26

### Notes
- Bitcoin removed fcntl.h and poll.h includes from both net.cpp and netbase.cpp
- Dash doesn't have the poll.h include in net.cpp, so only fcntl.h was removed there
- This architectural difference explains the 71.4% size ratio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies by removing unused system headers to streamline the codebase. No changes to features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->