### PR TITLE
Merge bitcoin/bitcoin#28144: test: fix intermittent failure in p2p_getaddr_caching.py

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -179,6 +179,11 @@ const CLogCategoryDesc LogCategories[] =
 #endif
     {BCLog::BLOCKSTORE, "blockstorage"},
     {BCLog::TXRECONCILIATION, "txreconciliation"},
+<<<<<<< HEAD
+=======
+    {BCLog::SCAN, "scan"},
+    {BCLog::TXPACKAGES, "txpackages"},
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 
@@ -296,6 +301,7 @@ std::string LogCategoryToStr(BCLog::LogFlags category)
         return "blockstorage";
     case BCLog::LogFlags::TXRECONCILIATION:
         return "txreconciliation";
+<<<<<<< HEAD
     /* Start Dash */
     case BCLog::LogFlags::CHAINLOCKS:
         return "chainlocks";
@@ -328,6 +334,12 @@ std::string LogCategoryToStr(BCLog::LogFlags category)
     case BCLog::LogFlags::NET_NETCONN:
         return "net|netconn";
     /* End Dash */
+=======
+    case BCLog::LogFlags::SCAN:
+        return "scan";
+    case BCLog::LogFlags::TXPACKAGES:
+        return "txpackages";
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
     case BCLog::LogFlags::ALL:
         return "all";
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -67,6 +67,7 @@ namespace BCLog {
 #endif
         BLOCKSTORE  = (1 << 26),
         TXRECONCILIATION = (1 << 27),
+<<<<<<< HEAD
 
         //Start Dash
         CHAINLOCKS  = ((uint64_t)1 << 32),
@@ -91,6 +92,11 @@ namespace BCLog {
         //End Dash
 
         ALL         = ~(uint64_t)0,
+=======
+        SCAN        = (1 << 28),
+        TXPACKAGES  = (1 << 29),
+        ALL         = ~(uint32_t)0,
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
     };
     enum class Level {
         Trace = 0, // High-volume or detailed logging for development/debugging

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3219,26 +3219,84 @@ void PeerManagerImpl::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
 
         const MempoolAcceptResult result = m_chainman.ProcessTransaction(porphanTx);
         const TxValidationState& state = result.m_state;
+<<<<<<< HEAD
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
             _RelayTransaction(porphanTx->GetHash());
             m_orphanage.AddChildrenToWorkSet(*porphanTx, orphan_work_set);
+=======
+        const uint256& orphanHash = porphanTx->GetHash();
+        const uint256& orphan_wtxid = porphanTx->GetWitnessHash();
+
+        if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
+            LogPrint(BCLog::TXPACKAGES, "   accepted orphan tx %s (wtxid=%s)\n", orphanHash.ToString(), orphan_wtxid.ToString());
+            LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (wtxid=%s) (poolsz %u txn, %u kB)\n",
+                peer.m_id,
+                orphanHash.ToString(),
+                orphan_wtxid.ToString(),
+                m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
+            RelayTransaction(orphanHash, porphanTx->GetWitnessHash());
+            m_orphanage.AddChildrenToWorkSet(*porphanTx);
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
             m_orphanage.EraseTx(orphanHash);
             break;
         } else if (state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
             if (state.IsInvalid()) {
-                LogPrint(BCLog::MEMPOOL, "   invalid orphan tx %s from peer=%d. %s\n",
+                LogPrint(BCLog::TXPACKAGES, "   invalid orphan tx %s (wtxid=%s) from peer=%d. %s\n",
                     orphanHash.ToString(),
+<<<<<<< HEAD
                     from_peer,
+=======
+                    orphan_wtxid.ToString(),
+                    peer.m_id,
+                    state.ToString());
+                LogPrint(BCLog::MEMPOOLREJ, "%s (wtxid=%s) from peer=%d was not accepted: %s\n",
+                    orphanHash.ToString(),
+                    orphan_wtxid.ToString(),
+                    peer.m_id,
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
                     state.ToString());
                 // Maybe punish peer that gave us an invalid orphan tx
                 MaybePunishNodeForTx(from_peer, state);
             }
             // Has inputs but not accepted to mempool
             // Probably non-standard or insufficient fee
+<<<<<<< HEAD
             LogPrint(BCLog::MEMPOOL, "   removed orphan tx %s\n", orphanHash.ToString());
             m_recent_rejects.insert(orphanHash);
+=======
+            LogPrint(BCLog::TXPACKAGES, "   removed orphan tx %s (wtxid=%s)\n", orphanHash.ToString(), orphan_wtxid.ToString());
+            if (state.GetResult() != TxValidationResult::TX_WITNESS_STRIPPED) {
+                // We can add the wtxid of this transaction to our reject filter.
+                // Do not add txids of witness transactions or witness-stripped
+                // transactions to the filter, as they can have been malleated;
+                // adding such txids to the reject filter would potentially
+                // interfere with relay of valid transactions from peers that
+                // do not support wtxid-based relay. See
+                // https://github.com/bitcoin/bitcoin/issues/8279 for details.
+                // We can remove this restriction (and always add wtxids to
+                // the filter even for witness stripped transactions) once
+                // wtxid-based relay is broadly deployed.
+                // See also comments in https://github.com/bitcoin/bitcoin/pull/18044#discussion_r443419034
+                // for concerns around weakening security of unupgraded nodes
+                // if we start doing this too early.
+                m_recent_rejects.insert(porphanTx->GetWitnessHash());
+                // If the transaction failed for TX_INPUTS_NOT_STANDARD,
+                // then we know that the witness was irrelevant to the policy
+                // failure, since this check depends only on the txid
+                // (the scriptPubKey being spent is covered by the txid).
+                // Add the txid to the reject filter to prevent repeated
+                // processing of this transaction in the event that child
+                // transactions are later received (resulting in
+                // parent-fetching by txid via the orphan-handling logic).
+                if (state.GetResult() == TxValidationResult::TX_INPUTS_NOT_STANDARD && porphanTx->GetWitnessHash() != porphanTx->GetHash()) {
+                    // We only add the txid if it differs from the wtxid, to
+                    // avoid wasting entries in the rolling bloom filter.
+                    m_recent_rejects.insert(porphanTx->GetHash());
+                }
+            }
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
             m_orphanage.EraseTx(orphanHash);
             break;
         }
@@ -4473,6 +4531,7 @@ void PeerManagerImpl::ProcessMessage(
 
         if (AlreadyHave(inv)) {
             if (pfrom.HasPermission(NetPermissionFlags::ForceRelay)) {
+<<<<<<< HEAD
                 // Always relay transactions received from peers with forcerelay permission, even
                 // if they were already in the mempool,
                 // allowing the node to function as a gateway for
@@ -4482,8 +4541,35 @@ void PeerManagerImpl::ProcessMessage(
                 } else {
                     LogPrintf("Force relaying tx %s from peer=%d\n", tx.GetHash().ToString(), pfrom.GetId());
                     _RelayTransaction(tx.GetHash());
+=======
+                // Always relay transactions received from peers with forcerelay
+                // permission, even if they were already in the mempool, allowing
+                // the node to function as a gateway for nodes hidden behind it.
+                if (!m_mempool.exists(GenTxid::Txid(tx.GetHash()))) {
+                    LogPrintf("Not relaying non-mempool transaction %s (wtxid=%s) from forcerelay peer=%d\n",
+                              tx.GetHash().ToString(), tx.GetWitnessHash().ToString(), pfrom.GetId());
+                } else {
+                    LogPrintf("Force relaying tx %s (wtxid=%s) from peer=%d\n",
+                              tx.GetHash().ToString(), tx.GetWitnessHash().ToString(), pfrom.GetId());
+                    RelayTransaction(tx.GetHash(), tx.GetWitnessHash());
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
                 }
             }
+            // If a tx is detected by m_recent_rejects it is ignored. Because we haven't
+            // submitted the tx to our mempool, we won't have computed a DoS
+            // score for it or determined exactly why we consider it invalid.
+            //
+            // This means we won't penalize any peer subsequently relaying a DoSy
+            // tx (even if we penalized the first peer who gave it to us) because
+            // we have to account for m_recent_rejects showing false positives. In
+            // other words, we shouldn't penalize a peer if we aren't *sure* they
+            // submitted a DoSy tx.
+            //
+            // Note that m_recent_rejects doesn't just record DoSy or invalid
+            // transactions, but any tx not accepted by the mempool, which may be
+            // due to node policy (vs. consensus). So we can't blanket penalize a
+            // peer simply for relaying a tx that our m_recent_rejects has caught,
+            // regardless of false positives.
             return;
         }
 
@@ -4503,10 +4589,18 @@ void PeerManagerImpl::ProcessMessage(
 
             pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
 
+<<<<<<< HEAD
             LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (poolsz %u txn, %u kB)\n",
                      pfrom.GetId(),
                      tx.GetHash().ToString(),
                      m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
+=======
+            LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (wtxid=%s) (poolsz %u txn, %u kB)\n",
+                pfrom.GetId(),
+                tx.GetHash().ToString(),
+                tx.GetWitnessHash().ToString(),
+                m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
 
             // Recursively process any orphan transactions that depended on this one
             ProcessOrphanTx(peer->m_orphan_work_set);
@@ -4555,7 +4649,9 @@ void PeerManagerImpl::ProcessMessage(
                     LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
                 }
             } else {
-                LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s\n",tx.GetHash().ToString());
+                LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s (wtxid=%s)\n",
+                         tx.GetHash().ToString(),
+                         tx.GetWitnessHash().ToString());
                 // We will continue to reject this tx since it has rejected
                 // parents so avoid re-requesting it from other peers.
                 m_recent_rejects.insert(tx.GetHash());
@@ -4568,6 +4664,7 @@ void PeerManagerImpl::ProcessMessage(
             }
         }
 
+<<<<<<< HEAD
         // If a tx has been detected by m_recent_rejects, we will have reached
         // this point and the tx will have been ignored. Because we haven't
         // submitted the tx to our mempool, we won't have computed a DoS
@@ -4585,8 +4682,12 @@ void PeerManagerImpl::ProcessMessage(
         // peer simply for relaying a tx that our m_recent_rejects has caught,
         // regardless of false positives.
 
+=======
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
         if (state.IsInvalid()) {
-            LogPrint(BCLog::MEMPOOLREJ, "%s from peer=%d was not accepted: %s\n", tx.GetHash().ToString(),
+            LogPrint(BCLog::MEMPOOLREJ, "%s (wtxid=%s) from peer=%d was not accepted: %s\n",
+                tx.GetHash().ToString(),
+                tx.GetWitnessHash().ToString(),
                 pfrom.GetId(),
                 state.ToString());
             MaybePunishNodeForTx(pfrom.GetId(), state);

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -23,6 +23,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     AssertLockHeld(g_cs_orphans);
 
     const uint256& hash = tx->GetHash();
+    const uint256& wtxid = tx->GetWitnessHash();
     if (m_orphans.count(hash))
         return false;
 
@@ -36,7 +37,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     unsigned int sz = GetSerializeSize(*tx, CTransaction::CURRENT_VERSION);
     if (sz > MAX_STANDARD_TX_SIZE)
     {
-        LogPrint(BCLog::MEMPOOL, "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
+        LogPrint(BCLog::TXPACKAGES, "ignoring large orphan tx (size: %u, txid: %s, wtxid: %s)\n", sz, hash.ToString(), wtxid.ToString());
         return false;
     }
 
@@ -47,9 +48,13 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
 
+<<<<<<< HEAD
     m_orphan_tx_size += sz;
 
     LogPrint(BCLog::MEMPOOL, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
+=======
+    LogPrint(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s) (mapsz %u outsz %u)\n", hash.ToString(), wtxid.ToString(),
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
              m_orphans.size(), m_outpoint_to_orphan_it.size());
     ::g_stats_client->inc("transactions.orphans.add", 1.0f);
     ::g_stats_client->gauge("transactions.orphans", m_orphans.size());
@@ -82,6 +87,8 @@ int TxOrphanage::EraseTx(const uint256& txid)
         m_orphan_list[old_pos] = it_last;
         it_last->second.list_pos = old_pos;
     }
+    const auto& wtxid = it->second.tx->GetWitnessHash();
+    LogPrint(BCLog::TXPACKAGES, "   removed orphan tx %s (wtxid=%s)\n", txid.ToString(), wtxid.ToString());
     m_orphan_list.pop_back();
 
     assert(m_orphan_tx_size >= it->second.nTxSize);
@@ -106,7 +113,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
             nErased += EraseTx(maybeErase->second.tx->GetHash());
         }
     }
-    if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx from peer=%d\n", nErased, peer);
+    if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx from peer=%d\n", nErased, peer);
 }
 
 unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
@@ -132,7 +139,7 @@ unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
         }
         // Sweep again 5 minutes after the next entry that expires in order to batch the linear scan.
         nNextSweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
-        if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx due to expiration\n", nErased);
+        if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx due to expiration\n", nErased);
     }
     FastRandomContext rng;
     while (!m_orphans.empty() && m_orphan_tx_size > max_orphans_size)
@@ -142,7 +149,11 @@ unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
         EraseTx(m_orphan_list[randompos]->first);
         ++nEvicted;
     }
