### PR TITLE
Merge bitcoin/bitcoin#28149: net processing: clamp PeerManager::Options user input

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -43,6 +43,7 @@
 #include <atomic>
 #include <chrono>
 #include <future>
+#include <limits>
 #include <list>
 #include <memory>
 #include <optional>
@@ -1770,7 +1771,7 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
 
 void PeerManagerImpl::AddToCompactExtraTransactions(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans)
 {
-    size_t max_extra_txn = gArgs.GetIntArg("-blockreconstructionextratxn", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN);
+    uint32_t max_extra_txn = uint32_t(std::clamp<int64_t>(gArgs.GetIntArg("-blockreconstructionextratxn", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN), 0, std::numeric_limits<uint32_t>::max()));
     if (max_extra_txn <= 0)
         return;
     if (!vExtraTxnForCompact.size())
@@ -4549,7 +4550,7 @@ void PeerManagerImpl::ProcessMessage(
                 }
 
                 // DoS prevention: do not allow m_orphans to grow unbounded (see CVE-2012-3789)
-                unsigned int nMaxOrphanTxSize = (unsigned int)std::max((int64_t)0, gArgs.GetIntArg("-maxorphantxsize", DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE)) * 1000000;
+                uint32_t nMaxOrphanTxSize = uint32_t(std::clamp<int64_t>(gArgs.GetIntArg("-maxorphantxsize", DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE), 0, std::numeric_limits<uint32_t>::max() / 1000000)) * 1000000;
                 unsigned int nEvicted = m_orphanage.LimitOrphans(nMaxOrphanTxSize);
                 if (nEvicted > 0) {
                     LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -29,9 +29,10 @@ struct CJContext;
 struct LLMQContext;
 
 /** Default for -maxorphantxsize, maximum size in megabytes the orphan map can grow before entries are removed */
-static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE = 10; // this allows around 100 TXs of max size (and many more of normal size)
-/** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
-static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
+static const uint32_t DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE = 10; // this allows around 100 TXs of max size (and many more of normal size)
+/** Default number of non-mempool transactions to keep around for block reconstruction. Includes
+    orphan, replaced, and rejected transactions. */
+static const uint32_t DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_PEERBLOCKFILTERS = false;
 /** Threshold for marking a node to be discouraged, e.g. disconnected and added to the discouragement filter. */


### PR DESCRIPTION
Backports bitcoin/bitcoin#28149

Original commit: 0d9a13ddd8

This adapts Bitcoin's bounds checking improvements for `-maxorphantx` and `-blockreconstructionextratxn` parameters to Dash's architecture.

### Changes:
- Add proper bounds checking using `std::clamp` to ensure values fit within `uint32_t` bounds
- Change types from `unsigned int`/`size_t` to `uint32_t` for consistency
- Update documentation comments
- Add `<limits>` include for `std::numeric_limits`

### Architecture Differences:
Since Dash doesn't have the `PeerManager::Options` struct pattern that Bitcoin uses, this implements the bounds checking directly where the parameters are used in `net_processing.cpp`.

Note: Dash uses `-maxorphantxsize` (in MB) while Bitcoin uses `-maxorphantx` (count), so the bounds checking for orphan size includes division protection to prevent overflow when converting MB to bytes.

Backported from Bitcoin Core v0.26