### PR TITLE
Merge bitcoin/bitcoin#28168: refactor: Remove unused raw-pointer read helper from univalue

### DIFF
--- a/linux64_build_logs.txt
+++ b/linux64_build_logs.txt
@@ -1,0 +1,1048 @@
+﻿2025-07-27T16:07:36.6857914Z Current runner version: '2.326.0'
+2025-07-27T16:07:36.6881793Z ##[group]Runner Image Provisioner
+2025-07-27T16:07:36.6882661Z Hosted Compute Agent
+2025-07-27T16:07:36.6883296Z Version: 20250711.363
+2025-07-27T16:07:36.6883840Z Commit: 6785254374ce925a23743850c1cb91912ce5c14c
+2025-07-27T16:07:36.6884515Z Build Date: 2025-07-11T20:04:25Z
+2025-07-27T16:07:36.6885143Z ##[endgroup]
+2025-07-27T16:07:36.6885665Z ##[group]Operating System
+2025-07-27T16:07:36.6886263Z Ubuntu
+2025-07-27T16:07:36.6886844Z 24.04.2
+2025-07-27T16:07:36.6887327Z LTS
+2025-07-27T16:07:36.6887745Z ##[endgroup]
+2025-07-27T16:07:36.6888266Z ##[group]Runner Image
+2025-07-27T16:07:36.6888820Z Image: ubuntu-24.04
+2025-07-27T16:07:36.6889333Z Version: 20250720.1.0
+2025-07-27T16:07:36.6890773Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250720.1/images/ubuntu/Ubuntu2404-Readme.md
+2025-07-27T16:07:36.6892312Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250720.1
+2025-07-27T16:07:36.6893605Z ##[endgroup]
+2025-07-27T16:07:36.6894833Z ##[group]GITHUB_TOKEN Permissions
+2025-07-27T16:07:36.6896893Z Contents: read
+2025-07-27T16:07:36.6897549Z Metadata: read
+2025-07-27T16:07:36.6898079Z Packages: write
+2025-07-27T16:07:36.6898580Z ##[endgroup]
+2025-07-27T16:07:36.6901020Z Secret source: Actions
+2025-07-27T16:07:36.6901721Z Prepare workflow directory
+2025-07-27T16:07:36.7431827Z Prepare all required actions
+2025-07-27T16:07:36.7468325Z Getting action download info
+2025-07-27T16:07:37.0750342Z ##[group]Download immutable action package 'actions/checkout@v4'
+2025-07-27T16:07:37.0751520Z Version: 4.2.2
+2025-07-27T16:07:37.0752479Z Digest: sha256:ccb2698953eaebd21c7bf6268a94f9c26518a7e38e27e0b83c1fe1ad049819b1
+2025-07-27T16:07:37.0753592Z Source commit SHA: 11bd71901bbe5b1630ceea73d27597364c9af683
+2025-07-27T16:07:37.0754406Z ##[endgroup]
+2025-07-27T16:07:37.1577128Z ##[group]Download immutable action package 'actions/cache@v4'
+2025-07-27T16:07:37.1577949Z Version: 4.2.3
+2025-07-27T16:07:37.1578767Z Digest: sha256:c8a3bb963e1f1826d8fcc8d1354f0dd29d8ac1db1d4f6f20247055ae11b81ed9
+2025-07-27T16:07:37.1579945Z Source commit SHA: 5a3ec84eff668545956fd18022155c47e93e2684
+2025-07-27T16:07:37.1580775Z ##[endgroup]
+2025-07-27T16:07:37.2664664Z ##[group]Download immutable action package 'actions/upload-artifact@v4'
+2025-07-27T16:07:37.2665577Z Version: 4.6.2
+2025-07-27T16:07:37.2666317Z Digest: sha256:290722aa3281d5caf23d0acdc3dbeb3424786a1a01a9cc97e72f147225e37c38
+2025-07-27T16:07:37.2667215Z Source commit SHA: ea165f8d65b6e75b540449e92b4886f43607fa02
+2025-07-27T16:07:37.2667986Z ##[endgroup]
+2025-07-27T16:07:37.4680048Z Uses: DashCoreAutoGuix/dash/.github/workflows/build-src.yml@refs/heads/backport-0.26-batch-441-pr-28168 (9e6db0326f9d12ed12714a56c8f415305305f906)
+2025-07-27T16:07:37.4684761Z ##[group] Inputs
+2025-07-27T16:07:37.4685238Z   build-target: linux64
+2025-07-27T16:07:37.4686061Z   container-path: ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-441-pr-28168
+2025-07-27T16:07:37.4688295Z   depends-key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-27T16:07:37.4690319Z ##[endgroup]
+2025-07-27T16:07:37.4690738Z Complete job name: linux64-build / Build source
+2025-07-27T16:07:37.5148640Z ##[group]Checking docker version
+2025-07-27T16:07:37.5161917Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2025-07-27T16:07:37.5554539Z '1.48'
+2025-07-27T16:07:37.5566253Z Docker daemon API version: '1.48'
+2025-07-27T16:07:37.5567006Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2025-07-27T16:07:37.5726601Z '1.48'
+2025-07-27T16:07:37.5740957Z Docker client API version: '1.48'
+2025-07-27T16:07:37.5746472Z ##[endgroup]
+2025-07-27T16:07:37.5750179Z ##[group]Clean up resources from previous jobs
+2025-07-27T16:07:37.5755356Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=19fd45"
+2025-07-27T16:07:37.5901741Z ##[command]/usr/bin/docker network prune --force --filter "label=19fd45"
+2025-07-27T16:07:37.6030584Z ##[endgroup]
+2025-07-27T16:07:37.6031067Z ##[group]Create local container network
+2025-07-27T16:07:37.6041306Z ##[command]/usr/bin/docker network create --label 19fd45 github_network_544409b2d59249139504f245caa863e3
+2025-07-27T16:07:37.6531362Z 2024f5c91a4508e14a48663b990218fbe257c8a153967acdf91b6d07a000b4e5
+2025-07-27T16:07:37.6552041Z ##[endgroup]
+2025-07-27T16:07:37.6577126Z ##[group]Starting job container
+2025-07-27T16:07:37.6599455Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_a3a90bac-2d1e-4f67-8fa2-9999f8cc8aaf login ghcr.io -u DashCoreAutoGuix --password-stdin
+2025-07-27T16:07:37.9283970Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_a3a90bac-2d1e-4f67-8fa2-9999f8cc8aaf pull ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-441-pr-28168
+2025-07-27T16:07:38.3834576Z backport-0.26-batch-441-pr-28168: Pulling from dashcoreautoguix/dash/dashcore-ci-runner
+2025-07-27T16:07:38.4634258Z 32f112e3802c: Pulling fs layer
+2025-07-27T16:07:38.4635353Z 3c418bbf5534: Pulling fs layer
+2025-07-27T16:07:38.4636243Z 824b5144f7af: Pulling fs layer
+2025-07-27T16:07:38.4637108Z bb9f5c709011: Pulling fs layer
+2025-07-27T16:07:38.4638019Z c31b5eed60b6: Pulling fs layer
+2025-07-27T16:07:38.4639020Z da96180e845f: Pulling fs layer
+2025-07-27T16:07:38.4640103Z f28d6a4cf5de: Pulling fs layer
+2025-07-27T16:07:38.4640986Z 49cbdb9e902d: Pulling fs layer
+2025-07-27T16:07:38.4641855Z 247fd41058fa: Pulling fs layer
+2025-07-27T16:07:38.4642708Z d6a01b6e446c: Pulling fs layer
+2025-07-27T16:07:38.4643565Z 4f4fb700ef54: Pulling fs layer
+2025-07-27T16:07:38.4644417Z 1382f2390a1c: Pulling fs layer
+2025-07-27T16:07:38.4645309Z be38403a389e: Pulling fs layer
+2025-07-27T16:07:38.4646522Z 409781d99354: Pulling fs layer
+2025-07-27T16:07:38.4647463Z c418b82685d0: Pulling fs layer
+2025-07-27T16:07:38.4648380Z 4f4fb700ef54: Waiting
+2025-07-27T16:07:38.4649285Z 49cbdb9e902d: Waiting
+2025-07-27T16:07:38.4650281Z 1382f2390a1c: Waiting
+2025-07-27T16:07:38.4651115Z 247fd41058fa: Waiting
+2025-07-27T16:07:38.4651939Z d6a01b6e446c: Waiting
+2025-07-27T16:07:38.4652797Z be38403a389e: Waiting
+2025-07-27T16:07:38.4653639Z 409781d99354: Waiting
+2025-07-27T16:07:38.4654486Z c418b82685d0: Waiting
+2025-07-27T16:07:38.4655343Z bb9f5c709011: Waiting
+2025-07-27T16:07:38.4656205Z c31b5eed60b6: Waiting
+2025-07-27T16:07:38.4657059Z f28d6a4cf5de: Waiting
+2025-07-27T16:07:38.4658069Z da96180e845f: Waiting
+2025-07-27T16:07:38.5713389Z 3c418bbf5534: Verifying Checksum
+2025-07-27T16:07:38.5715260Z 3c418bbf5534: Download complete
+2025-07-27T16:07:38.5959058Z 824b5144f7af: Verifying Checksum
+2025-07-27T16:07:38.5961036Z 824b5144f7af: Download complete
+2025-07-27T16:07:38.7098681Z 32f112e3802c: Verifying Checksum
+2025-07-27T16:07:38.7103301Z 32f112e3802c: Download complete
+2025-07-27T16:07:38.8899232Z c31b5eed60b6: Verifying Checksum
+2025-07-27T16:07:38.8900162Z c31b5eed60b6: Download complete
+2025-07-27T16:07:38.9353675Z da96180e845f: Download complete
+2025-07-27T16:07:38.9844140Z f28d6a4cf5de: Verifying Checksum
+2025-07-27T16:07:38.9847386Z f28d6a4cf5de: Download complete
+2025-07-27T16:07:39.0824745Z 49cbdb9e902d: Verifying Checksum
+2025-07-27T16:07:39.0826300Z 49cbdb9e902d: Download complete
+2025-07-27T16:07:39.0945273Z bb9f5c709011: Verifying Checksum
+2025-07-27T16:07:39.0946942Z bb9f5c709011: Download complete
+2025-07-27T16:07:39.1625162Z d6a01b6e446c: Verifying Checksum
+2025-07-27T16:07:39.1630955Z d6a01b6e446c: Download complete
+2025-07-27T16:07:39.1874721Z 4f4fb700ef54: Verifying Checksum
+2025-07-27T16:07:39.1875223Z 4f4fb700ef54: Download complete
+2025-07-27T16:07:39.6921495Z be38403a389e: Verifying Checksum
+2025-07-27T16:07:39.6922284Z be38403a389e: Download complete
+2025-07-27T16:07:39.8048605Z 409781d99354: Verifying Checksum
+2025-07-27T16:07:39.8059156Z 409781d99354: Download complete
+2025-07-27T16:07:39.8705319Z 247fd41058fa: Verifying Checksum
+2025-07-27T16:07:39.8711825Z 247fd41058fa: Download complete
+2025-07-27T16:07:39.8856204Z c418b82685d0: Verifying Checksum
+2025-07-27T16:07:39.8856718Z c418b82685d0: Download complete
+2025-07-27T16:07:40.2910037Z 32f112e3802c: Pull complete
+2025-07-27T16:07:41.3788859Z 1382f2390a1c: Verifying Checksum
+2025-07-27T16:07:43.8369189Z 3c418bbf5534: Pull complete
+2025-07-27T16:07:43.9263251Z 824b5144f7af: Pull complete
+2025-07-27T16:07:48.0726994Z bb9f5c709011: Pull complete
+2025-07-27T16:07:51.6205442Z c31b5eed60b6: Pull complete
+2025-07-27T16:07:52.6449255Z da96180e845f: Pull complete
+2025-07-27T16:07:52.6960841Z f28d6a4cf5de: Pull complete
+2025-07-27T16:07:52.7359372Z 49cbdb9e902d: Pull complete
+2025-07-27T16:07:58.7324103Z 247fd41058fa: Pull complete
+2025-07-27T16:07:58.7471112Z d6a01b6e446c: Pull complete
+2025-07-27T16:07:58.7559681Z 4f4fb700ef54: Pull complete
+2025-07-27T16:08:13.5187337Z 1382f2390a1c: Pull complete
+2025-07-27T16:08:17.3259131Z be38403a389e: Pull complete
+2025-07-27T16:08:17.4203923Z 409781d99354: Pull complete
+2025-07-27T16:08:17.4297886Z c418b82685d0: Pull complete
+2025-07-27T16:08:17.4339058Z Digest: sha256:2e4f00206b6cc963ec8e1992a24f73997c04ffa4422e711d91522b99e08bdc53
+2025-07-27T16:08:17.4349820Z Status: Downloaded newer image for ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-441-pr-28168
+2025-07-27T16:08:17.4359429Z ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-441-pr-28168
+2025-07-27T16:08:17.4440830Z ##[command]/usr/bin/docker create --name 583f9bb235cb456f9e726402141548ca_ghcriodashcoreautoguixdashdashcorecirunnerbackport026batch441pr28168_8ff915 --label 19fd45 --workdir /__w/dash/dash --network github_network_544409b2d59249139504f245caa863e3 --user root -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" -v "/home/runner/actions-runner/cached/externals":"/__e":ro -v "/home/runner/work/_temp":"/__w/_temp" -v "/home/runner/work/_actions":"/__w/_actions" -v "/opt/hostedtoolcache":"/__t" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-441-pr-28168 "-f" "/dev/null"
+2025-07-27T16:08:17.4681483Z 85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926
+2025-07-27T16:08:17.4704102Z ##[command]/usr/bin/docker start 85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926
+2025-07-27T16:08:17.6184181Z 85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926
+2025-07-27T16:08:17.6204472Z ##[command]/usr/bin/docker ps --all --filter id=85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926 --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2025-07-27T16:08:17.6315216Z 85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926 Up Less than a second
+2025-07-27T16:08:17.6334171Z ##[command]/usr/bin/docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" 85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926
+2025-07-27T16:08:17.6445347Z HOME=/github/home
+2025-07-27T16:08:17.6445695Z GITHUB_ACTIONS=true
+2025-07-27T16:08:17.6445993Z CI=true
+2025-07-27T16:08:17.6446834Z PATH=/opt/shellcheck:/usr/local/pyenv/shims:/usr/local/pyenv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+2025-07-27T16:08:17.6448211Z DEBIAN_FRONTEND=noninteractive
+2025-07-27T16:08:17.6448571Z TZ=Europe/London
+2025-07-27T16:08:17.6448966Z APT_ARGS=-y --no-install-recommends --no-upgrade
+2025-07-27T16:08:17.6449429Z PYENV_ROOT=/usr/local/pyenv
+2025-07-27T16:08:17.6450038Z LD_LIBRARY_PATH=/usr/lib/llvm-18/lib
+2025-07-27T16:08:17.6465848Z ##[endgroup]
+2025-07-27T16:08:17.6474951Z ##[group]Waiting for all services to be ready
+2025-07-27T16:08:17.6476630Z ##[endgroup]
+2025-07-27T16:08:17.6701859Z ##[group]Run actions/checkout@v4
+2025-07-27T16:08:17.6702373Z with:
+2025-07-27T16:08:17.6702552Z   fetch-depth: 50
+2025-07-27T16:08:17.6702749Z   repository: DashCoreAutoGuix/dash
+2025-07-27T16:08:17.6703368Z   token: ***
+2025-07-27T16:08:17.6703545Z   ssh-strict: true
+2025-07-27T16:08:17.6703715Z   ssh-user: git
+2025-07-27T16:08:17.6703898Z   persist-credentials: true
+2025-07-27T16:08:17.6704102Z   clean: true
+2025-07-27T16:08:17.6704287Z   sparse-checkout-cone-mode: true
+2025-07-27T16:08:17.6704508Z   fetch-tags: false
+2025-07-27T16:08:17.6704691Z   show-progress: true
+2025-07-27T16:08:17.6704869Z   lfs: false
+2025-07-27T16:08:17.6705026Z   submodules: false
+2025-07-27T16:08:17.6705201Z   set-safe-directory: true
+2025-07-27T16:08:17.6705625Z ##[endgroup]
+2025-07-27T16:08:17.6824305Z ##[command]/usr/bin/docker exec  85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T16:08:17.8879838Z Syncing repository: DashCoreAutoGuix/dash
+2025-07-27T16:08:17.8881283Z ##[group]Getting Git version info
+2025-07-27T16:08:17.8881691Z Working directory is '/__w/dash/dash'
+2025-07-27T16:08:17.8882472Z [command]/usr/bin/git version
+2025-07-27T16:08:17.8883035Z git version 2.43.0
+2025-07-27T16:08:17.8910978Z ##[endgroup]
+2025-07-27T16:08:17.8926356Z Temporarily overriding HOME='/__w/_temp/0466c9ab-7558-4351-8e98-7f1e3637f28c' before making global git config changes
+2025-07-27T16:08:17.8927214Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-27T16:08:17.8931742Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-27T16:08:17.8964058Z Deleting the contents of '/__w/dash/dash'
+2025-07-27T16:08:17.8968761Z ##[group]Initializing the repository
+2025-07-27T16:08:17.8980735Z [command]/usr/bin/git init /__w/dash/dash
+2025-07-27T16:08:17.9011636Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-07-27T16:08:17.9012362Z hint: is subject to change. To configure the initial branch name to use in all
+2025-07-27T16:08:17.9012837Z hint: of your new repositories, which will suppress this warning, call:
+2025-07-27T16:08:17.9013151Z hint: 
+2025-07-27T16:08:17.9013406Z hint: 	git config --global init.defaultBranch <name>
+2025-07-27T16:08:17.9013691Z hint: 
+2025-07-27T16:08:17.9013942Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-07-27T16:08:17.9014367Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-07-27T16:08:17.9014701Z hint: 
+2025-07-27T16:08:17.9014875Z hint: 	git branch -m <name>
+2025-07-27T16:08:17.9019047Z Initialized empty Git repository in /__w/dash/dash/.git/
+2025-07-27T16:08:17.9030445Z [command]/usr/bin/git remote add origin https://github.com/DashCoreAutoGuix/dash
+2025-07-27T16:08:17.9060314Z ##[endgroup]
+2025-07-27T16:08:17.9060917Z ##[group]Disabling automatic garbage collection
+2025-07-27T16:08:17.9064670Z [command]/usr/bin/git config --local gc.auto 0
+2025-07-27T16:08:17.9091771Z ##[endgroup]
+2025-07-27T16:08:17.9092185Z ##[group]Setting up auth
+2025-07-27T16:08:17.9098528Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-27T16:08:17.9128127Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-27T16:08:17.9338787Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-27T16:08:17.9368533Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-27T16:08:17.9573433Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-07-27T16:08:17.9608508Z ##[endgroup]
+2025-07-27T16:08:17.9609158Z ##[group]Fetching the repository
+2025-07-27T16:08:17.9618597Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=50 origin +9e6db0326f9d12ed12714a56c8f415305305f906:refs/remotes/origin/backport-0.26-batch-441-pr-28168
+2025-07-27T16:08:19.9909293Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-27T16:08:19.9910325Z  * [new ref]         9e6db0326f9d12ed12714a56c8f415305305f906 -> origin/backport-0.26-batch-441-pr-28168
+2025-07-27T16:08:19.9932652Z ##[endgroup]
+2025-07-27T16:08:19.9933219Z ##[group]Determining the checkout info
+2025-07-27T16:08:19.9934601Z ##[endgroup]
+2025-07-27T16:08:19.9941191Z [command]/usr/bin/git sparse-checkout disable
+2025-07-27T16:08:19.9979846Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-07-27T16:08:20.0006039Z ##[group]Checking out the ref
+2025-07-27T16:08:20.0010640Z [command]/usr/bin/git checkout --progress --force -B backport-0.26-batch-441-pr-28168 refs/remotes/origin/backport-0.26-batch-441-pr-28168
+2025-07-27T16:08:20.3848286Z Switched to a new branch 'backport-0.26-batch-441-pr-28168'
+2025-07-27T16:08:20.3848980Z branch 'backport-0.26-batch-441-pr-28168' set up to track 'origin/backport-0.26-batch-441-pr-28168'.
+2025-07-27T16:08:20.3873946Z ##[endgroup]
+2025-07-27T16:08:20.3922702Z [command]/usr/bin/git log -1 --format=%H
+2025-07-27T16:08:20.3945771Z 9e6db0326f9d12ed12714a56c8f415305305f906
+2025-07-27T16:08:20.4171708Z ##[group]Run git config --global --add safe.directory "$PWD"
+2025-07-27T16:08:20.4172174Z [36;1mgit config --global --add safe.directory "$PWD"[0m
+2025-07-27T16:08:20.4172538Z [36;1mgit fetch -fu origin develop:develop[0m
+2025-07-27T16:08:20.4172820Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-27T16:08:20.4173054Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-27T16:08:20.4173299Z [36;1mecho "HOST=${HOST}" >> $GITHUB_OUTPUT[0m
+2025-07-27T16:08:20.4173572Z [36;1mecho "PR_BASE_SHA=" >> $GITHUB_OUTPUT[0m
+2025-07-27T16:08:20.4177430Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-27T16:08:20.4177731Z ##[endgroup]
+2025-07-27T16:08:20.6745770Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-27T16:08:20.6746451Z  * [new branch]      develop    -> develop
+2025-07-27T16:08:20.6746900Z  * [new branch]      develop    -> origin/develop
+2025-07-27T16:08:20.6830575Z Setting specific values in env
+2025-07-27T16:08:20.6831543Z Fallback to default values in env (if not yet set)
+2025-07-27T16:08:20.7324694Z ##[group]Run actions/cache/restore@v4
+2025-07-27T16:08:20.7324952Z with:
+2025-07-27T16:08:20.7325169Z   path: depends/built
+depends/x86_64-pc-linux-gnu
+
+2025-07-27T16:08:20.7326182Z   key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-27T16:08:20.7327152Z   fail-on-cache-miss: true
+2025-07-27T16:08:20.7327384Z   enableCrossOsArchive: false
+2025-07-27T16:08:20.7327592Z   lookup-only: false
+2025-07-27T16:08:20.7327779Z ##[endgroup]
+2025-07-27T16:08:20.7331495Z ##[command]/usr/bin/docker exec  85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T16:08:21.1303450Z Cache hit for: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-27T16:08:22.2069438Z Received 90046447 of 90046447 (100.0%), 92.5 MBs/sec
+2025-07-27T16:08:22.2071342Z Cache Size: ~86 MB (90046447 B)
+2025-07-27T16:08:22.2098207Z [command]/usr/bin/tar -xf /__w/_temp/6ea302fa-b407-4112-9ba6-54446931f919/cache.tzst -P -C /__w/dash/dash --use-compress-program unzstd
+2025-07-27T16:08:23.4726764Z Cache restored successfully
+2025-07-27T16:08:23.4962331Z Cache restored from key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-27T16:08:23.6575907Z ##[group]Run actions/cache@v4
+2025-07-27T16:08:23.6576149Z with:
+2025-07-27T16:08:23.6576320Z   path: /cache
+
+2025-07-27T16:08:23.6576847Z   key: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-9e6db0326f9d12ed12714a56c8f415305305f906
+2025-07-27T16:08:23.6577868Z   restore-keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-
+
+2025-07-27T16:08:23.6578317Z   enableCrossOsArchive: false
+2025-07-27T16:08:23.6578548Z   fail-on-cache-miss: false
+2025-07-27T16:08:23.6578753Z   lookup-only: false
+2025-07-27T16:08:23.6578932Z   save-always: false
+2025-07-27T16:08:23.6579109Z ##[endgroup]
+2025-07-27T16:08:23.6583584Z ##[command]/usr/bin/docker exec  85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T16:08:24.0130800Z Cache not found for input keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-9e6db0326f9d12ed12714a56c8f415305305f906, ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-
+2025-07-27T16:08:24.0236670Z ##[group]Run CCACHE_SIZE="400M"
+2025-07-27T16:08:24.0236951Z [36;1mCCACHE_SIZE="400M"[0m
+2025-07-27T16:08:24.0237181Z [36;1mCACHE_DIR="/cache"[0m
+2025-07-27T16:08:24.0237386Z [36;1mmkdir /output[0m
+2025-07-27T16:08:24.0237589Z [36;1mBASE_OUTDIR="/output"[0m
+2025-07-27T16:08:24.0237805Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-27T16:08:24.0238041Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-27T16:08:24.0238274Z [36;1m./ci/dash/build_src.sh[0m
+2025-07-27T16:08:24.0238490Z [36;1mccache -X 9[0m
+2025-07-27T16:08:24.0238681Z [36;1mccache -c[0m
+2025-07-27T16:08:24.0239018Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-27T16:08:24.0239283Z ##[endgroup]
+2025-07-27T16:08:24.0893471Z Setting specific values in env
+2025-07-27T16:08:24.0893985Z Fallback to default values in env (if not yet set)
+2025-07-27T16:08:24.1267225Z Setting specific values in env
+2025-07-27T16:08:24.1267733Z Fallback to default values in env (if not yet set)
+2025-07-27T16:08:24.2007882Z Statistics zeroed
+2025-07-27T16:08:24.2008163Z Set cache size limit to 400.0 MB
+2025-07-27T16:08:29.1376572Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-27T16:08:29.1377513Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-27T16:08:29.1621056Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-27T16:08:29.1621757Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-27T16:08:29.1892695Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-27T16:08:29.2170655Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-27T16:08:29.2451091Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-27T16:08:29.2729079Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-27T16:08:31.2920117Z configure.ac:38: installing 'build-aux/compile'
+2025-07-27T16:08:31.2937874Z configure.ac:12: installing 'build-aux/config.guess'
+2025-07-27T16:08:31.2956052Z configure.ac:12: installing 'build-aux/config.sub'
+2025-07-27T16:08:31.2973972Z configure.ac:17: installing 'build-aux/install-sh'
+2025-07-27T16:08:31.2992958Z configure.ac:17: installing 'build-aux/missing'
+2025-07-27T16:08:31.3618573Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-27T16:08:33.7054995Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-27T16:08:33.7055711Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-27T16:08:33.7290108Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-27T16:08:33.7290825Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-27T16:08:33.7493457Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-27T16:08:33.7707357Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-27T16:08:33.7918467Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-27T16:08:33.8128018Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-27T16:08:35.2614986Z configure.ac:39: installing 'build-aux/ar-lib'
+2025-07-27T16:08:35.2632605Z configure.ac:37: installing 'build-aux/compile'
+2025-07-27T16:08:35.2651141Z configure.ac:24: installing 'build-aux/config.guess'
+2025-07-27T16:08:35.2669082Z configure.ac:24: installing 'build-aux/config.sub'
+2025-07-27T16:08:35.2686794Z configure.ac:27: installing 'build-aux/install-sh'
+2025-07-27T16:08:35.2705629Z configure.ac:27: installing 'build-aux/missing'
+2025-07-27T16:08:35.3037371Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-27T16:08:35.3370124Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-27T16:08:35.4309810Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-27T16:08:35.4310534Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-27T16:08:35.4566227Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-27T16:08:35.4567042Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-27T16:08:35.4993290Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-27T16:08:35.5423869Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-27T16:08:35.5858048Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-27T16:08:35.6294417Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-27T16:08:38.2199054Z configure.ac:105: installing 'build-aux/compile'
+2025-07-27T16:08:38.2217560Z configure.ac:48: installing 'build-aux/config.guess'
+2025-07-27T16:08:38.2236362Z configure.ac:48: installing 'build-aux/config.sub'
+2025-07-27T16:08:38.2254057Z configure.ac:55: installing 'build-aux/install-sh'
+2025-07-27T16:08:38.2272072Z configure.ac:55: installing 'build-aux/missing'
+2025-07-27T16:08:38.4738191Z src/Makefile.am: installing 'build-aux/depcomp'
+2025-07-27T16:08:41.0168969Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-27T16:08:41.2102175Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T16:08:41.2177463Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-27T16:08:41.2191192Z checking pkg-config is at least version 0.9.0... yes
+2025-07-27T16:08:41.2633021Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T16:08:41.2680843Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T16:08:41.2760713Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T16:08:41.2788814Z checking whether build environment is sane... yes
+2025-07-27T16:08:41.2849040Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T16:08:41.2870227Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T16:08:41.2874554Z checking for gawk... gawk
+2025-07-27T16:08:41.2940443Z checking whether make sets $(MAKE)... yes
+2025-07-27T16:08:41.2992729Z checking whether make supports nested variables... yes
+2025-07-27T16:08:41.3035645Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-27T16:08:41.3038386Z checking whether make supports nested variables... (cached) yes
+2025-07-27T16:08:41.3589479Z checking whether the C++ compiler works... yes
+2025-07-27T16:08:41.3590353Z checking for C++ compiler default output file name... a.out
+2025-07-27T16:08:41.3910839Z checking for suffix of executables... 
+2025-07-27T16:08:41.4360533Z checking whether we are cross compiling... no
+2025-07-27T16:08:41.4527052Z checking for suffix of object files... o
+2025-07-27T16:08:41.4669935Z checking whether the compiler supports GNU C++... yes
+2025-07-27T16:08:41.4826652Z checking whether g++ -m64 accepts -g... yes
+2025-07-27T16:08:41.7661999Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-27T16:08:41.8135455Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-27T16:08:41.8210235Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T16:08:41.8213567Z checking dependency style of g++ -m64... none
+2025-07-27T16:08:41.9005752Z checking whether g++ -m64 supports C++20 features with -std=c++20... yes
+2025-07-27T16:08:41.9008526Z checking for x86_64-pc-linux-gnu-g++... g++ -m64 -std=c++20
+2025-07-27T16:08:41.9296498Z checking whether the compiler supports GNU Objective C++... no
+2025-07-27T16:08:41.9571489Z checking whether g++ -m64 -std=c++20 accepts -g... no
+2025-07-27T16:08:41.9575459Z checking dependency style of g++ -m64 -std=c++20... none
+2025-07-27T16:08:41.9600704Z checking how to print strings... printf
+2025-07-27T16:08:41.9603051Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T16:08:41.9980922Z checking whether the compiler supports GNU C... yes
+2025-07-27T16:08:42.0130944Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T16:08:42.0476311Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T16:08:42.0748083Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T16:08:42.0751168Z checking dependency style of gcc -m64... none
+2025-07-27T16:08:42.0790374Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T16:08:42.0821819Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T16:08:42.0837307Z checking for egrep... /usr/bin/grep -E
+2025-07-27T16:08:42.0853140Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T16:08:42.0900873Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T16:08:42.0925287Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T16:08:42.0927445Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T16:08:42.1216578Z checking the name lister (nm) interface... BSD nm
+2025-07-27T16:08:42.1217114Z checking whether ln -s works... yes
+2025-07-27T16:08:42.1259477Z checking the maximum length of command line arguments... 3145728
+2025-07-27T16:08:42.1286428Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T16:08:42.1288026Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T16:08:42.1289380Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T16:08:42.1295508Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T16:08:42.1300625Z checking for file... file
+2025-07-27T16:08:42.1332613Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T16:08:42.1334004Z checking for objdump... objdump
+2025-07-27T16:08:42.1334529Z checking how to recognize dependent libraries... pass_all
+2025-07-27T16:08:42.1335070Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T16:08:42.1335488Z checking for dlltool... no
+2025-07-27T16:08:42.1335945Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T16:08:42.1336426Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T16:08:42.1672071Z checking for archiver @FILE support... @
+2025-07-27T16:08:42.1673461Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T16:08:42.1676070Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T16:08:42.2340350Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T16:08:42.2357867Z checking for sysroot... no
+2025-07-27T16:08:42.2401710Z checking for a working dd... /usr/bin/dd
+2025-07-27T16:08:42.2439891Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T16:08:42.2544454Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T16:08:42.2550206Z checking for mt... no
+2025-07-27T16:08:42.2580344Z checking if : is a manifest tool... no
+2025-07-27T16:08:42.2727195Z checking for stdio.h... yes
+2025-07-27T16:08:42.2890006Z checking for stdlib.h... yes
+2025-07-27T16:08:42.3055861Z checking for string.h... yes
+2025-07-27T16:08:42.3230821Z checking for inttypes.h... yes
+2025-07-27T16:08:42.3404683Z checking for stdint.h... yes
+2025-07-27T16:08:42.3584593Z checking for strings.h... yes
+2025-07-27T16:08:42.3764967Z checking for sys/stat.h... yes
+2025-07-27T16:08:42.3945766Z checking for sys/types.h... yes
+2025-07-27T16:08:42.4147955Z checking for unistd.h... yes
+2025-07-27T16:08:42.4354118Z checking for dlfcn.h... yes
+2025-07-27T16:08:42.4392680Z checking for objdir... .libs
+2025-07-27T16:08:42.4970894Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T16:08:42.4971888Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T16:08:42.5103933Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T16:08:42.5662196Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T16:08:42.5872141Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T16:08:42.5872780Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T16:08:42.5966275Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T16:08:42.6168311Z checking whether -lc should be explicitly linked in... no
+2025-07-27T16:08:42.6645390Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T16:08:42.6646228Z checking how to hardcode library paths into programs... immediate
+2025-07-27T16:08:42.6663506Z checking whether stripping libraries is possible... yes
+2025-07-27T16:08:42.6664506Z checking if libtool supports shared libraries... yes
+2025-07-27T16:08:42.6668985Z checking whether to build shared libraries... yes
+2025-07-27T16:08:42.6669997Z checking whether to build static libraries... yes
+2025-07-27T16:08:42.6926165Z checking how to run the C++ preprocessor... g++ -m64 -std=c++20 -E
+2025-07-27T16:08:42.7664736Z checking for ld used by g++ -m64 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-27T16:08:42.7689826Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-27T16:08:42.7760188Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T16:08:42.8352824Z checking for g++ -m64 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-27T16:08:42.8502388Z checking if g++ -m64 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-27T16:08:42.9083353Z checking if g++ -m64 -std=c++20 static flag -static works... yes
+2025-07-27T16:08:42.9308927Z checking if g++ -m64 -std=c++20 supports -c -o file.o... yes
+2025-07-27T16:08:42.9310206Z checking if g++ -m64 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-27T16:08:42.9312082Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T16:08:42.9358303Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-27T16:08:42.9361232Z checking how to hardcode library paths into programs... immediate
+2025-07-27T16:08:42.9367067Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-27T16:08:42.9373401Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-27T16:08:42.9378304Z checking for gcov... /usr/bin/gcov
+2025-07-27T16:08:42.9383466Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-27T16:08:42.9389081Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-27T16:08:42.9394202Z checking for lcov... no
+2025-07-27T16:08:42.9397731Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-27T16:08:42.9402921Z checking for genhtml... no
+2025-07-27T16:08:42.9406433Z checking for git... /usr/bin/git
+2025-07-27T16:08:42.9410126Z checking for ccache... /usr/bin/ccache
+2025-07-27T16:08:42.9414741Z checking for xgettext... /usr/bin/xgettext
+2025-07-27T16:08:42.9419135Z checking for hexdump... /usr/bin/hexdump
+2025-07-27T16:08:42.9424723Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-27T16:08:42.9429451Z checking for objcopy... /usr/bin/objcopy
+2025-07-27T16:08:42.9433900Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T16:08:42.9438271Z checking for objdump... /usr/bin/objdump
+2025-07-27T16:08:42.9443356Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-27T16:08:42.9448848Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-27T16:08:42.9453640Z checking for doxygen... no
+2025-07-27T16:08:42.9606213Z checking whether C++ compiler accepts -Werror... yes
+2025-07-27T16:08:42.9958842Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-27T16:08:43.0388357Z checking for execinfo.h... yes
+2025-07-27T16:08:43.0744165Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-27T16:08:43.0941208Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-27T16:08:43.1114891Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-27T16:08:43.1285261Z checking whether C++ compiler accepts -Wdangling-reference... yes
+2025-07-27T16:08:43.1454652Z checking whether C++ compiler accepts -Wattributes... yes
+2025-07-27T16:08:43.1626546Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-27T16:08:43.1795635Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-27T16:08:43.1965190Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-27T16:08:43.2137261Z checking whether C++ compiler accepts -Wall... yes
+2025-07-27T16:08:43.2308616Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-27T16:08:43.2446823Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-27T16:08:43.2623208Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-27T16:08:43.2794966Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-27T16:08:43.2968029Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-27T16:08:43.3141811Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-27T16:08:43.3339464Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-27T16:08:43.3533947Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-27T16:08:43.3713374Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-27T16:08:43.3961559Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-27T16:08:43.4139365Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-27T16:08:43.4409882Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-27T16:08:43.4587048Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-27T16:08:43.4765080Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-27T16:08:43.4939655Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-27T16:08:43.5112917Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-27T16:08:43.5285146Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-27T16:08:43.5464089Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-27T16:08:43.5645033Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-27T16:08:43.5845078Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-27T16:08:43.6021195Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-27T16:08:43.6203322Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-27T16:08:43.6386088Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-27T16:08:43.6540049Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-27T16:08:43.6716023Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-27T16:08:43.6889409Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-27T16:08:43.7064730Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-27T16:08:43.7235430Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-27T16:08:44.1898864Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-27T16:08:44.2349863Z checking for SSE4.2 intrinsics... yes
+2025-07-27T16:08:44.6788810Z checking for SSE4.1 intrinsics... yes
+2025-07-27T16:08:45.1082632Z checking for AVX2 intrinsics... yes
+2025-07-27T16:08:45.5522833Z checking for x86 SHA-NI intrinsics... yes
+2025-07-27T16:08:45.5693909Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-27T16:08:45.5850363Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-27T16:08:45.5995199Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-27T16:08:45.6145202Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-27T16:08:45.6980368Z checking whether byte ordering is bigendian... no
+2025-07-27T16:08:45.7206534Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-27T16:08:45.7517554Z checking whether gcc -m64 is Clang... no
+2025-07-27T16:08:45.7975753Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-27T16:08:45.8339728Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-27T16:08:45.8340635Z checking whether more special flags are required for pthreads... no
+2025-07-27T16:08:45.8703361Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-27T16:08:46.7055919Z checking whether std::atomic can be used without link library... yes
+2025-07-27T16:08:46.7064312Z checking for special C compiler options needed for large files... no
+2025-07-27T16:08:46.7256274Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-27T16:08:46.7572911Z checking for g++ -m64 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-27T16:08:46.8073796Z checking whether strerror_r is declared... yes
+2025-07-27T16:08:46.8297762Z checking whether strerror_r returns char *... yes
+2025-07-27T16:08:46.8447345Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-27T16:08:46.8597655Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-27T16:08:46.8744649Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-27T16:08:46.8884145Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-27T16:08:46.9050692Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-27T16:08:46.9134856Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-27T16:08:46.9215999Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-27T16:08:46.9467147Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-27T16:08:46.9720753Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-27T16:08:46.9970318Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-27T16:08:47.0223080Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-27T16:08:47.0602454Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-27T16:08:47.0979269Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-27T16:08:47.1357089Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-27T16:08:47.1729288Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-27T16:08:47.2153617Z checking for sys/select.h... yes
+2025-07-27T16:08:47.2573897Z checking for sys/prctl.h... yes
+2025-07-27T16:08:47.2885454Z checking for vm/vm_param.h... no
+2025-07-27T16:08:47.3193085Z checking for sys/vmmeter.h... no
+2025-07-27T16:08:47.3501338Z checking for sys/resources.h... no
+2025-07-27T16:08:47.3782637Z checking whether getifaddrs is declared... yes
+2025-07-27T16:08:47.4218486Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-27T16:08:47.4499907Z checking whether freeifaddrs is declared... yes
+2025-07-27T16:08:47.4940647Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-27T16:08:47.5461167Z checking whether fork is declared... yes
+2025-07-27T16:08:47.5965735Z checking whether setsid is declared... yes
+2025-07-27T16:08:47.6468449Z checking whether pipe2 is declared... yes
+2025-07-27T16:08:47.6701236Z checking for mallopt M_ARENA_MAX... yes
+2025-07-27T16:08:47.6937742Z checking for getmemoryinfo... yes
+2025-07-27T16:08:47.7135257Z checking for posix_fallocate... yes
+2025-07-27T16:08:47.7283089Z checking for default visibility attribute... yes
+2025-07-27T16:08:47.7432562Z checking for dllexport attribute... no
+2025-07-27T16:08:48.2258150Z checking for thread_local support... yes
+2025-07-27T16:08:48.2544887Z checking for Linux getrandom syscall... yes
+2025-07-27T16:08:48.2862806Z checking for getentropy via random.h... yes
+2025-07-27T16:08:48.3058363Z checking for sysctl... no
+2025-07-27T16:08:48.3251181Z checking for sysctl KERN_ARND... no
+2025-07-27T16:08:48.3618021Z checking for library containing backtrace... none required
+2025-07-27T16:08:48.3858890Z checking for fdatasync... yes
+2025-07-27T16:08:48.4060726Z checking for F_FULLFSYNC... no
+2025-07-27T16:08:48.4265878Z checking for O_CLOEXEC... yes
+2025-07-27T16:08:48.4423167Z checking for __builtin_prefetch... yes
+2025-07-27T16:08:48.4821084Z checking for _mm_prefetch... yes
+2025-07-27T16:08:48.5020229Z checking for strong getauxval support in the system headers... yes
+2025-07-27T16:08:48.5288425Z checking for sockaddr_un... yes
+2025-07-27T16:08:48.5755617Z checking for std::system... yes
+2025-07-27T16:08:48.6041032Z checking for ::_wsystem... no
+2025-07-27T16:08:48.6206664Z checking for Qt5Core >= 5.11.3... yes
+2025-07-27T16:08:48.6315652Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-27T16:08:48.6424264Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-27T16:08:48.6532130Z checking for Qt5Network >= 5.11.3... yes
+2025-07-27T16:08:48.6640005Z checking for Qt5Test >= 5.11.3... yes
+2025-07-27T16:08:48.6748700Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-27T16:08:48.8859716Z checking for static Qt... yes
+2025-07-27T16:08:48.8972539Z checking for Qt5AccessibilitySupport... yes
+2025-07-27T16:08:48.9082566Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-27T16:08:48.9190335Z checking for Qt5EdidSupport... yes
+2025-07-27T16:08:48.9301879Z checking for Qt5EventDispatcherSupport... yes
+2025-07-27T16:08:48.9412344Z checking for Qt5FbSupport... yes
+2025-07-27T16:08:48.9524305Z checking for Qt5FontDatabaseSupport... yes
+2025-07-27T16:08:48.9635243Z checking for Qt5ThemeSupport... yes
+2025-07-27T16:08:48.9747812Z checking for Qt5InputSupport... yes
+2025-07-27T16:08:48.9862331Z checking for Qt5ServiceSupport... yes
+2025-07-27T16:08:48.9989380Z checking for Qt5XcbQpa... yes
+2025-07-27T16:08:49.0102914Z checking for Qt5XkbCommonSupport... yes
+2025-07-27T16:08:51.0101614Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-27T16:08:53.0867851Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-27T16:08:53.3006970Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-27T16:08:53.3019668Z checking for moc-qt5... no
+2025-07-27T16:08:53.3020612Z checking for moc5... no
+2025-07-27T16:08:53.3022953Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-27T16:08:53.3024855Z checking for uic-qt5... no
+2025-07-27T16:08:53.3025464Z checking for uic5... no
+2025-07-27T16:08:53.3027224Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-27T16:08:53.3028558Z checking for rcc-qt5... no
+2025-07-27T16:08:53.3030168Z checking for rcc5... no
+2025-07-27T16:08:53.3032359Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-27T16:08:53.3034007Z checking for lrelease-qt5... no
+2025-07-27T16:08:53.3034782Z checking for lrelease5... no
+2025-07-27T16:08:53.3037260Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-27T16:08:53.3038750Z checking for lupdate-qt5... no
+2025-07-27T16:08:53.3040765Z checking for lupdate5... no
+2025-07-27T16:08:53.3042873Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-27T16:08:53.3044962Z checking for lconvert-qt5... no
+2025-07-27T16:08:53.3045524Z checking for lconvert5... no
+2025-07-27T16:08:53.3047345Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-27T16:08:53.3078255Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-27T16:08:53.3079195Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-27T16:08:54.1914516Z checking for Berkeley DB C++ headers... default
+2025-07-27T16:08:54.2318271Z checking for main in -ldb_cxx-4.8... yes
+2025-07-27T16:08:54.2468175Z checking for sqlite3 >= 3.7.17... yes
+2025-07-27T16:08:54.2468800Z checking whether to build wallet with support for sqlite... yes
+2025-07-27T16:08:54.2660209Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-27T16:08:54.3144060Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-27T16:08:54.3548959Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-27T16:08:54.3998903Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-27T16:08:54.4037391Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-27T16:08:54.4484123Z checking for miniupnpc/upnperrors.h... yes
+2025-07-27T16:08:54.4522629Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-27T16:08:54.4603726Z checking whether miniUPnPc API version is supported... yes
+2025-07-27T16:08:54.5085648Z checking for natpmp.h... yes
+2025-07-27T16:08:54.5441490Z checking for initnatpmp in -lnatpmp... yes
+2025-07-27T16:08:54.5518624Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-27T16:08:54.5521082Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-27T16:08:54.5522220Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-27T16:08:54.5523685Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-27T16:08:54.5524617Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-27T16:08:54.5663459Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-27T16:08:54.5947225Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-27T16:08:57.4301695Z checking for Boost Process... yes
+2025-07-27T16:08:57.4516364Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-27T16:08:57.4893267Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-27T16:08:57.5152548Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-27T16:08:57.5272410Z checking for libevent >= 2.1.8... yes
+2025-07-27T16:08:57.5386287Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-27T16:08:57.5720656Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-27T16:08:57.5847041Z checking for libqrencode... yes
+2025-07-27T16:08:57.5962037Z checking for libzmq >= 4... yes
+2025-07-27T16:08:57.6537710Z checking for gmp.h... yes
+2025-07-27T16:08:57.6900015Z checking for __gmpz_init in -lgmp... yes
+2025-07-27T16:08:57.7015241Z checking for libmultiprocess... no
+2025-07-27T16:08:57.7094437Z checking whether to build dashd... yes
+2025-07-27T16:08:57.7096995Z checking whether to build dash-cli... yes
+2025-07-27T16:08:57.7097520Z checking whether to build dash-tx... yes
+2025-07-27T16:08:57.7098000Z checking whether to build dash-wallet... yes
+2025-07-27T16:08:57.7099309Z checking whether to build libraries... no
+2025-07-27T16:08:57.7101632Z checking if ccache should be used... yes
+2025-07-27T16:08:57.7371995Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-27T16:08:57.7483960Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-27T16:08:57.7485571Z checking if wallet should be enabled... yes
+2025-07-27T16:08:57.7487762Z checking whether to build with support for UPnP... yes
+2025-07-27T16:08:57.7489239Z checking whether to build with support for NAT-PMP... yes
+2025-07-27T16:08:57.7492919Z checking whether to build GUI with support for D-Bus... yes
+2025-07-27T16:08:57.7494156Z checking whether to build GUI with support for QR codes... yes
+2025-07-27T16:08:57.7496627Z checking whether to build test_dash-qt... yes
+2025-07-27T16:08:57.7497683Z checking whether to build test_dash... yes
+2025-07-27T16:08:57.7498157Z checking whether to reduce exports... yes
+2025-07-27T16:08:57.7628689Z checking whether dsymutil needs -flat... yes
+2025-07-27T16:08:57.7629284Z 
+2025-07-27T16:08:57.8060347Z checking that generated files are newer than configure... done
+2025-07-27T16:08:57.8067514Z configure: creating ./config.status
+2025-07-27T16:08:58.4486722Z config.status: creating Makefile
+2025-07-27T16:08:58.4610820Z config.status: creating src/Makefile
+2025-07-27T16:08:58.5182692Z config.status: creating doc/man/Makefile
+2025-07-27T16:08:58.5342405Z config.status: creating share/setup.nsi
+2025-07-27T16:08:58.5505301Z config.status: creating share/qt/Info.plist
+2025-07-27T16:08:58.5666746Z config.status: creating test/config.ini
+2025-07-27T16:08:58.5825868Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-27T16:08:58.5993560Z config.status: creating src/config/bitcoin-config.h
+2025-07-27T16:08:58.6163736Z config.status: linking ../contrib/filter-lcov.py to contrib/filter-lcov.py
+2025-07-27T16:08:58.6227799Z config.status: linking ../src/.bear-tidy-config to src/.bear-tidy-config
+2025-07-27T16:08:58.6291403Z config.status: linking ../src/.clang-tidy to src/.clang-tidy
+2025-07-27T16:08:58.6366387Z config.status: linking ../test/functional/test_runner.py to test/functional/test_runner.py
+2025-07-27T16:08:58.6441917Z config.status: linking ../test/fuzz/test_runner.py to test/fuzz/test_runner.py
+2025-07-27T16:08:58.6515467Z config.status: linking ../test/util/test_runner.py to test/util/test_runner.py
+2025-07-27T16:08:58.6580613Z config.status: linking ../test/util/rpcauth-test.py to test/util/rpcauth-test.py
+2025-07-27T16:08:58.6610792Z config.status: executing depfiles commands
+2025-07-27T16:08:58.6624136Z config.status: executing libtool commands
+2025-07-27T16:08:58.6739905Z === configuring in src/dashbls (/__w/dash/dash/build-ci/src/dashbls)
+2025-07-27T16:08:58.6794829Z configure: running /bin/bash ../../../src/dashbls/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/dashbls
+2025-07-27T16:08:58.7958018Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T16:08:58.8448082Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T16:08:58.8495316Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T16:08:58.8573612Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T16:08:58.8601893Z checking whether build environment is sane... yes
+2025-07-27T16:08:58.8662705Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T16:08:58.8683111Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T16:08:58.8686934Z checking for gawk... gawk
+2025-07-27T16:08:58.8749800Z checking whether make sets $(MAKE)... yes
+2025-07-27T16:08:58.8801145Z checking whether make supports nested variables... yes
+2025-07-27T16:08:58.8842949Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-27T16:08:58.8844563Z checking whether make supports nested variables... (cached) yes
+2025-07-27T16:08:58.8847342Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T16:08:58.9392702Z checking whether the C compiler works... yes
+2025-07-27T16:08:58.9393146Z checking for C compiler default output file name... a.out
+2025-07-27T16:08:58.9679858Z checking for suffix of executables... 
+2025-07-27T16:08:59.0034711Z checking whether we are cross compiling... no
+2025-07-27T16:08:59.0189828Z checking for suffix of object files... o
+2025-07-27T16:08:59.0323914Z checking whether the compiler supports GNU C... yes
+2025-07-27T16:08:59.0472238Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T16:08:59.0826924Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T16:08:59.1091745Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T16:08:59.1164938Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T16:08:59.1168531Z checking dependency style of gcc -m64... none
+2025-07-27T16:08:59.1504607Z checking whether the compiler supports GNU C++... yes
+2025-07-27T16:08:59.1662957Z checking whether g++ -m64 accepts -g... yes
+2025-07-27T16:08:59.4463661Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-27T16:08:59.4931790Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-27T16:08:59.4934632Z checking dependency style of g++ -m64... none
+2025-07-27T16:08:59.5319830Z checking whether g++ -m64 supports C++14 features with -std=c++14... yes
+2025-07-27T16:08:59.5343734Z checking how to print strings... printf
+2025-07-27T16:08:59.5381818Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T16:08:59.5410652Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T16:08:59.5425567Z checking for egrep... /usr/bin/grep -E
+2025-07-27T16:08:59.5440217Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T16:08:59.5486768Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T16:08:59.5510658Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T16:08:59.5512581Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T16:08:59.5792276Z checking the name lister (nm) interface... BSD nm
+2025-07-27T16:08:59.5793112Z checking whether ln -s works... yes
+2025-07-27T16:08:59.5834984Z checking the maximum length of command line arguments... 3145728
+2025-07-27T16:08:59.5861555Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T16:08:59.5862670Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T16:08:59.5863491Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T16:08:59.5867751Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T16:08:59.5872568Z checking for file... file
+2025-07-27T16:08:59.5876543Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T16:08:59.5880909Z checking for objdump... objdump
+2025-07-27T16:08:59.5885180Z checking how to recognize dependent libraries... pass_all
+2025-07-27T16:08:59.5889303Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T16:08:59.5893852Z checking for dlltool... no
+2025-07-27T16:08:59.5895504Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T16:08:59.5897106Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T16:08:59.6225617Z checking for archiver @FILE support... @
+2025-07-27T16:08:59.6226700Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T16:08:59.6232412Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T16:08:59.6892563Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T16:08:59.6908330Z checking for sysroot... no
+2025-07-27T16:08:59.6949314Z checking for a working dd... /usr/bin/dd
+2025-07-27T16:08:59.6987475Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T16:08:59.7086466Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T16:08:59.7091375Z checking for mt... no
+2025-07-27T16:08:59.7122025Z checking if : is a manifest tool... no
+2025-07-27T16:08:59.7266005Z checking for stdio.h... yes
+2025-07-27T16:08:59.7422260Z checking for stdlib.h... yes
+2025-07-27T16:08:59.7585188Z checking for string.h... yes
+2025-07-27T16:08:59.7755871Z checking for inttypes.h... yes
+2025-07-27T16:08:59.7927210Z checking for stdint.h... yes
+2025-07-27T16:08:59.8098499Z checking for strings.h... yes
+2025-07-27T16:08:59.8274145Z checking for sys/stat.h... yes
+2025-07-27T16:08:59.8451172Z checking for sys/types.h... yes
+2025-07-27T16:08:59.8650026Z checking for unistd.h... yes
+2025-07-27T16:08:59.8852914Z checking for dlfcn.h... yes
+2025-07-27T16:08:59.8887211Z checking for objdir... .libs
+2025-07-27T16:08:59.9467004Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T16:08:59.9467781Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T16:08:59.9600306Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T16:09:00.0169350Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T16:09:00.0383017Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T16:09:00.0383675Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T16:09:00.0477453Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T16:09:00.0954183Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T16:09:00.0955933Z checking how to hardcode library paths into programs... immediate
+2025-07-27T16:09:00.0972231Z checking whether stripping libraries is possible... yes
+2025-07-27T16:09:00.0972985Z checking if libtool supports shared libraries... yes
+2025-07-27T16:09:00.0973941Z checking whether to build shared libraries... no
+2025-07-27T16:09:00.0974490Z checking whether to build static libraries... yes
+2025-07-27T16:09:00.1226741Z checking how to run the C++ preprocessor... g++ -m64 -std=c++14 -E
+2025-07-27T16:09:00.1948147Z checking for ld used by g++ -m64 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-27T16:09:00.1972456Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-27T16:09:00.2042091Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T16:09:00.2627423Z checking for g++ -m64 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-27T16:09:00.2777806Z checking if g++ -m64 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-27T16:09:00.3351112Z checking if g++ -m64 -std=c++14 static flag -static works... yes
+2025-07-27T16:09:00.3571146Z checking if g++ -m64 -std=c++14 supports -c -o file.o... yes
+2025-07-27T16:09:00.3572546Z checking if g++ -m64 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-27T16:09:00.3574184Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T16:09:00.3619367Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-27T16:09:00.3620786Z checking how to hardcode library paths into programs... immediate
+2025-07-27T16:09:00.3627627Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-27T16:09:00.3634262Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-27T16:09:00.3636206Z checking for ranlib... (cached) ranlib
+2025-07-27T16:09:00.3641611Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-27T16:09:00.3643619Z checking for strip... (cached) strip
+2025-07-27T16:09:00.3646773Z checking dependency style of gcc -m64... none
+2025-07-27T16:09:00.3788954Z checking whether C compiler accepts -Werror... yes
+2025-07-27T16:09:00.4032196Z checking for gmp.h... yes
+2025-07-27T16:09:00.4340711Z checking for __gmpz_init in -lgmp... yes
+2025-07-27T16:09:00.4512056Z checking gmp version >= 6.2... yes
+2025-07-27T16:09:00.4538765Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-27T16:09:00.4550965Z checking pkg-config is at least version 0.9.0... yes
+2025-07-27T16:09:00.4637654Z checking if gcc -m64 supports -pipe... yes
+2025-07-27T16:09:00.4732293Z checking if gcc -m64 supports -fomit-frame-pointer... yes
+2025-07-27T16:09:00.4972687Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-27T16:09:00.5267003Z checking whether gcc -m64 is Clang... no
+2025-07-27T16:09:00.5700148Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-27T16:09:00.6056246Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-27T16:09:00.6056982Z checking whether more special flags are required for pthreads... no
+2025-07-27T16:09:00.6407792Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-27T16:09:00.6723805Z checking for library containing clock_gettime... none required
+2025-07-27T16:09:00.6892831Z checking whether C compiler accepts -fPIC... yes
+2025-07-27T16:09:00.7058368Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-27T16:09:00.7201769Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-27T16:09:00.7367097Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-27T16:09:00.7525509Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-27T16:09:00.7683698Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-27T16:09:00.7901284Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-27T16:09:00.8119404Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-27T16:09:00.8335294Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-27T16:09:00.8552222Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-27T16:09:00.8852138Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-27T16:09:00.9154137Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-27T16:09:00.9454239Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-27T16:09:00.9756130Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-27T16:09:00.9928611Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-27T16:09:00.9929694Z checking whether to build runtest... yes
+2025-07-27T16:09:00.9930648Z checking whether to build runbench... yes
+2025-07-27T16:09:01.0157685Z checking that generated files are newer than configure... done
+2025-07-27T16:09:01.0163075Z configure: creating ./config.status
+2025-07-27T16:09:01.5621757Z config.status: creating Makefile
+2025-07-27T16:09:01.5831917Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-27T16:09:01.5972123Z config.status: executing depfiles commands
+2025-07-27T16:09:01.5986100Z config.status: executing libtool commands
+2025-07-27T16:09:01.6110852Z 
+2025-07-27T16:09:01.6111408Z Options used to compile and link:
+2025-07-27T16:09:01.6112069Z   target os           = linux
+2025-07-27T16:09:01.6112876Z   backend             = gmp
+2025-07-27T16:09:01.6113324Z   build bench         = yes
+2025-07-27T16:09:01.6113775Z   build test          = yes
+2025-07-27T16:09:01.6114252Z   use debug           = no
+2025-07-27T16:09:01.6114696Z   use hardening       = yes
+2025-07-27T16:09:01.6115187Z   use optimizations   = yes
+2025-07-27T16:09:01.6115511Z 
+2025-07-27T16:09:01.6115892Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-27T16:09:01.6117122Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-27T16:09:01.6118028Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-27T16:09:01.6118692Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-27T16:09:01.6119378Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-27T16:09:01.6119784Z 
+2025-07-27T16:09:01.6466267Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/src/secp256k1)
+2025-07-27T16:09:01.6521450Z configure: running /bin/bash ../../../src/secp256k1/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/secp256k1
+2025-07-27T16:09:01.7658348Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T16:09:01.8164534Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T16:09:01.8211674Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T16:09:01.8288873Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T16:09:01.8316648Z checking whether build environment is sane... yes
+2025-07-27T16:09:01.8376961Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T16:09:01.8397969Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T16:09:01.8402169Z checking for gawk... gawk
+2025-07-27T16:09:01.8463583Z checking whether make sets $(MAKE)... yes
+2025-07-27T16:09:01.8515535Z checking whether make supports nested variables... yes
+2025-07-27T16:09:01.8556825Z checking whether make supports nested variables... (cached) yes
+2025-07-27T16:09:01.8559355Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T16:09:01.9108829Z checking whether the C compiler works... yes
+2025-07-27T16:09:01.9109481Z checking for C compiler default output file name... a.out
+2025-07-27T16:09:01.9406689Z checking for suffix of executables... 
+2025-07-27T16:09:01.9769975Z checking whether we are cross compiling... no
+2025-07-27T16:09:01.9927080Z checking for suffix of object files... o
+2025-07-27T16:09:02.0059647Z checking whether the compiler supports GNU C... yes
+2025-07-27T16:09:02.0204758Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T16:09:02.0545483Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T16:09:02.0808119Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T16:09:02.0877928Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T16:09:02.0882286Z checking dependency style of gcc -m64... none
+2025-07-27T16:09:02.0885661Z checking dependency style of gcc -m64... none
+2025-07-27T16:09:02.0887265Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T16:09:02.1140811Z checking the archiver (ar) interface... ar
+2025-07-27T16:09:02.1163091Z checking how to print strings... printf
+2025-07-27T16:09:02.1200713Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T16:09:02.1228847Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T16:09:02.1244224Z checking for egrep... /usr/bin/grep -E
+2025-07-27T16:09:02.1259760Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T16:09:02.1307244Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T16:09:02.1331290Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T16:09:02.1334542Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T16:09:02.1608821Z checking the name lister (nm) interface... BSD nm
+2025-07-27T16:09:02.1609353Z checking whether ln -s works... yes
+2025-07-27T16:09:02.1649999Z checking the maximum length of command line arguments... 3145728
+2025-07-27T16:09:02.1674854Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T16:09:02.1678114Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T16:09:02.1679011Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T16:09:02.1682470Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T16:09:02.1686485Z checking for file... file
+2025-07-27T16:09:02.1690487Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T16:09:02.1695297Z checking for objdump... objdump
+2025-07-27T16:09:02.1698860Z checking how to recognize dependent libraries... pass_all
+2025-07-27T16:09:02.1703720Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T16:09:02.1707682Z checking for dlltool... no
+2025-07-27T16:09:02.1709310Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T16:09:02.1711810Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T16:09:02.2034841Z checking for archiver @FILE support... @
+2025-07-27T16:09:02.2036330Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T16:09:02.2038593Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T16:09:02.2684370Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T16:09:02.2700467Z checking for sysroot... no
+2025-07-27T16:09:02.2741074Z checking for a working dd... /usr/bin/dd
+2025-07-27T16:09:02.2779224Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T16:09:02.2880192Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T16:09:02.2884259Z checking for mt... no
+2025-07-27T16:09:02.2915112Z checking if : is a manifest tool... no
+2025-07-27T16:09:02.3064957Z checking for stdio.h... yes
+2025-07-27T16:09:02.3227088Z checking for stdlib.h... yes
+2025-07-27T16:09:02.3399892Z checking for string.h... yes
+2025-07-27T16:09:02.3580896Z checking for inttypes.h... yes
+2025-07-27T16:09:02.3761033Z checking for stdint.h... yes
+2025-07-27T16:09:02.3945014Z checking for strings.h... yes
+2025-07-27T16:09:02.4129870Z checking for sys/stat.h... yes
+2025-07-27T16:09:02.4320441Z checking for sys/types.h... yes
+2025-07-27T16:09:02.4535445Z checking for unistd.h... yes
+2025-07-27T16:09:02.4751617Z checking for dlfcn.h... yes
+2025-07-27T16:09:02.4791985Z checking for objdir... .libs
+2025-07-27T16:09:02.5393998Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T16:09:02.5394745Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T16:09:02.5531446Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T16:09:02.6083416Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T16:09:02.6289830Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T16:09:02.6290479Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T16:09:02.6382984Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T16:09:02.6850937Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T16:09:02.6852881Z checking how to hardcode library paths into programs... immediate
+2025-07-27T16:09:02.6868779Z checking whether stripping libraries is possible... yes
+2025-07-27T16:09:02.6870014Z checking if libtool supports shared libraries... yes
+2025-07-27T16:09:02.6870609Z checking whether to build shared libraries... no
+2025-07-27T16:09:02.6871088Z checking whether to build static libraries... yes
+2025-07-27T16:09:02.6974523Z checking if gcc -m64 supports -Werror... yes
+2025-07-27T16:09:02.7066537Z checking if gcc -m64 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-27T16:09:02.7155922Z checking if gcc -m64 supports -Wno-overlength-strings... yes
+2025-07-27T16:09:02.7245848Z checking if gcc -m64 supports -Wall... yes
+2025-07-27T16:09:02.7335785Z checking if gcc -m64 supports -Wno-unused-function... yes
+2025-07-27T16:09:02.7425749Z checking if gcc -m64 supports -Wextra... yes
+2025-07-27T16:09:02.7515773Z checking if gcc -m64 supports -Wcast-align... yes
+2025-07-27T16:09:02.7604885Z checking if gcc -m64 supports -Wcast-align=strict... yes
+2025-07-27T16:09:02.7841234Z checking if gcc -m64 supports -Wconditional-uninitialized... no
+2025-07-27T16:09:02.8042333Z checking if gcc -m64 supports -Wreserved-identifier... no
+2025-07-27T16:09:02.8132625Z checking if gcc -m64 supports -fvisibility=hidden... yes
+2025-07-27T16:09:02.8274086Z checking for valgrind support... 
+2025-07-27T16:09:02.8594768Z checking for x86_64 assembly availability... yes
+2025-07-27T16:09:02.8817298Z checking that generated files are newer than configure... done
+2025-07-27T16:09:02.8820359Z configure: creating ./config.status
+2025-07-27T16:09:03.2677290Z config.status: creating Makefile
+2025-07-27T16:09:03.2801184Z config.status: creating libsecp256k1.pc
+2025-07-27T16:09:03.2905148Z config.status: executing depfiles commands
+2025-07-27T16:09:03.2919223Z config.status: executing libtool commands
+2025-07-27T16:09:03.3003327Z 
+2025-07-27T16:09:03.3003660Z Build Options:
+2025-07-27T16:09:03.3004045Z   with external callbacks = no
+2025-07-27T16:09:03.3004437Z   with benchmarks         = no
+2025-07-27T16:09:03.3004804Z   with tests              = yes
+2025-07-27T16:09:03.3005166Z   with ctime tests        = no
+2025-07-27T16:09:03.3005514Z   with coverage           = no
+2025-07-27T16:09:03.3005870Z   with examples           = no
+2025-07-27T16:09:03.3006213Z   module ecdh             = no
+2025-07-27T16:09:03.3006554Z   module recovery         = yes
+2025-07-27T16:09:03.3006928Z   module extrakeys        = yes
+2025-07-27T16:09:03.3007305Z   module schnorrsig       = yes
+2025-07-27T16:09:03.3007623Z   module ellswift         = yes
+2025-07-27T16:09:03.3007840Z 
+2025-07-27T16:09:03.3009473Z   asm                     = x86_64
+2025-07-27T16:09:03.3010362Z   ecmult window size      = 15
+2025-07-27T16:09:03.3011019Z   ecmult gen prec. bits   = 4
+2025-07-27T16:09:03.3011318Z 
+2025-07-27T16:09:03.3011481Z   valgrind                = no
+2025-07-27T16:09:03.3011878Z   CC                      = gcc -m64
+2025-07-27T16:09:03.3012509Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-27T16:09:03.3013442Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-27T16:09:03.3014600Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-27T16:09:03.3014989Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-27T16:09:03.3318182Z 
+2025-07-27T16:09:03.3318691Z Options used to compile and link:
+2025-07-27T16:09:03.3319205Z   boost process       = yes
+2025-07-27T16:09:03.3319831Z   multiprocess        = no
+2025-07-27T16:09:03.3320268Z   with libs           = no
+2025-07-27T16:09:03.3320662Z   with wallet         = yes
+2025-07-27T16:09:03.3321381Z     with sqlite       = yes
+2025-07-27T16:09:03.3321848Z     with bdb          = yes
+2025-07-27T16:09:03.3322294Z   with gui / qt       = yes
+2025-07-27T16:09:03.3322631Z     with qr           = yes
+2025-07-27T16:09:03.3322980Z   with zmq            = yes
+2025-07-27T16:09:03.3323303Z   with test           = yes
+2025-07-27T16:09:03.3323598Z   with fuzz binary    = no
+2025-07-27T16:09:03.3323894Z   with bench          = yes
+2025-07-27T16:09:03.3324218Z   with upnp           = yes
+2025-07-27T16:09:03.3324559Z   with natpmp         = yes
+2025-07-27T16:09:03.3324912Z   USDT tracing        = yes
+2025-07-27T16:09:03.3325266Z   sanitizers          = 
+2025-07-27T16:09:03.3325628Z   debug enabled       = no
+2025-07-27T16:09:03.3326427Z   stacktraces enabled = yes
+2025-07-27T16:09:03.3326796Z   crash hooks enabled = no
+2025-07-27T16:09:03.3327175Z   miner enabled       = yes
+2025-07-27T16:09:03.3327422Z   gprof enabled       = no
+2025-07-27T16:09:03.3327637Z   werror              = yes
+2025-07-27T16:09:03.3327781Z 
+2025-07-27T16:09:03.3327876Z   target os           = linux-gnu
+2025-07-27T16:09:03.3328114Z   build os            = linux-gnu
+2025-07-27T16:09:03.3328285Z 
+2025-07-27T16:09:03.3328397Z   CC                  = /usr/bin/ccache gcc -m64
+2025-07-27T16:09:03.3328786Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-27T16:09:03.3329930Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-27T16:09:03.3330715Z   CXX                 = /usr/bin/ccache g++ -m64 -std=c++20
+2025-07-27T16:09:03.3333789Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-27T16:09:03.3338206Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-27T16:09:03.3339138Z   AR                  = ar
+2025-07-27T16:09:03.3339801Z   ARFLAGS             = cr
+2025-07-27T16:09:03.3340039Z 
+2025-07-27T16:09:03.3913151Z make  distdir-am
+2025-07-27T16:09:03.3965944Z make[1]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-27T16:09:03.3967037Z if test -d "dashcore-linux64"; then find "dashcore-linux64" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "dashcore-linux64" || { sleep 5 && rm -rf "dashcore-linux64"; }; else :; fi
+2025-07-27T16:09:03.3980254Z test -d "dashcore-linux64" || mkdir "dashcore-linux64"
+2025-07-27T16:09:03.6029470Z  (cd src && make  top_distdir=../dashcore-linux64 distdir=../dashcore-linux64/src \
+2025-07-27T16:09:03.6031008Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-27T16:09:03.6274343Z make[2]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-27T16:09:03.6275011Z make  distdir-am
+2025-07-27T16:09:03.7571898Z make[3]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-27T16:09:03.8478662Z Generated bench/data/block813851.raw.h
+2025-07-27T16:09:03.8587314Z make[3]: *** No rule to make target 'wallet/test/fuzz/coincontrol.cpp', needed by 'distdir-am'.  Stop.
+2025-07-27T16:09:03.8588069Z make[3]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-27T16:09:03.8595485Z make[2]: *** [Makefile:20826: distdir] Error 2
+2025-07-27T16:09:03.8595974Z make[2]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-27T16:09:03.8603597Z make[1]: *** [Makefile:894: distdir-am] Error 1
+2025-07-27T16:09:03.8604364Z make[1]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-27T16:09:03.8606353Z make: *** [Makefile:888: distdir] Error 2
+2025-07-27T16:09:03.8653814Z ##[error]Process completed with exit code 2.
+2025-07-27T16:09:03.8748122Z Post job cleanup.
+2025-07-27T16:09:03.8752068Z ##[command]/usr/bin/docker exec  85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T16:09:04.0665871Z [command]/usr/bin/git version
+2025-07-27T16:09:04.0705775Z git version 2.43.0
+2025-07-27T16:09:04.0747308Z Copying '/github/home/.gitconfig' to '/__w/_temp/92ca38d9-847a-4735-9b62-5c9b52a852a3/.gitconfig'
+2025-07-27T16:09:04.0759454Z Temporarily overriding HOME='/__w/_temp/92ca38d9-847a-4735-9b62-5c9b52a852a3' before making global git config changes
+2025-07-27T16:09:04.0760740Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-27T16:09:04.0766994Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-27T16:09:04.0802939Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-27T16:09:04.0847434Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-27T16:09:04.1082512Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-27T16:09:04.1105998Z http.https://github.com/.extraheader
+2025-07-27T16:09:04.1119186Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-07-27T16:09:04.1150788Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-27T16:09:04.1475627Z Stop and remove container: 583f9bb235cb456f9e726402141548ca_ghcriodashcoreautoguixdashdashcorecirunnerbackport026batch441pr28168_8ff915
+2025-07-27T16:09:04.1481054Z ##[command]/usr/bin/docker rm --force 85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926
+2025-07-27T16:09:04.2686653Z 85fea03b2d286bf85fa55d45b700f9ded9bbced9e8ece100ffeed40f3decc926
+2025-07-27T16:09:04.2717070Z Remove container network: github_network_544409b2d59249139504f245caa863e3
+2025-07-27T16:09:04.2721454Z ##[command]/usr/bin/docker network rm github_network_544409b2d59249139504f245caa863e3
+2025-07-27T16:09:04.3884385Z github_network_544409b2d59249139504f245caa863e3
+2025-07-27T16:09:04.3940529Z Evaluate and set job outputs
+2025-07-27T16:09:04.3945952Z Cleaning up orphan processes

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -1,5 +1,4 @@
 # Copyright (c) 2013-2016 The Bitcoin Core developers
-# Copyright (c) 2014-2018 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,25 +7,22 @@ noinst_PROGRAMS += test/fuzz/fuzz
 endif
 
 if ENABLE_TESTS
-bin_PROGRAMS += test/test_dash
+bin_PROGRAMS += test/test_bitcoin
 endif
 
 TEST_SRCDIR = test
-TEST_BINARY=test/test_dash$(EXEEXT)
+TEST_BINARY=test/test_bitcoin$(EXEEXT)
 FUZZ_BINARY=test/fuzz/fuzz$(EXEEXT)
 
 JSON_TEST_FILES = \
-  test/data/blockfilters.json \
+  test/data/script_tests.json \
+  test/data/bip341_wallet_vectors.json \
   test/data/base58_encode_decode.json \
-  test/data/bip39_vectors.json \
+  test/data/blockfilters.json \
   test/data/key_io_valid.json \
   test/data/key_io_invalid.json \
-  test/data/proposals_valid.json \
-  test/data/proposals_invalid.json \
   test/data/script_tests.json \
   test/data/sighash.json \
-  test/data/trivially_invalid.json \
-  test/data/trivially_valid.json \
   test/data/tx_invalid.json \
   test/data/tx_valid.json
 
@@ -40,27 +36,22 @@ BITCOIN_TEST_SUITE = \
   $(TEST_UTIL_H)
 
 FUZZ_SUITE_LD_COMMON = \
- $(LIBTEST_FUZZ) \
  $(LIBTEST_UTIL) \
+ $(LIBTEST_FUZZ) \
  $(LIBBITCOIN_NODE) \
+ $(LIBBITCOIN_WALLET) \
  $(LIBBITCOIN_COMMON) \
  $(LIBBITCOIN_UTIL) \
  $(LIBBITCOIN_CONSENSUS) \
- $(LIBBITCOIN_WALLET) \
  $(LIBBITCOIN_CRYPTO) \
  $(LIBBITCOIN_CLI) \
- $(LIBDASHBLS) \
- $(BDB_LIBS) \
- $(SQLITE_LIBS) \
  $(LIBUNIVALUE) \
  $(LIBLEVELDB) \
  $(LIBMEMENV) \
  $(LIBSECP256K1) \
  $(MINISKETCH_LIBS) \
  $(EVENT_LIBS) \
- $(EVENT_PTHREADS_LIBS) \
- $(GMP_LIBS) \
- $(BACKTRACE_LIB)
+ $(EVENT_PTHREADS_LIBS)
 
 if USE_UPNP
 FUZZ_SUITE_LD_COMMON += $(MINIUPNPC_LIBS)
@@ -70,102 +61,80 @@ if USE_NATPMP
 FUZZ_SUITE_LD_COMMON += $(NATPMP_LIBS)
 endif
 
-# test_dash binary #
+# test_bitcoin binary #
 BITCOIN_TESTS =\
+  test/addrman_tests.cpp \
+  test/allocator_tests.cpp \
+  test/amount_tests.cpp \
   test/argsman_tests.cpp \
   test/arith_uint256_tests.cpp \
-  test/scriptnum10.h \
-  test/addrman_tests.cpp \
-  test/amount_tests.cpp \
-  test/allocator_tests.cpp \
   test/banman_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
   test/bech32_tests.cpp \
   test/bip32_tests.cpp \
-  test/bip324_tests.cpp \
-  test/block_reward_reallocation_tests.cpp \
   test/blockchain_tests.cpp \
   test/blockencodings_tests.cpp \
-  test/blockfilter_tests.cpp \
   test/blockfilter_index_tests.cpp \
+  test/blockfilter_tests.cpp \
   test/blockmanager_tests.cpp \
   test/bloom_tests.cpp \
-  test/bls_tests.cpp \
   test/bswap_tests.cpp \
-  test/checkdatasig_tests.cpp \
   test/checkqueue_tests.cpp \
-  test/cachemap_tests.cpp \
-  test/cachemultimap_tests.cpp \
   test/coins_tests.cpp \
   test/coinstatsindex_tests.cpp \
   test/compilerbug_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \
+  test/dbwrapper_tests.cpp \
   test/denialofservice_tests.cpp \
-  test/dip0020opcodes_tests.cpp \
   test/descriptor_tests.cpp \
-  test/dynamic_activation_thresholds_tests.cpp \
-  test/evo_assetlocks_tests.cpp \
-  test/evo_deterministicmns_tests.cpp \
-  test/evo_islock_tests.cpp \
-  test/evo_mnhf_tests.cpp \
-  test/evo_netinfo_tests.cpp \
-  test/evo_simplifiedmns_tests.cpp \
-  test/evo_trivialvalidation.cpp \
-  test/evo_utils_tests.cpp \
   test/flatfile_tests.cpp \
   test/fs_tests.cpp \
   test/getarg_tests.cpp \
-  test/governance_validators_tests.cpp \
   test/hash_tests.cpp \
+  test/headers_sync_chainwork_tests.cpp \
+  test/httpserver_tests.cpp \
   test/i2p_tests.cpp \
   test/interfaces_tests.cpp \
   test/key_io_tests.cpp \
   test/key_tests.cpp \
-  test/lcg.h \
-  test/limitedmap_tests.cpp \
-  test/llmq_dkg_tests.cpp \
-  test/llmq_chainlock_tests.cpp \
-  test/llmq_commitment_tests.cpp \
-  test/llmq_hash_tests.cpp \
-  test/llmq_params_tests.cpp \
-  test/llmq_snapshot_tests.cpp \
-  test/llmq_utils_tests.cpp \
   test/logging_tests.cpp \
-  test/dbwrapper_tests.cpp \
-  test/validation_tests.cpp \
   test/mempool_tests.cpp \
   test/merkle_tests.cpp \
   test/merkleblock_tests.cpp \
-  test/minisketch_tests.cpp \
   test/miner_tests.cpp \
+  test/miniminer_tests.cpp \
+  test/miniscript_tests.cpp \
+  test/minisketch_tests.cpp \
   test/multisig_tests.cpp \
-  test/net_peer_connection_tests.cpp \
   test/net_peer_eviction_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
   test/orphanage_tests.cpp \
   test/pmt_tests.cpp \
+  test/policy_fee_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pool_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
-  test/ratecheck_tests.cpp \
+  test/rbf_tests.cpp \
+  test/rest_tests.cpp \
+  test/result_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \
   test/scheduler_tests.cpp \
   test/script_p2sh_tests.cpp \
-  test/script_p2pk_tests.cpp \
-  test/script_p2pkh_tests.cpp \
   test/script_parse_tests.cpp \
+  test/script_segwit_tests.cpp \
   test/script_standard_tests.cpp \
   test/script_tests.cpp \
+  test/scriptnum10.h \
   test/scriptnum_tests.cpp \
   test/serfloat_tests.cpp \
   test/serialize_tests.cpp \
@@ -175,32 +144,33 @@ BITCOIN_TESTS =\
   test/skiplist_tests.cpp \
   test/sock_tests.cpp \
   test/streams_tests.cpp \
-  test/subsidy_tests.cpp \
   test/sync_tests.cpp \
   test/system_tests.cpp \
-  test/util_threadnames_tests.cpp \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
+  test/translation_tests.cpp \
   test/txindex_tests.cpp \
   test/txpackage_tests.cpp \
   test/txreconciliation_tests.cpp \
+  test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
   test/util_tests.cpp \
+  test/util_threadnames_tests.cpp \
   test/validation_block_tests.cpp \
   test/validation_chainstate_tests.cpp \
   test/validation_chainstatemanager_tests.cpp \
   test/validation_flush_tests.cpp \
+  test/validation_tests.cpp \
   test/validationinterface_tests.cpp \
   test/versionbits_tests.cpp \
   test/xoroshiro128plusplus_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \
-  wallet/test/bip39_tests.cpp \
-  wallet/test/coinjoin_tests.cpp \
+  wallet/test/feebumper_tests.cpp \
   wallet/test/psbt_wallet_tests.cpp \
   wallet/test/spend_tests.cpp \
   wallet/test/wallet_tests.cpp \
@@ -210,10 +180,12 @@ BITCOIN_TESTS += \
   wallet/test/coinselector_tests.cpp \
   wallet/test/init_tests.cpp \
   wallet/test/ismine_tests.cpp \
-  wallet/test/scriptpubkeyman_tests.cpp
+  wallet/test/rpc_util_tests.cpp \
+  wallet/test/scriptpubkeyman_tests.cpp \
+  wallet/test/walletload_tests.cpp \
+  wallet/test/group_outputs_tests.cpp
 
 FUZZ_SUITE_LD_COMMON +=\
- $(LIBBITCOIN_WALLET) \
  $(SQLITE_LIBS) \
  $(BDB_LIBS)
 
@@ -222,7 +194,10 @@ BITCOIN_TESTS += wallet/test/db_tests.cpp
 endif
 
 FUZZ_WALLET_SRC = \
- wallet/test/fuzz/coinselection.cpp
+ wallet/test/fuzz/coincontrol.cpp \
+ wallet/test/fuzz/coinselection.cpp \
+ wallet/test/fuzz/fees.cpp \
+ wallet/test/fuzz/parse_iso8601.cpp
 
 if USE_SQLITE
 FUZZ_WALLET_SRC += \
@@ -230,30 +205,29 @@ FUZZ_WALLET_SRC += \
 endif # USE_SQLITE
 
 BITCOIN_TEST_SUITE += \
-  wallet/test/util.cpp \
-  wallet/test/util.h \
   wallet/test/wallet_test_fixture.cpp \
   wallet/test/wallet_test_fixture.h \
   wallet/test/init_test_fixture.cpp \
   wallet/test/init_test_fixture.h
 endif # ENABLE_WALLET
 
-test_test_dash_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)
-test_test_dash_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(TESTDEFS) $(BOOST_CPPFLAGS) $(EVENT_CFLAGS)
-test_test_dash_LDADD = $(LIBTEST_UTIL)
+test_test_bitcoin_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)
+test_test_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(TESTDEFS) $(BOOST_CPPFLAGS) $(EVENT_CFLAGS)
+test_test_bitcoin_LDADD = $(LIBTEST_UTIL)
 if ENABLE_WALLET
-test_test_dash_LDADD += $(LIBBITCOIN_WALLET)
-test_test_dash_CPPFLAGS += $(BDB_CPPFLAGS)
+test_test_bitcoin_LDADD += $(LIBBITCOIN_WALLET)
+test_test_bitcoin_CPPFLAGS += $(BDB_CPPFLAGS)
 endif
-test_test_dash_LDADD += $(LIBBITCOIN_NODE) $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CONSENSUS) $(LIBBITCOIN_CRYPTO) $(LIBUNIVALUE) \
-  $(LIBDASHBLS) $(LIBLEVELDB) $(LIBMEMENV) $(BACKTRACE_LIB) $(LIBSECP256K1) $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS) $(MINISKETCH_LIBS)
-test_test_dash_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
-test_test_dash_LDADD += $(BDB_LIBS) $(MINIUPNPC_LIBS) $(SQLITE_LIBS) $(NATPMP_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(GMP_LIBS)
-test_test_dash_LDFLAGS = $(LDFLAGS_WRAP_EXCEPTIONS) $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS) -static
+test_test_bitcoin_LDADD += $(LIBBITCOIN_NODE) $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CONSENSUS) $(LIBBITCOIN_CRYPTO) $(LIBUNIVALUE) \
+  $(LIBLEVELDB) $(LIBMEMENV) $(LIBSECP256K1) $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS) $(MINISKETCH_LIBS)
+test_test_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+
+test_test_bitcoin_LDADD += $(BDB_LIBS) $(MINIUPNPC_LIBS) $(NATPMP_LIBS) $(SQLITE_LIBS)
+test_test_bitcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS) -static
 
 if ENABLE_ZMQ
-test_test_dash_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
+test_test_bitcoin_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 FUZZ_SUITE_LD_COMMON += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 endif
 
@@ -261,7 +235,7 @@ if ENABLE_FUZZ_BINARY
 test_fuzz_fuzz_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
 test_fuzz_fuzz_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_fuzz_LDADD = $(FUZZ_SUITE_LD_COMMON)
-test_fuzz_fuzz_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(LDFLAGS_WRAP_EXCEPTIONS) $(PTHREAD_FLAGS)
+test_fuzz_fuzz_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS) $(RUNTIME_LDFLAGS)
 test_fuzz_fuzz_SOURCES = \
  $(FUZZ_WALLET_SRC) \
  test/fuzz/addition_overflow.cpp \
@@ -272,7 +246,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/banman.cpp \
  test/fuzz/base_encode_decode.cpp \
  test/fuzz/bech32.cpp \
- test/fuzz/bip324.cpp \
+ test/fuzz/bitdeque.cpp \
  test/fuzz/block.cpp \
  test/fuzz/block_header.cpp \
  test/fuzz/blockfilter.cpp \
@@ -287,6 +261,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/crypto_aes256.cpp \
  test/fuzz/crypto_aes256cbc.cpp \
  test/fuzz/crypto_chacha20.cpp \
+ test/fuzz/crypto_chacha20_poly1305_aead.cpp \
  test/fuzz/crypto_common.cpp \
  test/fuzz/crypto_diff_fuzz_chacha20.cpp \
  test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp \
@@ -301,8 +276,10 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/flatfile.cpp \
  test/fuzz/float.cpp \
  test/fuzz/golomb_rice.cpp \
+ test/fuzz/headerssync.cpp \
  test/fuzz/hex.cpp \
  test/fuzz/http_request.cpp \
+ test/fuzz/i2p.cpp \
  test/fuzz/integer.cpp \
  test/fuzz/key.cpp \
  test/fuzz/key_io.cpp \
@@ -311,7 +288,9 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/locale.cpp \
  test/fuzz/merkleblock.cpp \
  test/fuzz/message.cpp \
+ test/fuzz/miniscript.cpp \
  test/fuzz/minisketch.cpp \
+ test/fuzz/mini_miner.cpp \
  test/fuzz/muhash.cpp \
  test/fuzz/multiplication_overflow.cpp \
  test/fuzz/net.cpp \
@@ -321,10 +300,10 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/node_eviction.cpp \
  test/fuzz/p2p_transport_serialization.cpp \
  test/fuzz/parse_hd_keypath.cpp \
- test/fuzz/parse_iso8601.cpp \
  test/fuzz/parse_numbers.cpp \
  test/fuzz/parse_script.cpp \
  test/fuzz/parse_univalue.cpp \
+ test/fuzz/partially_downloaded_block.cpp \
  test/fuzz/policy_estimator.cpp \
  test/fuzz/policy_estimator_io.cpp \
  test/fuzz/poolresource.cpp \
@@ -336,9 +315,11 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/protocol.cpp \
  test/fuzz/psbt.cpp \
  test/fuzz/random.cpp \
+ test/fuzz/rbf.cpp \
  test/fuzz/rolling_bloom_filter.cpp \
  test/fuzz/rpc.cpp \
  test/fuzz/script.cpp \
+ test/fuzz/script_assets_test_minimizer.cpp \
  test/fuzz/script_bitcoin_consensus.cpp \
  test/fuzz/script_descriptor_cache.cpp \
  test/fuzz/script_flags.cpp \
@@ -351,6 +332,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/secp256k1_ec_seckey_import_export_der.cpp \
  test/fuzz/secp256k1_ecdsa_signature_parse_der_lax.cpp \
  test/fuzz/signature_checker.cpp \
+ test/fuzz/signet.cpp \
  test/fuzz/socks5.cpp \
  test/fuzz/span.cpp \
  test/fuzz/spanparsing.cpp \
@@ -363,12 +345,15 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/tx_in.cpp \
  test/fuzz/tx_out.cpp \
  test/fuzz/tx_pool.cpp \
+ test/fuzz/txorphan.cpp \
+ test/fuzz/txrequest.cpp \
  test/fuzz/utxo_snapshot.cpp \
+ test/fuzz/utxo_total_supply.cpp \
  test/fuzz/validation_load_mempool.cpp \
  test/fuzz/versionbits.cpp
 endif # ENABLE_FUZZ_BINARY
 
-nodist_test_test_dash_SOURCES = $(GENERATED_TEST_FILES)
+nodist_test_test_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
 
 $(BITCOIN_TESTS): $(GENERATED_TEST_FILES)
 
@@ -377,24 +362,22 @@ CLEAN_BITCOIN_TEST = test/*.gcda test/*.gcno test/fuzz/*.gcda test/fuzz/*.gcno t
 CLEANFILES += $(CLEAN_BITCOIN_TEST)
 
 if TARGET_WINDOWS
-dash_test: $(TEST_BINARY)
+bitcoin_test: $(TEST_BINARY)
 else
 if ENABLE_BENCH
-dash_test: $(TEST_BINARY) $(BENCH_BINARY)
+bitcoin_test: $(TEST_BINARY) $(BENCH_BINARY)
 else
-dash_test: $(TEST_BINARY)
+bitcoin_test: $(TEST_BINARY)
 endif
 endif
 
-dash_test_check: $(TEST_BINARY) FORCE
+bitcoin_test_check: $(TEST_BINARY) FORCE
 	$(MAKE) check-TESTS TESTS=$^
 
-dash_test_clean : FORCE
-	rm -f $(CLEAN_BITCOIN_TEST) $(test_test_dash_OBJECTS) $(TEST_BINARY)
+bitcoin_test_clean : FORCE
+	rm -f $(CLEAN_BITCOIN_TEST) $(test_test_bitcoin_OBJECTS) $(TEST_BINARY)
 
-check-unit: $(BITCOIN_TESTS:.cpp=.cpp.test)
-
-check-local: check-unit
+check-local: $(BITCOIN_TESTS:.cpp=.cpp.test)
 if BUILD_BITCOIN_TX
 	@echo "Running test/util/test_runner.py..."
 	$(PYTHON) $(top_builddir)/test/util/test_runner.py
@@ -404,14 +387,14 @@ endif
 if TARGET_WINDOWS
 else
 if ENABLE_BENCH
-	@echo "Running bench/bench_dash (one iteration sanity check, only high priority)..."
+	@echo "Running bench/bench_bitcoin (one iteration sanity check, only high priority)..."
 	$(BENCH_BINARY) -sanity-check -priority-level=high
 endif
 endif
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C secp256k1 check
 
 if ENABLE_TESTS
-UNIVALUE_TESTS = univalue/test/object univalue/test/unitester univalue/test/no_nul
+UNIVALUE_TESTS = univalue/test/object univalue/test/unitester
 noinst_PROGRAMS += $(UNIVALUE_TESTS)
 TESTS += $(UNIVALUE_TESTS)
 
@@ -419,11 +402,6 @@ univalue_test_unitester_SOURCES = $(UNIVALUE_TEST_UNITESTER_INT)
 univalue_test_unitester_LDADD = $(LIBUNIVALUE)
 univalue_test_unitester_CPPFLAGS = -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT) -DJSON_TEST_SRC=\"$(srcdir)/$(UNIVALUE_TEST_DATA_DIR_INT)\"
 univalue_test_unitester_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
-
-univalue_test_no_nul_SOURCES = $(UNIVALUE_TEST_NO_NUL_INT)
-univalue_test_no_nul_LDADD = $(LIBUNIVALUE)
-univalue_test_no_nul_CPPFLAGS = -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT)
-univalue_test_no_nul_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
 univalue_test_object_SOURCES = $(UNIVALUE_TEST_OBJECT_INT)
 univalue_test_object_LDADD = $(LIBUNIVALUE)
@@ -448,10 +426,10 @@ endif
 
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)
-	@{ \
+	$(AM_V_GEN) { \
+	 echo "#include <string>" && \
 	 echo "namespace json_tests{" && \
-	 echo "static unsigned const char $(*F)[] = {" && \
+	 echo "static const std::string $(*F){" && \
 	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
 	 echo "};};"; \
 	} > "$@.new" && mv -f "$@.new" "$@"
-	@echo "Generated $@"

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -194,10 +194,7 @@ BITCOIN_TESTS += wallet/test/db_tests.cpp
 endif
 
 FUZZ_WALLET_SRC = \
- wallet/test/fuzz/coincontrol.cpp \
- wallet/test/fuzz/coinselection.cpp \
- wallet/test/fuzz/fees.cpp \
- wallet/test/fuzz/parse_iso8601.cpp
+ wallet/test/fuzz/coinselection.cpp
 
 if USE_SQLITE
 FUZZ_WALLET_SRC += \

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_SUITE(base58_tests)
 // Goal: test low-level base58 encoding functionality
 BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 {
-    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
+    UniValue tests = read_json(json_tests::base58_encode_decode);
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
         std::string strTest = test.write();
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 // Goal: test low-level base58 decoding functionality
 BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
 {
-    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
+    UniValue tests = read_json(json_tests::base58_encode_decode);
     std::vector<unsigned char> result;
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -128,9 +128,7 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
 BOOST_AUTO_TEST_CASE(blockfilters_json_test)
 {
     UniValue json;
-    std::string json_data(json_tests::blockfilters,
-                          json_tests::blockfilters + sizeof(json_tests::blockfilters));
-    if (!json.read(json_data) || !json.isArray()) {
+    if (!json.read(json_tests::blockfilters) || !json.isArray()) {
         BOOST_ERROR("Parse error.");
         return;
     }

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -22,7 +22,7 @@ BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 // Goal: check that parsed keys match test payload
 BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
+    UniValue tests = read_json(json_tests::key_io_valid);
     CKey privkey;
     CTxDestination destination;
     SelectParams(CBaseChainParams::MAIN);
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 // Goal: check that generated keys match test vectors
 BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
+    UniValue tests = read_json(json_tests::key_io_valid);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 // Goal: check that base58 parsing code is robust against a variety of corrupted data
 BOOST_AUTO_TEST_CASE(key_io_invalid)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_invalid, json_tests::key_io_invalid + sizeof(json_tests::key_io_invalid))); // Negative testcases
+    UniValue tests = read_json(json_tests::key_io_invalid); // Negative testcases
     CKey privkey;
     CTxDestination destination;
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -19,7 +19,7 @@
 static UniValue JSON(std::string_view json)
 {
     UniValue value;
-    BOOST_CHECK(value.read(json.data(), json.size()));
+    BOOST_CHECK(value.read(json));
     return value;
 }
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1,20 +1,25 @@
-// Copyright (c) 2011-2021 The Bitcoin Core developers
+// Copyright (c) 2011-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/data/script_tests.json.h>
+#include <test/data/bip341_wallet_vectors.json.h>
 
+#include <common/system.h>
 #include <core_io.h>
 #include <key.h>
 #include <rpc/util.h>
 #include <script/script.h>
 #include <script/script_error.h>
+#include <script/sigcache.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <streams.h>
 #include <test/util/json.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 #if defined(HAVE_CONSENSUS_LIB)
@@ -59,7 +64,6 @@ static ScriptErrorDesc script_errors[]={
     {SCRIPT_ERR_EQUALVERIFY, "EQUALVERIFY"},
     {SCRIPT_ERR_CHECKMULTISIGVERIFY, "CHECKMULTISIGVERIFY"},
     {SCRIPT_ERR_CHECKSIGVERIFY, "CHECKSIGVERIFY"},
-    {SCRIPT_ERR_CHECKDATASIGVERIFY, "CHECKDATASIGVERIFY"},
     {SCRIPT_ERR_NUMEQUALVERIFY, "NUMEQUALVERIFY"},
     {SCRIPT_ERR_BAD_OPCODE, "BAD_OPCODE"},
     {SCRIPT_ERR_DISABLED_OPCODE, "DISABLED_OPCODE"},
@@ -76,13 +80,17 @@ static ScriptErrorDesc script_errors[]={
     {SCRIPT_ERR_SIG_NULLDUMMY, "SIG_NULLDUMMY"},
     {SCRIPT_ERR_PUBKEYTYPE, "PUBKEYTYPE"},
     {SCRIPT_ERR_CLEANSTACK, "CLEANSTACK"},
+    {SCRIPT_ERR_MINIMALIF, "MINIMALIF"},
     {SCRIPT_ERR_SIG_NULLFAIL, "NULLFAIL"},
     {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS, "DISCOURAGE_UPGRADABLE_NOPS"},
-    {SCRIPT_ERR_INVALID_SPLIT_RANGE, "SPLIT_RANGE"},
-    {SCRIPT_ERR_INVALID_OPERAND_SIZE, "OPERAND_SIZE"},
-    {SCRIPT_ERR_INVALID_NUMBER_RANGE, "INVALID_NUMBER_RANGE"},
-    {SCRIPT_ERR_DIV_BY_ZERO, "DIV_BY_ZERO"},
-    {SCRIPT_ERR_MOD_BY_ZERO, "MOD_BY_ZERO"},
+    {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM, "DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"},
+    {SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH, "WITNESS_PROGRAM_WRONG_LENGTH"},
+    {SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY, "WITNESS_PROGRAM_WITNESS_EMPTY"},
+    {SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH, "WITNESS_PROGRAM_MISMATCH"},
+    {SCRIPT_ERR_WITNESS_MALLEATED, "WITNESS_MALLEATED"},
+    {SCRIPT_ERR_WITNESS_MALLEATED_P2SH, "WITNESS_MALLEATED_P2SH"},
+    {SCRIPT_ERR_WITNESS_UNEXPECTED, "WITNESS_UNEXPECTED"},
+    {SCRIPT_ERR_WITNESS_PUBKEYTYPE, "WITNESS_PUBKEYTYPE"},
     {SCRIPT_ERR_OP_CODESEPARATOR, "OP_CODESEPARATOR"},
     {SCRIPT_ERR_SIG_FINDANDDELETE, "SIG_FINDANDDELETE"},
 };
@@ -107,15 +115,18 @@ static ScriptError_t ParseScriptError(const std::string& name)
 
 BOOST_FIXTURE_TEST_SUITE(script_tests, BasicTestingSetup)
 
-
-void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, uint32_t flags, const std::string& message, int scriptError)
+void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScriptWitness& scriptWitness, uint32_t flags, const std::string& message, int scriptError, CAmount nValue = 0)
 {
     bool expect = (scriptError == SCRIPT_ERR_OK);
+    if (flags & SCRIPT_VERIFY_CLEANSTACK) {
+        flags |= SCRIPT_VERIFY_P2SH;
+        flags |= SCRIPT_VERIFY_WITNESS;
+    }
     ScriptError err;
-    const CTransaction txCredit{BuildCreditingTransaction(scriptPubKey)};
-    CMutableTransaction tx = BuildSpendingTransaction(scriptSig, txCredit);
+    const CTransaction txCredit{BuildCreditingTransaction(scriptPubKey, nValue)};
+    CMutableTransaction tx = BuildSpendingTransaction(scriptSig, scriptWitness, txCredit);
     CMutableTransaction tx2 = tx;
-    BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message);
+    BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message);
     BOOST_CHECK_MESSAGE(err == scriptError, FormatScriptError(err) + " where " + FormatScriptError((ScriptError_t)scriptError) + " expected: " + message);
 
     // Verify that removing flags from a passing test or adding flags to a failing test does not change the result.
@@ -123,17 +134,23 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, uint32_t flag
         uint32_t extra_flags(InsecureRandBits(16));
         uint32_t combined_flags{expect ? (flags & ~extra_flags) : (flags | extra_flags)};
         // Weed out some invalid flag combinations.
-        if (combined_flags & SCRIPT_VERIFY_CLEANSTACK && ~combined_flags & SCRIPT_VERIFY_P2SH) continue;
-        BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, combined_flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message + strprintf(" (with flags %x)", combined_flags));
+        if (combined_flags & SCRIPT_VERIFY_CLEANSTACK && ~combined_flags & (SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS)) continue;
+        if (combined_flags & SCRIPT_VERIFY_WITNESS && ~combined_flags & SCRIPT_VERIFY_P2SH) continue;
+        BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, combined_flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message + strprintf(" (with flags %x)", combined_flags));
     }
 
 #if defined(HAVE_CONSENSUS_LIB)
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << tx2;
-    uint32_t libconsensus_flags{flags & dashconsensus_SCRIPT_FLAGS_VERIFY_ALL};
+    uint32_t libconsensus_flags{flags & bitcoinconsensus_SCRIPT_FLAGS_VERIFY_ALL};
     if (libconsensus_flags == flags) {
         int expectedSuccessCode = expect ? 1 : 0;
-        BOOST_CHECK_MESSAGE(dashconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), 0, libconsensus_flags, nullptr) == expectedSuccessCode, message);
+        if (flags & bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS) {
+            BOOST_CHECK_MESSAGE(bitcoinconsensus_verify_script_with_amount(scriptPubKey.data(), scriptPubKey.size(), txCredit.vout[0].nValue, UCharCast(stream.data()), stream.size(), 0, libconsensus_flags, nullptr) == expectedSuccessCode, message);
+        } else {
+            BOOST_CHECK_MESSAGE(bitcoinconsensus_verify_script_with_amount(scriptPubKey.data(), scriptPubKey.size(), 0, UCharCast(stream.data()), stream.size(), 0, libconsensus_flags, nullptr) == expectedSuccessCode, message);
+            BOOST_CHECK_MESSAGE(bitcoinconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), 0, libconsensus_flags, nullptr) == expectedSuccessCode, message);
+        }
     }
 #endif
 }
@@ -212,18 +229,30 @@ struct KeyData
     }
 };
 
+enum class WitnessMode {
+    NONE,
+    PKH,
+    SH
+};
 
 class TestBuilder
 {
 private:
-    CScript scriptPubKey;
+    //! Actually executed script
+    CScript script;
+    //! The P2SH redeemscript
+    CScript redeemscript;
+    //! The Witness embedded script
+    CScript witscript;
+    CScriptWitness scriptWitness;
     CTransactionRef creditTx;
     CMutableTransaction spendTx;
-    bool havePush;
+    bool havePush{false};
     std::vector<unsigned char> push;
     std::string comment;
     uint32_t flags;
-    int scriptError;
+    int scriptError{SCRIPT_ERR_OK};
+    CAmount nValue;
 
     void DoPush()
     {
@@ -241,14 +270,26 @@ private:
     }
 
 public:
-    TestBuilder(const CScript& script_, const std::string& comment_, uint32_t flags_, bool P2SH = false) : scriptPubKey(script_), havePush(false), comment(comment_), flags(flags_), scriptError(SCRIPT_ERR_OK)
+    TestBuilder(const CScript& script_, const std::string& comment_, uint32_t flags_, bool P2SH = false, WitnessMode wm = WitnessMode::NONE, int witnessversion = 0, CAmount nValue_ = 0) : script(script_), comment(comment_), flags(flags_), nValue(nValue_)
     {
-        if (P2SH) {
-            creditTx = MakeTransactionRef(BuildCreditingTransaction(CScript() << OP_HASH160 << ToByteVector(CScriptID(script_)) << OP_EQUAL));
-        } else {
-            creditTx = MakeTransactionRef(BuildCreditingTransaction(script_));
+        CScript scriptPubKey = script;
+        if (wm == WitnessMode::PKH) {
+            uint160 hash;
+            CHash160().Write(Span{script}.subspan(1)).Finalize(hash);
+            script = CScript() << OP_DUP << OP_HASH160 << ToByteVector(hash) << OP_EQUALVERIFY << OP_CHECKSIG;
+            scriptPubKey = CScript() << witnessversion << ToByteVector(hash);
+        } else if (wm == WitnessMode::SH) {
+            witscript = scriptPubKey;
+            uint256 hash;
+            CSHA256().Write(witscript.data(), witscript.size()).Finalize(hash.begin());
+            scriptPubKey = CScript() << witnessversion << ToByteVector(hash);
         }
-        spendTx = BuildSpendingTransaction(CScript(), *creditTx);
+        if (P2SH) {
+            redeemscript = scriptPubKey;
+            scriptPubKey = CScript() << OP_HASH160 << ToByteVector(CScriptID(redeemscript)) << OP_EQUAL;
+        }
+        creditTx = MakeTransactionRef(BuildCreditingTransaction(scriptPubKey, nValue));
+        spendTx = BuildSpendingTransaction(CScript(), CScriptWitness(), *creditTx);
     }
 
     TestBuilder& ScriptError(ScriptError_t err)
@@ -271,26 +312,21 @@ public:
         return *this;
     }
 
-    [[maybe_unused]] TestBuilder& Push(const std::string& hex)
+    TestBuilder& Push(const std::string& hex)
     {
         DoPush(ParseHex(hex));
         return *this;
     }
 
-    [[maybe_unused]] TestBuilder& Push(const uint256& hash)
+    TestBuilder& Push(const CScript& _script)
     {
-        DoPush(ToByteVector(hash));
+        DoPush(std::vector<unsigned char>(_script.begin(), _script.end()));
         return *this;
     }
 
-    [[maybe_unused]] TestBuilder& Push(const CScript& script)
+    TestBuilder& PushSig(const CKey& key, int nHashType = SIGHASH_ALL, unsigned int lenR = 32, unsigned int lenS = 32, SigVersion sigversion = SigVersion::BASE, CAmount amount = 0)
     {
-         DoPush(std::vector<unsigned char>(script.begin(), script.end()));
-        return *this;
-    }
-
-    std::vector<uint8_t> DoSignECDSA(const CKey& key, const uint256& hash, unsigned int lenR = 32, unsigned int lenS = 32) const
-    {
+        uint256 hash = SignatureHash(script, spendTx, 0, nHashType, amount, sigversion);
         std::vector<unsigned char> vchSig, r, s;
         uint32_t iter = 0;
         do {
@@ -301,29 +337,16 @@ public:
             r = std::vector<unsigned char>(vchSig.begin() + 4, vchSig.begin() + 4 + vchSig[3]);
             s = std::vector<unsigned char>(vchSig.begin() + 6 + vchSig[3], vchSig.begin() + 6 + vchSig[3] + vchSig[5 + vchSig[3]]);
         } while (lenR != r.size() || lenS != s.size());
-
-        return vchSig;
-    }
-
-    TestBuilder& PushSig(const CKey& key, int nHashType = SIGHASH_ALL, unsigned int lenR = 32, unsigned int lenS = 32)
-    {
-        uint256 hash = SignatureHash(scriptPubKey, spendTx, 0, nHashType, 0, SigVersion::BASE);
-        std::vector<uint8_t> vchSig = DoSignECDSA(key, hash, lenR, lenS);
         vchSig.push_back(static_cast<unsigned char>(nHashType));
         DoPush(vchSig);
         return *this;
     }
 
-    TestBuilder& PushDataSig(const CKey& key, const std::vector<uint8_t>& data, unsigned int lenR = 32, unsigned int lenS = 32)
+    TestBuilder& PushWitSig(const CKey& key, CAmount amount = -1, int nHashType = SIGHASH_ALL, unsigned int lenR = 32, unsigned int lenS = 32, SigVersion sigversion = SigVersion::WITNESS_V0)
     {
-        std::vector<uint8_t> vchHash(32);
-        CSHA256().Write(data.data(), data.size()).Finalize(vchHash.data());
-
-        std::vector<uint8_t> vchSig = DoSignECDSA(key, uint256(vchHash), lenR, lenS);
-        vchSig.push_back(static_cast<unsigned char>(SIGHASH_ALL));
-
-        DoPush(vchSig);
-        return *this;
+        if (amount == -1)
+            amount = nValue;
+        return PushSig(key, nHashType, lenR, lenS, sigversion, amount).AsWit();
     }
 
     TestBuilder& Push(const CPubKey& pubkey)
@@ -334,8 +357,14 @@ public:
 
     TestBuilder& PushRedeem()
     {
-        DoPush(std::vector<unsigned char>(scriptPubKey.begin(), scriptPubKey.end()));
+        DoPush(std::vector<unsigned char>(redeemscript.begin(), redeemscript.end()));
         return *this;
+    }
+
+    TestBuilder& PushWitRedeem()
+    {
+        DoPush(std::vector<unsigned char>(witscript.begin(), witscript.end()));
+        return AsWit();
     }
 
     TestBuilder& EditPush(unsigned int pos, const std::string& hexin, const std::string& hexout)
@@ -362,8 +391,16 @@ public:
     {
         TestBuilder copy = *this; // Make a copy so we can rollback the push.
         DoPush();
-        DoTest(creditTx->vout[0].scriptPubKey, spendTx.vin[0].scriptSig, flags, comment, scriptError);
+        DoTest(creditTx->vout[0].scriptPubKey, spendTx.vin[0].scriptSig, scriptWitness, flags, comment, scriptError, nValue);
         *this = copy;
+        return *this;
+    }
+
+    TestBuilder& AsWit()
+    {
+        assert(havePush);
+        scriptWitness.stack.push_back(push);
+        havePush = false;
         return *this;
     }
 
@@ -371,6 +408,14 @@ public:
     {
         DoPush();
         UniValue array(UniValue::VARR);
+        if (!scriptWitness.stack.empty()) {
+            UniValue wit(UniValue::VARR);
+            for (unsigned i = 0; i < scriptWitness.stack.size(); i++) {
+                wit.push_back(HexStr(scriptWitness.stack[i]));
+            }
+            wit.push_back(ValueFromAmount(nValue));
+            array.push_back(wit);
+        }
         array.push_back(FormatScript(spendTx.vin[0].scriptSig));
         array.push_back(FormatScript(creditTx->vout[0].scriptPubKey));
         array.push_back(FormatScriptFlags(flags));
@@ -664,184 +709,188 @@ BOOST_AUTO_TEST_CASE(script_build)
                                 "P2SH with CLEANSTACK", SCRIPT_VERIFY_CLEANSTACK | SCRIPT_VERIFY_P2SH, true
                                ).PushSig(keys.key0).PushRedeem());
 
-    // Test OP_CHECKDATASIG
-    const uint32_t checkdatasigflags = SCRIPT_VERIFY_STRICTENC |
-                                       SCRIPT_VERIFY_NULLFAIL;
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "Basic P2WSH", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH,
+                                0, 1).PushWitSig(keys.key0).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "Basic P2WPKH", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::PKH,
+                                0, 1).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "Basic P2SH(P2WSH)", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::SH,
+                                0, 1).PushWitSig(keys.key0).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "Basic P2SH(P2WPKH)", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::PKH,
+                                0, 1).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
+                                "Basic P2WSH with the wrong key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH
+                               ).PushWitSig(keys.key0).PushWitRedeem().ScriptError(SCRIPT_ERR_EVAL_FALSE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1),
+                                "Basic P2WPKH with the wrong key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::PKH
+                               ).PushWitSig(keys.key0).Push(keys.pubkey1).AsWit().ScriptError(SCRIPT_ERR_EVAL_FALSE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
+                                "Basic P2SH(P2WSH) with the wrong key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::SH
+                               ).PushWitSig(keys.key0).PushWitRedeem().PushRedeem().ScriptError(SCRIPT_ERR_EVAL_FALSE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1),
+                                "Basic P2SH(P2WPKH) with the wrong key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::PKH
+                               ).PushWitSig(keys.key0).Push(keys.pubkey1).AsWit().PushRedeem().ScriptError(SCRIPT_ERR_EVAL_FALSE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
+                                "Basic P2WSH with the wrong key but no WITNESS", SCRIPT_VERIFY_P2SH, false, WitnessMode::SH
+                               ).PushWitSig(keys.key0).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1),
+                                "Basic P2WPKH with the wrong key but no WITNESS", SCRIPT_VERIFY_P2SH, false, WitnessMode::PKH
+                               ).PushWitSig(keys.key0).Push(keys.pubkey1).AsWit());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
+                                "Basic P2SH(P2WSH) with the wrong key but no WITNESS", SCRIPT_VERIFY_P2SH, true, WitnessMode::SH
+                               ).PushWitSig(keys.key0).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1),
+                                "Basic P2SH(P2WPKH) with the wrong key but no WITNESS", SCRIPT_VERIFY_P2SH, true, WitnessMode::PKH
+                               ).PushWitSig(keys.key0).Push(keys.pubkey1).AsWit().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "Basic P2WSH with wrong value", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH,
+                                0, 0).PushWitSig(keys.key0, 1).PushWitRedeem().ScriptError(SCRIPT_ERR_EVAL_FALSE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "Basic P2WPKH with wrong value", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::PKH,
+                                0, 0).PushWitSig(keys.key0, 1).Push(keys.pubkey0).AsWit().ScriptError(SCRIPT_ERR_EVAL_FALSE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "Basic P2SH(P2WSH) with wrong value", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::SH,
+                                0, 0).PushWitSig(keys.key0, 1).PushWitRedeem().PushRedeem().ScriptError(SCRIPT_ERR_EVAL_FALSE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "Basic P2SH(P2WPKH) with wrong value", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::PKH,
+                                0, 0).PushWitSig(keys.key0, 1).Push(keys.pubkey0).AsWit().PushRedeem().ScriptError(SCRIPT_ERR_EVAL_FALSE));
 
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKDATASIG,
-                    "Standard CHECKDATASIG", checkdatasigflags)
-            .PushDataSig(keys.key1, {})
-            .Num(0));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIG << OP_NOT,
-                                "CHECKDATASIG with NULLFAIL flags",
-                                checkdatasigflags)
-                        .PushDataSig(keys.key1, {})
-                        .Num(1)
-                        .ScriptError(SCRIPT_ERR_SIG_NULLFAIL));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIG << OP_NOT,
-                                "CHECKDATASIG without NULLFAIL flags",
-                                checkdatasigflags & ~SCRIPT_VERIFY_NULLFAIL)
-                        .PushDataSig(keys.key1, {})
-                        .Num(1));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIG << OP_NOT,
-                                "CHECKDATASIG empty signature",
-                                checkdatasigflags)
-                        .Num(0)
-                        .Num(0));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKDATASIG,
-                    "CHECKDATASIG with High S but no Low S", checkdatasigflags)
-            .PushDataSig(keys.key1, {}, 32, 33)
-            .Num(0));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKDATASIG,
-                    "CHECKDATASIG with High S",
-                    checkdatasigflags | SCRIPT_VERIFY_LOW_S)
-            .PushDataSig(keys.key1, {}, 32, 33)
-            .Num(0)
-            .ScriptError(SCRIPT_ERR_SIG_HIGH_S));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKDATASIG,
-                    "CHECKDATASIG with too little R padding but no DERSIG",
-                    checkdatasigflags & ~SCRIPT_VERIFY_STRICTENC)
-            .PushDataSig(keys.key1, {}, 33, 32)
-            .EditPush(1, "45022100", "440220")
-            .Num(0));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKDATASIG,
-                    "CHECKDATASIG with too little R padding", checkdatasigflags)
-            .PushDataSig(keys.key1, {}, 33, 32)
-            .EditPush(1, "45022100", "440220")
-            .Num(0)
-            .ScriptError(SCRIPT_ERR_SIG_DER));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKDATASIG,
-                    "CHECKDATASIG with hybrid pubkey but no STRICTENC",
-                    checkdatasigflags & ~SCRIPT_VERIFY_STRICTENC)
-            .PushDataSig(keys.key0, {})
-            .Num(0));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKDATASIG,
-                    "CHECKDATASIG with hybrid pubkey", checkdatasigflags)
-            .PushDataSig(keys.key0, {})
-            .Num(0)
-            .ScriptError(SCRIPT_ERR_PUBKEYTYPE));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKDATASIG
-                              << OP_NOT,
-                    "CHECKDATASIG with invalid hybrid pubkey but no STRICTENC",
-                    0)
-            .PushDataSig(keys.key0, {})
-            .DamagePush(10)
-            .Num(0));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKDATASIG,
-                    "CHECKDATASIG with invalid hybrid pubkey",
-                    checkdatasigflags)
-            .PushDataSig(keys.key0, {})
-            .DamagePush(10)
-            .Num(0)
-            .ScriptError(SCRIPT_ERR_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "P2WPKH with future witness version", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH |
+                                SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM, false, WitnessMode::PKH, 1
+                               ).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit().ScriptError(SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM));
+    {
+        CScript witscript = CScript() << ToByteVector(keys.pubkey0);
+        uint256 hash;
+        CSHA256().Write(witscript.data(), witscript.size()).Finalize(hash.begin());
+        std::vector<unsigned char> hashBytes = ToByteVector(hash);
+        hashBytes.pop_back();
+        tests.push_back(TestBuilder(CScript() << OP_0 << hashBytes,
+                                    "P2WPKH with wrong witness program length", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false
+                                   ).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit().ScriptError(SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH));
+    }
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "P2WSH with empty witness", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH
+                               ).ScriptError(SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY));
+    {
+        CScript witscript = CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG;
+        tests.push_back(TestBuilder(witscript,
+                                    "P2WSH with witness program mismatch", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH
+                                   ).PushWitSig(keys.key0).Push(witscript).DamagePush(0).AsWit().ScriptError(SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH));
+    }
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "P2WPKH with witness program mismatch", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::PKH
+                               ).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit().Push("0").AsWit().ScriptError(SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "P2WPKH with non-empty scriptSig", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::PKH
+                               ).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit().Num(11).ScriptError(SCRIPT_ERR_WITNESS_MALLEATED));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1),
+                                "P2SH(P2WPKH) with superfluous push in scriptSig", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::PKH
+                               ).PushWitSig(keys.key0).Push(keys.pubkey1).AsWit().Num(11).PushRedeem().ScriptError(SCRIPT_ERR_WITNESS_MALLEATED_P2SH));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "P2PK with witness", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH
+                               ).PushSig(keys.key0).Push("0").AsWit().ScriptError(SCRIPT_ERR_WITNESS_UNEXPECTED));
 
-    // Test OP_CHECKDATASIGVERIFY
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "Standard CHECKDATASIGVERIFY",
-                                checkdatasigflags)
-                        .PushDataSig(keys.key1, {})
-                        .Num(0));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIGVERIFY with NULLFAIL flags",
-                                checkdatasigflags)
-                        .PushDataSig(keys.key1, {})
-                        .Num(1)
-                        .ScriptError(SCRIPT_ERR_SIG_NULLFAIL));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIGVERIFY without NULLFAIL flags",
-                                checkdatasigflags & ~SCRIPT_VERIFY_NULLFAIL)
-                        .PushDataSig(keys.key1, {})
-                        .Num(1)
-                        .ScriptError(SCRIPT_ERR_CHECKDATASIGVERIFY));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIGVERIFY empty signature",
-                                checkdatasigflags)
-                        .Num(0)
-                        .Num(0)
-                        .ScriptError(SCRIPT_ERR_CHECKDATASIGVERIFY));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIG with High S but no Low S",
-                                checkdatasigflags)
-                        .PushDataSig(keys.key1, {}, 32, 33)
-                        .Num(0));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIG with High S",
-                                checkdatasigflags | SCRIPT_VERIFY_LOW_S)
-                        .PushDataSig(keys.key1, {}, 32, 33)
-                        .Num(0)
-                        .ScriptError(SCRIPT_ERR_SIG_HIGH_S));
-    tests.push_back(
-        TestBuilder(
-            CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKDATASIGVERIFY
-                      << OP_TRUE,
-            "CHECKDATASIGVERIFY with too little R padding but no DERSIG",
-            checkdatasigflags & ~SCRIPT_VERIFY_STRICTENC)
-            .PushDataSig(keys.key1, {}, 33, 32)
-            .EditPush(1, "45022100", "440220")
-            .Num(0));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIGVERIFY with too little R padding",
-                                checkdatasigflags)
-                        .PushDataSig(keys.key1, {}, 33, 32)
-                        .EditPush(1, "45022100", "440220")
-                        .Num(0)
-                        .ScriptError(SCRIPT_ERR_SIG_DER));
-    tests.push_back(
-        TestBuilder(CScript() << ToByteVector(keys.pubkey0H)
-                              << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                    "CHECKDATASIGVERIFY with hybrid pubkey but no STRICTENC",
-                    checkdatasigflags & ~SCRIPT_VERIFY_STRICTENC)
-            .PushDataSig(keys.key0, {})
-            .Num(0));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIGVERIFY with hybrid pubkey",
-                                checkdatasigflags)
-                        .PushDataSig(keys.key0, {})
-                        .Num(0)
-                        .ScriptError(SCRIPT_ERR_PUBKEYTYPE));
-    tests.push_back(
-        TestBuilder(
-            CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKDATASIGVERIFY
-                      << OP_TRUE,
-            "CHECKDATASIGVERIFY with invalid hybrid pubkey but no STRICTENC",
-            0)
-            .PushDataSig(keys.key0, {})
-            .DamagePush(10)
-            .Num(0)
-            .ScriptError(SCRIPT_ERR_CHECKDATASIGVERIFY));
-    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H)
-                                          << OP_CHECKDATASIGVERIFY << OP_TRUE,
-                                "CHECKDATASIGVERIFY with invalid hybrid pubkey",
-                                checkdatasigflags)
-                        .PushDataSig(keys.key0, {})
-                        .DamagePush(10)
-                        .Num(0)
-                        .ScriptError(SCRIPT_ERR_PUBKEYTYPE));
+    // Compressed keys should pass SCRIPT_VERIFY_WITNESS_PUBKEYTYPE
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0C) << OP_CHECKSIG,
+                                "Basic P2WSH with compressed key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).PushWitSig(keys.key0C).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0C),
+                                "Basic P2WPKH with compressed key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::PKH,
+                                0, 1).PushWitSig(keys.key0C).Push(keys.pubkey0C).AsWit());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0C) << OP_CHECKSIG,
+                                "Basic P2SH(P2WSH) with compressed key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).PushWitSig(keys.key0C).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0C),
+                                "Basic P2SH(P2WPKH) with compressed key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::PKH,
+                                0, 1).PushWitSig(keys.key0C).Push(keys.pubkey0C).AsWit().PushRedeem());
+
+    // Testing uncompressed key in witness with SCRIPT_VERIFY_WITNESS_PUBKEYTYPE
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "Basic P2WSH", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).PushWitSig(keys.key0).PushWitRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "Basic P2WPKH", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::PKH,
+                                0, 1).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
+                                "Basic P2SH(P2WSH)", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).PushWitSig(keys.key0).PushWitRedeem().PushRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0),
+                                "Basic P2SH(P2WPKH)", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::PKH,
+                                0, 1).PushWitSig(keys.key0).Push(keys.pubkey0).AsWit().PushRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+
+    // P2WSH 1-of-2 multisig with compressed keys
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with compressed keys", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0C).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with compressed keys", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0C).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with compressed keys", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1C).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with compressed keys", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1C).PushWitRedeem().PushRedeem());
+
+    // P2WSH 1-of-2 multisig with first key uncompressed
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with first key uncompressed and signing with the first key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG first key uncompressed and signing with the first key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with first key uncompressed and signing with the first key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0).PushWitRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with first key uncompressed and signing with the first key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0).PushWitRedeem().PushRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with first key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1C).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with first key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1C).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with first key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1C).PushWitRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with first key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1C).PushWitRedeem().PushRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    // P2WSH 1-of-2 multisig with second key uncompressed
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with second key uncompressed and signing with the first key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0C).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG second key uncompressed and signing with the first key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0C).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with second key uncompressed and signing with the first key should pass as the uncompressed key is not used", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0C).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with second key uncompressed and signing with the first key should pass as the uncompressed key is not used", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key0C).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with second key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1).PushWitRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with second key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1).PushWitRedeem().PushRedeem());
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2WSH CHECKMULTISIG with second key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, false, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1).PushWitRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
+    tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1) << ToByteVector(keys.pubkey0C) << OP_2 << OP_CHECKMULTISIG,
+                                "P2SH(P2WSH) CHECKMULTISIG with second key uncompressed and signing with the second key", SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, true, WitnessMode::SH,
+                                0, 1).Push(CScript()).AsWit().PushWitSig(keys.key1).PushWitRedeem().PushRedeem().ScriptError(SCRIPT_ERR_WITNESS_PUBKEYTYPE));
 
     std::set<std::string> tests_set;
 
     {
-        UniValue json_tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
+        UniValue json_tests = read_json(json_tests::script_tests);
 
         for (unsigned int idx = 0; idx < json_tests.size(); idx++) {
             const UniValue& tv = json_tests[idx];
@@ -875,29 +924,42 @@ BOOST_AUTO_TEST_CASE(script_json_test)
 {
     // Read tests from test/data/script_tests.json
     // Format is an array of arrays
-    // Inner arrays are [ "scriptSig", "scriptPubKey", "flags", "expected_scripterror" ]
+    // Inner arrays are [ ["wit"..., nValue]?, "scriptSig", "scriptPubKey", "flags", "expected_scripterror" ]
     // ... where scriptSig and scriptPubKey are stringified
     // scripts.
-    UniValue tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
+    // If a witness is given, then the last value in the array should be the
+    // amount (nValue) to use in the crediting tx
+    UniValue tests = read_json(json_tests::script_tests);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
-        UniValue test = tests[idx];
+        const UniValue& test = tests[idx];
         std::string strTest = test.write();
-        if (test.size() < 4) // Allow size > 3; extra stuff ignored (useful for comments)
+        CScriptWitness witness;
+        CAmount nValue = 0;
+        unsigned int pos = 0;
+        if (test.size() > 0 && test[pos].isArray()) {
+            unsigned int i=0;
+            for (i = 0; i < test[pos].size()-1; i++) {
+                witness.stack.push_back(ParseHex(test[pos][i].get_str()));
+            }
+            nValue = AmountFromValue(test[pos][i]);
+            pos++;
+        }
+        if (test.size() < 4 + pos) // Allow size > 3; extra stuff ignored (useful for comments)
         {
             if (test.size() != 1) {
                 BOOST_ERROR("Bad test: " << strTest);
             }
             continue;
         }
-        std::string scriptSigString = test[0].get_str();
+        std::string scriptSigString = test[pos++].get_str();
         CScript scriptSig = ParseScript(scriptSigString);
-        std::string scriptPubKeyString = test[1].get_str();
+        std::string scriptPubKeyString = test[pos++].get_str();
         CScript scriptPubKey = ParseScript(scriptPubKeyString);
-        unsigned int scriptflags = ParseScriptFlags(test[2].get_str());
-        int scriptError = ParseScriptError(test[3].get_str());
+        unsigned int scriptflags = ParseScriptFlags(test[pos++].get_str());
+        int scriptError = ParseScriptError(test[pos++].get_str());
 
-        DoTest(scriptPubKey, scriptSig, scriptflags, strTest, scriptError);
+        DoTest(scriptPubKey, scriptSig, witness, scriptflags, strTest, scriptError, nValue);
     }
 }
 
@@ -997,21 +1059,21 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG12)
     scriptPubKey12 << OP_1 << ToByteVector(key1.GetPubKey()) << ToByteVector(key2.GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
 
     const CTransaction txFrom12{BuildCreditingTransaction(scriptPubKey12)};
-    CMutableTransaction txTo12 = BuildSpendingTransaction(CScript(), txFrom12);
+    CMutableTransaction txTo12 = BuildSpendingTransaction(CScript(), CScriptWitness(), txFrom12);
 
     CScript goodsig1 = sign_multisig(scriptPubKey12, key1, CTransaction(txTo12));
-    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey12, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
     txTo12.vout[0].nValue = 2;
-    BOOST_CHECK(!VerifyScript(goodsig1, scriptPubKey12, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(goodsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     CScript goodsig2 = sign_multisig(scriptPubKey12, key2, CTransaction(txTo12));
-    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey12, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     CScript badsig1 = sign_multisig(scriptPubKey12, key3, CTransaction(txTo12));
-    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey12, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey12, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 }
 
@@ -1028,59 +1090,59 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
     scriptPubKey23 << OP_2 << ToByteVector(key1.GetPubKey()) << ToByteVector(key2.GetPubKey()) << ToByteVector(key3.GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
 
     const CTransaction txFrom23{BuildCreditingTransaction(scriptPubKey23)};
-    CMutableTransaction txTo23 = BuildSpendingTransaction(CScript(), txFrom23);
+    CMutableTransaction txTo23 = BuildSpendingTransaction(CScript(), CScriptWitness(), txFrom23);
 
     std::vector<CKey> keys;
     keys.push_back(key1); keys.push_back(key2);
     CScript goodsig1 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key1); keys.push_back(key3);
     CScript goodsig2 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key3);
     CScript goodsig3 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(VerifyScript(goodsig3, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(VerifyScript(goodsig3, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key2); // Can't re-use sig
     CScript badsig1 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key1); // sigs must be in correct order
     CScript badsig2 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig2, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig2, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key3); keys.push_back(key2); // sigs must be in correct order
     CScript badsig3 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig3, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig3, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key4); keys.push_back(key2); // sigs must match pubkeys
     CScript badsig4 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig4, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig4, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key1); keys.push_back(key4); // sigs must match pubkeys
     CScript badsig5 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig5, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig5, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear(); // Must have signatures
     CScript badsig6 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
-    BOOST_CHECK(!VerifyScript(badsig6, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
+    BOOST_CHECK(!VerifyScript(badsig6, scriptPubKey23, nullptr, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
 }
 
@@ -1090,7 +1152,7 @@ SignatureData CombineSignatures(const CTxOut& txout, const CMutableTransaction& 
     SignatureData data;
     data.MergeSignatureData(scriptSig1);
     data.MergeSignatureData(scriptSig2);
-    ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(&tx, 0, txout.nValue), txout.scriptPubKey, data);
+    ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(tx, 0, txout.nValue, SIGHASH_DEFAULT), txout.scriptPubKey, data);
     return data;
 }
 
@@ -1110,7 +1172,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     }
 
     CMutableTransaction txFrom = BuildCreditingTransaction(GetScriptForDestination(PKHash(keys[0].GetPubKey())));
-    CMutableTransaction txTo = BuildSpendingTransaction(CScript(), CTransaction(txFrom));
+    CMutableTransaction txTo = BuildSpendingTransaction(CScript(), CScriptWitness(), CTransaction(txFrom));
     CScript& scriptPubKey = txFrom.vout[0].scriptPubKey;
     SignatureData scriptSig;
 
@@ -1119,7 +1181,8 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     BOOST_CHECK(combined.scriptSig.empty());
 
     // Single signature case:
-    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL)); // changes scriptSig
+    SignatureData dummy;
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, dummy)); // changes scriptSig
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSig, empty);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
@@ -1127,7 +1190,8 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
     SignatureData scriptSigCopy = scriptSig;
     // Signing again will give a different, valid signature:
-    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
+    SignatureData dummy_b;
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, dummy_b));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined.scriptSig == scriptSigCopy.scriptSig || combined.scriptSig == scriptSig.scriptSig);
@@ -1136,14 +1200,16 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     CScript pkSingle; pkSingle << ToByteVector(keys[0].GetPubKey()) << OP_CHECKSIG;
     BOOST_CHECK(keystore.AddCScript(pkSingle));
     scriptPubKey = GetScriptForDestination(ScriptHash(pkSingle));
-    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
+    SignatureData dummy_c;
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, dummy_c));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSig, empty);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
     combined = CombineSignatures(txFrom.vout[0], txTo, empty, scriptSig);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
     scriptSigCopy = scriptSig;
-    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
+    SignatureData dummy_d;
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, dummy_d));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined.scriptSig == scriptSigCopy.scriptSig || combined.scriptSig == scriptSig.scriptSig);
@@ -1151,7 +1217,8 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     // Hardest case:  Multisig 2-of-3
     scriptPubKey = GetScriptForMultisig(2, pubkeys);
     BOOST_CHECK(keystore.AddCScript(scriptPubKey));
-    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
+    SignatureData dummy_e;
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, dummy_e));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSig, empty);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
@@ -1215,7 +1282,7 @@ BOOST_AUTO_TEST_CASE(script_standard_push)
         CScript script;
         script << i;
         BOOST_CHECK_MESSAGE(script.IsPushOnly(), "Number " << i << " is not pure push.");
-        BOOST_CHECK_MESSAGE(VerifyScript(script, CScript() << OP_1, SCRIPT_VERIFY_MINIMALDATA, BaseSignatureChecker(), &err), "Number " << i << " push is not minimal data.");
+        BOOST_CHECK_MESSAGE(VerifyScript(script, CScript() << OP_1, nullptr, SCRIPT_VERIFY_MINIMALDATA, BaseSignatureChecker(), &err), "Number " << i << " push is not minimal data.");
         BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
     }
 
@@ -1224,7 +1291,7 @@ BOOST_AUTO_TEST_CASE(script_standard_push)
         CScript script;
         script << data;
         BOOST_CHECK_MESSAGE(script.IsPushOnly(), "Length " << i << " is not pure push.");
-        BOOST_CHECK_MESSAGE(VerifyScript(script, CScript() << OP_1, SCRIPT_VERIFY_MINIMALDATA, BaseSignatureChecker(), &err), "Length " << i << " push is not minimal data.");
+        BOOST_CHECK_MESSAGE(VerifyScript(script, CScript() << OP_1, nullptr, SCRIPT_VERIFY_MINIMALDATA, BaseSignatureChecker(), &err), "Length " << i << " push is not minimal data.");
         BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
     }
 }
@@ -1270,13 +1337,11 @@ BOOST_AUTO_TEST_CASE(script_GetScriptAsm)
     BOOST_CHECK_EQUAL(derSig + "83 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "83")) << vchPubKey));
 }
 
-static CScript
-ScriptFromHex(const char* hex)
+static CScript ScriptFromHex(const std::string& str)
 {
-    std::vector<unsigned char> data = ParseHex(hex);
+    std::vector<unsigned char> data = ParseHex(str);
     return CScript(data.begin(), data.end());
 }
-
 
 BOOST_AUTO_TEST_CASE(script_FindAndDelete)
 {
@@ -1387,117 +1452,384 @@ BOOST_AUTO_TEST_CASE(script_FindAndDelete)
     BOOST_CHECK(s == expect);
 }
 
+BOOST_AUTO_TEST_CASE(script_HasValidOps)
+{
+    // Exercise the HasValidOps functionality
+    CScript script;
+    script = ScriptFromHex("76a9141234567890abcdefa1a2a3a4a5a6a7a8a9a0aaab88ac"); // Normal script
+    BOOST_CHECK(script.HasValidOps());
+    script = ScriptFromHex("76a914ff34567890abcdefa1a2a3a4a5a6a7a8a9a0aaab88ac");
+    BOOST_CHECK(script.HasValidOps());
+    script = ScriptFromHex("ff88ac"); // Script with OP_INVALIDOPCODE explicit
+    BOOST_CHECK(!script.HasValidOps());
+    script = ScriptFromHex("88acc0"); // Script with undefined opcode
+    BOOST_CHECK(!script.HasValidOps());
+}
+
+static CMutableTransaction TxFromHex(const std::string& str)
+{
+    CMutableTransaction tx;
+    SpanReader{SER_DISK, SERIALIZE_TRANSACTION_NO_WITNESS, ParseHex(str)} >> tx;
+    return tx;
+}
+
+static std::vector<CTxOut> TxOutsFromJSON(const UniValue& univalue)
+{
+    assert(univalue.isArray());
+    std::vector<CTxOut> prevouts;
+    for (size_t i = 0; i < univalue.size(); ++i) {
+        CTxOut txout;
+        SpanReader{SER_DISK, 0, ParseHex(univalue[i].get_str())} >> txout;
+        prevouts.push_back(std::move(txout));
+    }
+    return prevouts;
+}
+
+static CScriptWitness ScriptWitnessFromJSON(const UniValue& univalue)
+{
+    assert(univalue.isArray());
+    CScriptWitness scriptwitness;
+    for (size_t i = 0; i < univalue.size(); ++i) {
+        auto bytes = ParseHex(univalue[i].get_str());
+        scriptwitness.stack.push_back(std::move(bytes));
+    }
+    return scriptwitness;
+}
+
 #if defined(HAVE_CONSENSUS_LIB)
 
-/* Test simple (successful) usage of dashconsensus_verify_script */
-BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_returns_true)
+/* Test simple (successful) usage of bitcoinconsensus_verify_script */
+BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_returns_true)
 {
     unsigned int libconsensus_flags = 0;
     int nIn = 0;
 
     CScript scriptPubKey;
     CScript scriptSig;
+    CScriptWitness wit;
 
     scriptPubKey << OP_1;
-    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
-    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey, 1)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, wit, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;
 
-    dashconsensus_error err;
-    int result = dashconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
+    bitcoinconsensus_error err;
+    int result = bitcoinconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
     BOOST_CHECK_EQUAL(result, 1);
-    BOOST_CHECK_EQUAL(err, dashconsensus_ERR_OK);
+    BOOST_CHECK_EQUAL(err, bitcoinconsensus_ERR_OK);
 }
 
-/* Test dashconsensus_verify_script returns invalid tx index err*/
-BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_tx_index_err)
+/* Test bitcoinconsensus_verify_script returns invalid tx index err*/
+BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_tx_index_err)
 {
     unsigned int libconsensus_flags = 0;
     int nIn = 3;
 
     CScript scriptPubKey;
     CScript scriptSig;
+    CScriptWitness wit;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
-    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey, 1)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, wit, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;
 
-    dashconsensus_error err;
-    int result = dashconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
+    bitcoinconsensus_error err;
+    int result = bitcoinconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
     BOOST_CHECK_EQUAL(result, 0);
-    BOOST_CHECK_EQUAL(err, dashconsensus_ERR_TX_INDEX);
+    BOOST_CHECK_EQUAL(err, bitcoinconsensus_ERR_TX_INDEX);
 }
 
-/* Test dashconsensus_verify_script returns tx size mismatch err*/
-BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_tx_size)
+/* Test bitcoinconsensus_verify_script returns tx size mismatch err*/
+BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_tx_size)
 {
     unsigned int libconsensus_flags = 0;
     int nIn = 0;
 
     CScript scriptPubKey;
     CScript scriptSig;
+    CScriptWitness wit;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
-    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey, 1)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, wit, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;
 
-    dashconsensus_error err;
-    int result = dashconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size() * 2, nIn, libconsensus_flags, &err);
+    bitcoinconsensus_error err;
+    int result = bitcoinconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size() * 2, nIn, libconsensus_flags, &err);
     BOOST_CHECK_EQUAL(result, 0);
-    BOOST_CHECK_EQUAL(err, dashconsensus_ERR_TX_SIZE_MISMATCH);
+    BOOST_CHECK_EQUAL(err, bitcoinconsensus_ERR_TX_SIZE_MISMATCH);
 }
 
-/* Test dashconsensus_verify_script returns invalid tx serialization error */
-BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_tx_serialization)
+/* Test bitcoinconsensus_verify_script returns invalid tx serialization error */
+BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_tx_serialization)
 {
     unsigned int libconsensus_flags = 0;
     int nIn = 0;
 
     CScript scriptPubKey;
     CScript scriptSig;
+    CScriptWitness wit;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
-    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey, 1)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, wit, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << 0xffffffff;
 
-    dashconsensus_error err;
-    int result = dashconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
+    bitcoinconsensus_error err;
+    int result = bitcoinconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
     BOOST_CHECK_EQUAL(result, 0);
-    BOOST_CHECK_EQUAL(err, dashconsensus_ERR_TX_DESERIALIZE);
+    BOOST_CHECK_EQUAL(err, bitcoinconsensus_ERR_TX_DESERIALIZE);
 }
 
