### PR TITLE
Merge bitcoin/bitcoin#28067: descriptors: do not return top-level only funcs as sub descriptors

### DIFF
--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1089,6 +1089,10 @@ std::unique_ptr<DescriptorImpl> InferScript(const CScript& script, ParseScriptCo
         }
     }
 
+    // The following descriptors are all top-level only descriptors.
+    // So if we are not at the top level, return early.
+    if (ctx != ParseScriptContext::TOP) return nullptr;
+
     CTxDestination dest;
     if (ExtractDestination(script, dest)) {
         if (GetScriptForDestination(dest) == script) {


### PR DESCRIPTION
Backports bitcoin/bitcoin#28067

Original commit: 7edce77ff3725f8650bb1ae6b45b1cee100db280

Backported from Bitcoin Core v0.26