### PR TITLE
Merge bitcoin/bitcoin#28059: refactor: Make more transaction size variables signed

### DIFF
--- a/linux_build_logs.txt
+++ b/linux_build_logs.txt
@@ -1,0 +1,1943 @@
+﻿2025-07-27T17:36:07.3698513Z Current runner version: '2.326.0'
+2025-07-27T17:36:07.3722472Z ##[group]Runner Image Provisioner
+2025-07-27T17:36:07.3723312Z Hosted Compute Agent
+2025-07-27T17:36:07.3723896Z Version: 20250711.363
+2025-07-27T17:36:07.3724528Z Commit: 6785254374ce925a23743850c1cb91912ce5c14c
+2025-07-27T17:36:07.3725253Z Build Date: 2025-07-11T20:04:25Z
+2025-07-27T17:36:07.3725884Z ##[endgroup]
+2025-07-27T17:36:07.3726420Z ##[group]Operating System
+2025-07-27T17:36:07.3727019Z Ubuntu
+2025-07-27T17:36:07.3727468Z 24.04.2
+2025-07-27T17:36:07.3727993Z LTS
+2025-07-27T17:36:07.3728438Z ##[endgroup]
+2025-07-27T17:36:07.3728939Z ##[group]Runner Image
+2025-07-27T17:36:07.3729471Z Image: ubuntu-24.04
+2025-07-27T17:36:07.3730060Z Version: 20250720.1.0
+2025-07-27T17:36:07.3731066Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250720.1/images/ubuntu/Ubuntu2404-Readme.md
+2025-07-27T17:36:07.3732841Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250720.1
+2025-07-27T17:36:07.3733854Z ##[endgroup]
+2025-07-27T17:36:07.3734973Z ##[group]GITHUB_TOKEN Permissions
+2025-07-27T17:36:07.3736790Z Contents: read
+2025-07-27T17:36:07.3737329Z Metadata: read
+2025-07-27T17:36:07.3737905Z Packages: write
+2025-07-27T17:36:07.3738412Z ##[endgroup]
+2025-07-27T17:36:07.3740427Z Secret source: Actions
+2025-07-27T17:36:07.3741242Z Prepare workflow directory
+2025-07-27T17:36:07.4341049Z Prepare all required actions
+2025-07-27T17:36:07.4379189Z Getting action download info
+2025-07-27T17:36:07.8337761Z ##[group]Download immutable action package 'actions/checkout@v4'
+2025-07-27T17:36:07.8338967Z Version: 4.2.2
+2025-07-27T17:36:07.8339940Z Digest: sha256:ccb2698953eaebd21c7bf6268a94f9c26518a7e38e27e0b83c1fe1ad049819b1
+2025-07-27T17:36:07.8341100Z Source commit SHA: 11bd71901bbe5b1630ceea73d27597364c9af683
+2025-07-27T17:36:07.8342189Z ##[endgroup]
+2025-07-27T17:36:07.9599295Z ##[group]Download immutable action package 'actions/cache@v4'
+2025-07-27T17:36:07.9600156Z Version: 4.2.3
+2025-07-27T17:36:07.9600946Z Digest: sha256:c8a3bb963e1f1826d8fcc8d1354f0dd29d8ac1db1d4f6f20247055ae11b81ed9
+2025-07-27T17:36:07.9602179Z Source commit SHA: 5a3ec84eff668545956fd18022155c47e93e2684
+2025-07-27T17:36:07.9602861Z ##[endgroup]
+2025-07-27T17:36:08.0644574Z ##[group]Download immutable action package 'actions/upload-artifact@v4'
+2025-07-27T17:36:08.0645413Z Version: 4.6.2
+2025-07-27T17:36:08.0646153Z Digest: sha256:290722aa3281d5caf23d0acdc3dbeb3424786a1a01a9cc97e72f147225e37c38
+2025-07-27T17:36:08.0647044Z Source commit SHA: ea165f8d65b6e75b540449e92b4886f43607fa02
+2025-07-27T17:36:08.0647857Z ##[endgroup]
+2025-07-27T17:36:08.2682974Z Uses: DashCoreAutoGuix/dash/.github/workflows/build-src.yml@refs/heads/backport-0.26-batch-445-pr-28059 (fcbe3bbb34aacfd243cadeb49dc6634ecc67cb39)
+2025-07-27T17:36:08.2687747Z ##[group] Inputs
+2025-07-27T17:36:08.2688255Z   build-target: linux64
+2025-07-27T17:36:08.2689100Z   container-path: ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-445-pr-28059
+2025-07-27T17:36:08.2691313Z   depends-key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-b8f6bdc378882d7ee86748f7a6c006157448c47775e3a5ee41806889c488ad2d
+2025-07-27T17:36:08.2693328Z ##[endgroup]
+2025-07-27T17:36:08.2693776Z Complete job name: linux64-build / Build source
+2025-07-27T17:36:08.3157713Z ##[group]Checking docker version
+2025-07-27T17:36:08.3170777Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2025-07-27T17:36:08.4092347Z '1.48'
+2025-07-27T17:36:08.4105726Z Docker daemon API version: '1.48'
+2025-07-27T17:36:08.4106466Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2025-07-27T17:36:08.4262034Z '1.48'
+2025-07-27T17:36:08.4276208Z Docker client API version: '1.48'
+2025-07-27T17:36:08.4280755Z ##[endgroup]
+2025-07-27T17:36:08.4284393Z ##[group]Clean up resources from previous jobs
+2025-07-27T17:36:08.4289306Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=20627b"
+2025-07-27T17:36:08.4457902Z ##[command]/usr/bin/docker network prune --force --filter "label=20627b"
+2025-07-27T17:36:08.4597870Z ##[endgroup]
+2025-07-27T17:36:08.4598336Z ##[group]Create local container network
+2025-07-27T17:36:08.4608613Z ##[command]/usr/bin/docker network create --label 20627b github_network_48e0c5aed8724f6ca8a6b36517541da9
+2025-07-27T17:36:08.5152220Z 813d692d6d8462e424dfc4fc05fb6767c331a5e0a3c3c40be69348332a78c2dd
+2025-07-27T17:36:08.5169805Z ##[endgroup]
+2025-07-27T17:36:08.5193710Z ##[group]Starting job container
+2025-07-27T17:36:08.5214953Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_0a3b2c77-4380-40b3-bb3f-8690f3c93226 login ghcr.io -u DashCoreAutoGuix --password-stdin
+2025-07-27T17:36:08.9881014Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_0a3b2c77-4380-40b3-bb3f-8690f3c93226 pull ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-445-pr-28059
+2025-07-27T17:36:09.6652067Z backport-0.26-batch-445-pr-28059: Pulling from dashcoreautoguix/dash/dashcore-ci-runner
+2025-07-27T17:36:09.8149118Z 32f112e3802c: Pulling fs layer
+2025-07-27T17:36:09.8150197Z 3c418bbf5534: Pulling fs layer
+2025-07-27T17:36:09.8150997Z 824b5144f7af: Pulling fs layer
+2025-07-27T17:36:09.8152016Z bb9f5c709011: Pulling fs layer
+2025-07-27T17:36:09.8152884Z c31b5eed60b6: Pulling fs layer
+2025-07-27T17:36:09.8153714Z da96180e845f: Pulling fs layer
+2025-07-27T17:36:09.8154519Z f28d6a4cf5de: Pulling fs layer
+2025-07-27T17:36:09.8155308Z 49cbdb9e902d: Pulling fs layer
+2025-07-27T17:36:09.8156105Z 247fd41058fa: Pulling fs layer
+2025-07-27T17:36:09.8156882Z d6a01b6e446c: Pulling fs layer
+2025-07-27T17:36:09.8157678Z 4f4fb700ef54: Pulling fs layer
+2025-07-27T17:36:09.8158521Z 1382f2390a1c: Pulling fs layer
+2025-07-27T17:36:09.8159331Z be38403a389e: Pulling fs layer
+2025-07-27T17:36:09.8160533Z 409781d99354: Pulling fs layer
+2025-07-27T17:36:09.8161958Z c418b82685d0: Pulling fs layer
+2025-07-27T17:36:09.8162957Z da96180e845f: Waiting
+2025-07-27T17:36:09.8163768Z f28d6a4cf5de: Waiting
+2025-07-27T17:36:09.8164554Z 49cbdb9e902d: Waiting
+2025-07-27T17:36:09.8165311Z 247fd41058fa: Waiting
+2025-07-27T17:36:09.8166098Z d6a01b6e446c: Waiting
+2025-07-27T17:36:09.8166855Z 4f4fb700ef54: Waiting
+2025-07-27T17:36:09.8167614Z 1382f2390a1c: Waiting
+2025-07-27T17:36:09.8168366Z be38403a389e: Waiting
+2025-07-27T17:36:09.8169137Z 409781d99354: Waiting
+2025-07-27T17:36:09.8169901Z c418b82685d0: Waiting
+2025-07-27T17:36:09.8170873Z bb9f5c709011: Waiting
+2025-07-27T17:36:09.8172025Z c31b5eed60b6: Waiting
+2025-07-27T17:36:10.0849121Z 824b5144f7af: Download complete
+2025-07-27T17:36:10.0896754Z 3c418bbf5534: Verifying Checksum
+2025-07-27T17:36:10.0897522Z 3c418bbf5534: Download complete
+2025-07-27T17:36:10.4844264Z 32f112e3802c: Verifying Checksum
+2025-07-27T17:36:10.4844864Z 32f112e3802c: Download complete
+2025-07-27T17:36:11.1363351Z da96180e845f: Verifying Checksum
+2025-07-27T17:36:11.1364000Z da96180e845f: Download complete
+2025-07-27T17:36:11.3299281Z c31b5eed60b6: Verifying Checksum
+2025-07-27T17:36:11.3302048Z c31b5eed60b6: Download complete
+2025-07-27T17:36:11.3762721Z f28d6a4cf5de: Verifying Checksum
+2025-07-27T17:36:11.3764717Z f28d6a4cf5de: Download complete
+2025-07-27T17:36:11.5489171Z 49cbdb9e902d: Download complete
+2025-07-27T17:36:11.5725277Z 32f112e3802c: Pull complete
+2025-07-27T17:36:11.7626359Z d6a01b6e446c: Verifying Checksum
+2025-07-27T17:36:11.7627266Z d6a01b6e446c: Download complete
+2025-07-27T17:36:11.9141925Z 4f4fb700ef54: Verifying Checksum
+2025-07-27T17:36:11.9142927Z 4f4fb700ef54: Download complete
+2025-07-27T17:36:12.2113279Z 3c418bbf5534: Pull complete
+2025-07-27T17:36:12.3622968Z 824b5144f7af: Pull complete
+2025-07-27T17:36:12.3644084Z bb9f5c709011: Download complete
+2025-07-27T17:36:14.5533387Z be38403a389e: Verifying Checksum
+2025-07-27T17:36:14.5534030Z be38403a389e: Download complete
+2025-07-27T17:36:14.8031729Z 409781d99354: Verifying Checksum
+2025-07-27T17:36:14.8033519Z 409781d99354: Download complete
+2025-07-27T17:36:15.0339308Z c418b82685d0: Download complete
+2025-07-27T17:36:15.2340411Z 247fd41058fa: Verifying Checksum
+2025-07-27T17:36:15.2340884Z 247fd41058fa: Download complete
+2025-07-27T17:36:18.7063473Z bb9f5c709011: Pull complete
+2025-07-27T17:36:22.7235165Z 1382f2390a1c: Verifying Checksum
+2025-07-27T17:36:22.7235683Z 1382f2390a1c: Download complete
+2025-07-27T17:36:23.2023929Z c31b5eed60b6: Pull complete
+2025-07-27T17:36:24.2384416Z da96180e845f: Pull complete
+2025-07-27T17:36:24.2960154Z f28d6a4cf5de: Pull complete
+2025-07-27T17:36:24.3434472Z 49cbdb9e902d: Pull complete
+2025-07-27T17:36:30.3582825Z 247fd41058fa: Pull complete
+2025-07-27T17:36:30.3773519Z d6a01b6e446c: Pull complete
+2025-07-27T17:36:30.3895500Z 4f4fb700ef54: Pull complete
+2025-07-27T17:36:45.2575054Z 1382f2390a1c: Pull complete
+2025-07-27T17:36:49.1075221Z be38403a389e: Pull complete
+2025-07-27T17:36:49.2049213Z 409781d99354: Pull complete
+2025-07-27T17:36:49.2172226Z c418b82685d0: Pull complete
+2025-07-27T17:36:49.2221244Z Digest: sha256:75317160a4e15adac20f80ff574c9c08fc5039cbb82a4204eb7055873934edc8
+2025-07-27T17:36:49.2232669Z Status: Downloaded newer image for ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-445-pr-28059
+2025-07-27T17:36:49.2243467Z ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-445-pr-28059
+2025-07-27T17:36:49.2325855Z ##[command]/usr/bin/docker create --name 44574f199b85469bb9fd39adade63007_ghcriodashcoreautoguixdashdashcorecirunnerbackport026batch445pr28059_440143 --label 20627b --workdir /__w/dash/dash --network github_network_48e0c5aed8724f6ca8a6b36517541da9 --user root -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" -v "/home/runner/actions-runner/cached/externals":"/__e":ro -v "/home/runner/work/_temp":"/__w/_temp" -v "/home/runner/work/_actions":"/__w/_actions" -v "/opt/hostedtoolcache":"/__t" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-445-pr-28059 "-f" "/dev/null"
+2025-07-27T17:36:49.2617726Z 687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2
+2025-07-27T17:36:49.2640831Z ##[command]/usr/bin/docker start 687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2
+2025-07-27T17:36:49.4523320Z 687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2
+2025-07-27T17:36:49.4543021Z ##[command]/usr/bin/docker ps --all --filter id=687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2 --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2025-07-27T17:36:49.4657264Z 687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2 Up Less than a second
+2025-07-27T17:36:49.4676234Z ##[command]/usr/bin/docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" 687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2
+2025-07-27T17:36:49.4787177Z HOME=/github/home
+2025-07-27T17:36:49.4787552Z GITHUB_ACTIONS=true
+2025-07-27T17:36:49.4787880Z CI=true
+2025-07-27T17:36:49.4788762Z PATH=/opt/shellcheck:/usr/local/pyenv/shims:/usr/local/pyenv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+2025-07-27T17:36:49.4789757Z DEBIAN_FRONTEND=noninteractive
+2025-07-27T17:36:49.4790115Z TZ=Europe/London
+2025-07-27T17:36:49.4790853Z APT_ARGS=-y --no-install-recommends --no-upgrade
+2025-07-27T17:36:49.4791327Z PYENV_ROOT=/usr/local/pyenv
+2025-07-27T17:36:49.4791906Z LD_LIBRARY_PATH=/usr/lib/llvm-18/lib
+2025-07-27T17:36:49.4809845Z ##[endgroup]
+2025-07-27T17:36:49.4819335Z ##[group]Waiting for all services to be ready
+2025-07-27T17:36:49.4821075Z ##[endgroup]
+2025-07-27T17:36:49.5047717Z ##[group]Run actions/checkout@v4
+2025-07-27T17:36:49.5048262Z with:
+2025-07-27T17:36:49.5048433Z   fetch-depth: 50
+2025-07-27T17:36:49.5048635Z   repository: DashCoreAutoGuix/dash
+2025-07-27T17:36:49.5049029Z   token: ***
+2025-07-27T17:36:49.5049204Z   ssh-strict: true
+2025-07-27T17:36:49.5049374Z   ssh-user: git
+2025-07-27T17:36:49.5049761Z   persist-credentials: true
+2025-07-27T17:36:49.5049963Z   clean: true
+2025-07-27T17:36:49.5050139Z   sparse-checkout-cone-mode: true
+2025-07-27T17:36:49.5050361Z   fetch-tags: false
+2025-07-27T17:36:49.5050540Z   show-progress: true
+2025-07-27T17:36:49.5050716Z   lfs: false
+2025-07-27T17:36:49.5050869Z   submodules: false
+2025-07-27T17:36:49.5051044Z   set-safe-directory: true
+2025-07-27T17:36:49.5051461Z ##[endgroup]
+2025-07-27T17:36:49.5172747Z ##[command]/usr/bin/docker exec  687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T17:36:49.7248753Z Syncing repository: DashCoreAutoGuix/dash
+2025-07-27T17:36:49.7250334Z ##[group]Getting Git version info
+2025-07-27T17:36:49.7250820Z Working directory is '/__w/dash/dash'
+2025-07-27T17:36:49.7251538Z [command]/usr/bin/git version
+2025-07-27T17:36:49.7252182Z git version 2.43.0
+2025-07-27T17:36:49.7278128Z ##[endgroup]
+2025-07-27T17:36:49.7292831Z Temporarily overriding HOME='/__w/_temp/666431b8-bbbe-4cdc-89ae-b50e9493cd7f' before making global git config changes
+2025-07-27T17:36:49.7293769Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-27T17:36:49.7308985Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-27T17:36:49.7344261Z Deleting the contents of '/__w/dash/dash'
+2025-07-27T17:36:49.7348171Z ##[group]Initializing the repository
+2025-07-27T17:36:49.7352179Z [command]/usr/bin/git init /__w/dash/dash
+2025-07-27T17:36:49.7384091Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-07-27T17:36:49.7384707Z hint: is subject to change. To configure the initial branch name to use in all
+2025-07-27T17:36:49.7385493Z hint: of your new repositories, which will suppress this warning, call:
+2025-07-27T17:36:49.7386032Z hint: 
+2025-07-27T17:36:49.7386448Z hint: 	git config --global init.defaultBranch <name>
+2025-07-27T17:36:49.7386948Z hint: 
+2025-07-27T17:36:49.7387781Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-07-27T17:36:49.7388529Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-07-27T17:36:49.7388886Z hint: 
+2025-07-27T17:36:49.7389064Z hint: 	git branch -m <name>
+2025-07-27T17:36:49.7394809Z Initialized empty Git repository in /__w/dash/dash/.git/
+2025-07-27T17:36:49.7407406Z [command]/usr/bin/git remote add origin https://github.com/DashCoreAutoGuix/dash
+2025-07-27T17:36:49.7438330Z ##[endgroup]
+2025-07-27T17:36:49.7438914Z ##[group]Disabling automatic garbage collection
+2025-07-27T17:36:49.7442962Z [command]/usr/bin/git config --local gc.auto 0
+2025-07-27T17:36:49.7469979Z ##[endgroup]
+2025-07-27T17:36:49.7470572Z ##[group]Setting up auth
+2025-07-27T17:36:49.7477968Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-27T17:36:49.7506554Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-27T17:36:49.7718319Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-27T17:36:49.7745383Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-27T17:36:49.7950210Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-07-27T17:36:49.7984552Z ##[endgroup]
+2025-07-27T17:36:49.7984911Z ##[group]Fetching the repository
+2025-07-27T17:36:49.7993280Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=50 origin +fcbe3bbb34aacfd243cadeb49dc6634ecc67cb39:refs/remotes/origin/backport-0.26-batch-445-pr-28059
+2025-07-27T17:36:52.0213289Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-27T17:36:52.0214234Z  * [new ref]           fcbe3bbb34aacfd243cadeb49dc6634ecc67cb39 -> origin/backport-0.26-batch-445-pr-28059
+2025-07-27T17:36:52.0237776Z ##[endgroup]
+2025-07-27T17:36:52.0238336Z ##[group]Determining the checkout info
+2025-07-27T17:36:52.0239781Z ##[endgroup]
+2025-07-27T17:36:52.0245104Z [command]/usr/bin/git sparse-checkout disable
+2025-07-27T17:36:52.0282099Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-07-27T17:36:52.0309790Z ##[group]Checking out the ref
+2025-07-27T17:36:52.0315226Z [command]/usr/bin/git checkout --progress --force -B backport-0.26-batch-445-pr-28059 refs/remotes/origin/backport-0.26-batch-445-pr-28059
+2025-07-27T17:36:52.4338353Z Switched to a new branch 'backport-0.26-batch-445-pr-28059'
+2025-07-27T17:36:52.4338934Z branch 'backport-0.26-batch-445-pr-28059' set up to track 'origin/backport-0.26-batch-445-pr-28059'.
+2025-07-27T17:36:52.4364386Z ##[endgroup]
+2025-07-27T17:36:52.4402147Z [command]/usr/bin/git log -1 --format=%H
+2025-07-27T17:36:52.4426110Z fcbe3bbb34aacfd243cadeb49dc6634ecc67cb39
+2025-07-27T17:36:52.4659884Z ##[group]Run git config --global --add safe.directory "$PWD"
+2025-07-27T17:36:52.4660334Z [36;1mgit config --global --add safe.directory "$PWD"[0m
+2025-07-27T17:36:52.4660711Z [36;1mgit fetch -fu origin develop:develop[0m
+2025-07-27T17:36:52.4660978Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-27T17:36:52.4661207Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-27T17:36:52.4661458Z [36;1mecho "HOST=${HOST}" >> $GITHUB_OUTPUT[0m
+2025-07-27T17:36:52.4661855Z [36;1mecho "PR_BASE_SHA=" >> $GITHUB_OUTPUT[0m
+2025-07-27T17:36:52.4665559Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-27T17:36:52.4665853Z ##[endgroup]
+2025-07-27T17:36:52.8647496Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-27T17:36:52.8648071Z  * [new branch]        develop    -> develop
+2025-07-27T17:36:52.8722144Z  * [new branch]        develop    -> origin/develop
+2025-07-27T17:36:52.8722644Z Setting specific values in env
+2025-07-27T17:36:52.8723165Z Fallback to default values in env (if not yet set)
+2025-07-27T17:36:52.9215763Z ##[group]Run actions/cache/restore@v4
+2025-07-27T17:36:52.9216030Z with:
+2025-07-27T17:36:52.9216241Z   path: depends/built
+depends/x86_64-pc-linux-gnu
+
+2025-07-27T17:36:52.9217230Z   key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-b8f6bdc378882d7ee86748f7a6c006157448c47775e3a5ee41806889c488ad2d
+2025-07-27T17:36:52.9218174Z   fail-on-cache-miss: true
+2025-07-27T17:36:52.9218382Z   enableCrossOsArchive: false
+2025-07-27T17:36:52.9218593Z   lookup-only: false
+2025-07-27T17:36:52.9218768Z ##[endgroup]
+2025-07-27T17:36:52.9222172Z ##[command]/usr/bin/docker exec  687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T17:36:53.4717052Z Cache hit for: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-b8f6bdc378882d7ee86748f7a6c006157448c47775e3a5ee41806889c488ad2d
+2025-07-27T17:36:54.7765540Z Received 4194304 of 90045762 (4.7%), 4.0 MBs/sec
+2025-07-27T17:36:55.6701448Z Received 90045762 of 90045762 (100.0%), 45.3 MBs/sec
+2025-07-27T17:36:55.6704387Z Cache Size: ~86 MB (90045762 B)
+2025-07-27T17:36:55.6801213Z [command]/usr/bin/tar -xf /__w/_temp/8c327f5b-639b-421d-83d8-24b3d1bb2f85/cache.tzst -P -C /__w/dash/dash --use-compress-program unzstd
+2025-07-27T17:36:56.8671002Z Cache restored successfully
+2025-07-27T17:36:56.8921016Z Cache restored from key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-b8f6bdc378882d7ee86748f7a6c006157448c47775e3a5ee41806889c488ad2d
+2025-07-27T17:36:57.0673127Z ##[group]Run actions/cache@v4
+2025-07-27T17:36:57.0673387Z with:
+2025-07-27T17:36:57.0673558Z   path: /cache
+
+2025-07-27T17:36:57.0674086Z   key: ccache-970e218ae9acc233930877ab16bb2e30f5a2f176d33ec97075ec9249fe97c966-linux64-fcbe3bbb34aacfd243cadeb49dc6634ecc67cb39
+2025-07-27T17:36:57.0675087Z   restore-keys: ccache-970e218ae9acc233930877ab16bb2e30f5a2f176d33ec97075ec9249fe97c966-linux64-
+
+2025-07-27T17:36:57.0675545Z   enableCrossOsArchive: false
+2025-07-27T17:36:57.0675770Z   fail-on-cache-miss: false
+2025-07-27T17:36:57.0675981Z   lookup-only: false
+2025-07-27T17:36:57.0676167Z   save-always: false
+2025-07-27T17:36:57.0676347Z ##[endgroup]
+2025-07-27T17:36:57.0679480Z ##[command]/usr/bin/docker exec  687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T17:36:57.5951938Z Cache not found for input keys: ccache-970e218ae9acc233930877ab16bb2e30f5a2f176d33ec97075ec9249fe97c966-linux64-fcbe3bbb34aacfd243cadeb49dc6634ecc67cb39, ccache-970e218ae9acc233930877ab16bb2e30f5a2f176d33ec97075ec9249fe97c966-linux64-
+2025-07-27T17:36:57.6048693Z ##[group]Run CCACHE_SIZE="400M"
+2025-07-27T17:36:57.6048976Z [36;1mCCACHE_SIZE="400M"[0m
+2025-07-27T17:36:57.6049191Z [36;1mCACHE_DIR="/cache"[0m
+2025-07-27T17:36:57.6049412Z [36;1mmkdir /output[0m
+2025-07-27T17:36:57.6049621Z [36;1mBASE_OUTDIR="/output"[0m
+2025-07-27T17:36:57.6049837Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-27T17:36:57.6050072Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-27T17:36:57.6050308Z [36;1m./ci/dash/build_src.sh[0m
+2025-07-27T17:36:57.6050520Z [36;1mccache -X 9[0m
+2025-07-27T17:36:57.6050704Z [36;1mccache -c[0m
+2025-07-27T17:36:57.6051041Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-27T17:36:57.6051304Z ##[endgroup]
+2025-07-27T17:36:57.6603891Z Setting specific values in env
+2025-07-27T17:36:57.6604448Z Fallback to default values in env (if not yet set)
+2025-07-27T17:36:57.6978571Z Setting specific values in env
+2025-07-27T17:36:57.6978911Z Fallback to default values in env (if not yet set)
+2025-07-27T17:36:57.7723823Z Statistics zeroed
+2025-07-27T17:36:57.7724191Z Set cache size limit to 400.0 MB
+2025-07-27T17:37:02.7015908Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-27T17:37:02.7016663Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-27T17:37:02.7262009Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-27T17:37:02.7262442Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-27T17:37:02.7536792Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-27T17:37:02.7817768Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-27T17:37:02.8097004Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-27T17:37:02.8376726Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-27T17:37:04.9095453Z configure.ac:38: installing 'build-aux/compile'
+2025-07-27T17:37:04.9113782Z configure.ac:12: installing 'build-aux/config.guess'
+2025-07-27T17:37:04.9132799Z configure.ac:12: installing 'build-aux/config.sub'
+2025-07-27T17:37:04.9152304Z configure.ac:17: installing 'build-aux/install-sh'
+2025-07-27T17:37:04.9171764Z configure.ac:17: installing 'build-aux/missing'
+2025-07-27T17:37:04.9818963Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-27T17:37:07.3413295Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-27T17:37:07.3413909Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-27T17:37:07.3650670Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-27T17:37:07.3651378Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-27T17:37:07.3850929Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-27T17:37:07.4058587Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-27T17:37:07.4266839Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-27T17:37:07.4476512Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-27T17:37:08.9126908Z configure.ac:39: installing 'build-aux/ar-lib'
+2025-07-27T17:37:08.9144197Z configure.ac:37: installing 'build-aux/compile'
+2025-07-27T17:37:08.9162404Z configure.ac:24: installing 'build-aux/config.guess'
+2025-07-27T17:37:08.9179957Z configure.ac:24: installing 'build-aux/config.sub'
+2025-07-27T17:37:08.9198510Z configure.ac:27: installing 'build-aux/install-sh'
+2025-07-27T17:37:08.9217510Z configure.ac:27: installing 'build-aux/missing'
+2025-07-27T17:37:08.9554625Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-27T17:37:08.9890294Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-27T17:37:09.0832509Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-27T17:37:09.0833241Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-27T17:37:09.1088943Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-27T17:37:09.1089567Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-27T17:37:09.1512214Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-27T17:37:09.1942980Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-27T17:37:09.2376585Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-27T17:37:09.2810265Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-27T17:37:11.8636005Z configure.ac:105: installing 'build-aux/compile'
+2025-07-27T17:37:11.8653444Z configure.ac:48: installing 'build-aux/config.guess'
+2025-07-27T17:37:11.8671519Z configure.ac:48: installing 'build-aux/config.sub'
+2025-07-27T17:37:11.8689090Z configure.ac:55: installing 'build-aux/install-sh'
+2025-07-27T17:37:11.8706879Z configure.ac:55: installing 'build-aux/missing'
+2025-07-27T17:37:12.1196224Z src/Makefile.am: installing 'build-aux/depcomp'
+2025-07-27T17:37:14.6505071Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-27T17:37:14.8398263Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T17:37:14.8475209Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-27T17:37:14.8488791Z checking pkg-config is at least version 0.9.0... yes
+2025-07-27T17:37:14.8937464Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:14.8985130Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:14.9065464Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T17:37:14.9093401Z checking whether build environment is sane... yes
+2025-07-27T17:37:14.9153729Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T17:37:14.9174525Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T17:37:14.9178844Z checking for gawk... gawk
+2025-07-27T17:37:14.9243533Z checking whether make sets $(MAKE)... yes
+2025-07-27T17:37:14.9296725Z checking whether make supports nested variables... yes
+2025-07-27T17:37:14.9338461Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-27T17:37:14.9340921Z checking whether make supports nested variables... (cached) yes
+2025-07-27T17:37:14.9896055Z checking whether the C++ compiler works... yes
+2025-07-27T17:37:14.9896740Z checking for C++ compiler default output file name... a.out
+2025-07-27T17:37:15.0237572Z checking for suffix of executables... 
+2025-07-27T17:37:15.0708532Z checking whether we are cross compiling... no
+2025-07-27T17:37:15.0884379Z checking for suffix of object files... o
+2025-07-27T17:37:15.1038632Z checking whether the compiler supports GNU C++... yes
+2025-07-27T17:37:15.1203477Z checking whether g++ -m64 accepts -g... yes
+2025-07-27T17:37:15.4088476Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-27T17:37:15.4571719Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-27T17:37:15.4646580Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T17:37:15.4650424Z checking dependency style of g++ -m64... none
+2025-07-27T17:37:15.5459866Z checking whether g++ -m64 supports C++20 features with -std=c++20... yes
+2025-07-27T17:37:15.5462475Z checking for x86_64-pc-linux-gnu-g++... g++ -m64 -std=c++20
+2025-07-27T17:37:15.5752789Z checking whether the compiler supports GNU Objective C++... no
+2025-07-27T17:37:15.6027283Z checking whether g++ -m64 -std=c++20 accepts -g... no
+2025-07-27T17:37:15.6029756Z checking dependency style of g++ -m64 -std=c++20... none
+2025-07-27T17:37:15.6055094Z checking how to print strings... printf
+2025-07-27T17:37:15.6057061Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T17:37:15.6450151Z checking whether the compiler supports GNU C... yes
+2025-07-27T17:37:15.6613399Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T17:37:15.6968633Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T17:37:15.7236284Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T17:37:15.7238696Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:15.7279287Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T17:37:15.7311198Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T17:37:15.7326629Z checking for egrep... /usr/bin/grep -E
+2025-07-27T17:37:15.7342774Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T17:37:15.7389696Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T17:37:15.7413790Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T17:37:15.7436115Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T17:37:15.7704943Z checking the name lister (nm) interface... BSD nm
+2025-07-27T17:37:15.7705528Z checking whether ln -s works... yes
+2025-07-27T17:37:15.7749823Z checking the maximum length of command line arguments... 3145728
+2025-07-27T17:37:15.7776974Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T17:37:15.7778075Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T17:37:15.7778998Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T17:37:15.7785388Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T17:37:15.7790453Z checking for file... file
+2025-07-27T17:37:15.7795837Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:37:15.7800885Z checking for objdump... objdump
+2025-07-27T17:37:15.7805361Z checking how to recognize dependent libraries... pass_all
+2025-07-27T17:37:15.7810864Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T17:37:15.7816332Z checking for dlltool... no
+2025-07-27T17:37:15.7817704Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T17:37:15.7819546Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:37:15.8160976Z checking for archiver @FILE support... @
+2025-07-27T17:37:15.8162375Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T17:37:15.8164807Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T17:37:15.8836265Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T17:37:15.8854496Z checking for sysroot... no
+2025-07-27T17:37:15.8899810Z checking for a working dd... /usr/bin/dd
+2025-07-27T17:37:15.8938361Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T17:37:15.9046697Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T17:37:15.9052665Z checking for mt... no
+2025-07-27T17:37:15.9084294Z checking if : is a manifest tool... no
+2025-07-27T17:37:15.9233125Z checking for stdio.h... yes
+2025-07-27T17:37:15.9395431Z checking for stdlib.h... yes
+2025-07-27T17:37:15.9568006Z checking for string.h... yes
+2025-07-27T17:37:15.9745182Z checking for inttypes.h... yes
+2025-07-27T17:37:15.9924581Z checking for stdint.h... yes
+2025-07-27T17:37:16.0108198Z checking for strings.h... yes
+2025-07-27T17:37:16.0292630Z checking for sys/stat.h... yes
+2025-07-27T17:37:16.0477132Z checking for sys/types.h... yes
+2025-07-27T17:37:16.0686610Z checking for unistd.h... yes
+2025-07-27T17:37:16.0900883Z checking for dlfcn.h... yes
+2025-07-27T17:37:16.0941328Z checking for objdir... .libs
+2025-07-27T17:37:16.1548654Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T17:37:16.1549701Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:16.1684303Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:16.2248987Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T17:37:16.2463184Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T17:37:16.2463745Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:16.2555678Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:16.2759372Z checking whether -lc should be explicitly linked in... no
+2025-07-27T17:37:16.3250917Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T17:37:16.3251875Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:16.3268420Z checking whether stripping libraries is possible... yes
+2025-07-27T17:37:16.3269063Z checking if libtool supports shared libraries... yes
+2025-07-27T17:37:16.3269624Z checking whether to build shared libraries... yes
+2025-07-27T17:37:16.3270449Z checking whether to build static libraries... yes
+2025-07-27T17:37:16.3527773Z checking how to run the C++ preprocessor... g++ -m64 -std=c++20 -E
+2025-07-27T17:37:16.4269737Z checking for ld used by g++ -m64 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-27T17:37:16.4294360Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-27T17:37:16.4365547Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:16.4958714Z checking for g++ -m64 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:16.5113728Z checking if g++ -m64 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:16.5698218Z checking if g++ -m64 -std=c++20 static flag -static works... yes
+2025-07-27T17:37:16.5925440Z checking if g++ -m64 -std=c++20 supports -c -o file.o... yes
+2025-07-27T17:37:16.5926254Z checking if g++ -m64 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:16.5927106Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:16.5974195Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-27T17:37:16.5976153Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:16.5983644Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-27T17:37:16.5991014Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-27T17:37:16.5998503Z checking for gcov... /usr/bin/gcov
+2025-07-27T17:37:16.6005689Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-27T17:37:16.6012370Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-27T17:37:16.6018543Z checking for lcov... no
+2025-07-27T17:37:16.6023327Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-27T17:37:16.6027702Z checking for genhtml... no
+2025-07-27T17:37:16.6031315Z checking for git... /usr/bin/git
+2025-07-27T17:37:16.6035842Z checking for ccache... /usr/bin/ccache
+2025-07-27T17:37:16.6040116Z checking for xgettext... /usr/bin/xgettext
+2025-07-27T17:37:16.6044855Z checking for hexdump... /usr/bin/hexdump
+2025-07-27T17:37:16.6049552Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-27T17:37:16.6054956Z checking for objcopy... /usr/bin/objcopy
+2025-07-27T17:37:16.6058904Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:37:16.6063882Z checking for objdump... /usr/bin/objdump
+2025-07-27T17:37:16.6069092Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-27T17:37:16.6074531Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-27T17:37:16.6079240Z checking for doxygen... no
+2025-07-27T17:37:16.6233564Z checking whether C++ compiler accepts -Werror... yes
+2025-07-27T17:37:16.6586077Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-27T17:37:16.7018790Z checking for execinfo.h... yes
+2025-07-27T17:37:16.7372195Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-27T17:37:16.7564005Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-27T17:37:16.7736728Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-27T17:37:16.7908247Z checking whether C++ compiler accepts -Wdangling-reference... yes
+2025-07-27T17:37:16.8079607Z checking whether C++ compiler accepts -Wattributes... yes
+2025-07-27T17:37:16.8255301Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-27T17:37:16.8427080Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-27T17:37:16.8600940Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-27T17:37:16.8775912Z checking whether C++ compiler accepts -Wall... yes
+2025-07-27T17:37:16.8948142Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-27T17:37:16.9087167Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-27T17:37:16.9262511Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-27T17:37:16.9436000Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-27T17:37:16.9609230Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-27T17:37:16.9782907Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-27T17:37:16.9981401Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-27T17:37:17.0232196Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-27T17:37:17.0408622Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-27T17:37:17.0655395Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-27T17:37:17.0833365Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-27T17:37:17.1095118Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-27T17:37:17.1272455Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-27T17:37:17.1445493Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-27T17:37:17.1619966Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-27T17:37:17.1793397Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-27T17:37:17.1967626Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-27T17:37:17.2140899Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-27T17:37:17.2316754Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-27T17:37:17.2512519Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-27T17:37:17.2686734Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-27T17:37:17.2864354Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-27T17:37:17.3040780Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-27T17:37:17.3186602Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-27T17:37:17.3362253Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-27T17:37:17.3534304Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-27T17:37:17.3711205Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-27T17:37:17.3882870Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-27T17:37:17.8542981Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-27T17:37:17.8988311Z checking for SSE4.2 intrinsics... yes
+2025-07-27T17:37:18.3444552Z checking for SSE4.1 intrinsics... yes
+2025-07-27T17:37:18.7722610Z checking for AVX2 intrinsics... yes
+2025-07-27T17:37:19.2158446Z checking for x86 SHA-NI intrinsics... yes
+2025-07-27T17:37:19.2329036Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-27T17:37:19.2484406Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-27T17:37:19.2623908Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-27T17:37:19.2772897Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-27T17:37:19.3600795Z checking whether byte ordering is bigendian... no
+2025-07-27T17:37:19.3817525Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-27T17:37:19.4113300Z checking whether gcc -m64 is Clang... no
+2025-07-27T17:37:19.4550816Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-27T17:37:19.4900695Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-27T17:37:19.4901533Z checking whether more special flags are required for pthreads... no
+2025-07-27T17:37:19.5250655Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-27T17:37:20.3498856Z checking whether std::atomic can be used without link library... yes
+2025-07-27T17:37:20.3507361Z checking for special C compiler options needed for large files... no
+2025-07-27T17:37:20.3701912Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-27T17:37:20.4019628Z checking for g++ -m64 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-27T17:37:20.4519936Z checking whether strerror_r is declared... yes
+2025-07-27T17:37:20.4742017Z checking whether strerror_r returns char *... yes
+2025-07-27T17:37:20.4892505Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-27T17:37:20.5041449Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-27T17:37:20.5190485Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-27T17:37:20.5331031Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-27T17:37:20.5497956Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-27T17:37:20.5579981Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-27T17:37:20.5662624Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-27T17:37:20.5910624Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-27T17:37:20.6165138Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-27T17:37:20.6416409Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-27T17:37:20.6671389Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-27T17:37:20.7042321Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-27T17:37:20.7414537Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-27T17:37:20.7789990Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-27T17:37:20.8160549Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-27T17:37:20.8600964Z checking for sys/select.h... yes
+2025-07-27T17:37:20.9028697Z checking for sys/prctl.h... yes
+2025-07-27T17:37:20.9343417Z checking for vm/vm_param.h... no
+2025-07-27T17:37:20.9656407Z checking for sys/vmmeter.h... no
+2025-07-27T17:37:20.9967343Z checking for sys/resources.h... no
+2025-07-27T17:37:21.0252509Z checking whether getifaddrs is declared... yes
+2025-07-27T17:37:21.0712306Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-27T17:37:21.1006132Z checking whether freeifaddrs is declared... yes
+2025-07-27T17:37:21.1453617Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-27T17:37:21.1971366Z checking whether fork is declared... yes
+2025-07-27T17:37:21.2481077Z checking whether setsid is declared... yes
+2025-07-27T17:37:21.2984921Z checking whether pipe2 is declared... yes
+2025-07-27T17:37:21.3219839Z checking for mallopt M_ARENA_MAX... yes
+2025-07-27T17:37:21.3462319Z checking for getmemoryinfo... yes
+2025-07-27T17:37:21.3667368Z checking for posix_fallocate... yes
+2025-07-27T17:37:21.3820100Z checking for default visibility attribute... yes
+2025-07-27T17:37:21.3971492Z checking for dllexport attribute... no
+2025-07-27T17:37:21.8898490Z checking for thread_local support... yes
+2025-07-27T17:37:21.9186439Z checking for Linux getrandom syscall... yes
+2025-07-27T17:37:21.9508670Z checking for getentropy via random.h... yes
+2025-07-27T17:37:21.9706784Z checking for sysctl... no
+2025-07-27T17:37:21.9903415Z checking for sysctl KERN_ARND... no
+2025-07-27T17:37:22.0280446Z checking for library containing backtrace... none required
+2025-07-27T17:37:22.0525703Z checking for fdatasync... yes
+2025-07-27T17:37:22.0731080Z checking for F_FULLFSYNC... no
+2025-07-27T17:37:22.0943654Z checking for O_CLOEXEC... yes
+2025-07-27T17:37:22.1110383Z checking for __builtin_prefetch... yes
+2025-07-27T17:37:22.1529908Z checking for _mm_prefetch... yes
+2025-07-27T17:37:22.1733451Z checking for strong getauxval support in the system headers... yes
+2025-07-27T17:37:22.2002546Z checking for sockaddr_un... yes
+2025-07-27T17:37:22.2479354Z checking for std::system... yes
+2025-07-27T17:37:22.2764771Z checking for ::_wsystem... no
+2025-07-27T17:37:22.2930213Z checking for Qt5Core >= 5.11.3... yes
+2025-07-27T17:37:22.3039857Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-27T17:37:22.3149890Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-27T17:37:22.3259749Z checking for Qt5Network >= 5.11.3... yes
+2025-07-27T17:37:22.3368109Z checking for Qt5Test >= 5.11.3... yes
+2025-07-27T17:37:22.3475982Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-27T17:37:22.5601903Z checking for static Qt... yes
+2025-07-27T17:37:22.5716703Z checking for Qt5AccessibilitySupport... yes
+2025-07-27T17:37:22.5824743Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-27T17:37:22.5932598Z checking for Qt5EdidSupport... yes
+2025-07-27T17:37:22.6043594Z checking for Qt5EventDispatcherSupport... yes
+2025-07-27T17:37:22.6155001Z checking for Qt5FbSupport... yes
+2025-07-27T17:37:22.6266863Z checking for Qt5FontDatabaseSupport... yes
+2025-07-27T17:37:22.6378447Z checking for Qt5ThemeSupport... yes
+2025-07-27T17:37:22.6493127Z checking for Qt5InputSupport... yes
+2025-07-27T17:37:22.6608637Z checking for Qt5ServiceSupport... yes
+2025-07-27T17:37:22.6736821Z checking for Qt5XcbQpa... yes
+2025-07-27T17:37:22.6849243Z checking for Qt5XkbCommonSupport... yes
+2025-07-27T17:37:24.6586267Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-27T17:37:26.7070778Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-27T17:37:26.9215421Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-27T17:37:26.9227733Z checking for moc-qt5... no
+2025-07-27T17:37:26.9228781Z checking for moc5... no
+2025-07-27T17:37:26.9230631Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-27T17:37:26.9232768Z checking for uic-qt5... no
+2025-07-27T17:37:26.9233638Z checking for uic5... no
+2025-07-27T17:37:26.9236192Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-27T17:37:26.9237136Z checking for rcc-qt5... no
+2025-07-27T17:37:26.9238270Z checking for rcc5... no
+2025-07-27T17:37:26.9240374Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-27T17:37:26.9242887Z checking for lrelease-qt5... no
+2025-07-27T17:37:26.9243532Z checking for lrelease5... no
+2025-07-27T17:37:26.9245171Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-27T17:37:26.9245941Z checking for lupdate-qt5... no
+2025-07-27T17:37:26.9247283Z checking for lupdate5... no
+2025-07-27T17:37:26.9249438Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-27T17:37:26.9250534Z checking for lconvert-qt5... no
+2025-07-27T17:37:26.9251375Z checking for lconvert5... no
+2025-07-27T17:37:26.9253436Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-27T17:37:26.9285027Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-27T17:37:26.9285993Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-27T17:37:27.7931488Z checking for Berkeley DB C++ headers... default
+2025-07-27T17:37:27.8337567Z checking for main in -ldb_cxx-4.8... yes
+2025-07-27T17:37:27.8487699Z checking for sqlite3 >= 3.7.17... yes
+2025-07-27T17:37:27.8488567Z checking whether to build wallet with support for sqlite... yes
+2025-07-27T17:37:27.8684871Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-27T17:37:27.9168643Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-27T17:37:27.9589096Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-27T17:37:28.0045497Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-27T17:37:28.0084540Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-27T17:37:28.0533439Z checking for miniupnpc/upnperrors.h... yes
+2025-07-27T17:37:28.0574527Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-27T17:37:28.0657874Z checking whether miniUPnPc API version is supported... yes
+2025-07-27T17:37:28.1146147Z checking for natpmp.h... yes
+2025-07-27T17:37:28.1504599Z checking for initnatpmp in -lnatpmp... yes
+2025-07-27T17:37:28.1579794Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-27T17:37:28.1583431Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-27T17:37:28.1584682Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-27T17:37:28.1586072Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-27T17:37:28.1586879Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-27T17:37:28.1727675Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-27T17:37:28.2013257Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-27T17:37:31.0422869Z checking for Boost Process... yes
+2025-07-27T17:37:31.0641307Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-27T17:37:31.1029941Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-27T17:37:31.1299042Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-27T17:37:31.1417297Z checking for libevent >= 2.1.8... yes
+2025-07-27T17:37:31.1530191Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-27T17:37:31.1870953Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-27T17:37:31.1997920Z checking for libqrencode... yes
+2025-07-27T17:37:31.2112366Z checking for libzmq >= 4... yes
+2025-07-27T17:37:31.2687749Z checking for gmp.h... yes
+2025-07-27T17:37:31.3051818Z checking for __gmpz_init in -lgmp... yes
+2025-07-27T17:37:31.3168607Z checking for libmultiprocess... no
+2025-07-27T17:37:31.3250233Z checking whether to build dashd... yes
+2025-07-27T17:37:31.3251489Z checking whether to build dash-cli... yes
+2025-07-27T17:37:31.3253048Z checking whether to build dash-tx... yes
+2025-07-27T17:37:31.3254045Z checking whether to build dash-wallet... yes
+2025-07-27T17:37:31.3254551Z checking whether to build libraries... no
+2025-07-27T17:37:31.3256949Z checking if ccache should be used... yes
+2025-07-27T17:37:31.3534721Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-27T17:37:31.3651997Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-27T17:37:31.3653484Z checking if wallet should be enabled... yes
+2025-07-27T17:37:31.3655237Z checking whether to build with support for UPnP... yes
+2025-07-27T17:37:31.3657321Z checking whether to build with support for NAT-PMP... yes
+2025-07-27T17:37:31.3660111Z checking whether to build GUI with support for D-Bus... yes
+2025-07-27T17:37:31.3661979Z checking whether to build GUI with support for QR codes... yes
+2025-07-27T17:37:31.3663537Z checking whether to build test_dash-qt... yes
+2025-07-27T17:37:31.3664070Z checking whether to build test_dash... yes
+2025-07-27T17:37:31.3664534Z checking whether to reduce exports... yes
+2025-07-27T17:37:31.3793428Z checking whether dsymutil needs -flat... yes
+2025-07-27T17:37:31.3793832Z 
+2025-07-27T17:37:31.4228644Z checking that generated files are newer than configure... done
+2025-07-27T17:37:31.4235102Z configure: creating ./config.status
+2025-07-27T17:37:32.0662072Z config.status: creating Makefile
+2025-07-27T17:37:32.0786357Z config.status: creating src/Makefile
+2025-07-27T17:37:32.1361954Z config.status: creating doc/man/Makefile
+2025-07-27T17:37:32.1522540Z config.status: creating share/setup.nsi
+2025-07-27T17:37:32.1686981Z config.status: creating share/qt/Info.plist
+2025-07-27T17:37:32.1847714Z config.status: creating test/config.ini
+2025-07-27T17:37:32.2008421Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-27T17:37:32.2177789Z config.status: creating src/config/bitcoin-config.h
+2025-07-27T17:37:32.2348866Z config.status: linking ../contrib/filter-lcov.py to contrib/filter-lcov.py
+2025-07-27T17:37:32.2412756Z config.status: linking ../src/.bear-tidy-config to src/.bear-tidy-config
+2025-07-27T17:37:32.2477158Z config.status: linking ../src/.clang-tidy to src/.clang-tidy
+2025-07-27T17:37:32.2551341Z config.status: linking ../test/functional/test_runner.py to test/functional/test_runner.py
+2025-07-27T17:37:32.2624703Z config.status: linking ../test/fuzz/test_runner.py to test/fuzz/test_runner.py
+2025-07-27T17:37:32.2698865Z config.status: linking ../test/util/test_runner.py to test/util/test_runner.py
+2025-07-27T17:37:32.2763580Z config.status: linking ../test/util/rpcauth-test.py to test/util/rpcauth-test.py
+2025-07-27T17:37:32.2794748Z config.status: executing depfiles commands
+2025-07-27T17:37:32.2808187Z config.status: executing libtool commands
+2025-07-27T17:37:32.2924384Z === configuring in src/dashbls (/__w/dash/dash/build-ci/src/dashbls)
+2025-07-27T17:37:32.2979009Z configure: running /bin/bash ../../../src/dashbls/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/dashbls
+2025-07-27T17:37:32.4130123Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T17:37:32.4613882Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:32.4660493Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:32.4737834Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T17:37:32.4766288Z checking whether build environment is sane... yes
+2025-07-27T17:37:32.4825629Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T17:37:32.4846640Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T17:37:32.4851085Z checking for gawk... gawk
+2025-07-27T17:37:32.4913686Z checking whether make sets $(MAKE)... yes
+2025-07-27T17:37:32.4965715Z checking whether make supports nested variables... yes
+2025-07-27T17:37:32.5006647Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-27T17:37:32.5008679Z checking whether make supports nested variables... (cached) yes
+2025-07-27T17:37:32.5010969Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T17:37:32.5556845Z checking whether the C compiler works... yes
+2025-07-27T17:37:32.5557511Z checking for C compiler default output file name... a.out
+2025-07-27T17:37:32.5839055Z checking for suffix of executables... 
+2025-07-27T17:37:32.6194186Z checking whether we are cross compiling... no
+2025-07-27T17:37:32.6352045Z checking for suffix of object files... o
+2025-07-27T17:37:32.6486005Z checking whether the compiler supports GNU C... yes
+2025-07-27T17:37:32.6637537Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T17:37:32.6983335Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T17:37:32.7247253Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T17:37:32.7318486Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T17:37:32.7322470Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:32.7654778Z checking whether the compiler supports GNU C++... yes
+2025-07-27T17:37:32.7808088Z checking whether g++ -m64 accepts -g... yes
+2025-07-27T17:37:33.0645137Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-27T17:37:33.1122489Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-27T17:37:33.1124918Z checking dependency style of g++ -m64... none
+2025-07-27T17:37:33.1519750Z checking whether g++ -m64 supports C++14 features with -std=c++14... yes
+2025-07-27T17:37:33.1543186Z checking how to print strings... printf
+2025-07-27T17:37:33.1580536Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T17:37:33.1610953Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T17:37:33.1626107Z checking for egrep... /usr/bin/grep -E
+2025-07-27T17:37:33.1641372Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T17:37:33.1688359Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T17:37:33.1712980Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T17:37:33.1715512Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T17:37:33.1992513Z checking the name lister (nm) interface... BSD nm
+2025-07-27T17:37:33.1993414Z checking whether ln -s works... yes
+2025-07-27T17:37:33.2035728Z checking the maximum length of command line arguments... 3145728
+2025-07-27T17:37:33.2062195Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T17:37:33.2064476Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T17:37:33.2065346Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T17:37:33.2070134Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T17:37:33.2075293Z checking for file... file
+2025-07-27T17:37:33.2079659Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:37:33.2084510Z checking for objdump... objdump
+2025-07-27T17:37:33.2087966Z checking how to recognize dependent libraries... pass_all
+2025-07-27T17:37:33.2092600Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T17:37:33.2096991Z checking for dlltool... no
+2025-07-27T17:37:33.2099299Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T17:37:33.2100989Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:37:33.2440921Z checking for archiver @FILE support... @
+2025-07-27T17:37:33.2441792Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T17:37:33.2444003Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T17:37:33.3104907Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T17:37:33.3121468Z checking for sysroot... no
+2025-07-27T17:37:33.3165207Z checking for a working dd... /usr/bin/dd
+2025-07-27T17:37:33.3203729Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T17:37:33.3305193Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T17:37:33.3309670Z checking for mt... no
+2025-07-27T17:37:33.3340684Z checking if : is a manifest tool... no
+2025-07-27T17:37:33.3491526Z checking for stdio.h... yes
+2025-07-27T17:37:33.3653745Z checking for stdlib.h... yes
+2025-07-27T17:37:33.3823012Z checking for string.h... yes
+2025-07-27T17:37:33.3999278Z checking for inttypes.h... yes
+2025-07-27T17:37:33.4180075Z checking for stdint.h... yes
+2025-07-27T17:37:33.4356406Z checking for strings.h... yes
+2025-07-27T17:37:33.4536332Z checking for sys/stat.h... yes
+2025-07-27T17:37:33.4718541Z checking for sys/types.h... yes
+2025-07-27T17:37:33.4929183Z checking for unistd.h... yes
+2025-07-27T17:37:33.5141800Z checking for dlfcn.h... yes
+2025-07-27T17:37:33.5176740Z checking for objdir... .libs
+2025-07-27T17:37:33.5764735Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T17:37:33.5765437Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:33.5900314Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:33.6473355Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T17:37:33.6687820Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T17:37:33.6688498Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:33.6780484Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:33.7261000Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T17:37:33.7262092Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:33.7277730Z checking whether stripping libraries is possible... yes
+2025-07-27T17:37:33.7278374Z checking if libtool supports shared libraries... yes
+2025-07-27T17:37:33.7278957Z checking whether to build shared libraries... no
+2025-07-27T17:37:33.7279476Z checking whether to build static libraries... yes
+2025-07-27T17:37:33.7540804Z checking how to run the C++ preprocessor... g++ -m64 -std=c++14 -E
+2025-07-27T17:37:33.8292520Z checking for ld used by g++ -m64 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-27T17:37:33.8317433Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-27T17:37:33.8389938Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:33.8986768Z checking for g++ -m64 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:33.9136420Z checking if g++ -m64 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:33.9727140Z checking if g++ -m64 -std=c++14 static flag -static works... yes
+2025-07-27T17:37:33.9950760Z checking if g++ -m64 -std=c++14 supports -c -o file.o... yes
+2025-07-27T17:37:33.9951502Z checking if g++ -m64 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:33.9952649Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:33.9997923Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-27T17:37:33.9999321Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:34.0006694Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-27T17:37:34.0013586Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-27T17:37:34.0015922Z checking for ranlib... (cached) ranlib
+2025-07-27T17:37:34.0020908Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-27T17:37:34.0023380Z checking for strip... (cached) strip
+2025-07-27T17:37:34.0026678Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:34.0171122Z checking whether C compiler accepts -Werror... yes
+2025-07-27T17:37:34.0419079Z checking for gmp.h... yes
+2025-07-27T17:37:34.0735758Z checking for __gmpz_init in -lgmp... yes
+2025-07-27T17:37:34.0911236Z checking gmp version >= 6.2... yes
+2025-07-27T17:37:34.0939242Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-27T17:37:34.0951844Z checking pkg-config is at least version 0.9.0... yes
+2025-07-27T17:37:34.1038854Z checking if gcc -m64 supports -pipe... yes
+2025-07-27T17:37:34.1134304Z checking if gcc -m64 supports -fomit-frame-pointer... yes
+2025-07-27T17:37:34.1380117Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-27T17:37:34.1676388Z checking whether gcc -m64 is Clang... no
+2025-07-27T17:37:34.2112830Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-27T17:37:34.2463792Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-27T17:37:34.2464551Z checking whether more special flags are required for pthreads... no
+2025-07-27T17:37:34.2816556Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-27T17:37:34.3137920Z checking for library containing clock_gettime... none required
+2025-07-27T17:37:34.3311855Z checking whether C compiler accepts -fPIC... yes
+2025-07-27T17:37:34.3479630Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-27T17:37:34.3627681Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-27T17:37:34.3799422Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-27T17:37:34.3963228Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-27T17:37:34.4129101Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-27T17:37:34.4351933Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-27T17:37:34.4577880Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-27T17:37:34.4811930Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-27T17:37:34.5047200Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-27T17:37:34.5370186Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-27T17:37:34.5685446Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-27T17:37:34.6006178Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-27T17:37:34.6324331Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-27T17:37:34.6514150Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-27T17:37:34.6515523Z checking whether to build runtest... yes
+2025-07-27T17:37:34.6516000Z checking whether to build runbench... yes
+2025-07-27T17:37:34.6752340Z checking that generated files are newer than configure... done
+2025-07-27T17:37:34.6757233Z configure: creating ./config.status
+2025-07-27T17:37:35.2160645Z config.status: creating Makefile
+2025-07-27T17:37:35.2377689Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-27T17:37:35.2521989Z config.status: executing depfiles commands
+2025-07-27T17:37:35.2535445Z config.status: executing libtool commands
+2025-07-27T17:37:35.2663918Z 
+2025-07-27T17:37:35.2664797Z Options used to compile and link:
+2025-07-27T17:37:35.2665450Z   target os           = linux
+2025-07-27T17:37:35.2665833Z   backend             = gmp
+2025-07-27T17:37:35.2666185Z   build bench         = yes
+2025-07-27T17:37:35.2666529Z   build test          = yes
+2025-07-27T17:37:35.2666888Z   use debug           = no
+2025-07-27T17:37:35.2667203Z   use hardening       = yes
+2025-07-27T17:37:35.2667540Z   use optimizations   = yes
+2025-07-27T17:37:35.2667763Z 
+2025-07-27T17:37:35.2668032Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-27T17:37:35.2668957Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-27T17:37:35.2669599Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-27T17:37:35.2670271Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-27T17:37:35.2670919Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-27T17:37:35.2671101Z 
+2025-07-27T17:37:35.3031408Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/src/secp256k1)
+2025-07-27T17:37:35.3090637Z configure: running /bin/bash ../../../src/secp256k1/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/secp256k1
+2025-07-27T17:37:35.4240818Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T17:37:35.4739062Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:35.4787001Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:35.4864553Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T17:37:35.4892568Z checking whether build environment is sane... yes
+2025-07-27T17:37:35.4952183Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T17:37:35.4973419Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T17:37:35.4977347Z checking for gawk... gawk
+2025-07-27T17:37:35.5040137Z checking whether make sets $(MAKE)... yes
+2025-07-27T17:37:35.5092828Z checking whether make supports nested variables... yes
+2025-07-27T17:37:35.5134539Z checking whether make supports nested variables... (cached) yes
+2025-07-27T17:37:35.5137043Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T17:37:35.5685983Z checking whether the C compiler works... yes
+2025-07-27T17:37:35.5686989Z checking for C compiler default output file name... a.out
+2025-07-27T17:37:35.5972080Z checking for suffix of executables... 
+2025-07-27T17:37:35.6327863Z checking whether we are cross compiling... no
+2025-07-27T17:37:35.6486186Z checking for suffix of object files... o
+2025-07-27T17:37:35.6623405Z checking whether the compiler supports GNU C... yes
+2025-07-27T17:37:35.6773165Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T17:37:35.7116787Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T17:37:35.7375602Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T17:37:35.7447596Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T17:37:35.7450832Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:35.7454726Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:35.7456068Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:37:35.7713383Z checking the archiver (ar) interface... ar
+2025-07-27T17:37:35.7736149Z checking how to print strings... printf
+2025-07-27T17:37:35.7773970Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T17:37:35.7803440Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T17:37:35.7818503Z checking for egrep... /usr/bin/grep -E
+2025-07-27T17:37:35.7834125Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T17:37:35.7879624Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T17:37:35.7903305Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T17:37:35.7905240Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T17:37:35.8178959Z checking the name lister (nm) interface... BSD nm
+2025-07-27T17:37:35.8179527Z checking whether ln -s works... yes
+2025-07-27T17:37:35.8219608Z checking the maximum length of command line arguments... 3145728
+2025-07-27T17:37:35.8244707Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T17:37:35.8246411Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T17:37:35.8247265Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T17:37:35.8252072Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T17:37:35.8256323Z checking for file... file
+2025-07-27T17:37:35.8260620Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:37:35.8265028Z checking for objdump... objdump
+2025-07-27T17:37:35.8268605Z checking how to recognize dependent libraries... pass_all
+2025-07-27T17:37:35.8273852Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T17:37:35.8277669Z checking for dlltool... no
+2025-07-27T17:37:35.8280324Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T17:37:35.8281079Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:37:35.8611774Z checking for archiver @FILE support... @
+2025-07-27T17:37:35.8612546Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T17:37:35.8614678Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T17:37:35.9267149Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T17:37:35.9282605Z checking for sysroot... no
+2025-07-27T17:37:35.9323925Z checking for a working dd... /usr/bin/dd
+2025-07-27T17:37:35.9361722Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T17:37:35.9460499Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T17:37:35.9465101Z checking for mt... no
+2025-07-27T17:37:35.9495451Z checking if : is a manifest tool... no
+2025-07-27T17:37:35.9639655Z checking for stdio.h... yes
+2025-07-27T17:37:35.9796888Z checking for stdlib.h... yes
+2025-07-27T17:37:35.9958817Z checking for string.h... yes
+2025-07-27T17:37:36.0130527Z checking for inttypes.h... yes
+2025-07-27T17:37:36.0300455Z checking for stdint.h... yes
+2025-07-27T17:37:36.0472516Z checking for strings.h... yes
+2025-07-27T17:37:36.0655847Z checking for sys/stat.h... yes
+2025-07-27T17:37:36.0837170Z checking for sys/types.h... yes
+2025-07-27T17:37:36.1035564Z checking for unistd.h... yes
+2025-07-27T17:37:36.1241205Z checking for dlfcn.h... yes
+2025-07-27T17:37:36.1279455Z checking for objdir... .libs
+2025-07-27T17:37:36.1849987Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T17:37:36.1850754Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:36.1982736Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:36.2543440Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T17:37:36.2752483Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T17:37:36.2753149Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:36.2847946Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:36.3328484Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T17:37:36.3330246Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:36.3347667Z checking whether stripping libraries is possible... yes
+2025-07-27T17:37:36.3348337Z checking if libtool supports shared libraries... yes
+2025-07-27T17:37:36.3348935Z checking whether to build shared libraries... no
+2025-07-27T17:37:36.3349498Z checking whether to build static libraries... yes
+2025-07-27T17:37:36.3453560Z checking if gcc -m64 supports -Werror... yes
+2025-07-27T17:37:36.3548681Z checking if gcc -m64 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-27T17:37:36.3642737Z checking if gcc -m64 supports -Wno-overlength-strings... yes
+2025-07-27T17:37:36.3735189Z checking if gcc -m64 supports -Wall... yes
+2025-07-27T17:37:36.3828684Z checking if gcc -m64 supports -Wno-unused-function... yes
+2025-07-27T17:37:36.3920934Z checking if gcc -m64 supports -Wextra... yes
+2025-07-27T17:37:36.4014650Z checking if gcc -m64 supports -Wcast-align... yes
+2025-07-27T17:37:36.4105782Z checking if gcc -m64 supports -Wcast-align=strict... yes
+2025-07-27T17:37:36.4342282Z checking if gcc -m64 supports -Wconditional-uninitialized... no
+2025-07-27T17:37:36.4544481Z checking if gcc -m64 supports -Wreserved-identifier... no
+2025-07-27T17:37:36.4638279Z checking if gcc -m64 supports -fvisibility=hidden... yes
+2025-07-27T17:37:36.4784528Z checking for valgrind support... 
+2025-07-27T17:37:36.5114875Z checking for x86_64 assembly availability... yes
+2025-07-27T17:37:36.5342387Z checking that generated files are newer than configure... done
+2025-07-27T17:37:36.5345324Z configure: creating ./config.status
+2025-07-27T17:37:36.9273271Z config.status: creating Makefile
+2025-07-27T17:37:36.9399556Z config.status: creating libsecp256k1.pc
+2025-07-27T17:37:36.9505385Z config.status: executing depfiles commands
+2025-07-27T17:37:36.9518229Z config.status: executing libtool commands
+2025-07-27T17:37:36.9606336Z 
+2025-07-27T17:37:36.9607007Z Build Options:
+2025-07-27T17:37:36.9607379Z   with external callbacks = no
+2025-07-27T17:37:36.9607736Z   with benchmarks         = no
+2025-07-27T17:37:36.9607966Z   with tests              = yes
+2025-07-27T17:37:36.9608177Z   with ctime tests        = no
+2025-07-27T17:37:36.9608385Z   with coverage           = no
+2025-07-27T17:37:36.9608585Z   with examples           = no
+2025-07-27T17:37:36.9608777Z   module ecdh             = no
+2025-07-27T17:37:36.9608998Z   module recovery         = yes
+2025-07-27T17:37:36.9609212Z   module extrakeys        = yes
+2025-07-27T17:37:36.9609426Z   module schnorrsig       = yes
+2025-07-27T17:37:36.9609653Z   module ellswift         = yes
+2025-07-27T17:37:36.9609793Z 
+2025-07-27T17:37:36.9609874Z   asm                     = x86_64
+2025-07-27T17:37:36.9610098Z   ecmult window size      = 15
+2025-07-27T17:37:36.9610311Z   ecmult gen prec. bits   = 4
+2025-07-27T17:37:36.9610459Z 
+2025-07-27T17:37:36.9610544Z   valgrind                = no
+2025-07-27T17:37:36.9610752Z   CC                      = gcc -m64
+2025-07-27T17:37:36.9611082Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-27T17:37:36.9612578Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-27T17:37:36.9613581Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-27T17:37:36.9613967Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-27T17:37:36.9929401Z 
+2025-07-27T17:37:36.9930031Z Options used to compile and link:
+2025-07-27T17:37:36.9930544Z   boost process       = yes
+2025-07-27T17:37:36.9930925Z   multiprocess        = no
+2025-07-27T17:37:36.9931292Z   with libs           = no
+2025-07-27T17:37:36.9931877Z   with wallet         = yes
+2025-07-27T17:37:36.9932566Z     with sqlite       = yes
+2025-07-27T17:37:36.9932954Z     with bdb          = yes
+2025-07-27T17:37:36.9933299Z   with gui / qt       = yes
+2025-07-27T17:37:36.9933640Z     with qr           = yes
+2025-07-27T17:37:36.9933968Z   with zmq            = yes
+2025-07-27T17:37:36.9934296Z   with test           = yes
+2025-07-27T17:37:36.9934627Z   with fuzz binary    = no
+2025-07-27T17:37:36.9934965Z   with bench          = yes
+2025-07-27T17:37:36.9935302Z   with upnp           = yes
+2025-07-27T17:37:36.9935632Z   with natpmp         = yes
+2025-07-27T17:37:36.9935968Z   USDT tracing        = yes
+2025-07-27T17:37:36.9936309Z   sanitizers          = 
+2025-07-27T17:37:36.9936588Z   debug enabled       = no
+2025-07-27T17:37:36.9936804Z   stacktraces enabled = yes
+2025-07-27T17:37:36.9937017Z   crash hooks enabled = no
+2025-07-27T17:37:36.9937220Z   miner enabled       = yes
+2025-07-27T17:37:36.9937429Z   gprof enabled       = no
+2025-07-27T17:37:36.9937634Z   werror              = yes
+2025-07-27T17:37:36.9937782Z 
+2025-07-27T17:37:36.9937873Z   target os           = linux-gnu
+2025-07-27T17:37:36.9938100Z   build os            = linux-gnu
+2025-07-27T17:37:36.9938254Z 
+2025-07-27T17:37:36.9938371Z   CC                  = /usr/bin/ccache gcc -m64
+2025-07-27T17:37:36.9938740Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-27T17:37:36.9939574Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-27T17:37:36.9940297Z   CXX                 = /usr/bin/ccache g++ -m64 -std=c++20
+2025-07-27T17:37:36.9944301Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-27T17:37:36.9948892Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-27T17:37:36.9949807Z   AR                  = ar
+2025-07-27T17:37:36.9950165Z   ARFLAGS             = cr
+2025-07-27T17:37:36.9950390Z 
+2025-07-27T17:37:37.0537308Z make  distdir-am
+2025-07-27T17:37:37.0591796Z make[1]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-27T17:37:37.0592811Z if test -d "dashcore-linux64"; then find "dashcore-linux64" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "dashcore-linux64" || { sleep 5 && rm -rf "dashcore-linux64"; }; else :; fi
+2025-07-27T17:37:37.0607065Z test -d "dashcore-linux64" || mkdir "dashcore-linux64"
+2025-07-27T17:37:37.2642057Z  (cd src && make  top_distdir=../dashcore-linux64 distdir=../dashcore-linux64/src \
+2025-07-27T17:37:37.2643216Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-27T17:37:37.2886582Z make[2]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-27T17:37:37.2887095Z make  distdir-am
+2025-07-27T17:37:37.4191271Z make[3]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-27T17:37:37.5040176Z Generated bench/data/block813851.raw.h
+2025-07-27T17:37:37.5273541Z Generated test/data/blockfilters.json.h
+2025-07-27T17:37:37.5354800Z Generated test/data/base58_encode_decode.json.h
+2025-07-27T17:37:37.5443597Z Generated test/data/bip39_vectors.json.h
+2025-07-27T17:37:37.5534097Z Generated test/data/key_io_valid.json.h
+2025-07-27T17:37:37.5616964Z Generated test/data/key_io_invalid.json.h
+2025-07-27T17:37:37.5698299Z Generated test/data/proposals_valid.json.h
+2025-07-27T17:37:37.5783182Z Generated test/data/proposals_invalid.json.h
+2025-07-27T17:37:37.6135038Z Generated test/data/script_tests.json.h
+2025-07-27T17:37:37.6419331Z Generated test/data/sighash.json.h
+2025-07-27T17:37:37.6509420Z Generated test/data/trivially_invalid.json.h
+2025-07-27T17:37:37.6611818Z Generated test/data/trivially_valid.json.h
+2025-07-27T17:37:37.6732036Z Generated test/data/tx_invalid.json.h
+2025-07-27T17:37:37.6857586Z Generated test/data/tx_valid.json.h
+2025-07-27T17:37:37.6937814Z Generated test/data/asmap.raw.h
+2025-07-27T17:37:40.1885192Z  (cd secp256k1 && make  top_distdir=../../dashcore-linux64 distdir=../../dashcore-linux64/src/secp256k1 \
+2025-07-27T17:37:40.1885789Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-27T17:37:40.1923397Z make[4]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-27T17:37:40.1924002Z make  distdir-am
+2025-07-27T17:37:40.2039114Z make[5]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-27T17:37:40.2039688Z :
+2025-07-27T17:37:40.2040205Z test -d "../../dashcore-linux64/src/secp256k1" || mkdir "../../dashcore-linux64/src/secp256k1"
+2025-07-27T17:37:40.4220645Z test -n ":" \
+2025-07-27T17:37:40.4221188Z || find "../../dashcore-linux64/src/secp256k1" -type d ! -perm -755 \
+2025-07-27T17:37:40.4221765Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-27T17:37:40.4222100Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-27T17:37:40.4222430Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-27T17:37:40.4222887Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/src/secp256k1/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-27T17:37:40.4223356Z || chmod -R a+r "../../dashcore-linux64/src/secp256k1"
+2025-07-27T17:37:40.4234819Z make[5]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-27T17:37:40.4237975Z make[4]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-27T17:37:40.4242899Z make[3]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-27T17:37:40.4251005Z make[2]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-27T17:37:40.4516560Z  (cd doc/man && make  top_distdir=../../dashcore-linux64 distdir=../../dashcore-linux64/doc/man \
+2025-07-27T17:37:40.4517530Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-27T17:37:40.4539444Z make[2]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-27T17:37:40.4539969Z make  distdir-am
+2025-07-27T17:37:40.4572276Z make[3]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-27T17:37:40.4746153Z make[3]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-27T17:37:40.4747671Z make[2]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-27T17:37:40.4752935Z make  \
+2025-07-27T17:37:40.4753230Z   top_distdir="dashcore-linux64" distdir="dashcore-linux64" \
+2025-07-27T17:37:40.4753563Z   dist-hook
+2025-07-27T17:37:40.4787418Z make[2]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-27T17:37:40.4789165Z /usr/bin/git archive --format=tar HEAD -- src/clientversion.cpp | ${TAR-tar} -C dashcore-linux64 -xf -
+2025-07-27T17:37:40.4817150Z fatal: pathspec 'src/clientversion.cpp' did not match any files
+2025-07-27T17:37:40.4820042Z tar: This does not look like a tar archive
+2025-07-27T17:37:40.4820706Z tar: Exiting with failure status due to previous errors
+2025-07-27T17:37:40.4824656Z make[2]: [Makefile:1226: dist-hook] Error 2 (ignored)
+2025-07-27T17:37:40.4825216Z make[2]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-27T17:37:40.4826401Z test -n "" \
+2025-07-27T17:37:40.4826769Z || find "dashcore-linux64" -type d ! -perm -755 \
+2025-07-27T17:37:40.4827245Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-27T17:37:40.4827564Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-27T17:37:40.4827905Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-27T17:37:40.4828337Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-27T17:37:40.4828940Z || chmod -R a+r "dashcore-linux64"
+2025-07-27T17:37:40.5042897Z make[1]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-27T17:37:40.6096280Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T17:37:40.6169361Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-27T17:37:40.6181134Z checking pkg-config is at least version 0.9.0... yes
+2025-07-27T17:37:40.6632184Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:40.6679863Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:40.6759228Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T17:37:40.6787050Z checking whether build environment is sane... yes
+2025-07-27T17:37:40.6854400Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T17:37:40.6867089Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T17:37:40.6871279Z checking for gawk... gawk
+2025-07-27T17:37:40.6933670Z checking whether make sets $(MAKE)... yes
+2025-07-27T17:37:40.6986326Z checking whether make supports nested variables... yes
+2025-07-27T17:37:40.7028259Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-27T17:37:40.7029465Z checking whether make supports nested variables... (cached) yes
+2025-07-27T17:37:40.7570286Z checking whether the C++ compiler works... yes
+2025-07-27T17:37:40.7570901Z checking for C++ compiler default output file name... a.out
+2025-07-27T17:37:40.7893343Z checking for suffix of executables... 
+2025-07-27T17:37:40.8339893Z checking whether we are cross compiling... no
+2025-07-27T17:37:40.8506152Z checking for suffix of object files... o
+2025-07-27T17:37:40.8647153Z checking whether the compiler supports GNU C++... yes
+2025-07-27T17:37:40.8803712Z checking whether g++ -m64 accepts -g... yes
+2025-07-27T17:37:41.1618523Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-27T17:37:41.2093684Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-27T17:37:41.2169173Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T17:37:41.2172707Z checking dependency style of g++ -m64... none
+2025-07-27T17:37:41.2961379Z checking whether g++ -m64 supports C++20 features with -std=c++20... yes
+2025-07-27T17:37:41.2964235Z checking for x86_64-pc-linux-gnu-g++... g++ -m64 -std=c++20
+2025-07-27T17:37:41.3252360Z checking whether the compiler supports GNU Objective C++... no
+2025-07-27T17:37:41.3527319Z checking whether g++ -m64 -std=c++20 accepts -g... no
+2025-07-27T17:37:41.3530453Z checking dependency style of g++ -m64 -std=c++20... none
+2025-07-27T17:37:41.3554142Z checking how to print strings... printf
+2025-07-27T17:37:41.3556552Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T17:37:41.3939271Z checking whether the compiler supports GNU C... yes
+2025-07-27T17:37:41.4092200Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T17:37:41.4440204Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T17:37:41.4705248Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T17:37:41.4707873Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:41.4746217Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T17:37:41.4776178Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T17:37:41.4791515Z checking for egrep... /usr/bin/grep -E
+2025-07-27T17:37:41.4807539Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T17:37:41.4854396Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T17:37:41.4878200Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T17:37:41.4879702Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T17:37:41.5156663Z checking the name lister (nm) interface... BSD nm
+2025-07-27T17:37:41.5157214Z checking whether ln -s works... yes
+2025-07-27T17:37:41.5199765Z checking the maximum length of command line arguments... 3145728
+2025-07-27T17:37:41.5227373Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T17:37:41.5228504Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T17:37:41.5229370Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T17:37:41.5234789Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T17:37:41.5239403Z checking for file... file
+2025-07-27T17:37:41.5243961Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:37:41.5249048Z checking for objdump... objdump
+2025-07-27T17:37:41.5253200Z checking how to recognize dependent libraries... pass_all
+2025-07-27T17:37:41.5258112Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T17:37:41.5262728Z checking for dlltool... no
+2025-07-27T17:37:41.5264391Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T17:37:41.5265695Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:37:41.5596527Z checking for archiver @FILE support... @
+2025-07-27T17:37:41.5597162Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T17:37:41.5600104Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T17:37:41.6250904Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T17:37:41.6267393Z checking for sysroot... no
+2025-07-27T17:37:41.6309065Z checking for a working dd... /usr/bin/dd
+2025-07-27T17:37:41.6347113Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T17:37:41.6447211Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T17:37:41.6451703Z checking for mt... no
+2025-07-27T17:37:41.6482818Z checking if : is a manifest tool... no
+2025-07-27T17:37:41.6628823Z checking for stdio.h... yes
+2025-07-27T17:37:41.6784625Z checking for stdlib.h... yes
+2025-07-27T17:37:41.6949656Z checking for string.h... yes
+2025-07-27T17:37:41.7119438Z checking for inttypes.h... yes
+2025-07-27T17:37:41.7287766Z checking for stdint.h... yes
+2025-07-27T17:37:41.7459662Z checking for strings.h... yes
+2025-07-27T17:37:41.7633910Z checking for sys/stat.h... yes
+2025-07-27T17:37:41.7812953Z checking for sys/types.h... yes
+2025-07-27T17:37:41.8012689Z checking for unistd.h... yes
+2025-07-27T17:37:41.8217457Z checking for dlfcn.h... yes
+2025-07-27T17:37:41.8255855Z checking for objdir... .libs
+2025-07-27T17:37:41.8832427Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T17:37:41.8832987Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:41.8966546Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:41.9524929Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T17:37:41.9741509Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T17:37:41.9742312Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:41.9834991Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:42.0037785Z checking whether -lc should be explicitly linked in... no
+2025-07-27T17:37:42.0514479Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T17:37:42.0515420Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:42.0533428Z checking whether stripping libraries is possible... yes
+2025-07-27T17:37:42.0534074Z checking if libtool supports shared libraries... yes
+2025-07-27T17:37:42.0534636Z checking whether to build shared libraries... yes
+2025-07-27T17:37:42.0535196Z checking whether to build static libraries... yes
+2025-07-27T17:37:42.0793173Z checking how to run the C++ preprocessor... g++ -m64 -std=c++20 -E
+2025-07-27T17:37:42.1519371Z checking for ld used by g++ -m64 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-27T17:37:42.1544645Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-27T17:37:42.1613318Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:42.2203680Z checking for g++ -m64 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:42.2353116Z checking if g++ -m64 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:42.2931283Z checking if g++ -m64 -std=c++20 static flag -static works... yes
+2025-07-27T17:37:42.3153736Z checking if g++ -m64 -std=c++20 supports -c -o file.o... yes
+2025-07-27T17:37:42.3154486Z checking if g++ -m64 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:42.3157401Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:42.3202676Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-27T17:37:42.3205385Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:42.3212355Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-27T17:37:42.3217966Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-27T17:37:42.3222460Z checking for gcov... /usr/bin/gcov
+2025-07-27T17:37:42.3227105Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-27T17:37:42.3231717Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-27T17:37:42.3235754Z checking for lcov... no
+2025-07-27T17:37:42.3238964Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-27T17:37:42.3243089Z checking for genhtml... no
+2025-07-27T17:37:42.3246916Z checking for git... /usr/bin/git
+2025-07-27T17:37:42.3250286Z checking for ccache... /usr/bin/ccache
+2025-07-27T17:37:42.3254506Z checking for xgettext... /usr/bin/xgettext
+2025-07-27T17:37:42.3257822Z checking for hexdump... /usr/bin/hexdump
+2025-07-27T17:37:42.3261836Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-27T17:37:42.3266341Z checking for objcopy... /usr/bin/objcopy
+2025-07-27T17:37:42.3270717Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:37:42.3275049Z checking for objdump... /usr/bin/objdump
+2025-07-27T17:37:42.3279790Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-27T17:37:42.3284942Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-27T17:37:42.3288743Z checking for doxygen... no
+2025-07-27T17:37:42.3442328Z checking whether C++ compiler accepts -Werror... yes
+2025-07-27T17:37:42.3804057Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-27T17:37:42.4228677Z checking for execinfo.h... yes
+2025-07-27T17:37:42.4584247Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-27T17:37:42.4781537Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-27T17:37:42.4958195Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-27T17:37:42.5127255Z checking whether C++ compiler accepts -Wdangling-reference... yes
+2025-07-27T17:37:42.5299820Z checking whether C++ compiler accepts -Wattributes... yes
+2025-07-27T17:37:42.5478373Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-27T17:37:42.5654888Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-27T17:37:42.5831992Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-27T17:37:42.6007433Z checking whether C++ compiler accepts -Wall... yes
+2025-07-27T17:37:42.6182653Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-27T17:37:42.6321815Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-27T17:37:42.6500259Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-27T17:37:42.6680246Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-27T17:37:42.6855069Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-27T17:37:42.7030452Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-27T17:37:42.7228316Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-27T17:37:42.7420185Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-27T17:37:42.7595584Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-27T17:37:42.7851354Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-27T17:37:42.8033595Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-27T17:37:42.8306310Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-27T17:37:42.8484264Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-27T17:37:42.8663234Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-27T17:37:42.8837032Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-27T17:37:42.9017686Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-27T17:37:42.9195120Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-27T17:37:42.9376076Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-27T17:37:42.9555410Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-27T17:37:42.9760529Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-27T17:37:42.9943972Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-27T17:37:43.0132843Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-27T17:37:43.0320923Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-27T17:37:43.0476164Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-27T17:37:43.0662601Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-27T17:37:43.0848334Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-27T17:37:43.1034059Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-27T17:37:43.1221281Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-27T17:37:43.5987270Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-27T17:37:43.6432374Z checking for SSE4.2 intrinsics... yes
+2025-07-27T17:37:44.0907109Z checking for SSE4.1 intrinsics... yes
+2025-07-27T17:37:44.5128820Z checking for AVX2 intrinsics... yes
+2025-07-27T17:37:44.9511459Z checking for x86 SHA-NI intrinsics... yes
+2025-07-27T17:37:44.9683099Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-27T17:37:44.9837115Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-27T17:37:44.9976366Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-27T17:37:45.0124223Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-27T17:37:45.0941221Z checking whether byte ordering is bigendian... no
+2025-07-27T17:37:45.1161488Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-27T17:37:45.1457475Z checking whether gcc -m64 is Clang... no
+2025-07-27T17:37:45.1896356Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-27T17:37:45.2242611Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-27T17:37:45.2243413Z checking whether more special flags are required for pthreads... no
+2025-07-27T17:37:45.2593703Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-27T17:37:46.0968002Z checking whether std::atomic can be used without link library... yes
+2025-07-27T17:37:46.0980163Z checking for special C compiler options needed for large files... no
+2025-07-27T17:37:46.1175368Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-27T17:37:46.1496492Z checking for g++ -m64 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-27T17:37:46.1999817Z checking whether strerror_r is declared... yes
+2025-07-27T17:37:46.2220502Z checking whether strerror_r returns char *... yes
+2025-07-27T17:37:46.2372793Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-27T17:37:46.2524228Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-27T17:37:46.2675499Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-27T17:37:46.2820148Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-27T17:37:46.2991035Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-27T17:37:46.3074462Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-27T17:37:46.3157200Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-27T17:37:46.3415776Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-27T17:37:46.3671989Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-27T17:37:46.3928177Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-27T17:37:46.4183633Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-27T17:37:46.4551544Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-27T17:37:46.4928637Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-27T17:37:46.5308558Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-27T17:37:46.5680824Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-27T17:37:46.6111724Z checking for sys/select.h... yes
+2025-07-27T17:37:46.6540150Z checking for sys/prctl.h... yes
+2025-07-27T17:37:46.6852747Z checking for vm/vm_param.h... no
+2025-07-27T17:37:46.7163656Z checking for sys/vmmeter.h... no
+2025-07-27T17:37:46.7473946Z checking for sys/resources.h... no
+2025-07-27T17:37:46.7745831Z checking whether getifaddrs is declared... yes
+2025-07-27T17:37:46.8178177Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-27T17:37:46.8465680Z checking whether freeifaddrs is declared... yes
+2025-07-27T17:37:46.8907750Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-27T17:37:46.9419485Z checking whether fork is declared... yes
+2025-07-27T17:37:46.9921975Z checking whether setsid is declared... yes
+2025-07-27T17:37:47.0430281Z checking whether pipe2 is declared... yes
+2025-07-27T17:37:47.0668162Z checking for mallopt M_ARENA_MAX... yes
+2025-07-27T17:37:47.0909292Z checking for getmemoryinfo... yes
+2025-07-27T17:37:47.1113154Z checking for posix_fallocate... yes
+2025-07-27T17:37:47.1260043Z checking for default visibility attribute... yes
+2025-07-27T17:37:47.1405407Z checking for dllexport attribute... no
+2025-07-27T17:37:47.6292273Z checking for thread_local support... yes
+2025-07-27T17:37:47.6574605Z checking for Linux getrandom syscall... yes
+2025-07-27T17:37:47.6895104Z checking for getentropy via random.h... yes
+2025-07-27T17:37:47.7104028Z checking for sysctl... no
+2025-07-27T17:37:47.7293795Z checking for sysctl KERN_ARND... no
+2025-07-27T17:37:47.7658143Z checking for library containing backtrace... none required
+2025-07-27T17:37:47.7897053Z checking for fdatasync... yes
+2025-07-27T17:37:47.8094662Z checking for F_FULLFSYNC... no
+2025-07-27T17:37:47.8298563Z checking for O_CLOEXEC... yes
+2025-07-27T17:37:47.8453586Z checking for __builtin_prefetch... yes
+2025-07-27T17:37:47.8858740Z checking for _mm_prefetch... yes
+2025-07-27T17:37:47.9057931Z checking for strong getauxval support in the system headers... yes
+2025-07-27T17:37:47.9326724Z checking for sockaddr_un... yes
+2025-07-27T17:37:47.9796536Z checking for std::system... yes
+2025-07-27T17:37:48.0082955Z checking for ::_wsystem... no
+2025-07-27T17:37:48.0246960Z checking for Qt5Core >= 5.11.3... yes
+2025-07-27T17:37:48.0353596Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-27T17:37:48.0463615Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-27T17:37:48.0572299Z checking for Qt5Network >= 5.11.3... yes
+2025-07-27T17:37:48.0682173Z checking for Qt5Test >= 5.11.3... yes
+2025-07-27T17:37:48.0788930Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-27T17:37:48.2892087Z checking for static Qt... yes
+2025-07-27T17:37:48.3006636Z checking for Qt5AccessibilitySupport... yes
+2025-07-27T17:37:48.3115186Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-27T17:37:48.3225306Z checking for Qt5EdidSupport... yes
+2025-07-27T17:37:48.3337232Z checking for Qt5EventDispatcherSupport... yes
+2025-07-27T17:37:48.3447644Z checking for Qt5FbSupport... yes
+2025-07-27T17:37:48.3558984Z checking for Qt5FontDatabaseSupport... yes
+2025-07-27T17:37:48.3671110Z checking for Qt5ThemeSupport... yes
+2025-07-27T17:37:48.3785241Z checking for Qt5InputSupport... yes
+2025-07-27T17:37:48.3898472Z checking for Qt5ServiceSupport... yes
+2025-07-27T17:37:48.4027144Z checking for Qt5XcbQpa... yes
+2025-07-27T17:37:48.4139892Z checking for Qt5XkbCommonSupport... yes
+2025-07-27T17:37:50.3963331Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-27T17:37:52.4561003Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-27T17:37:52.6672768Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-27T17:37:52.6685049Z checking for moc-qt5... no
+2025-07-27T17:37:52.6685561Z checking for moc5... no
+2025-07-27T17:37:52.6687713Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-27T17:37:52.6689662Z checking for uic-qt5... no
+2025-07-27T17:37:52.6691211Z checking for uic5... no
+2025-07-27T17:37:52.6694066Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-27T17:37:52.6695159Z checking for rcc-qt5... no
+2025-07-27T17:37:52.6696715Z checking for rcc5... no
+2025-07-27T17:37:52.6698818Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-27T17:37:52.6700044Z checking for lrelease-qt5... no
+2025-07-27T17:37:52.6701378Z checking for lrelease5... no
+2025-07-27T17:37:52.6703566Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-27T17:37:52.6706212Z checking for lupdate-qt5... no
+2025-07-27T17:37:52.6706827Z checking for lupdate5... no
+2025-07-27T17:37:52.6708119Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-27T17:37:52.6709630Z checking for lconvert-qt5... no
+2025-07-27T17:37:52.6710305Z checking for lconvert5... no
+2025-07-27T17:37:52.6712274Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-27T17:37:52.6744425Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-27T17:37:52.6745388Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-27T17:37:53.5319208Z checking for Berkeley DB C++ headers... default
+2025-07-27T17:37:53.5721162Z checking for main in -ldb_cxx-4.8... yes
+2025-07-27T17:37:53.5858265Z checking for sqlite3 >= 3.7.17... yes
+2025-07-27T17:37:53.5858920Z checking whether to build wallet with support for sqlite... yes
+2025-07-27T17:37:53.6054419Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-27T17:37:53.6520653Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-27T17:37:53.6932860Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-27T17:37:53.7387786Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-27T17:37:53.7426514Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-27T17:37:53.7884198Z checking for miniupnpc/upnperrors.h... yes
+2025-07-27T17:37:53.7924608Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-27T17:37:53.8008549Z checking whether miniUPnPc API version is supported... yes
+2025-07-27T17:37:53.8505054Z checking for natpmp.h... yes
+2025-07-27T17:37:53.8868382Z checking for initnatpmp in -lnatpmp... yes
+2025-07-27T17:37:53.8943561Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-27T17:37:53.8945670Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-27T17:37:53.8947346Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-27T17:37:53.8948173Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-27T17:37:53.8948793Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-27T17:37:53.9091916Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-27T17:37:53.9371739Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-27T17:37:56.7928560Z checking for Boost Process... yes
+2025-07-27T17:37:56.8142029Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-27T17:37:56.8526417Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-27T17:37:56.8791399Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-27T17:37:56.8907546Z checking for libevent >= 2.1.8... yes
+2025-07-27T17:37:56.9021698Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-27T17:37:56.9355520Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-27T17:37:56.9481318Z checking for libqrencode... yes
+2025-07-27T17:37:56.9595584Z checking for libzmq >= 4... yes
+2025-07-27T17:37:57.0170784Z checking for gmp.h... yes
+2025-07-27T17:37:57.0533102Z checking for __gmpz_init in -lgmp... yes
+2025-07-27T17:37:57.0646664Z checking for libmultiprocess... no
+2025-07-27T17:37:57.0725377Z checking whether to build dashd... yes
+2025-07-27T17:37:57.0726528Z checking whether to build dash-cli... yes
+2025-07-27T17:37:57.0727460Z checking whether to build dash-tx... yes
+2025-07-27T17:37:57.0728661Z checking whether to build dash-wallet... yes
+2025-07-27T17:37:57.0729390Z checking whether to build libraries... no
+2025-07-27T17:37:57.0732360Z checking if ccache should be used... yes
+2025-07-27T17:37:57.0827744Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-27T17:37:57.0940354Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-27T17:37:57.0942603Z checking if wallet should be enabled... yes
+2025-07-27T17:37:57.0945580Z checking whether to build with support for UPnP... yes
+2025-07-27T17:37:57.0947318Z checking whether to build with support for NAT-PMP... yes
+2025-07-27T17:37:57.0949826Z checking whether to build GUI with support for D-Bus... yes
+2025-07-27T17:37:57.0951278Z checking whether to build GUI with support for QR codes... yes
+2025-07-27T17:37:57.0952420Z checking whether to build test_dash-qt... yes
+2025-07-27T17:37:57.0953059Z checking whether to build test_dash... yes
+2025-07-27T17:37:57.0953985Z checking whether to reduce exports... yes
+2025-07-27T17:37:57.1084381Z checking whether dsymutil needs -flat... yes
+2025-07-27T17:37:57.1084670Z 
+2025-07-27T17:37:57.1521430Z checking that generated files are newer than configure... done
+2025-07-27T17:37:57.1527779Z configure: creating ./config.status
+2025-07-27T17:37:57.7894839Z config.status: creating Makefile
+2025-07-27T17:37:57.8035308Z config.status: creating src/Makefile
+2025-07-27T17:37:57.8607396Z config.status: creating doc/man/Makefile
+2025-07-27T17:37:57.8759422Z config.status: creating share/setup.nsi
+2025-07-27T17:37:57.8915814Z config.status: creating share/qt/Info.plist
+2025-07-27T17:37:57.9070374Z config.status: creating test/config.ini
+2025-07-27T17:37:57.9223112Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-27T17:37:57.9383209Z config.status: creating src/config/bitcoin-config.h
+2025-07-27T17:37:57.9836749Z config.status: executing depfiles commands
+2025-07-27T17:37:57.9850066Z config.status: executing libtool commands
+2025-07-27T17:37:57.9966401Z === configuring in src/dashbls (/__w/dash/dash/build-ci/dashcore-linux64/src/dashbls)
+2025-07-27T17:37:58.0011436Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-27T17:37:58.1179505Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T17:37:58.1663845Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:58.1711365Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T17:37:58.1790521Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T17:37:58.1818690Z checking whether build environment is sane... yes
+2025-07-27T17:37:58.1879186Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T17:37:58.1900056Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T17:37:58.1904359Z checking for gawk... gawk
+2025-07-27T17:37:58.1967319Z checking whether make sets $(MAKE)... yes
+2025-07-27T17:37:58.2019800Z checking whether make supports nested variables... yes
+2025-07-27T17:37:58.2060922Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-27T17:37:58.2062949Z checking whether make supports nested variables... (cached) yes
+2025-07-27T17:37:58.2065779Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T17:37:58.2612297Z checking whether the C compiler works... yes
+2025-07-27T17:37:58.2612741Z checking for C compiler default output file name... a.out
+2025-07-27T17:37:58.2898474Z checking for suffix of executables... 
+2025-07-27T17:37:58.3257596Z checking whether we are cross compiling... no
+2025-07-27T17:37:58.3417523Z checking for suffix of object files... o
+2025-07-27T17:37:58.3551333Z checking whether the compiler supports GNU C... yes
+2025-07-27T17:37:58.3703073Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T17:37:58.4049040Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T17:37:58.4314591Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T17:37:58.4386932Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T17:37:58.4390813Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:58.4727249Z checking whether the compiler supports GNU C++... yes
+2025-07-27T17:37:58.4886057Z checking whether g++ -m64 accepts -g... yes
+2025-07-27T17:37:58.7687437Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-27T17:37:58.8157645Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-27T17:37:58.8159800Z checking dependency style of g++ -m64... none
+2025-07-27T17:37:58.8554518Z checking whether g++ -m64 supports C++14 features with -std=c++14... yes
+2025-07-27T17:37:58.8578586Z checking how to print strings... printf
+2025-07-27T17:37:58.8617068Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T17:37:58.8647231Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T17:37:58.8662967Z checking for egrep... /usr/bin/grep -E
+2025-07-27T17:37:58.8677901Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T17:37:58.8724436Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T17:37:58.8748148Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T17:37:58.8750358Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T17:37:58.9025578Z checking the name lister (nm) interface... BSD nm
+2025-07-27T17:37:58.9026150Z checking whether ln -s works... yes
+2025-07-27T17:37:58.9068631Z checking the maximum length of command line arguments... 3145728
+2025-07-27T17:37:58.9094999Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T17:37:58.9096499Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T17:37:58.9097404Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T17:37:58.9102300Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T17:37:58.9106611Z checking for file... file
+2025-07-27T17:37:58.9110794Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:37:58.9115658Z checking for objdump... objdump
+2025-07-27T17:37:58.9119557Z checking how to recognize dependent libraries... pass_all
+2025-07-27T17:37:58.9124293Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T17:37:58.9128689Z checking for dlltool... no
+2025-07-27T17:37:58.9129874Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T17:37:58.9132061Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:37:58.9459614Z checking for archiver @FILE support... @
+2025-07-27T17:37:58.9460272Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T17:37:58.9463140Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T17:37:59.0117339Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T17:37:59.0132907Z checking for sysroot... no
+2025-07-27T17:37:59.0174515Z checking for a working dd... /usr/bin/dd
+2025-07-27T17:37:59.0213345Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T17:37:59.0311243Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T17:37:59.0316204Z checking for mt... no
+2025-07-27T17:37:59.0346931Z checking if : is a manifest tool... no
+2025-07-27T17:37:59.0490387Z checking for stdio.h... yes
+2025-07-27T17:37:59.0646858Z checking for stdlib.h... yes
+2025-07-27T17:37:59.0814412Z checking for string.h... yes
+2025-07-27T17:37:59.0983932Z checking for inttypes.h... yes
+2025-07-27T17:37:59.1153350Z checking for stdint.h... yes
+2025-07-27T17:37:59.1324832Z checking for strings.h... yes
+2025-07-27T17:37:59.1502292Z checking for sys/stat.h... yes
+2025-07-27T17:37:59.1680314Z checking for sys/types.h... yes
+2025-07-27T17:37:59.1878306Z checking for unistd.h... yes
+2025-07-27T17:37:59.2085574Z checking for dlfcn.h... yes
+2025-07-27T17:37:59.2119210Z checking for objdir... .libs
+2025-07-27T17:37:59.2704288Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T17:37:59.2705067Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:59.2844588Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:59.3418371Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T17:37:59.3629913Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T17:37:59.3630583Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:59.3722650Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:59.4197952Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T17:37:59.4198737Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:59.4217122Z checking whether stripping libraries is possible... yes
+2025-07-27T17:37:59.4217771Z checking if libtool supports shared libraries... yes
+2025-07-27T17:37:59.4219170Z checking whether to build shared libraries... no
+2025-07-27T17:37:59.4219711Z checking whether to build static libraries... yes
+2025-07-27T17:37:59.4471030Z checking how to run the C++ preprocessor... g++ -m64 -std=c++14 -E
+2025-07-27T17:37:59.5194696Z checking for ld used by g++ -m64 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-27T17:37:59.5218354Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-27T17:37:59.5288652Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:59.5876033Z checking for g++ -m64 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:37:59.6026416Z checking if g++ -m64 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:37:59.6610987Z checking if g++ -m64 -std=c++14 static flag -static works... yes
+2025-07-27T17:37:59.6832365Z checking if g++ -m64 -std=c++14 supports -c -o file.o... yes
+2025-07-27T17:37:59.6833117Z checking if g++ -m64 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-27T17:37:59.6834326Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:37:59.6881277Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-27T17:37:59.6882586Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:37:59.6889496Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-27T17:37:59.6894704Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-27T17:37:59.6896692Z checking for ranlib... (cached) ranlib
+2025-07-27T17:37:59.6901012Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-27T17:37:59.6903796Z checking for strip... (cached) strip
+2025-07-27T17:37:59.6907023Z checking dependency style of gcc -m64... none
+2025-07-27T17:37:59.7050901Z checking whether C compiler accepts -Werror... yes
+2025-07-27T17:37:59.7294324Z checking for gmp.h... yes
+2025-07-27T17:37:59.7610477Z checking for __gmpz_init in -lgmp... yes
+2025-07-27T17:37:59.7784478Z checking gmp version >= 6.2... yes
+2025-07-27T17:37:59.7812273Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-27T17:37:59.7823802Z checking pkg-config is at least version 0.9.0... yes
+2025-07-27T17:37:59.7912449Z checking if gcc -m64 supports -pipe... yes
+2025-07-27T17:37:59.8007212Z checking if gcc -m64 supports -fomit-frame-pointer... yes
+2025-07-27T17:37:59.8252909Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-27T17:37:59.8548706Z checking whether gcc -m64 is Clang... no
+2025-07-27T17:37:59.8982191Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-27T17:37:59.9346641Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-27T17:37:59.9347419Z checking whether more special flags are required for pthreads... no
+2025-07-27T17:37:59.9698996Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-27T17:38:00.0021335Z checking for library containing clock_gettime... none required
+2025-07-27T17:38:00.0192518Z checking whether C compiler accepts -fPIC... yes
+2025-07-27T17:38:00.0366227Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-27T17:38:00.0514254Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-27T17:38:00.0689497Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-27T17:38:00.0856826Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-27T17:38:00.1023225Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-27T17:38:00.1251043Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-27T17:38:00.1475867Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-27T17:38:00.1697067Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-27T17:38:00.1914026Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-27T17:38:00.2219119Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-27T17:38:00.2527105Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-27T17:38:00.2837606Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-27T17:38:00.3143835Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-27T17:38:00.3323953Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-27T17:38:00.3324967Z checking whether to build runtest... yes
+2025-07-27T17:38:00.3325453Z checking whether to build runbench... yes
+2025-07-27T17:38:00.3553953Z checking that generated files are newer than configure... done
+2025-07-27T17:38:00.3558418Z configure: creating ./config.status
+2025-07-27T17:38:00.8850136Z config.status: creating Makefile
+2025-07-27T17:38:00.9064737Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-27T17:38:00.9197313Z config.status: executing depfiles commands
+2025-07-27T17:38:00.9211352Z config.status: executing libtool commands
+2025-07-27T17:38:00.9341538Z 
+2025-07-27T17:38:00.9342222Z Options used to compile and link:
+2025-07-27T17:38:00.9342665Z   target os           = linux
+2025-07-27T17:38:00.9343060Z   backend             = gmp
+2025-07-27T17:38:00.9343731Z   build bench         = yes
+2025-07-27T17:38:00.9344074Z   build test          = yes
+2025-07-27T17:38:00.9344432Z   use debug           = no
+2025-07-27T17:38:00.9344798Z   use hardening       = yes
+2025-07-27T17:38:00.9345186Z   use optimizations   = yes
+2025-07-27T17:38:00.9345403Z 
+2025-07-27T17:38:00.9345682Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-27T17:38:00.9346591Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-27T17:38:00.9347722Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-27T17:38:00.9349075Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-27T17:38:00.9349964Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-27T17:38:00.9350150Z 
+2025-07-27T17:38:00.9700482Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/dashcore-linux64/src/secp256k1)
+2025-07-27T17:38:00.9744488Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-27T17:38:01.0913261Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-27T17:38:01.1412372Z checking build system type... x86_64-pc-linux-gnu
+2025-07-27T17:38:01.1458875Z checking host system type... x86_64-pc-linux-gnu
+2025-07-27T17:38:01.1536840Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-27T17:38:01.1565349Z checking whether build environment is sane... yes
+2025-07-27T17:38:01.1625494Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-27T17:38:01.1646030Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-27T17:38:01.1649936Z checking for gawk... gawk
+2025-07-27T17:38:01.1712529Z checking whether make sets $(MAKE)... yes
+2025-07-27T17:38:01.1763966Z checking whether make supports nested variables... yes
+2025-07-27T17:38:01.1805991Z checking whether make supports nested variables... (cached) yes
+2025-07-27T17:38:01.1808257Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-27T17:38:01.2366752Z checking whether the C compiler works... yes
+2025-07-27T17:38:01.2367414Z checking for C compiler default output file name... a.out
+2025-07-27T17:38:01.2667141Z checking for suffix of executables... 
+2025-07-27T17:38:01.3036925Z checking whether we are cross compiling... no
+2025-07-27T17:38:01.3202193Z checking for suffix of object files... o
+2025-07-27T17:38:01.3345910Z checking whether the compiler supports GNU C... yes
+2025-07-27T17:38:01.3505699Z checking whether gcc -m64 accepts -g... yes
+2025-07-27T17:38:01.3864156Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-27T17:38:01.4142978Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-27T17:38:01.4216437Z checking whether make supports the include directive... yes (GNU style)
+2025-07-27T17:38:01.4219597Z checking dependency style of gcc -m64... none
+2025-07-27T17:38:01.4223526Z checking dependency style of gcc -m64... none
+2025-07-27T17:38:01.4225520Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:38:01.4491205Z checking the archiver (ar) interface... ar
+2025-07-27T17:38:01.4514744Z checking how to print strings... printf
+2025-07-27T17:38:01.4553885Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-27T17:38:01.4583602Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-27T17:38:01.4598990Z checking for egrep... /usr/bin/grep -E
+2025-07-27T17:38:01.4614328Z checking for fgrep... /usr/bin/grep -F
+2025-07-27T17:38:01.4661316Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-27T17:38:01.4686000Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-27T17:38:01.4688412Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-27T17:38:01.4970793Z checking the name lister (nm) interface... BSD nm
+2025-07-27T17:38:01.4971169Z checking whether ln -s works... yes
+2025-07-27T17:38:01.5013661Z checking the maximum length of command line arguments... 3145728
+2025-07-27T17:38:01.5040144Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-27T17:38:01.5042205Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-27T17:38:01.5043229Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-27T17:38:01.5047727Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-27T17:38:01.5052265Z checking for file... file
+2025-07-27T17:38:01.5056267Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-27T17:38:01.5060753Z checking for objdump... objdump
+2025-07-27T17:38:01.5064482Z checking how to recognize dependent libraries... pass_all
+2025-07-27T17:38:01.5069194Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-27T17:38:01.5073878Z checking for dlltool... no
+2025-07-27T17:38:01.5075890Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-27T17:38:01.5078007Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-27T17:38:01.5417336Z checking for archiver @FILE support... @
+2025-07-27T17:38:01.5417981Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-27T17:38:01.5420605Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-27T17:38:01.6092064Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-27T17:38:01.6109117Z checking for sysroot... no
+2025-07-27T17:38:01.6150761Z checking for a working dd... /usr/bin/dd
+2025-07-27T17:38:01.6189764Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-27T17:38:01.6290303Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-27T17:38:01.6295203Z checking for mt... no
+2025-07-27T17:38:01.6327819Z checking if : is a manifest tool... no
+2025-07-27T17:38:01.6474321Z checking for stdio.h... yes
+2025-07-27T17:38:01.6638496Z checking for stdlib.h... yes
+2025-07-27T17:38:01.6806574Z checking for string.h... yes
+2025-07-27T17:38:01.6982315Z checking for inttypes.h... yes
+2025-07-27T17:38:01.7158190Z checking for stdint.h... yes
+2025-07-27T17:38:01.7338824Z checking for strings.h... yes
+2025-07-27T17:38:01.7517849Z checking for sys/stat.h... yes
+2025-07-27T17:38:01.7700857Z checking for sys/types.h... yes
+2025-07-27T17:38:01.7905739Z checking for unistd.h... yes
+2025-07-27T17:38:01.8117774Z checking for dlfcn.h... yes
+2025-07-27T17:38:01.8157003Z checking for objdir... .libs
+2025-07-27T17:38:01.8769876Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-27T17:38:01.8770484Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-27T17:38:01.8909090Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-27T17:38:01.9477090Z checking if gcc -m64 static flag -static works... yes
+2025-07-27T17:38:01.9692933Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-27T17:38:01.9693587Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-27T17:38:01.9786643Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-27T17:38:02.0272456Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-27T17:38:02.0273181Z checking how to hardcode library paths into programs... immediate
+2025-07-27T17:38:02.0289572Z checking whether stripping libraries is possible... yes
+2025-07-27T17:38:02.0290365Z checking if libtool supports shared libraries... yes
+2025-07-27T17:38:02.0290880Z checking whether to build shared libraries... no
+2025-07-27T17:38:02.0291401Z checking whether to build static libraries... yes
+2025-07-27T17:38:02.0399352Z checking if gcc -m64 supports -Werror... yes
+2025-07-27T17:38:02.0496765Z checking if gcc -m64 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-27T17:38:02.0592704Z checking if gcc -m64 supports -Wno-overlength-strings... yes
+2025-07-27T17:38:02.0692515Z checking if gcc -m64 supports -Wall... yes
+2025-07-27T17:38:02.0786674Z checking if gcc -m64 supports -Wno-unused-function... yes
+2025-07-27T17:38:02.0881297Z checking if gcc -m64 supports -Wextra... yes
+2025-07-27T17:38:02.0977420Z checking if gcc -m64 supports -Wcast-align... yes
+2025-07-27T17:38:02.1074994Z checking if gcc -m64 supports -Wcast-align=strict... yes
+2025-07-27T17:38:02.1316694Z checking if gcc -m64 supports -Wconditional-uninitialized... no
+2025-07-27T17:38:02.1523197Z checking if gcc -m64 supports -Wreserved-identifier... no
+2025-07-27T17:38:02.1621124Z checking if gcc -m64 supports -fvisibility=hidden... yes
+2025-07-27T17:38:02.1773136Z checking for valgrind support... 
+2025-07-27T17:38:02.2112491Z checking for x86_64 assembly availability... yes
+2025-07-27T17:38:02.2341150Z checking that generated files are newer than configure... done
+2025-07-27T17:38:02.2344143Z configure: creating ./config.status
+2025-07-27T17:38:02.6260018Z config.status: creating Makefile
+2025-07-27T17:38:02.6385294Z config.status: creating libsecp256k1.pc
+2025-07-27T17:38:02.6492738Z config.status: executing depfiles commands
+2025-07-27T17:38:02.6506836Z config.status: executing libtool commands
+2025-07-27T17:38:02.6594815Z 
+2025-07-27T17:38:02.6595254Z Build Options:
+2025-07-27T17:38:02.6595613Z   with external callbacks = no
+2025-07-27T17:38:02.6595871Z   with benchmarks         = no
+2025-07-27T17:38:02.6596093Z   with tests              = yes
+2025-07-27T17:38:02.6596459Z   with ctime tests        = no
+2025-07-27T17:38:02.6596811Z   with coverage           = no
+2025-07-27T17:38:02.6597204Z   with examples           = no
+2025-07-27T17:38:02.6597571Z   module ecdh             = no
+2025-07-27T17:38:02.6597842Z   module recovery         = yes
+2025-07-27T17:38:02.6598164Z   module extrakeys        = yes
+2025-07-27T17:38:02.6598391Z   module schnorrsig       = yes
+2025-07-27T17:38:02.6598591Z   module ellswift         = yes
+2025-07-27T17:38:02.6598731Z 
+2025-07-27T17:38:02.6598804Z   asm                     = x86_64
+2025-07-27T17:38:02.6599021Z   ecmult window size      = 15
+2025-07-27T17:38:02.6599232Z   ecmult gen prec. bits   = 4
+2025-07-27T17:38:02.6599381Z 
+2025-07-27T17:38:02.6599451Z   valgrind                = no
+2025-07-27T17:38:02.6599658Z   CC                      = gcc -m64
+2025-07-27T17:38:02.6599980Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-27T17:38:02.6600908Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-27T17:38:02.6602063Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-27T17:38:02.6602486Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-27T17:38:02.6911963Z 
+2025-07-27T17:38:02.6912325Z Options used to compile and link:
+2025-07-27T17:38:02.6912793Z   boost process       = yes
+2025-07-27T17:38:02.6913194Z   multiprocess        = no
+2025-07-27T17:38:02.6913568Z   with libs           = no
+2025-07-27T17:38:02.6913932Z   with wallet         = yes
+2025-07-27T17:38:02.6914292Z     with sqlite       = yes
+2025-07-27T17:38:02.6914658Z     with bdb          = yes
+2025-07-27T17:38:02.6915007Z   with gui / qt       = yes
+2025-07-27T17:38:02.6915358Z     with qr           = yes
+2025-07-27T17:38:02.6915684Z   with zmq            = yes
+2025-07-27T17:38:02.6916006Z   with test           = yes
+2025-07-27T17:38:02.6916317Z   with fuzz binary    = no
+2025-07-27T17:38:02.6916541Z   with bench          = yes
+2025-07-27T17:38:02.6916742Z   with upnp           = yes
+2025-07-27T17:38:02.6916938Z   with natpmp         = yes
+2025-07-27T17:38:02.6917413Z   USDT tracing        = yes
+2025-07-27T17:38:02.6917620Z   sanitizers          = 
+2025-07-27T17:38:02.6917822Z   debug enabled       = no
+2025-07-27T17:38:02.6918033Z   stacktraces enabled = yes
+2025-07-27T17:38:02.6918254Z   crash hooks enabled = no
+2025-07-27T17:38:02.6918456Z   miner enabled       = yes
+2025-07-27T17:38:02.6918661Z   gprof enabled       = no
+2025-07-27T17:38:02.6918863Z   werror              = yes
+2025-07-27T17:38:02.6918989Z 
+2025-07-27T17:38:02.6919073Z   target os           = linux-gnu
+2025-07-27T17:38:02.6919296Z   build os            = linux-gnu
+2025-07-27T17:38:02.6919446Z 
+2025-07-27T17:38:02.6919552Z   CC                  = /usr/bin/ccache gcc -m64
+2025-07-27T17:38:02.6919933Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-27T17:38:02.6920852Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-27T17:38:02.6921774Z   CXX                 = /usr/bin/ccache g++ -m64 -std=c++20
+2025-07-27T17:38:02.6924153Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-27T17:38:02.6928438Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-27T17:38:02.6929340Z   AR                  = ar
+2025-07-27T17:38:02.6929682Z   ARFLAGS             = cr
+2025-07-27T17:38:02.6929911Z 
+2025-07-27T17:38:02.7557043Z Making install in src
+2025-07-27T17:38:02.7785204Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:38:02.8053696Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:38:02.8084089Z   CXX      dashd-bitcoind.o
+2025-07-27T17:38:02.8084538Z   CXX      libbitcoin_node_a-addrdb.o
+2025-07-27T17:38:02.8136649Z   CXX      libbitcoin_node_a-addressindex.o
+2025-07-27T17:38:02.8137165Z   CXX      libbitcoin_node_a-addrman.o
+2025-07-27T17:38:04.8885036Z   CXX      libbitcoin_node_a-banman.o
+2025-07-27T17:38:06.3042106Z   CXX      libbitcoin_node_a-batchedlogger.o
+2025-07-27T17:38:07.8247482Z   CXX      libbitcoin_node_a-bip324.o
+2025-07-27T17:38:08.5884816Z   CXX      libbitcoin_node_a-blockencodings.o
+2025-07-27T17:38:08.5924035Z   CXX      libbitcoin_node_a-blockfilter.o
+2025-07-27T17:38:10.3656644Z   CXX      libbitcoin_node_a-chain.o
+2025-07-27T17:38:10.7586788Z   CXX      libbitcoin_node_a-dbwrapper.o
+2025-07-27T17:38:11.2239930Z   CXX      libbitcoin_node_a-deploymentstatus.o
+2025-07-27T17:38:12.9653477Z   CXX      libbitcoin_node_a-dsnotificationinterface.o
+2025-07-27T17:38:13.4507609Z   CXX      libbitcoin_node_a-flatfile.o
+2025-07-27T17:38:14.9182870Z   CXX      libbitcoin_node_a-httprpc.o
+2025-07-27T17:38:14.9263991Z   CXX      libbitcoin_node_a-httpserver.o
+2025-07-27T17:38:16.9486142Z   CXX      libbitcoin_node_a-i2p.o
+2025-07-27T17:38:20.5579858Z   CXX      libbitcoin_node_a-init.o
+2025-07-27T17:38:20.6233309Z   CXX      libbitcoin_node_a-mapport.o
+2025-07-27T17:38:22.1605669Z   CXX      libbitcoin_node_a-net.o
+2025-07-27T17:38:22.7894901Z   CXX      libbitcoin_node_a-netfulfilledman.o
+2025-07-27T17:38:24.8517052Z   CXX      libbitcoin_node_a-netgroup.o
+2025-07-27T17:38:27.3229576Z   CXX      libbitcoin_node_a-net_processing.o
+2025-07-27T17:38:27.9220166Z   CXX      libbitcoin_node_a-noui.o
+2025-07-27T17:38:31.5789344Z   CXX      libbitcoin_node_a-pow.o
+2025-07-27T17:38:33.6278040Z   CXX      libbitcoin_node_a-rest.o
+2025-07-27T17:38:40.9883915Z   CXX      libbitcoin_node_a-shutdown.o
+2025-07-27T17:38:43.0099217Z   CXX      libbitcoin_node_a-spork.o
+2025-07-27T17:38:43.2457084Z   CXX      libbitcoin_node_a-timedata.o
+2025-07-27T17:38:44.0774037Z   CXX      libbitcoin_node_a-torcontrol.o
+2025-07-27T17:38:46.9008337Z   CXX      libbitcoin_node_a-txdb.o
+2025-07-27T17:38:50.4534360Z   CXX      libbitcoin_node_a-txmempool.o
+2025-07-27T17:38:52.2541959Z   CXX      libbitcoin_node_a-txorphanage.o
+2025-07-27T17:38:52.8612853Z   CXX      libbitcoin_node_a-validation.o
+2025-07-27T17:38:57.1394056Z   CXX      libbitcoin_node_a-validationinterface.o
+2025-07-27T17:38:57.9008554Z   CXX      libbitcoin_node_a-versionbits.o
+2025-07-27T17:39:00.0990264Z   CXX      coinjoin/libbitcoin_wallet_a-client.o
+2025-07-27T17:39:02.5488404Z   CXX      coinjoin/libbitcoin_wallet_a-interfaces.o
+2025-07-27T17:39:04.7989411Z txmempool.cpp: In member function ‘bool CTxMemPool::CalculateAncestorsAndCheckLimits(int64_t, size_t, setEntries&, CTxMemPoolEntry::Parents&, uint64_t, uint64_t, uint64_t, uint64_t, std::string&) const’:
+2025-07-27T17:39:04.7992336Z txmempool.cpp:220:43: error: comparison of integer expressions of different signedness: ‘int64_t’ {aka ‘long int’} and ‘uint64_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
+2025-07-27T17:39:04.7993623Z   220 |         } else if (totalSizeWithAncestors > limitAncestorSize) {
+2025-07-27T17:39:04.7994160Z       |                    ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
+2025-07-27T17:39:04.7994680Z cc1plus: all warnings being treated as errors
+2025-07-27T17:39:04.8033290Z make[2]: *** [Makefile:11892: libbitcoin_node_a-txmempool.o] Error 1
+2025-07-27T17:39:04.8038445Z make[2]: *** Waiting for unfinished jobs....
+2025-07-27T17:39:13.8994151Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:39:13.9000685Z make[1]: *** [Makefile:20556: install-recursive] Error 1
+2025-07-27T17:39:13.9001224Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:39:13.9008738Z make: *** [Makefile:789: install-recursive] Error 1
+2025-07-27T17:39:13.9014357Z Build failure. Verbose build follows.
+2025-07-27T17:39:13.9076837Z Making install in src
+2025-07-27T17:39:13.9308611Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:39:13.9581450Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:39:13.9586144Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o init/dashd-bitcoind.o `test -f 'init/bitcoind.cpp' || echo './'`init/bitcoind.cpp
+2025-07-27T17:39:16.3794217Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-coinjoin.o `test -f 'coinjoin/coinjoin.cpp' || echo './'`coinjoin/coinjoin.cpp
+2025-07-27T17:39:21.8479552Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-context.o `test -f 'coinjoin/context.cpp' || echo './'`coinjoin/context.cpp
+2025-07-27T17:39:26.2718796Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-server.o `test -f 'coinjoin/server.cpp' || echo './'`coinjoin/server.cpp
+2025-07-27T17:39:33.6189974Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o consensus/libbitcoin_node_a-tx_verify.o `test -f 'consensus/tx_verify.cpp' || echo './'`consensus/tx_verify.cpp
+2025-07-27T17:39:35.6248277Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-assetlocktx.o `test -f 'evo/assetlocktx.cpp' || echo './'`evo/assetlocktx.cpp
+2025-07-27T17:39:39.4168605Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-cbtx.o `test -f 'evo/cbtx.cpp' || echo './'`evo/cbtx.cpp
+2025-07-27T17:39:43.8104947Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-creditpool.o `test -f 'evo/creditpool.cpp' || echo './'`evo/creditpool.cpp
+2025-07-27T17:39:49.4884044Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-chainhelper.o `test -f 'evo/chainhelper.cpp' || echo './'`evo/chainhelper.cpp
+2025-07-27T17:39:51.9858666Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-deterministicmns.o `test -f 'evo/deterministicmns.cpp' || echo './'`evo/deterministicmns.cpp
+2025-07-27T17:40:01.5797367Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-dmnstate.o `test -f 'evo/dmnstate.cpp' || echo './'`evo/dmnstate.cpp
+2025-07-27T17:40:03.9522187Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-evodb.o `test -f 'evo/evodb.cpp' || echo './'`evo/evodb.cpp
+2025-07-27T17:40:06.5078450Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-mnauth.o `test -f 'evo/mnauth.cpp' || echo './'`evo/mnauth.cpp
+2025-07-27T17:40:11.4494663Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-mnhftx.o `test -f 'evo/mnhftx.cpp' || echo './'`evo/mnhftx.cpp
+2025-07-27T17:40:17.4375001Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-providertx.o `test -f 'evo/providertx.cpp' || echo './'`evo/providertx.cpp
+2025-07-27T17:40:20.2917847Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-simplifiedmns.o `test -f 'evo/simplifiedmns.cpp' || echo './'`evo/simplifiedmns.cpp
+2025-07-27T17:40:23.2030470Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-smldiff.o `test -f 'evo/smldiff.cpp' || echo './'`evo/smldiff.cpp
+2025-07-27T17:40:28.9686424Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-specialtx.o `test -f 'evo/specialtx.cpp' || echo './'`evo/specialtx.cpp
+2025-07-27T17:40:29.8462678Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-specialtxman.o `test -f 'evo/specialtxman.cpp' || echo './'`evo/specialtxman.cpp
+2025-07-27T17:40:37.2553304Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-classes.o `test -f 'governance/classes.cpp' || echo './'`governance/classes.cpp
+2025-07-27T17:40:41.7516879Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-exceptions.o `test -f 'governance/exceptions.cpp' || echo './'`governance/exceptions.cpp
+2025-07-27T17:40:42.4968194Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-governance.o `test -f 'governance/governance.cpp' || echo './'`governance/governance.cpp
+2025-07-27T17:40:53.6487736Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-object.o `test -f 'governance/object.cpp' || echo './'`governance/object.cpp
+2025-07-27T17:40:59.6800549Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-validators.o `test -f 'governance/validators.cpp' || echo './'`governance/validators.cpp
+2025-07-27T17:41:01.8364633Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-vote.o `test -f 'governance/vote.cpp' || echo './'`governance/vote.cpp
+2025-07-27T17:41:06.0483007Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-votedb.o `test -f 'governance/votedb.cpp' || echo './'`governance/votedb.cpp
+2025-07-27T17:41:07.4114231Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o gsl/libbitcoin_node_a-assert.o `test -f 'gsl/assert.cpp' || echo './'`gsl/assert.cpp
+2025-07-27T17:41:08.6363817Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-base.o `test -f 'index/base.cpp' || echo './'`index/base.cpp
+2025-07-27T17:41:13.0332766Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-blockfilterindex.o `test -f 'index/blockfilterindex.cpp' || echo './'`index/blockfilterindex.cpp
+2025-07-27T17:41:16.9548885Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-coinstatsindex.o `test -f 'index/coinstatsindex.cpp' || echo './'`index/coinstatsindex.cpp
+2025-07-27T17:41:21.3819429Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-txindex.o `test -f 'index/txindex.cpp' || echo './'`index/txindex.cpp
+2025-07-27T17:41:25.3685012Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-db.o `test -f 'instantsend/db.cpp' || echo './'`instantsend/db.cpp
+2025-07-27T17:41:29.7031539Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-instantsend.o `test -f 'instantsend/instantsend.cpp' || echo './'`instantsend/instantsend.cpp
+2025-07-27T17:41:37.5275179Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-lock.o `test -f 'instantsend/lock.cpp' || echo './'`instantsend/lock.cpp
+2025-07-27T17:41:38.7821290Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-signing.o `test -f 'instantsend/signing.cpp' || echo './'`instantsend/signing.cpp
+2025-07-27T17:41:44.6876652Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-blockprocessor.o `test -f 'llmq/blockprocessor.cpp' || echo './'`llmq/blockprocessor.cpp
+2025-07-27T17:41:52.5060302Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-chainlocks.o `test -f 'llmq/chainlocks.cpp' || echo './'`llmq/chainlocks.cpp
+2025-07-27T17:41:58.6091495Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-clsig.o `test -f 'llmq/clsig.cpp' || echo './'`llmq/clsig.cpp
+2025-07-27T17:41:59.9833955Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-commitment.o `test -f 'llmq/commitment.cpp' || echo './'`llmq/commitment.cpp
+2025-07-27T17:42:05.1050757Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-context.o `test -f 'llmq/context.cpp' || echo './'`llmq/context.cpp
+2025-07-27T17:42:09.8879857Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-debug.o `test -f 'llmq/debug.cpp' || echo './'`llmq/debug.cpp
+2025-07-27T17:42:13.8269051Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsession.o `test -f 'llmq/dkgsession.cpp' || echo './'`llmq/dkgsession.cpp
+2025-07-27T17:42:21.5365092Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsessionhandler.o `test -f 'llmq/dkgsessionhandler.cpp' || echo './'`llmq/dkgsessionhandler.cpp
+2025-07-27T17:42:29.6018767Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsessionmgr.o `test -f 'llmq/dkgsessionmgr.cpp' || echo './'`llmq/dkgsessionmgr.cpp
+2025-07-27T17:42:36.1195601Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-ehf_signals.o `test -f 'llmq/ehf_signals.cpp' || echo './'`llmq/ehf_signals.cpp
+2025-07-27T17:42:40.5965107Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-options.o `test -f 'llmq/options.cpp' || echo './'`llmq/options.cpp
+2025-07-27T17:42:43.4167828Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-quorums.o `test -f 'llmq/quorums.cpp' || echo './'`llmq/quorums.cpp
+2025-07-27T17:42:54.0705407Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-signing.o `test -f 'llmq/signing.cpp' || echo './'`llmq/signing.cpp
+2025-07-27T17:43:02.1247178Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-signing_shares.o `test -f 'llmq/signing_shares.cpp' || echo './'`llmq/signing_shares.cpp
+2025-07-27T17:43:12.9888719Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-snapshot.o `test -f 'llmq/snapshot.cpp' || echo './'`llmq/snapshot.cpp
+2025-07-27T17:43:18.6459772Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-utils.o `test -f 'llmq/utils.cpp' || echo './'`llmq/utils.cpp
+2025-07-27T17:43:25.2489456Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-node.o `test -f 'masternode/node.cpp' || echo './'`masternode/node.cpp
+2025-07-27T17:43:29.7831911Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-meta.o `test -f 'masternode/meta.cpp' || echo './'`masternode/meta.cpp
+2025-07-27T17:43:33.3268694Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-payments.o `test -f 'masternode/payments.cpp' || echo './'`masternode/payments.cpp
+2025-07-27T17:43:38.4025088Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-sync.o `test -f 'masternode/sync.cpp' || echo './'`masternode/sync.cpp
+2025-07-27T17:43:43.1235746Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-utils.o `test -f 'masternode/utils.cpp' || echo './'`masternode/utils.cpp
+2025-07-27T17:43:49.2098482Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-blockstorage.o `test -f 'node/blockstorage.cpp' || echo './'`node/blockstorage.cpp
+2025-07-27T17:43:55.1694827Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-caches.o `test -f 'node/caches.cpp' || echo './'`node/caches.cpp
+2025-07-27T17:43:58.0466450Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-chainstate.o `test -f 'node/chainstate.cpp' || echo './'`node/chainstate.cpp
+2025-07-27T17:44:02.0467383Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-coin.o `test -f 'node/coin.cpp' || echo './'`node/coin.cpp
+2025-07-27T17:44:05.1186960Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-coinstats.o `test -f 'node/coinstats.cpp' || echo './'`node/coinstats.cpp
+2025-07-27T17:44:08.8109602Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-connection_types.o `test -f 'node/connection_types.cpp' || echo './'`node/connection_types.cpp
+2025-07-27T17:44:09.1315918Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-context.o `test -f 'node/context.cpp' || echo './'`node/context.cpp
+2025-07-27T17:44:14.1477478Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-eviction.o `test -f 'node/eviction.cpp' || echo './'`node/eviction.cpp
+2025-07-27T17:44:16.1042209Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-interfaces.o `test -f 'node/interfaces.cpp' || echo './'`node/interfaces.cpp
+2025-07-27T17:44:23.2189500Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-miner.o `test -f 'node/miner.cpp' || echo './'`node/miner.cpp
+2025-07-27T17:44:29.9618416Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-minisketchwrapper.o `test -f 'node/minisketchwrapper.cpp' || echo './'`node/minisketchwrapper.cpp
+2025-07-27T17:44:31.7707976Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-psbt.o `test -f 'node/psbt.cpp' || echo './'`node/psbt.cpp
+2025-07-27T17:44:33.5866425Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-transaction.o `test -f 'node/transaction.cpp' || echo './'`node/transaction.cpp
+2025-07-27T17:44:37.3666086Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-txreconciliation.o `test -f 'node/txreconciliation.cpp' || echo './'`node/txreconciliation.cpp
+2025-07-27T17:44:39.8109453Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-interface_ui.o `test -f 'node/interface_ui.cpp' || echo './'`node/interface_ui.cpp
+2025-07-27T17:44:48.1092870Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-fees.o `test -f 'policy/fees.cpp' || echo './'`policy/fees.cpp
+2025-07-27T17:44:52.6646508Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-packages.o `test -f 'policy/packages.cpp' || echo './'`policy/packages.cpp
+2025-07-27T17:44:53.8578856Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-policy.o `test -f 'policy/policy.cpp' || echo './'`policy/policy.cpp
+2025-07-27T17:44:54.9099168Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-settings.o `test -f 'policy/settings.cpp' || echo './'`policy/settings.cpp
+2025-07-27T17:44:55.7426806Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-blockchain.o `test -f 'rpc/blockchain.cpp' || echo './'`rpc/blockchain.cpp
+2025-07-27T17:45:06.9517469Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-coinjoin.o `test -f 'rpc/coinjoin.cpp' || echo './'`rpc/coinjoin.cpp
+2025-07-27T17:45:13.5266892Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-evo.o `test -f 'rpc/evo.cpp' || echo './'`rpc/evo.cpp
+2025-07-27T17:45:24.4196248Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-fees.o `test -f 'rpc/fees.cpp' || echo './'`rpc/fees.cpp
+2025-07-27T17:45:28.7978324Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-index_util.o `test -f 'rpc/index_util.cpp' || echo './'`rpc/index_util.cpp
+2025-07-27T17:45:31.9002148Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-masternode.o `test -f 'rpc/masternode.cpp' || echo './'`rpc/masternode.cpp
+2025-07-27T17:45:40.1701004Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-mempool.o `test -f 'rpc/mempool.cpp' || echo './'`rpc/mempool.cpp
+2025-07-27T17:45:45.1718235Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-governance.o `test -f 'rpc/governance.cpp' || echo './'`rpc/governance.cpp
+2025-07-27T17:45:53.8930894Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-mining.o `test -f 'rpc/mining.cpp' || echo './'`rpc/mining.cpp
+2025-07-27T17:46:01.7138781Z rpc/mining.cpp: In lambda function:
+2025-07-27T17:46:01.7139422Z rpc/mining.cpp:671:25: warning: possibly dangling reference to a temporary [-Wdangling-reference]
+2025-07-27T17:46:01.7140049Z   671 |         const UniValue& modeval = find_value(oparam, "mode");
+2025-07-27T17:46:01.7140418Z       |                         ^~~~~~~
+2025-07-27T17:46:01.7142168Z rpc/mining.cpp:671:45: note: the temporary was destroyed at the end of the full expression ‘find_value((* & oparam), std::__cxx11::basic_string<char>(((const char*)"mode"), std::allocator<char>()))’
+2025-07-27T17:46:01.7143356Z   671 |         const UniValue& modeval = find_value(oparam, "mode");
+2025-07-27T17:46:01.7143727Z       |                                   ~~~~~~~~~~^~~~~~~~~~~~~~~~
+2025-07-27T17:46:01.7144210Z rpc/mining.cpp:684:29: warning: possibly dangling reference to a temporary [-Wdangling-reference]
+2025-07-27T17:46:01.7145032Z   684 |             const UniValue& dataval = find_value(oparam, "data");
+2025-07-27T17:46:01.7145366Z       |                             ^~~~~~~
+2025-07-27T17:46:01.7146362Z rpc/mining.cpp:684:49: note: the temporary was destroyed at the end of the full expression ‘find_value((* & oparam), std::__cxx11::basic_string<char>(((const char*)"data"), std::allocator<char>()))’
+2025-07-27T17:46:01.7149088Z   684 |             const UniValue& dataval = find_value(oparam, "data");
+2025-07-27T17:46:01.7149581Z       |                                       ~~~~~~~~~~^~~~~~~~~~~~~~~~
+2025-07-27T17:46:01.7150283Z rpc/mining.cpp:714:25: warning: possibly dangling reference to a temporary [-Wdangling-reference]
+2025-07-27T17:46:01.7151122Z   714 |         const UniValue& aClientRules = find_value(oparam, "rules");
+2025-07-27T17:46:01.7152102Z       |                         ^~~~~~~~~~~~
+2025-07-27T17:46:01.7153699Z rpc/mining.cpp:714:50: note: the temporary was destroyed at the end of the full expression ‘find_value((* & oparam), std::__cxx11::basic_string<char>(((const char*)"rules"), std::allocator<char>()))’
+2025-07-27T17:46:01.7155083Z   714 |         const UniValue& aClientRules = find_value(oparam, "rules");
+2025-07-27T17:46:01.7155730Z       |                                        ~~~~~~~~~~^~~~~~~~~~~~~~~~~
+2025-07-27T17:46:01.7240816Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-node.o `test -f 'rpc/node.cpp' || echo './'`rpc/node.cpp
+2025-07-27T17:46:08.9517724Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-net.o `test -f 'rpc/net.cpp' || echo './'`rpc/net.cpp
+2025-07-27T17:46:15.9226971Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-output_script.o `test -f 'rpc/output_script.cpp' || echo './'`rpc/output_script.cpp
+2025-07-27T17:46:19.5439759Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-quorums.o `test -f 'rpc/quorums.cpp' || echo './'`rpc/quorums.cpp
+2025-07-27T17:46:27.8306300Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-rawtransaction.o `test -f 'rpc/rawtransaction.cpp' || echo './'`rpc/rawtransaction.cpp
+2025-07-27T17:46:38.9775161Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-server.o `test -f 'rpc/server.cpp' || echo './'`rpc/server.cpp
+2025-07-27T17:46:45.0605298Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-server_util.o `test -f 'rpc/server_util.cpp' || echo './'`rpc/server_util.cpp
+2025-07-27T17:46:48.4392453Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-signmessage.o `test -f 'rpc/signmessage.cpp' || echo './'`rpc/signmessage.cpp
+2025-07-27T17:46:51.3375068Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-txoutproof.o `test -f 'rpc/txoutproof.cpp' || echo './'`rpc/txoutproof.cpp
+2025-07-27T17:46:55.8830878Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o script/libbitcoin_node_a-sigcache.o `test -f 'script/sigcache.cpp' || echo './'`script/sigcache.cpp
+2025-07-27T17:46:58.0547755Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o stats/libbitcoin_node_a-client.o `test -f 'stats/client.cpp' || echo './'`stats/client.cpp
+2025-07-27T17:47:00.7587944Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o stats/libbitcoin_node_a-rawsender.o `test -f 'stats/rawsender.cpp' || echo './'`stats/rawsender.cpp
+2025-07-27T17:47:03.2125568Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=dangling-reference -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o libbitcoin_node_a-txmempool.o `test -f 'txmempool.cpp' || echo './'`txmempool.cpp
+2025-07-27T17:47:12.3122200Z txmempool.cpp: In member function ‘bool CTxMemPool::CalculateAncestorsAndCheckLimits(int64_t, size_t, setEntries&, CTxMemPoolEntry::Parents&, uint64_t, uint64_t, uint64_t, uint64_t, std::string&) const’:
+2025-07-27T17:47:12.3127170Z txmempool.cpp:220:43: error: comparison of integer expressions of different signedness: ‘int64_t’ {aka ‘long int’} and ‘uint64_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
+2025-07-27T17:47:12.3128413Z   220 |         } else if (totalSizeWithAncestors > limitAncestorSize) {
+2025-07-27T17:47:12.3128950Z       |                    ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
+2025-07-27T17:47:12.3129411Z cc1plus: all warnings being treated as errors
+2025-07-27T17:47:12.3145868Z make[2]: *** [Makefile:11892: libbitcoin_node_a-txmempool.o] Error 1
+2025-07-27T17:47:12.3146951Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:47:12.3153188Z make[1]: *** [Makefile:20556: install-recursive] Error 1
+2025-07-27T17:47:12.3154197Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-27T17:47:12.3161169Z make: *** [Makefile:789: install-recursive] Error 1
+2025-07-27T17:47:12.3276011Z ##[error]Process completed with exit code 2.
+2025-07-27T17:47:12.3364349Z Post job cleanup.
+2025-07-27T17:47:12.3367957Z ##[command]/usr/bin/docker exec  687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2 sh -c "cat /etc/*release | grep ^ID"
+2025-07-27T17:47:12.5541408Z [command]/usr/bin/git version
+2025-07-27T17:47:12.5594817Z git version 2.43.0
+2025-07-27T17:47:12.5657533Z Copying '/github/home/.gitconfig' to '/__w/_temp/aefc1e8f-405e-4275-988f-e3e9836f9da1/.gitconfig'
+2025-07-27T17:47:12.5672548Z Temporarily overriding HOME='/__w/_temp/aefc1e8f-405e-4275-988f-e3e9836f9da1' before making global git config changes
+2025-07-27T17:47:12.5674414Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-27T17:47:12.5680144Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-27T17:47:12.5738840Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-27T17:47:12.5781480Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-27T17:47:12.6082017Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-27T17:47:12.6110774Z http.https://github.com/.extraheader
+2025-07-27T17:47:12.6128747Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-07-27T17:47:12.6170982Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-27T17:47:12.6617127Z Stop and remove container: 44574f199b85469bb9fd39adade63007_ghcriodashcoreautoguixdashdashcorecirunnerbackport026batch445pr28059_440143
+2025-07-27T17:47:12.6622198Z ##[command]/usr/bin/docker rm --force 687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2
+2025-07-27T17:47:12.7778039Z 687d3f63df8006c928fb76355050b76d577d278ca5845a86bba625f1256014e2
+2025-07-27T17:47:12.7809331Z Remove container network: github_network_48e0c5aed8724f6ca8a6b36517541da9
+2025-07-27T17:47:12.7814001Z ##[command]/usr/bin/docker network rm github_network_48e0c5aed8724f6ca8a6b36517541da9
+2025-07-27T17:47:12.9328909Z github_network_48e0c5aed8724f6ca8a6b36517541da9
+2025-07-27T17:47:12.9387297Z Evaluate and set job outputs
+2025-07-27T17:47:12.9393095Z Cleaning up orphan processes

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -191,7 +191,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     }
 }
 
-bool CTxMemPool::CalculateAncestorsAndCheckLimits(size_t entry_size,
+bool CTxMemPool::CalculateAncestorsAndCheckLimits(int64_t entry_size,
                                                   size_t entry_count,
                                                   setEntries& setAncestors,
                                                   CTxMemPoolEntry::Parents& staged_ancestors,
@@ -201,7 +201,7 @@ bool CTxMemPool::CalculateAncestorsAndCheckLimits(size_t entry_size,
                                                   uint64_t limitDescendantSize,
                                                   std::string &errString) const
 {
-    size_t totalSizeWithAncestors = entry_size;
+    int64_t totalSizeWithAncestors = entry_size;
 
     while (!staged_ancestors.empty()) {
         const CTxMemPoolEntry& stage = staged_ancestors.begin()->get();
@@ -248,7 +248,7 @@ bool CTxMemPool::CheckPackageLimits(const Package& package,
                                     std::string &errString) const
 {
     CTxMemPoolEntry::Parents staged_ancestors;
-    size_t total_size = 0;
+    int64_t total_size = 0;
     for (const auto& tx : package) {
         total_size += GetVirtualTransactionSize(*tx);
         for (const auto& input : tx->vin) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -196,9 +196,9 @@ bool CTxMemPool::CalculateAncestorsAndCheckLimits(int64_t entry_size,
                                                   setEntries& setAncestors,
                                                   CTxMemPoolEntry::Parents& staged_ancestors,
                                                   uint64_t limitAncestorCount,
-                                                  uint64_t limitAncestorSize,
+                                                  int64_t limitAncestorSize,
                                                   uint64_t limitDescendantCount,
-                                                  uint64_t limitDescendantSize,
+                                                  int64_t limitDescendantSize,
                                                   std::string &errString) const
 {
     int64_t totalSizeWithAncestors = entry_size;
@@ -242,9 +242,9 @@ bool CTxMemPool::CalculateAncestorsAndCheckLimits(int64_t entry_size,
 
 bool CTxMemPool::CheckPackageLimits(const Package& package,
                                     uint64_t limitAncestorCount,
-                                    uint64_t limitAncestorSize,
+                                    int64_t limitAncestorSize,
                                     uint64_t limitDescendantCount,
-                                    uint64_t limitDescendantSize,
+                                    int64_t limitDescendantSize,
                                     std::string &errString) const
 {
     CTxMemPoolEntry::Parents staged_ancestors;
@@ -278,9 +278,9 @@ bool CTxMemPool::CheckPackageLimits(const Package& package,
 bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry,
                                            setEntries &setAncestors,
                                            uint64_t limitAncestorCount,
-                                           uint64_t limitAncestorSize,
+                                           int64_t limitAncestorSize,
                                            uint64_t limitDescendantCount,
-                                           uint64_t limitDescendantSize,
+                                           int64_t limitDescendantSize,
                                            std::string &errString,
                                            bool fSearchForParents /* = true */) const
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -558,9 +558,9 @@ private:
                                           setEntries& setAncestors,
                                           CTxMemPoolEntry::Parents &staged_ancestors,
                                           uint64_t limitAncestorCount,
-                                          uint64_t limitAncestorSize,
+                                          int64_t limitAncestorSize,
                                           uint64_t limitDescendantCount,
-                                          uint64_t limitDescendantSize,
+                                          int64_t limitDescendantSize,
                                           std::string &errString) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
 public:
@@ -704,7 +704,7 @@ public:
      *  fSearchForParents = whether to search a tx's vin for in-mempool parents, or
      *    look up parents from mapLinks. Must be true for entries not in the mempool
      */
-    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, int64_t limitAncestorSize, uint64_t limitDescendantCount, int64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Calculate all in-mempool ancestors of a set of transactions not already in the mempool and
      * check ancestor and descendant limits. Heuristics are used to estimate the ancestor and
@@ -723,9 +723,9 @@ public:
      */
     bool CheckPackageLimits(const Package& package,
                             uint64_t limitAncestorCount,
-                            uint64_t limitAncestorSize,
+                            int64_t limitAncestorSize,
                             uint64_t limitDescendantCount,
-                            uint64_t limitDescendantSize,
+                            int64_t limitDescendantSize,
                             std::string &errString) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Populate setDescendants with all in-mempool descendants of hash.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -553,7 +553,7 @@ private:
      * param@[in]   staged_ancestors    Should contain entries in the mempool.
      * param@[out]  setAncestors        Will be populated with all mempool ancestors.
      */
-    bool CalculateAncestorsAndCheckLimits(size_t entry_size,
+    bool CalculateAncestorsAndCheckLimits(int64_t entry_size,
                                           size_t entry_count,
                                           setEntries& setAncestors,
                                           CTxMemPoolEntry::Parents &staged_ancestors,


### PR DESCRIPTION
Backports bitcoin/bitcoin#28059

Original commit: 7c66a4b610

This PR is a continuation of https://github.com/bitcoin/bitcoin/pull/23962 and it:
- gets rid of two static casts (not applicable to Dash)
- addresses https://github.com/bitcoin/bitcoin/pull/23962#issuecomment-1593289706
- is useful for https://github.com/bitcoin/bitcoin/pull/25972

Backported from Bitcoin Core v0.26