### PR TITLE
Merge bitcoin/bitcoin#28231: doc: remove Fedora libdb4-*-devel install docs

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -67,8 +67,8 @@ SQLite is required for the descriptor wallet:
 sudo apt-get install libsqlite3-dev
 ```
 
-Berkeley DB is required for the legacy wallet. Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages,
-but these will install Berkeley DB 5.1 or later. This will break binary wallet compatibility with the distributed
+Berkeley DB is only required for the legacy wallet. Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages,
+but these will install Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed
 executables, which are based on BerkeleyDB 4.8. If you do not care about wallet compatibility, pass
 `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
@@ -148,13 +148,7 @@ SQLite is required for the descriptor wallet:
 sudo dnf install sqlite-devel
 ```
 
-Berkeley DB is required for the legacy wallet:
-
-```sh
-sudo dnf install libdb4-devel libdb4-cxx-devel
-```
-
-Newer Fedora releases, since Fedora 33, have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
+Berkeley DB is only required for the legacy wallet. Fedora releases have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
 Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed executables, which
 are based on Berkeley DB 4.8. If you do not care about wallet compatibility,
 pass `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).


### PR DESCRIPTION
Backports bitcoin/bitcoin#28231

Original commit: 064919e00d

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Berkeley DB is only required for the legacy wallet.
  * Updated supported Berkeley DB version information for Ubuntu, Debian, and Fedora systems.
  * Revised Fedora instructions to reflect current package availability for Berkeley DB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->