+<<<<<<< HEAD
     return nEvicted;
+=======
+    if (nEvicted > 0) LogPrint(BCLog::TXPACKAGES, "orphanage overflow, removed %u tx\n", nEvicted);
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
 }
 
 void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>& orphan_work_set) const
@@ -153,6 +164,8 @@ void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
             for (const auto& elem : it_by_prev->second) {
                 orphan_work_set.insert(elem->first);
+                LogPrint(BCLog::TXPACKAGES, "added %s (wtxid=%s) to peer %d workset\n",
+                         tx.GetHash().ToString(), tx.GetWitnessHash().ToString(), elem->second.fromPeer);
             }
         }
     }
@@ -222,6 +235,6 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
         for (const uint256& orphanHash : vOrphanErase) {
             nErased += EraseTx(orphanHash);
         }
-        LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx included or conflicted by block\n", nErased);
+        LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -987,6 +987,32 @@ bool MemPoolAccept::Finalize(const ATMPArgs& args, Workspace& ws)
 
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
 
+<<<<<<< HEAD
+=======
+    // Remove conflicting transactions from the mempool
+    for (CTxMemPool::txiter it : ws.m_all_conflicting)
+    {
+        LogPrint(BCLog::MEMPOOL, "replacing tx %s (wtxid=%s) with %s (wtxid=%s) for %s additional fees, %d delta bytes\n",
+                it->GetTx().GetHash().ToString(),
+                it->GetTx().GetWitnessHash().ToString(),
+                hash.ToString(),
+                tx.GetWitnessHash().ToString(),
+                FormatMoney(ws.m_modified_fees - ws.m_conflicting_fees),
+                (int)entry->GetTxSize() - (int)ws.m_conflicting_size);
+        TRACE7(mempool, replaced,
+                it->GetTx().GetHash().data(),
+                it->GetTxSize(),
+                it->GetFee(),
+                std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count(),
+                hash.data(),
+                entry->GetTxSize(),
+                entry->GetFee()
+        );
+        ws.m_replaced_transactions.push_back(it->GetSharedTx());
+    }
+    m_pool.RemoveStaged(ws.m_all_conflicting, false, MemPoolRemovalReason::REPLACED);
+
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
     // This transaction should only count for fee estimation if:
     // - it's not being re-added during a reorg which bypasses typical mempool fee limits
     // - the node is not behind

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -4,7 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test addr response caching"""
 
-from test_framework.messages import msg_getaddr
+import time
+
 from test_framework.p2p import (
     P2PInterface,
     p2p_lock
@@ -18,6 +19,7 @@ from test_framework.util import (
 # As defined in net_processing.
 MAX_ADDR_TO_SEND = 1000
 MAX_PCT_ADDR_TO_SEND = 23
+
 
 class AddrReceiver(P2PInterface):
 
@@ -68,11 +70,8 @@ class AddrTest(BitcoinTestFramework):
         cur_mock_time = self.mocktime
         for i in range(N):
             addr_receiver_local = self.nodes[0].add_p2p_connection(AddrReceiver())
-            addr_receiver_local.send_and_ping(msg_getaddr())
             addr_receiver_onion1 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port1)
-            addr_receiver_onion1.send_and_ping(msg_getaddr())
             addr_receiver_onion2 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port2)
-            addr_receiver_onion2.send_and_ping(msg_getaddr())
 
             # Trigger response
             cur_mock_time += 5 * 60
@@ -103,11 +102,8 @@ class AddrTest(BitcoinTestFramework):
 
         self.log.info('After time passed, see a new response to addr request')
         addr_receiver_local = self.nodes[0].add_p2p_connection(AddrReceiver())
-        addr_receiver_local.send_and_ping(msg_getaddr())
         addr_receiver_onion1 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port1)
-        addr_receiver_onion1.send_and_ping(msg_getaddr())
         addr_receiver_onion2 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port2)
-        addr_receiver_onion2.send_and_ping(msg_getaddr())
 
         # Trigger response
         cur_mock_time += 5 * 60
@@ -120,6 +116,7 @@ class AddrTest(BitcoinTestFramework):
         assert(set(last_response_on_local_bind) != set(addr_receiver_local.get_received_addrs()))
         assert(set(last_response_on_onion_bind1) != set(addr_receiver_onion1.get_received_addrs()))
         assert(set(last_response_on_onion_bind2) != set(addr_receiver_onion2.get_received_addrs()))
+
 
 if __name__ == '__main__':
     AddrTest().main()

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -4,6 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test addr response caching"""
 