-/* Test dashconsensus_verify_script returns invalid flags err */
-BOOST_AUTO_TEST_CASE(dashconsensus_verify_script_invalid_flags)
+/* Test bitcoinconsensus_verify_script returns amount required error */
+BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_amount_required_err)
+{
+    unsigned int libconsensus_flags = bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS;
+    int nIn = 0;
+
+    CScript scriptPubKey;
+    CScript scriptSig;
+    CScriptWitness wit;
+
+    scriptPubKey << OP_EQUAL;
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey, 1)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, wit, creditTx)};
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << spendTx;
+
+    bitcoinconsensus_error err;
+    int result = bitcoinconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
+    BOOST_CHECK_EQUAL(result, 0);
+    BOOST_CHECK_EQUAL(err, bitcoinconsensus_ERR_AMOUNT_REQUIRED);
+}
+
+/* Test bitcoinconsensus_verify_script returns invalid flags err */
+BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_invalid_flags)
 {
     unsigned int libconsensus_flags = 1 << 3;
     int nIn = 0;
 
     CScript scriptPubKey;
     CScript scriptSig;
+    CScriptWitness wit;
 
     scriptPubKey << OP_EQUAL;
-    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey)};
-    CTransaction spendTx{BuildSpendingTransaction(scriptSig, creditTx)};
+    CTransaction creditTx{BuildCreditingTransaction(scriptPubKey, 1)};
+    CTransaction spendTx{BuildSpendingTransaction(scriptSig, wit, creditTx)};
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << spendTx;
 
