### PR TITLE
Merge bitcoin/bitcoin#28103: test: Add missing `set -ex` to ci/lint/06_script.sh

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C
 
+set -ex
+
 if [ -n "$LOCAL_BRANCH" ]; then
   # To faithfully recreate CI linting locally, specify all commits on the current
   # branch.

--- a/ci/lint/container-entrypoint.sh
+++ b/ci/lint/container-entrypoint.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
 export LC_ALL=C
 
 # Fixes permission issues when there is a container UID/GID mismatch with the owner

--- a/ci/lint/container-entrypoint.sh
+++ b/ci/lint/container-entrypoint.sh
@@ -10,6 +10,8 @@ export LC_ALL=C
 # of the mounted bitcoin src dir.
 git config --global --add safe.directory /bitcoin
 
+export PATH="/python_build/bin:${PATH}"
+
 if [ -z "$1" ]; then
   LOCAL_BRANCH=1 bash -ic "./ci/lint/06_script.sh"
 else

--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -1,0 +1,22 @@
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+# See test/lint/README.md for usage.
+
+FROM debian:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+
+COPY ./.python-version /.python-version
+COPY ./ci/lint/container-entrypoint.sh /entrypoint.sh
+COPY ./ci/lint/04_install.sh /install.sh
+
+RUN /install.sh && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && \
+    apt-get autoclean
+
+WORKDIR /bitcoin
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -8,4 +8,5 @@ export LC_ALL=C.UTF-8
 
 set -o errexit; source ./ci/test/00_setup_env.sh
 set -o errexit; source ./ci/lint/04_install.sh
-set -o errexit; source ./ci/lint/06_script.sh
+set -o errexit
+./ci/lint/06_script.sh

--- a/ci/test_imagefile
+++ b/ci/test_imagefile
@@ -1,0 +1,18 @@
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+# See ci/README.md for usage.
+
+ARG CI_IMAGE_NAME_TAG
+FROM ${CI_IMAGE_NAME_TAG}
+
+COPY ./ci/test/ /ci/
+WORKDIR /ci
+
+RUN ./04_install.sh
+
+WORKDIR /bitcoin
+COPY . .
+
+ENTRYPOINT ["./ci/test_run_all.sh"]


### PR DESCRIPTION
Backports bitcoin/bitcoin#28103

Original commit: d23fda0584

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved script reliability and debugging by updating shell options for better error handling and command tracing.
  * Updated a script to include copyright and licensing information.
  * Modified script execution flow for more robust and isolated linting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->