### PR TITLE
Merge bitcoin/bitcoin#28053: refactor: Move stopafterblockimport option out of blockstorage

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -144,7 +144,6 @@ using node::DashChainstateSetupClose;
 using node::DEFAULT_ADDRESSINDEX;
 using node::DEFAULT_PRINTPRIORITY;
 using node::DEFAULT_SPENTINDEX;
-using node::DEFAULT_STOPAFTERBLOCKIMPORT;
 using node::DEFAULT_TIMESTAMPINDEX;
 using node::LoadChainstate;
 using node::NodeContext;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -163,6 +163,7 @@ using wallet::DEFAULT_DISABLE_WALLET;
 static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
 static constexpr bool DEFAULT_REST_ENABLE{false};
 static constexpr bool DEFAULT_I2P_ACCEPT_INCOMING{true};
+static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
 
 #ifdef WIN32
 // Win32 LevelDB doesn't use filedescriptors, and the ones used for
@@ -2320,6 +2321,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     chainman.m_load_block = std::thread(&util::TraceThread, "loadblk", [=, &args, &chainman, &node] {
         ThreadImport(chainman, vImportFiles, args);
+        if (args.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
+            LogPrintf("Stopping after block import\n");
+            StartShutdown();
+            return;
+        }
 
         // force UpdatedBlockTip to initialize nCachedBlockHeight for DS, MN payments and budgets
         // but don't call it directly to prevent triggering of other listeners like zmq etc.

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -887,12 +887,6 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
                 return;
             }
         }
-
-        if (args.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
-            LogPrintf("Stopping after block import\n");
-            StartShutdown();
-            return;
-        }
     } // End scope of CImportingNow
 
     chainman.ActiveChainstate().LoadMempool(args);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -35,7 +35,6 @@ struct Params;
 namespace node {
 static constexpr bool DEFAULT_ADDRESSINDEX{false};
 static constexpr bool DEFAULT_SPENTINDEX{false};
-static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
 static constexpr bool DEFAULT_TIMESTAMPINDEX{false};
 
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */

--- a/src/test/llmq_commitment_tests.cpp
+++ b/src/test/llmq_commitment_tests.cpp
@@ -142,8 +142,8 @@ BOOST_AUTO_TEST_CASE(commitment_json_test)
     BOOST_CHECK(json.exists("signersCount"));
     BOOST_CHECK(json.exists("validMembersCount"));
 
-    BOOST_CHECK_EQUAL(json["signersCount"].get_int(), commitment.CountSigners());
-    BOOST_CHECK_EQUAL(json["validMembersCount"].get_int(), commitment.CountValidMembers());
+    BOOST_CHECK_EQUAL(json["signersCount"].getInt<int>(), commitment.CountSigners());
+    BOOST_CHECK_EQUAL(json["validMembersCount"].getInt<int>(), commitment.CountValidMembers());
 }
 
 BOOST_AUTO_TEST_CASE(commitment_bitvector_json_test)


### PR DESCRIPTION
Backports bitcoin/bitcoin#28053

Original commit: e253568da8

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of the shutdown process after block import when using the relevant command-line argument.
* **Refactor**
  * Streamlined internal logic related to stopping the application after block import, resulting in a cleaner shutdown process for users who utilize this option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->