### PR TITLE
Merge bitcoin/bitcoin#28113: kernel: Remove UniValue from kernel library

### DIFF
--- a/doc/release-notes-28113.md
+++ b/doc/release-notes-28113.md
@@ -1,0 +1,7 @@
+RPC Wallet
+----------
+
+- The `signrawtransactionwithkey`, `signrawtransactionwithwallet`,
+  `walletprocesspsbt` and `descriptorprocesspsbt` calls now return more
+  specific RPC_INVALID_PARAMETER instead of RPC_PARSE_ERROR if their
+  sighashtype argument is malformed or not a string.

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -516,6 +516,16 @@ static CAmount AmountFromValue(const UniValue& value)
     return amount;
 }
 
+static std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName)
+{
+    std::string strHex;
+    if (v.isStr())
+        strHex = v.getValStr();
+    if (!IsHex(strHex))
+        throw std::runtime_error(strName + " must be hexadecimal string (not '" + strHex + "')");
+    return ParseHex(strHex);
+}
+
 static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 {
     int nHashType = SIGHASH_ALL;

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -7,6 +7,7 @@
 
 #include <consensus/amount.h>
 #include <attributes.h>
+#include <util/result.h>
 
 #include <string>
 #include <vector>
@@ -46,8 +47,7 @@ bool DecodeHexBlockHeader(CBlockHeader&, const std::string& hex_header);
  * @see ParseHashV for an RPC-oriented version of this
  */
 bool ParseHashStr(const std::string& strHex, uint256& result);
-std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);
-int ParseSighashString(const UniValue& sighash);
+[[nodiscard]] util::Result<int> SighashFromStr(const std::string& sighash);
 
 // core_write.cpp
 UniValue ValueFromAmount(const CAmount amount);

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -11,6 +11,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>
+#include <util/result.h>
 #include <util/string.h>
 #include <util/strencodings.h>
 #include <version.h>
@@ -167,35 +168,20 @@ bool ParseHashStr(const std::string& strHex, uint256& result)
     return true;
 }
 
-std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName)
+util::Result<int> SighashFromStr(const std::string& sighash)
 {
-    std::string strHex;
-    if (v.isStr())
-        strHex = v.getValStr();
-    if (!IsHex(strHex))
-        throw std::runtime_error(strName + " must be hexadecimal string (not '" + strHex + "')");
-    return ParseHex(strHex);
-}
-
-int ParseSighashString(const UniValue& sighash)
-{
-    int hash_type = SIGHASH_ALL;
-    if (!sighash.isNull()) {
-        static std::map<std::string, int> map_sighash_values = {
-            {std::string("ALL"), int(SIGHASH_ALL)},
-            {std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY)},
-            {std::string("NONE"), int(SIGHASH_NONE)},
-            {std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY)},
-            {std::string("SINGLE"), int(SIGHASH_SINGLE)},
-            {std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY)},
-        };
-        std::string strHashType = sighash.get_str();
-        const auto& it = map_sighash_values.find(strHashType);
-        if (it != map_sighash_values.end()) {
-            hash_type = it->second;
-        } else {
-            throw std::runtime_error(strHashType + " is not a valid sighash parameter.");
-        }
+    static std::map<std::string, int> map_sighash_values = {
+        {std::string("ALL"), int(SIGHASH_ALL)},
+        {std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY)},
+        {std::string("NONE"), int(SIGHASH_NONE)},
+        {std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY)},
+        {std::string("SINGLE"), int(SIGHASH_SINGLE)},
+        {std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY)},
+    };
+    const auto& it = map_sighash_values.find(sighash);
+    if (it != map_sighash_values.end()) {
+        return it->second;
+    } else {
+        return util::Error{Untranslated(sighash + " is not a valid sighash parameter.")};
     }
-    return hash_type;
 }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -3,7 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparamsbase.h>
+#include <core_io.h>
 #include <consensus/amount.h>
+#include <script/interpreter.h>
 #include <key_io.h>
 #include <outputtype.h>
 #include <pubkey.h>
@@ -12,6 +14,7 @@
 #include <script/signingprovider.h>
 #include <tinyformat.h>
 #include <util/check.h>
+#include <util/result.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -318,6 +321,21 @@ public:
 UniValue DescribeAddress(const CTxDestination& dest)
 {
     return std::visit(DescribeAddressVisitor(), dest);
+}
+
+int ParseSighashString(const UniValue& sighash)
+{
+    if (sighash.isNull()) {
+        return SIGHASH_ALL;
+    }
+    if (!sighash.isStr()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "sighash needs to be null or string");
+    }
+    const auto result{SighashFromStr(sighash.get_str())};
+    if (!result) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, util::ErrorString(result).original);
+    }
+    return result.value();
 }
 
 unsigned int ParseConfirmTarget(const UniValue& value, unsigned int max_target)

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -112,6 +112,9 @@ CTxDestination AddAndGetMultisigDestination(const int required, const std::vecto
 
 UniValue DescribeAddress(const CTxDestination& dest);
 
+/** Parse a sighash string representation and raise an RPC error if it is invalid. */
+int ParseSighashString(const UniValue& sighash);
+
 //! Parse a confirm target option and raise an RPC error if it is invalid.
 unsigned int ParseConfirmTarget(const UniValue& value, unsigned int max_target);
 

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -3,8 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <core_io.h>
-#include <key.h>
 #include <rpc/client.h>
 #include <rpc/util.h>
 #include <script/sign.h>
@@ -62,12 +60,6 @@ FUZZ_TARGET(parse_univalue, .init = initialize_parse_univalue)
     } catch (const UniValue&) {
     }
     try {
-        (void)ParseHexUV(univalue, "A");
-        (void)ParseHexUV(univalue, random_string);
-    } catch (const UniValue&) {
-    } catch (const std::runtime_error&) {
-    }
-    try {
         (void)ParseHexV(univalue, "A");
     } catch (const UniValue&) {
     } catch (const std::runtime_error&) {
@@ -79,7 +71,7 @@ FUZZ_TARGET(parse_univalue, .init = initialize_parse_univalue)
     }
     try {
         (void)ParseSighashString(univalue);
-    } catch (const std::runtime_error&) {
+    } catch (const UniValue&) {
     }
     try {
         (void)AmountFromValue(univalue);


### PR DESCRIPTION
Backports bitcoin/bitcoin#28113

Original commit: 1ed8a0f8d2

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to clarify that certain RPC Wallet interface calls now return a more specific error code when the `sighashtype` argument is malformed, improving error feedback for users.

* **Bug Fixes**
  * Enhanced error handling in RPC Wallet commands by providing clearer error messages when an invalid `sighashtype` is supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->