### PR TITLE
Merge bitcoin/bitcoin#28148: refactor: consistently use ApplyArgsManOptions for PeerManager::Options

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1584,6 +1584,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     fListen = args.GetBoolArg("-listen", DEFAULT_LISTEN);
     fDiscover = args.GetBoolArg("-discover", true);
+    // TODO: This reads -blocksonly a second time. Bitcoin PR #28148 addresses this
+    // by using PeerManager::Options, but that requires PR #27499 to be backported first.
     const bool ignores_incoming_txs{args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)};
 
     // We need to initialize g_stats_client early as currently, g_stats_client is called


### PR DESCRIPTION
## Summary

This is a **partial backport** of Bitcoin PR #28148. The full backport requires `PeerManager::Options` infrastructure from PR #27499 which hasn't been backported to Dash yet.

**What this PR does:**
- Adds a TODO comment documenting that `-blocksonly` is read twice in the codebase
- Prepares for future full backport once PR #27499 is available

**Why partial backport:**
- Bitcoin PR #28148 refactors to use `ApplyArgsManOptions` with `PeerManager::Options`
- Dash's PeerManager doesn't have an Options struct yet (requires PR #27499)
- The duplicate read of `-blocksonly` is not critical, just suboptimal

## Test plan
- [x] Code compiles successfully
- [x] No functional changes, only adds a comment
- [x] Can be safely merged without affecting functionality

## Original PR description

> Consistently use `ApplyArgsManOptions` for `PeerManager::Options`, and initialize `PeerManager::Options` early to avoid reading `"-blocksonly"` twice.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clarifying comment regarding the handling of a specific configuration option during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->