### PR TITLE
Merge bitcoin/bitcoin#28035: test: Ignore UTF-8 errors in assert_debug_log

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -433,7 +433,11 @@ class TestNode():
         return self.chain_path / 'debug.log'
 
     def debug_log_bytes(self) -> int:
-        with open(self.debug_log_path, encoding='utf-8') as dl:
+        # Deprecated method name kept for compatibility, use debug_log_size instead
+        return self.debug_log_size(encoding='utf-8')
+
+    def debug_log_size(self, **kwargs) -> int:
+        with open(self.debug_log_path, **kwargs) as dl:
             dl.seek(0, 2)
             return dl.tell()
 
@@ -445,13 +449,13 @@ class TestNode():
         assert_equal(type(unexpected_msgs), list)
 
         time_end = time.time() + timeout * self.timeout_factor
-        prev_size = self.debug_log_bytes()
+        prev_size = self.debug_log_size(encoding="utf-8")  # Must use same encoding that is used to read() below
 
         yield
 
         while True:
             found = True
-            with open(self.debug_log_path, encoding='utf-8') as dl:
+            with open(self.debug_log_path, encoding="utf-8", errors="replace") as dl:
                 dl.seek(prev_size)
                 log = dl.read()
             print_log = " - " + "\n - ".join(log.splitlines())
@@ -476,7 +480,7 @@ class TestNode():
             the number of log lines we encountered when matching
         """
         time_end = time.time() + timeout * self.timeout_factor
-        prev_size = self.debug_log_bytes()
+        prev_size = self.debug_log_size(mode="rb")  # Must use same mode that is used to read() below
 
         yield
 

--- a/test/lint/lint-python-utf8-encoding.py
+++ b/test/lint/lint-python-utf8-encoding.py
@@ -29,7 +29,7 @@ def check_fileopens():
         if e.returncode > 1:
             raise e
 
-    filtered_fileopens = [fileopen for fileopen in fileopens if not re.search(r"encoding=.(ascii|utf8|utf-8).|open\([^,]*, ['\"][^'\"]*b[^'\"]*['\"]", fileopen)]
+    filtered_fileopens = [fileopen for fileopen in fileopens if not re.search(r"encoding=.(ascii|utf8|utf-8).|open\([^,]*, (\*\*kwargs|['\"][^'\"]*b[^'\"]*['\"])", fileopen)]
 
     return filtered_fileopens
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28035

Original commit: 54fe963a53f8a5c0bbaebcd9b146d3a37a35d6d6

Backported from Bitcoin Core v0.26

## Summary
This PR fixes two bugs in the test framework:
1. Fixes the `debug_log_size` helper to properly handle binary/text mode
2. Adds UTF-8 error handling to `assert_debug_log` to prevent decoding errors
3. Updates the lint script to ignore **kwargs in file open checks

## Changes
- Renamed `debug_log_bytes` to `debug_log_size` with kwargs support (kept backward compatibility in Dash)
- Added `errors="replace"` parameter when reading debug logs to handle UTF-8 errors gracefully
- Updated lint-python-utf8-encoding.py to recognize **kwargs pattern