### PR TITLE
Merge bitcoin/bitcoin#28194: test: python E721 and flake8 updates

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -33,13 +33,11 @@ if [ -z "${SKIP_PYTHON_INSTALL}" ]; then
     python3 --version
 fi
 
-${CI_RETRY_EXE} pip3 install \
-  codespell==2.2.5 \
-  flake8==6.1.0 \
-  lief==0.13.2 \
-  mypy==1.4.1 \
-  pyzmq==25.1.0 \
-  vulture==2.6
+${CI_RETRY_EXE} pip3 install codespell==2.0.0
+${CI_RETRY_EXE} pip3 install flake8==6.1.0
+${CI_RETRY_EXE} pip3 install mypy==0.910
+${CI_RETRY_EXE} pip3 install pyzmq==22.3.0
+${CI_RETRY_EXE} pip3 install vulture==2.3
 
 SHELLCHECK_VERSION=v0.8.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -33,11 +33,13 @@ if [ -z "${SKIP_PYTHON_INSTALL}" ]; then
     python3 --version
 fi
 
-${CI_RETRY_EXE} pip3 install codespell==2.0.0
-${CI_RETRY_EXE} pip3 install flake8==3.8.3
-${CI_RETRY_EXE} pip3 install mypy==0.910
-${CI_RETRY_EXE} pip3 install pyzmq==22.3.0
-${CI_RETRY_EXE} pip3 install vulture==2.3
+${CI_RETRY_EXE} pip3 install \
+  codespell==2.2.5 \
+  flake8==6.1.0 \
+  lief==0.13.2 \
+  mypy==1.4.1 \
+  pyzmq==25.1.0 \
+  vulture==2.6
 
 SHELLCHECK_VERSION=v0.8.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -32,7 +32,7 @@ class InvalidLocatorTest(BitcoinTestFramework):
             within_max_peer = node.add_p2p_connection(P2PInterface())
             msg.locator.vHave = [int(node.getblockhash(i - 1), 16) for i in range(block_count, block_count - (MAX_LOCATOR_SZ), -1)]
             within_max_peer.send_message(msg)
-            if type(msg) == msg_getheaders:
+            if type(msg) is msg_getheaders:
                 within_max_peer.wait_for_header(node.getbestblockhash())
             else:
                 within_max_peer.wait_for_block(int(node.getbestblockhash(), 16))

--- a/test/functional/test_framework/crypto/siphash.py
+++ b/test/functional/test_framework/crypto/siphash.py
@@ -31,7 +31,7 @@ def siphash_round(v0, v1, v2, v3):
 
 
 def siphash(k0, k1, data):
-    assert type(data) is bytes
+    assert(type(data) == bytes)
     v0 = 0x736f6d6570736575 ^ k0
     v1 = 0x646f72616e646f6d ^ k1
     v2 = 0x6c7967656e657261 ^ k0
@@ -61,5 +61,5 @@ def siphash(k0, k1, data):
 
 
 def siphash256(k0, k1, num):
-    assert type(num) is int
+    assert(type(num) == int)
     return siphash(k0, k1, num.to_bytes(32, 'little'))

--- a/test/functional/test_framework/crypto/siphash.py
+++ b/test/functional/test_framework/crypto/siphash.py
@@ -31,7 +31,7 @@ def siphash_round(v0, v1, v2, v3):
 
 
 def siphash(k0, k1, data):
-    assert(type(data) == bytes)
+    assert type(data) is bytes
     v0 = 0x736f6d6570736575 ^ k0
     v1 = 0x646f72616e646f6d ^ k1
     v2 = 0x6c7967656e657261 ^ k0
@@ -61,5 +61,5 @@ def siphash(k0, k1, data):
 
 
 def siphash256(k0, k1, num):
-    assert(type(num) == int)
+    assert type(num) is int
     return siphash(k0, k1, num.to_bytes(32, 'little'))


### PR DESCRIPTION
Backports bitcoin/bitcoin#28194

Original commit: e5a9f2fb62dc4db6cad21b2997d96a881ea64125

This PR updates our functional tests per E721 linting rules enforced by flake8 6.1.0, and updates our CI lint task to use that release.

Changes:
- Updates flake8 from 3.8.3 to 6.1.0 along with other linting dependencies
- Changes `type(x) == y` to `type(x) is y` in Python code to comply with E721
- Skipped descriptor_parse.cpp spelling fix as the file has different implementation in Dash

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded linting tool to latest version

* **Tests**
  * Enhanced type validation checks in test suite with stricter comparison methods

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->