### PR TITLE
Merge bitcoin/bitcoin#28071: ci: Add missing -O2 to valgrind tasks

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -15,5 +15,5 @@ export RUN_FUZZ_TESTS=true
 export FUZZ_TESTS_CONFIG="--valgrind"
 export GOAL="install"
 # Temporarily pin dwarf 4, until valgrind can understand clang's dwarf 5
-export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer CC=clang-18 CXX=clang++-18 CFLAGS='-gdwarf-4' CXXFLAGS='-gdwarf-4'"
+export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer CC='clang-18 -gdwarf-4' CXX='clang++-18 -gdwarf-4'"
 export CCACHE_SIZE=200M

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -12,4 +12,4 @@ export NO_DEPENDS=1
 export TEST_RUNNER_EXTRA="--exclude rpc_bind,feature_bind_extra --timeout-factor=4"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export GOAL="install"
 # Temporarily pin dwarf 4, until valgrind can understand clang's dwarf 5
-export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang-18 CXX=clang++-18 CFLAGS='-gdwarf-4' CXXFLAGS='-gdwarf-4'"  # TODO enable GUI
+export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC='clang-18 -gdwarf-4' CXX='clang++-18 -gdwarf-4'"  # TODO enable GUI

--- a/src/test/llmq_commitment_tests.cpp
+++ b/src/test/llmq_commitment_tests.cpp
@@ -142,8 +142,8 @@ BOOST_AUTO_TEST_CASE(commitment_json_test)
     BOOST_CHECK(json.exists("signersCount"));
     BOOST_CHECK(json.exists("validMembersCount"));
 
-    BOOST_CHECK_EQUAL(json["signersCount"].get_int(), commitment.CountSigners());
-    BOOST_CHECK_EQUAL(json["validMembersCount"].get_int(), commitment.CountValidMembers());
+    BOOST_CHECK_EQUAL(json["signersCount"].getInt<int>(), commitment.CountSigners());
+    BOOST_CHECK_EQUAL(json["validMembersCount"].getInt<int>(), commitment.CountValidMembers());
 }
 
 BOOST_AUTO_TEST_CASE(commitment_bitvector_json_test)


### PR DESCRIPTION
Backports bitcoin/bitcoin#28071

Original commit: 4a1aae6749

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration for environment setup, consolidating compiler flags into single variables for improved consistency. No impact on user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->