### PR TITLE
Merge bitcoin/bitcoin#28118: test: Add SyncWithValidationInterfaceQueue to mockscheduler RPC

### DIFF
--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -30,7 +30,6 @@
 #include <util/check.h>
 #include <util/system.h>
 #include <validation.h>
-#include <validationinterface.h>
 
 #include <masternode/sync.h>
 #include <spork.h>

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -30,6 +30,7 @@
 #include <util/check.h>
 #include <util/system.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <masternode/sync.h>
 #include <spork.h>

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -30,6 +30,7 @@
 #include <util/check.h>
 #include <util/system.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <masternode/sync.h>
 #include <spork.h>
@@ -266,10 +267,9 @@ static RPCHelpMan setmocktime()
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Mocktime cannot be negative: %s.", time));
     }
     SetMockTime(time);
-    if (auto* node_context = GetContext<NodeContext>(request.context)) {
-        for (const auto& chain_client : node_context->chain_clients) {
-            chain_client->setMockTime(time);
-        }
+    const NodeContext& node_context{EnsureAnyNodeContext(request.context)};
+    for (const auto& chain_client : node_context.chain_clients) {
+        chain_client->setMockTime(time);
     }
 
     return NullUniValue;
@@ -840,10 +840,9 @@ static RPCHelpMan mockscheduler()
         throw std::runtime_error("delta_time must be between 1 and 3600 seconds (1 hr)");
     }
 
-    auto* node_context = CHECK_NONFATAL(GetContext<NodeContext>(request.context));
-    // protect against null pointer dereference
-    CHECK_NONFATAL(node_context->scheduler);
-    node_context->scheduler->MockForward(std::chrono::seconds(delta_seconds));
+    const NodeContext& node_context{EnsureAnyNodeContext(request.context)};
+    CHECK_NONFATAL(node_context.scheduler)->MockForward(std::chrono::seconds{delta_seconds});
+    SyncWithValidationInterfaceQueue();
 
     return NullUniValue;
 },


### PR DESCRIPTION
Backports bitcoin/bitcoin#28118

Original commit: 64440bb733

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of mock time and scheduler-related RPC commands by enforcing required context and ensuring proper synchronization after scheduler operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->