+import time
+
 from test_framework.p2p import (
     P2PInterface,
     p2p_lock
@@ -65,7 +67,7 @@ class AddrTest(BitcoinTestFramework):
         last_response_on_onion_bind2 = None
         self.log.info('Send many addr requests within short time to receive same response')
         N = 5
-        cur_mock_time = self.mocktime
+        cur_mock_time = int(time.time())
         for i in range(N):
             addr_receiver_local = self.nodes[0].add_p2p_connection(AddrReceiver())
             addr_receiver_onion1 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port1)

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -4,8 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test addr response caching"""
 
-import time
-
 from test_framework.p2p import (
     P2PInterface,
     p2p_lock

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -107,12 +107,16 @@ class P2PPermissionsTests(BitcoinTestFramework):
 
         self.log.debug("Check that node[1] will send the tx to node[0] even though it is already in the mempool")
         self.connect_nodes(1, 0)
+<<<<<<< HEAD
 
         def in_mempool():
             self.bump_mocktime(1)
             return txid in self.nodes[0].getrawmempool()
 
         with self.nodes[1].assert_debug_log(["Force relaying tx {} from peer=0".format(txid)]):
+=======
+        with self.nodes[1].assert_debug_log(["Force relaying tx {} (wtxid={}) from peer=0".format(txid, tx.getwtxid())]):
+>>>>>>> 5666966dff (Merge bitcoin/bitcoin#28364: log: log wtxids when possible, add TXPACKAGES category)
             p2p_rebroadcast_wallet.send_txs_and_test([tx], self.nodes[1])
             self.wait_until(in_mempool)
 
@@ -125,14 +129,14 @@ class P2PPermissionsTests(BitcoinTestFramework):
             [tx],
             self.nodes[1],
             success=False,
-            reject_reason='{} from peer=0 was not accepted: txn-mempool-conflict'.format(txid)
+            reject_reason='{} (wtxid={}) from peer=0 was not accepted: txn-mempool-conflict'.format(txid, tx.getwtxid())
         )
 
         p2p_rebroadcast_wallet.send_txs_and_test(
             [tx],
             self.nodes[1],
             success=False,
-            reject_reason='Not relaying non-mempool transaction {} from forcerelay peer=0'.format(txid)
+            reject_reason='Not relaying non-mempool transaction {} (wtxid={}) from forcerelay peer=0'.format(txid, tx.getwtxid())
         )
 
     def checkpermission(self, args, expectedPermissions):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -695,10 +695,11 @@ class TestNode():
             p2p_conn.sync_with_ping()
 
             # Consistency check that the node received our user agent string.
-            # Find our connection in getpeerinfo by our address:port, as it is unique.
+            # Find our connection in getpeerinfo by our address:port and theirs, as this combination is unique.
             sockname = p2p_conn._transport.get_extra_info("socket").getsockname()
             our_addr_and_port = f"{sockname[0]}:{sockname[1]}"
-            info = [peer for peer in self.getpeerinfo() if peer["addr"] == our_addr_and_port]
+            dst_addr_and_port = f"{p2p_conn.dstaddr}:{p2p_conn.dstport}"
+            info = [peer for peer in self.getpeerinfo() if peer["addr"] == our_addr_and_port and peer["addrbind"] == dst_addr_and_port]
             assert_equal(len(info), 1)
             assert_equal(info[0]["subver"], p2p_conn.strSubVer)
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28144

Original commit: 1b5cbf71df

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified the addr response caching test by removing explicit address request messages and relying on default P2P connection behavior.
  * Improved peer connection identification in test logic to ensure more precise matching of local and remote endpoint addresses and ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->