-    dashconsensus_error err;
-    int result = dashconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
+    bitcoinconsensus_error err;
+    int result = bitcoinconsensus_verify_script(scriptPubKey.data(), scriptPubKey.size(), UCharCast(stream.data()), stream.size(), nIn, libconsensus_flags, &err);
     BOOST_CHECK_EQUAL(result, 0);
-    BOOST_CHECK_EQUAL(err, dashconsensus_ERR_INVALID_FLAGS);
+    BOOST_CHECK_EQUAL(err, bitcoinconsensus_ERR_INVALID_FLAGS);
 }
 
-#endif
+#endif // defined(HAVE_CONSENSUS_LIB)
+
+static std::vector<unsigned int> AllConsensusFlags()
+{
+    std::vector<unsigned int> ret;
+
+    for (unsigned int i = 0; i < 128; ++i) {
+        unsigned int flag = 0;
+        if (i & 1) flag |= SCRIPT_VERIFY_P2SH;
+        if (i & 2) flag |= SCRIPT_VERIFY_DERSIG;
+        if (i & 4) flag |= SCRIPT_VERIFY_NULLDUMMY;
+        if (i & 8) flag |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+        if (i & 16) flag |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
+        if (i & 32) flag |= SCRIPT_VERIFY_WITNESS;
+        if (i & 64) flag |= SCRIPT_VERIFY_TAPROOT;
+
+        // SCRIPT_VERIFY_WITNESS requires SCRIPT_VERIFY_P2SH
+        if (flag & SCRIPT_VERIFY_WITNESS && !(flag & SCRIPT_VERIFY_P2SH)) continue;
+        // SCRIPT_VERIFY_TAPROOT requires SCRIPT_VERIFY_WITNESS
+        if (flag & SCRIPT_VERIFY_TAPROOT && !(flag & SCRIPT_VERIFY_WITNESS)) continue;
+
+        ret.push_back(flag);
+    }
+
+    return ret;
+}
+
+/** Precomputed list of all valid combinations of consensus-relevant script validation flags. */
+static const std::vector<unsigned int> ALL_CONSENSUS_FLAGS = AllConsensusFlags();
+
+static void AssetTest(const UniValue& test)
+{
+    BOOST_CHECK(test.isObject());
+
+    CMutableTransaction mtx = TxFromHex(test["tx"].get_str());
+    const std::vector<CTxOut> prevouts = TxOutsFromJSON(test["prevouts"]);
+    BOOST_CHECK(prevouts.size() == mtx.vin.size());
+    size_t idx = test["index"].getInt<int64_t>();
+    uint32_t test_flags{ParseScriptFlags(test["flags"].get_str())};
+    bool fin = test.exists("final") && test["final"].get_bool();
+
+    if (test.exists("success")) {
+        mtx.vin[idx].scriptSig = ScriptFromHex(test["success"]["scriptSig"].get_str());
+        mtx.vin[idx].scriptWitness = ScriptWitnessFromJSON(test["success"]["witness"]);
+        CTransaction tx(mtx);
+        PrecomputedTransactionData txdata;
+        txdata.Init(tx, std::vector<CTxOut>(prevouts));
+        CachingTransactionSignatureChecker txcheck(&tx, idx, prevouts[idx].nValue, true, txdata);
+        for (const auto flags : ALL_CONSENSUS_FLAGS) {
+            // "final": true tests are valid for all flags. Others are only valid with flags that are
+            // a subset of test_flags.
+            if (fin || ((flags & test_flags) == flags)) {
+                bool ret = VerifyScript(tx.vin[idx].scriptSig, prevouts[idx].scriptPubKey, &tx.vin[idx].scriptWitness, flags, txcheck, nullptr);
+                BOOST_CHECK(ret);
+            }
+        }
+    }
+
+    if (test.exists("failure")) {
+        mtx.vin[idx].scriptSig = ScriptFromHex(test["failure"]["scriptSig"].get_str());
+        mtx.vin[idx].scriptWitness = ScriptWitnessFromJSON(test["failure"]["witness"]);
+        CTransaction tx(mtx);
+        PrecomputedTransactionData txdata;
+        txdata.Init(tx, std::vector<CTxOut>(prevouts));
+        CachingTransactionSignatureChecker txcheck(&tx, idx, prevouts[idx].nValue, true, txdata);
+        for (const auto flags : ALL_CONSENSUS_FLAGS) {
+            // If a test is supposed to fail with test_flags, it should also fail with any superset thereof.
+            if ((flags & test_flags) == test_flags) {
+                bool ret = VerifyScript(tx.vin[idx].scriptSig, prevouts[idx].scriptPubKey, &tx.vin[idx].scriptWitness, flags, txcheck, nullptr);
+                BOOST_CHECK(!ret);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(script_assets_test)
+{
+    // See src/test/fuzz/script_assets_test_minimizer.cpp for information on how to generate
+    // the script_assets_test.json file used by this test.
+
+    const char* dir = std::getenv("DIR_UNIT_TEST_DATA");
+    BOOST_WARN_MESSAGE(dir != nullptr, "Variable DIR_UNIT_TEST_DATA unset, skipping script_assets_test");
+    if (dir == nullptr) return;
+    auto path = fs::path(dir) / "script_assets_test.json";
+    bool exists = fs::exists(path);
+    BOOST_WARN_MESSAGE(exists, "File $DIR_UNIT_TEST_DATA/script_assets_test.json not found, skipping script_assets_test");
+    if (!exists) return;
+    std::ifstream file{path};
+    BOOST_CHECK(file.is_open());
+    file.seekg(0, std::ios::end);
+    size_t length = file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::string data(length, '\0');
+    file.read(data.data(), data.size());
+    UniValue tests = read_json(data);
+    BOOST_CHECK(tests.isArray());
+    BOOST_CHECK(tests.size() > 0);
+
+    for (size_t i = 0; i < tests.size(); i++) {
+        AssetTest(tests[i]);
+    }
+    file.close();
+}
+
+BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
+{
+    UniValue tests;
+    tests.read(json_tests::bip341_wallet_vectors);
+
+    const auto& vectors = tests["keyPathSpending"];
+
+    for (const auto& vec : vectors.getValues()) {
+        auto txhex = ParseHex(vec["given"]["rawUnsignedTx"].get_str());
+        CMutableTransaction tx;
+        SpanReader{SER_NETWORK, PROTOCOL_VERSION, txhex} >> tx;
+        std::vector<CTxOut> utxos;
+        for (const auto& utxo_spent : vec["given"]["utxosSpent"].getValues()) {
+            auto script_bytes = ParseHex(utxo_spent["scriptPubKey"].get_str());
+            CScript script{script_bytes.begin(), script_bytes.end()};
+            CAmount amount{utxo_spent["amountSats"].getInt<int>()};
+            utxos.emplace_back(amount, script);
+        }
+
+        PrecomputedTransactionData txdata;
+        txdata.Init(tx, std::vector<CTxOut>{utxos}, true);
+
+        BOOST_CHECK(txdata.m_bip341_taproot_ready);
+        BOOST_CHECK_EQUAL(HexStr(txdata.m_spent_amounts_single_hash), vec["intermediary"]["hashAmounts"].get_str());
+        BOOST_CHECK_EQUAL(HexStr(txdata.m_outputs_single_hash), vec["intermediary"]["hashOutputs"].get_str());
+        BOOST_CHECK_EQUAL(HexStr(txdata.m_prevouts_single_hash), vec["intermediary"]["hashPrevouts"].get_str());
+        BOOST_CHECK_EQUAL(HexStr(txdata.m_spent_scripts_single_hash), vec["intermediary"]["hashScriptPubkeys"].get_str());
+        BOOST_CHECK_EQUAL(HexStr(txdata.m_sequences_single_hash), vec["intermediary"]["hashSequences"].get_str());
+
+        for (const auto& input : vec["inputSpending"].getValues()) {
+            int txinpos = input["given"]["txinIndex"].getInt<int>();
+            int hashtype = input["given"]["hashType"].getInt<int>();
+
+            // Load key.
+            auto privkey = ParseHex(input["given"]["internalPrivkey"].get_str());
+            CKey key;
+            key.Set(privkey.begin(), privkey.end(), true);
+
+            // Load Merkle root.
+            uint256 merkle_root;
+            if (!input["given"]["merkleRoot"].isNull()) {
+                merkle_root = uint256{ParseHex(input["given"]["merkleRoot"].get_str())};
+            }
+
+            // Compute and verify (internal) public key.
+            XOnlyPubKey pubkey{key.GetPubKey()};
+            BOOST_CHECK_EQUAL(HexStr(pubkey), input["intermediary"]["internalPubkey"].get_str());
+
+            // Sign and verify signature.
+            FlatSigningProvider provider;
+            provider.keys[key.GetPubKey().GetID()] = key;
+            MutableTransactionSignatureCreator creator(tx, txinpos, utxos[txinpos].nValue, &txdata, hashtype);
+            std::vector<unsigned char> signature;
+            BOOST_CHECK(creator.CreateSchnorrSig(provider, signature, pubkey, nullptr, &merkle_root, SigVersion::TAPROOT));
+            BOOST_CHECK_EQUAL(HexStr(signature), input["expected"]["witness"][0].get_str());
+
+            // We can't observe the tweak used inside the signing logic, so verify by recomputing it.
+            BOOST_CHECK_EQUAL(HexStr(pubkey.ComputeTapTweakHash(merkle_root.IsNull() ? nullptr : &merkle_root)), input["intermediary"]["tweak"].get_str());
+
+            // We can't observe the sighash used inside the signing logic, so verify by recomputing it.
+            ScriptExecutionData sed;
+            sed.m_annex_init = true;
+            sed.m_annex_present = false;
+            uint256 sighash;
+            BOOST_CHECK(SignatureHashSchnorr(sighash, sed, tx, txinpos, hashtype, SigVersion::TAPROOT, txdata, MissingDataBehavior::FAIL));
+            BOOST_CHECK_EQUAL(HexStr(sighash), input["intermediary"]["sigHash"].get_str());
+
+            // To verify the sigmsg, hash the expected sigmsg, and compare it with the (expected) sighash.
+            BOOST_CHECK_EQUAL(HexStr((HashWriter{HASHER_TAPSIGHASH} << Span{ParseHex(input["intermediary"]["sigMsg"].get_str())}).GetSHA256()), input["intermediary"]["sigHash"].get_str());
+        }
+
+    }
+}
+
+BOOST_AUTO_TEST_CASE(compute_tapbranch)
+{
+    uint256 hash1 = uint256S("8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7");
+    uint256 hash2 = uint256S("f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a");
+    uint256 result = uint256S("a64c5b7b943315f9b805d7a7296bedfcfd08919270a1f7a1466e98f8693d8cd9");
+    BOOST_CHECK_EQUAL(ComputeTapbranchHash(hash1, hash2), result);
+}
+
+BOOST_AUTO_TEST_CASE(compute_tapleaf)
+{
+    const uint8_t script[6] = {'f','o','o','b','a','r'};
+    uint256 tlc0 = uint256S("edbc10c272a1215dcdcc11d605b9027b5ad6ed97cd45521203f136767b5b9c06");
+    uint256 tlc2 = uint256S("8b5c4f90ae6bf76e259dbef5d8a59df06359c391b59263741b25eca76451b27a");
+
+    BOOST_CHECK_EQUAL(ComputeTapleafHash(0xc0, Span(script)), tlc0);
+    BOOST_CHECK_EQUAL(ComputeTapleafHash(0xc2, Span(script)), tlc2);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
 // Goal: check that SignatureHash generates correct hash
 BOOST_AUTO_TEST_CASE(sighash_from_data)
 {
-    UniValue tests = read_json(std::string(json_tests::sighash, json_tests::sighash + sizeof(json_tests::sighash)));
+    UniValue tests = read_json(json_tests::sighash);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -150,7 +150,7 @@ BOOST_FIXTURE_TEST_SUITE(transaction_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(tx_valid)
 {
     // Read tests from test/data/tx_valid.json
-    UniValue tests = read_json(std::string(json_tests::tx_valid, json_tests::tx_valid + sizeof(json_tests::tx_valid)));
+    UniValue tests = read_json(json_tests::tx_valid);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
 BOOST_AUTO_TEST_CASE(tx_invalid)
 {
     // Read tests from test/data/tx_invalid.json
-    UniValue tests = read_json(std::string(json_tests::tx_invalid, json_tests::tx_invalid + sizeof(json_tests::tx_invalid)));
+    UniValue tests = read_json(json_tests::tx_invalid);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -3,61 +3,65 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#ifndef __UNIVALUE_H__
-#define __UNIVALUE_H__
+#ifndef BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H
+#define BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H
 
-#include <stdint.h>
-#include <string.h>
-
-#include <string>
-#include <vector>
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
 #include <map>
-#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 class UniValue {
 public:
     enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };
 
+    class type_error : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
     UniValue() { typ = VNULL; }
-    UniValue(UniValue::VType initialType, const std::string& initialStr = "") {
-        typ = initialType;
-        val = initialStr;
-    }
-    UniValue(uint64_t val_) {
-        setInt(val_);
-    }
-    UniValue(int64_t val_) {
-        setInt(val_);
-    }
-    UniValue(bool val_) {
-        setBool(val_);
-    }
-    UniValue(int val_) {
-        setInt(val_);
-    }
-    UniValue(double val_) {
-        setFloat(val_);
-    }
-    UniValue(const std::string& val_) {
-        setStr(val_);
-    }
-    UniValue(const char *val_) {
-        std::string s(val_);
-        setStr(s);
+    UniValue(UniValue::VType type, std::string str = {}) : typ{type}, val{std::move(str)} {}
+    template <typename Ref, typename T = std::remove_cv_t<std::remove_reference_t<Ref>>,
+              std::enable_if_t<std::is_floating_point_v<T> ||                      // setFloat
+                                   std::is_same_v<bool, T> ||                      // setBool
+                                   std::is_signed_v<T> || std::is_unsigned_v<T> || // setInt
+                                   std::is_constructible_v<std::string, T>,        // setStr
+                               bool> = true>
+    UniValue(Ref&& val)
+    {
+        if constexpr (std::is_floating_point_v<T>) {
+            setFloat(val);
+        } else if constexpr (std::is_same_v<bool, T>) {
+            setBool(val);
+        } else if constexpr (std::is_signed_v<T>) {
+            setInt(int64_t{val});
+        } else if constexpr (std::is_unsigned_v<T>) {
+            setInt(uint64_t{val});
+        } else {
+            setStr(std::string{std::forward<Ref>(val)});
+        }
     }
 
     void clear();
 
-    bool setNull();
-    bool setBool(bool val);
-    bool setNumStr(const std::string& val);
-    bool setInt(uint64_t val);
-    bool setInt(int64_t val);
-    bool setInt(int val_) { return setInt((int64_t)val_); }
-    bool setFloat(double val);
-    bool setStr(const std::string& val);
-    bool setArray();
-    bool setObject();
+    void setNull();
+    void setBool(bool val);
+    void setNumStr(std::string str);
+    void setInt(uint64_t val);
+    void setInt(int64_t val);
+    void setInt(int val_) { return setInt(int64_t{val_}); }
+    void setFloat(double val);
+    void setStr(std::string str);
+    void setArray();
+    void setObject();
 
     enum VType getType() const { return typ; }
     const std::string& getValStr() const { return val; }
@@ -65,7 +69,6 @@ public:
 
     size_t size() const { return values.size(); }
 
-    bool getBool() const { return isTrue(); }
     void getObjMap(std::map<std::string,UniValue>& kv) const;
     bool checkObject(const std::map<std::string,UniValue::VType>& memberTypes) const;
     const UniValue& operator[](const std::string& key) const;
@@ -81,79 +84,19 @@ public:
     bool isArray() const { return (typ == VARR); }
     bool isObject() const { return (typ == VOBJ); }
 
-    bool push_back(const UniValue& val);
-    bool push_back(const std::string& val_) {
-        UniValue tmpVal(VSTR, val_);
-        return push_back(tmpVal);
-    }
-    bool push_back(const char *val_) {
-        std::string s(val_);
-        return push_back(s);
-    }
-    bool push_back(uint64_t val_) {
-        UniValue tmpVal(val_);
-        return push_back(tmpVal);
-    }
-    bool push_back(int64_t val_) {
-        UniValue tmpVal(val_);
-        return push_back(tmpVal);
-    }
-    bool push_back(bool val_) {
-        UniValue tmpVal(val_);
-        return push_back(tmpVal);
-    }
-    bool push_back(int val_) {
-        UniValue tmpVal(val_);
-        return push_back(tmpVal);
-    }
-    bool push_back(double val_) {
-        UniValue tmpVal(val_);
-        return push_back(tmpVal);
-    }
-    bool push_backV(const std::vector<UniValue>& vec);
+    void push_back(UniValue val);
+    void push_backV(const std::vector<UniValue>& vec);
     template <class It>
-    bool push_backV(It first, It last);
+    void push_backV(It first, It last);
 
-    void __pushKV(const std::string& key, const UniValue& val);
-    bool pushKV(const std::string& key, const UniValue& val);
-    bool pushKV(const std::string& key, const std::string& val_) {
-        UniValue tmpVal(VSTR, val_);
-        return pushKV(key, tmpVal);
-    }
-    bool pushKV(const std::string& key, const char *val_) {
-        std::string _val(val_);
-        return pushKV(key, _val);
-    }
-    bool pushKV(const std::string& key, int64_t val_) {
-        UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
-    }
-    bool pushKV(const std::string& key, uint64_t val_) {
-        UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
-    }
-    bool pushKV(const std::string& key, bool val_) {
-        UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
-    }
-    bool pushKV(const std::string& key, int val_) {
-        UniValue tmpVal((int64_t)val_);
-        return pushKV(key, tmpVal);
-    }
-    bool pushKV(const std::string& key, double val_) {
-        UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
-    }
-    bool pushKVs(const UniValue& obj);
+    void pushKVEnd(std::string key, UniValue val);
+    void pushKV(std::string key, UniValue val);
+    void pushKVs(UniValue obj);
 
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
 
-    bool read(const char *raw, size_t len);
-    bool read(const char *raw) { return read(raw, strlen(raw)); }
-    bool read(const std::string& rawStr) {
-        return read(rawStr.data(), rawStr.size());
-    }
+    bool read(std::string_view raw);
 
 private:
     UniValue::VType typ;
@@ -161,6 +104,7 @@ private:
     std::vector<std::string> keys;
     std::vector<UniValue> values;
 
+    void checkType(const VType& expected) const;
     bool findKey(const std::string& key, size_t& retIdx) const;
     void writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
@@ -170,24 +114,36 @@ public:
     // value is of unexpected type
     const std::vector<std::string>& getKeys() const;
     const std::vector<UniValue>& getValues() const;
+    template <typename Int>
+    Int getInt() const;
     bool get_bool() const;
     const std::string& get_str() const;
-    int get_int() const;
-    int64_t get_int64() const;
     double get_real() const;
     const UniValue& get_obj() const;
     const UniValue& get_array() const;
 
     enum VType type() const { return getType(); }
-    friend const UniValue& find_value( const UniValue& obj, const std::string& name);
+    const UniValue& find_value(std::string_view key) const;
 };
 
 template <class It>
-bool UniValue::push_backV(It first, It last)
+void UniValue::push_backV(It first, It last)
 {
-    if (typ != VARR) return false;
+    checkType(VARR);
     values.insert(values.end(), first, last);
-    return true;
+}
+
+template <typename Int>
+Int UniValue::getInt() const
+{
+    static_assert(std::is_integral<Int>::value);
+    checkType(VNUM);
+    Int result;
+    const auto [first_nonmatching, error_condition] = std::from_chars(val.data(), val.data() + val.size(), result);
+    if (first_nonmatching != val.data() + val.size() || error_condition != std::errc{}) {
+        throw std::runtime_error("JSON integer out of range");
+    }
+    return result;
 }
 
 enum jtokentype {
@@ -245,6 +201,4 @@ static inline bool json_isspace(int ch)
 
 extern const UniValue NullUniValue;
 
-const UniValue& find_value( const UniValue& obj, const std::string& name);
-
-#endif // __UNIVALUE_H__
+#endif // BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -2,11 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <string.h>
+#include <univalue.h>
+#include <univalue_utffilter.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <string_view>
 #include <vector>
-#include <stdio.h>
-#include "univalue.h"
-#include "univalue_utffilter.h"
 
 /*
  * According to stackexchange, the original json test suite wanted
@@ -14,7 +18,7 @@
  * so we will follow PHP's lead, which should be more than sufficient
  * (further stackexchange comments indicate depth > 32 rarely occurs).
  */
-static const size_t MAX_JSON_DEPTH = 512;
+static constexpr size_t MAX_JSON_DEPTH = 512;
 
 static bool json_isdigit(int ch)
 {
@@ -256,7 +260,7 @@ enum expect_bits : unsigned {
 #define setExpect(bit) (expectMask |= EXP_##bit)
 #define clearExpect(bit) (expectMask &= ~EXP_##bit)
 
-bool UniValue::read(const char *raw, size_t size)
+bool UniValue::read(std::string_view str_in)
 {
     clear();
 
@@ -267,7 +271,8 @@ bool UniValue::read(const char *raw, size_t size)
     unsigned int consumed;
     enum jtokentype tok = JTOK_NONE;
     enum jtokentype last_tok = JTOK_NONE;
-    const char* end = raw + size;
+    const char* raw{str_in.data()};
+    const char* end{raw + str_in.size()};
     do {
         last_tok = tok;
 

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -2,26 +2,17 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <univalue.h>
+
 #include <cassert>
+#include <cstdio>
 #include <string>
-#include "univalue.h"
 
 #ifndef JSON_TEST_SRC
 #error JSON_TEST_SRC must point to test source directory
 #endif
 
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
-#endif
-
 std::string srcdir(JSON_TEST_SRC);
-static bool test_failed = false;
-
-#define d_assert(expr) { if (!(expr)) { test_failed = true; fprintf(stderr, "%s failed\n", filename.c_str()); } }
-#define f_assert(expr) { if (!(expr)) { test_failed = true; fprintf(stderr, "%s failed\n", __func__); } }
 
 static std::string rtrim(std::string s)
 {
@@ -42,9 +33,9 @@ static void runtest(std::string filename, const std::string& jdata)
         bool testResult = val.read(jdata);
 
         if (wantPass) {
-            d_assert(testResult == true);
+            assert(testResult == true);
         } else {
-            d_assert(testResult == false);
+            assert(testResult == false);
         }
 
         if (wantRoundTrip) {
@@ -142,30 +133,38 @@ void unescape_unicode_test()
     bool testResult;
     // Escaped ASCII (quote)
     testResult = val.read("[\"\\u0022\"]");
-    f_assert(testResult);
-    f_assert(val[0].get_str() == "\"");
+    assert(testResult);
+    assert(val[0].get_str() == "\"");
     // Escaped Basic Plane character, two-byte UTF-8
     testResult = val.read("[\"\\u0191\"]");
-    f_assert(testResult);
-    f_assert(val[0].get_str() == "\xc6\x91");
+    assert(testResult);
+    assert(val[0].get_str() == "\xc6\x91");
     // Escaped Basic Plane character, three-byte UTF-8
     testResult = val.read("[\"\\u2191\"]");
-    f_assert(testResult);
-    f_assert(val[0].get_str() == "\xe2\x86\x91");
+    assert(testResult);
+    assert(val[0].get_str() == "\xe2\x86\x91");
     // Escaped Supplementary Plane character U+1d161
     testResult = val.read("[\"\\ud834\\udd61\"]");
-    f_assert(testResult);
-    f_assert(val[0].get_str() == "\xf0\x9d\x85\xa1");
+    assert(testResult);
+    assert(val[0].get_str() == "\xf0\x9d\x85\xa1");
+}
+
+void no_nul_test()
+{
+    char buf[] = "___[1,2,3]___";
+    UniValue val;
+    assert(val.read({buf + 3, 7}));
 }
 
 int main (int argc, char *argv[])
 {
-    for (unsigned int fidx = 0; fidx < ARRAY_SIZE(filenames); fidx++) {
-        runtest_file(filenames[fidx]);
+    for (const auto& f: filenames) {
+        runtest_file(f);
     }
 
     unescape_unicode_test();
+    no_nul_test();
 
-    return test_failed ? 1 : 0;
+    return 0;
 }
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28168

Original commit: 8aa77a77e6

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded script testing to fully support SegWit and Taproot (witness) features, including new test cases for advanced script validation and assets.
  * Improved consensus library integration in script tests, now supporting witness and amount parameters.
  * Added new unit tests for Taproot utilities and JSON parsing with embedded nulls.

* **Refactor**
  * Modernized JSON parsing and UniValue API with C++17 features, improved type safety, and unified interfaces.
  * Simplified test data loading in multiple test files for improved clarity and maintainability.

* **Style**
  * Updated naming conventions and cleaned up build configuration to align with Bitcoin standards.

* **Bug Fixes**
  * Enhanced error handling and type checking in JSON and script tests for more robust validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->