### PR TITLE
Merge bitcoin/bitcoin#27620: test: miner: add coverage for `-blockmintxfee` setting

### DIFF
--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -28,7 +28,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    get_fee,
 )
 from test_framework.wallet import MiniWallet
 
@@ -74,7 +73,7 @@ class MiningTest(BitcoinTestFramework):
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 0)
 
-    def test_blockmintxfee_parameter(self):
+    def test_blockmintxfee_parameter(self) -> None:
         self.log.info("Test -blockmintxfee setting")
         self.restart_node(0, extra_args=['-minrelaytxfee=0', '-persistmempool=0'])
         node = self.nodes[0]
@@ -83,20 +82,20 @@ class MiningTest(BitcoinTestFramework):
         for blockmintxfee_sat_kvb in (DEFAULT_BLOCK_MIN_TX_FEE, 0, 50, 100, 500, 2500, 5000, 21000, 333333, 2500000):
             blockmintxfee_btc_kvb = blockmintxfee_sat_kvb / Decimal(COIN)
             if blockmintxfee_sat_kvb == DEFAULT_BLOCK_MIN_TX_FEE:
-                self.log.info(f"-> Default -blockmintxfee setting ({blockmintxfee_sat_kvb} sat/kvB)...")
+                self.log.info("-> Default -blockmintxfee setting (%d sat/kvB)...", blockmintxfee_sat_kvb)
             else:
                 blockmintxfee_parameter = f"-blockmintxfee={blockmintxfee_btc_kvb:.8f}"
-                self.log.info(f"-> Test {blockmintxfee_parameter} ({blockmintxfee_sat_kvb} sat/kvB)...")
+                self.log.info("-> Test %s (%d sat/kvB)...", blockmintxfee_parameter, blockmintxfee_sat_kvb)
                 self.restart_node(0, extra_args=[blockmintxfee_parameter, '-minrelaytxfee=0', '-persistmempool=0'])
                 self.wallet.rescan_utxos()  # to avoid spending outputs of txs that are not in mempool anymore after restart
 
             # submit one tx with exactly the blockmintxfee rate, and one slightly below
             tx_with_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
-            assert_equal(tx_with_min_feerate["fee"], get_fee(tx_with_min_feerate["tx"].get_vsize(), blockmintxfee_btc_kvb))
+            assert_equal(tx_with_min_feerate["fee"], int(tx_with_min_feerate["tx"].get_vsize() * blockmintxfee_btc_kvb))
             if blockmintxfee_btc_kvb > 0:
                 lowerfee_btc_kvb = blockmintxfee_btc_kvb - Decimal(10)/COIN  # 0.01 sat/vbyte lower
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=lowerfee_btc_kvb)
-                assert_equal(tx_below_min_feerate["fee"], get_fee(tx_below_min_feerate["tx"].get_vsize(), lowerfee_btc_kvb))
+                assert_equal(tx_below_min_feerate["fee"], int(tx_below_min_feerate["tx"].get_vsize() * lowerfee_btc_kvb))
             else:  # go below zero fee by using modified fees
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
                 node.prioritisetransaction(tx_below_min_feerate["txid"], 0, -1)

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -18,21 +18,25 @@ from test_framework.blocktools import (
     TIME_GENESIS_BLOCK,
 )
 from test_framework.messages import (
+    BLOCK_HEADER_SIZE,
     CBlock,
     CBlockHeader,
-    BLOCK_HEADER_SIZE,
+    COIN,
+    ser_uint256,
 )
 from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    get_fee,
 )
 from test_framework.wallet import MiniWallet
 
 
 VERSIONBITS_TOP_BITS = 0x20000000
 VERSIONBITS_DEPLOYMENT_TESTDUMMY_BIT = 28
+DEFAULT_BLOCK_MIN_TX_FEE = 1000  # default `-blockmintxfee` setting [sat/kvB]
 
 def assert_template(node, block, expect, rehash=True):
     if rehash:
@@ -70,6 +74,45 @@ class MiningTest(BitcoinTestFramework):
         self.restart_node(0)
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 0)
+
+    def test_blockmintxfee_parameter(self):
+        self.log.info("Test -blockmintxfee setting")
+        self.restart_node(0, extra_args=['-minrelaytxfee=0', '-persistmempool=0'])
+        node = self.nodes[0]
+
+        # test default (no parameter), zero and a bunch of arbitrary blockmintxfee rates [sat/kvB]
+        for blockmintxfee_sat_kvb in (DEFAULT_BLOCK_MIN_TX_FEE, 0, 50, 100, 500, 2500, 5000, 21000, 333333, 2500000):
+            blockmintxfee_btc_kvb = blockmintxfee_sat_kvb / Decimal(COIN)
+            if blockmintxfee_sat_kvb == DEFAULT_BLOCK_MIN_TX_FEE:
+                self.log.info(f"-> Default -blockmintxfee setting ({blockmintxfee_sat_kvb} sat/kvB)...")
+            else:
+                blockmintxfee_parameter = f"-blockmintxfee={blockmintxfee_btc_kvb:.8f}"
+                self.log.info(f"-> Test {blockmintxfee_parameter} ({blockmintxfee_sat_kvb} sat/kvB)...")
+                self.restart_node(0, extra_args=[blockmintxfee_parameter, '-minrelaytxfee=0', '-persistmempool=0'])
+                self.wallet.rescan_utxos()  # to avoid spending outputs of txs that are not in mempool anymore after restart
+
+            # submit one tx with exactly the blockmintxfee rate, and one slightly below
+            tx_with_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
+            assert_equal(tx_with_min_feerate["fee"], get_fee(tx_with_min_feerate["tx"].get_vsize(), blockmintxfee_btc_kvb))
+            if blockmintxfee_btc_kvb > 0:
+                lowerfee_btc_kvb = blockmintxfee_btc_kvb - Decimal(10)/COIN  # 0.01 sat/vbyte lower
+                tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=lowerfee_btc_kvb)
+                assert_equal(tx_below_min_feerate["fee"], get_fee(tx_below_min_feerate["tx"].get_vsize(), lowerfee_btc_kvb))
+            else:  # go below zero fee by using modified fees
+                tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
+                node.prioritisetransaction(tx_below_min_feerate["txid"], 0, -1)
+
+            # check that tx below specified fee-rate is neither in template nor in the actual block
+            block_template = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
+            block_template_txids = [tx['txid'] for tx in block_template['transactions']]
+            self.generate(self.wallet, 1, sync_fun=self.no_op)
+            block = node.getblock(node.getbestblockhash(), verbosity=2)
+            block_txids = [tx['txid'] for tx in block['tx']]
+
+            assert tx_with_min_feerate['txid'] in block_template_txids
+            assert tx_with_min_feerate['txid'] in block_txids
+            assert tx_below_min_feerate['txid'] not in block_template_txids
+            assert tx_below_min_feerate['txid'] not in block_txids
 
     def run_test(self):
         node = self.nodes[0]
@@ -255,6 +298,8 @@ class MiningTest(BitcoinTestFramework):
         node.submitheader(hexdata=CBlockHeader(block).serialize().hex())
         node.submitheader(hexdata=CBlockHeader(bad_block_root).serialize().hex())
         assert_equal(node.submitblock(hexdata=block.serialize().hex()), 'duplicate')  # valid
+
+        self.test_blockmintxfee_parameter()
 
 
 if __name__ == '__main__':

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -28,7 +28,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    get_fee,
 )
 from test_framework.wallet import MiniWallet
 
@@ -92,11 +91,11 @@ class MiningTest(BitcoinTestFramework):
 
             # submit one tx with exactly the blockmintxfee rate, and one slightly below
             tx_with_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
-            assert_equal(tx_with_min_feerate["fee"], get_fee(tx_with_min_feerate["tx"].get_vsize(), blockmintxfee_btc_kvb))
+            assert_equal(tx_with_min_feerate["fee"], tx_with_min_feerate["tx"].get_vsize() * blockmintxfee_btc_kvb)
             if blockmintxfee_btc_kvb > 0:
                 lowerfee_btc_kvb = blockmintxfee_btc_kvb - Decimal(10)/COIN  # 0.01 sat/vbyte lower
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=lowerfee_btc_kvb)
-                assert_equal(tx_below_min_feerate["fee"], get_fee(tx_below_min_feerate["tx"].get_vsize(), lowerfee_btc_kvb))
+                assert_equal(tx_below_min_feerate["fee"], tx_below_min_feerate["tx"].get_vsize() * lowerfee_btc_kvb)
             else:  # go below zero fee by using modified fees
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
                 node.prioritisetransaction(tx_below_min_feerate["txid"], 0, -1)

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -28,6 +28,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    get_fee,
 )
 from test_framework.wallet import MiniWallet
 
@@ -91,11 +92,11 @@ class MiningTest(BitcoinTestFramework):
 
             # submit one tx with exactly the blockmintxfee rate, and one slightly below
             tx_with_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
-            assert_equal(tx_with_min_feerate["fee"], tx_with_min_feerate["tx"].get_vsize() * blockmintxfee_btc_kvb)
+            assert_equal(tx_with_min_feerate["fee"], get_fee(tx_with_min_feerate["tx"].get_vsize(), blockmintxfee_btc_kvb))
             if blockmintxfee_btc_kvb > 0:
                 lowerfee_btc_kvb = blockmintxfee_btc_kvb - Decimal(10)/COIN  # 0.01 sat/vbyte lower
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=lowerfee_btc_kvb)
-                assert_equal(tx_below_min_feerate["fee"], tx_below_min_feerate["tx"].get_vsize() * lowerfee_btc_kvb)
+                assert_equal(tx_below_min_feerate["fee"], get_fee(tx_below_min_feerate["tx"].get_vsize(), lowerfee_btc_kvb))
             else:  # go below zero fee by using modified fees
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
                 node.prioritisetransaction(tx_below_min_feerate["txid"], 0, -1)

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -91,11 +91,11 @@ class MiningTest(BitcoinTestFramework):
 
             # submit one tx with exactly the blockmintxfee rate, and one slightly below
             tx_with_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
-            assert_equal(tx_with_min_feerate["fee"], int(tx_with_min_feerate["tx"].get_vsize() * blockmintxfee_btc_kvb))
+            assert_equal(tx_with_min_feerate["fee"], get_fee(tx_with_min_feerate["tx"].get_vsize(), blockmintxfee_btc_kvb))
             if blockmintxfee_btc_kvb > 0:
                 lowerfee_btc_kvb = blockmintxfee_btc_kvb - Decimal(10)/COIN  # 0.01 sat/vbyte lower
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=lowerfee_btc_kvb)
-                assert_equal(tx_below_min_feerate["fee"], int(tx_below_min_feerate["tx"].get_vsize() * lowerfee_btc_kvb))
+                assert_equal(tx_below_min_feerate["fee"], get_fee(tx_below_min_feerate["tx"].get_vsize(), lowerfee_btc_kvb))
             else:  # go below zero fee by using modified fees
                 tx_below_min_feerate = self.wallet.send_self_transfer(from_node=node, fee_rate=blockmintxfee_btc_kvb)
                 node.prioritisetransaction(tx_below_min_feerate["txid"], 0, -1)

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -28,6 +28,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    get_fee,
 )
 from test_framework.wallet import MiniWallet
 

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -84,7 +84,7 @@ class MiningTest(BitcoinTestFramework):
             if blockmintxfee_sat_kvb == DEFAULT_BLOCK_MIN_TX_FEE:
                 self.log.info("-> Default -blockmintxfee setting (%d sat/kvB)...", blockmintxfee_sat_kvb)
             else:
-                blockmintxfee_parameter = f"-blockmintxfee={blockmintxfee_btc_kvb:.8f}"
+                blockmintxfee_parameter = "-blockmintxfee={:.8f}".format(blockmintxfee_btc_kvb)
                 self.log.info("-> Test %s (%d sat/kvB)...", blockmintxfee_parameter, blockmintxfee_sat_kvb)
                 self.restart_node(0, extra_args=[blockmintxfee_parameter, '-minrelaytxfee=0', '-persistmempool=0'])
                 self.wallet.rescan_utxos()  # to avoid spending outputs of txs that are not in mempool anymore after restart

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -22,7 +22,6 @@ from test_framework.messages import (
     CBlock,
     CBlockHeader,
     COIN,
-    ser_uint256,
 )
 from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -25,6 +25,20 @@ from typing import Callable, Optional
 
 logger = logging.getLogger("TestFramework.utils")
 
+
+def ceildiv(a: int, b: int) -> int:
+    """Return ceil(a/b) as an integer."""
+    return -(-a // b)
+
+
+def get_fee(tx_vsize: int, fee_rate: Decimal) -> int:
+    """
+    Calculate fee (in satoshis) for a transaction with given vsize at fee_rate sat/kvB.
+    Uses transaction vsize and ceil-divides by 1000.
+    """
+    return int(fee_rate * ceildiv(tx_vsize, 1000))
+
+
 # Assert functions
 ##################
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27620

Original commit: 79954903b2a3e48d24f3f1c5b7ee527c4ab2de65

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify the behavior of the `-blockmintxfee` configuration parameter, ensuring transactions below the minimum fee are excluded from blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->