### PR TITLE
Merge bitcoin/bitcoin#28232: test: locked_wallet, skip default fee estimation

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -19,6 +19,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     count_bytes,
     find_vout_for_address,
+    get_fee,
     satoshi_round,
 )
 from test_framework.wallet_util import bytes_to_wif
@@ -550,6 +551,9 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_locked_wallet(self):
         self.log.info("Test fundrawtxn with locked wallet and hardened derivation")
 
+        # This test is not meant to exercise fee estimation. Making sure all txs are sent at a consistent fee rate.
+        self.nodes[1].settxfee(self.min_relay_tx_fee)
+        
         self.nodes[1].encryptwallet("test")
 
         if self.options.descriptors:
@@ -573,7 +577,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Choose 2 inputs
         # bnb doesn't work same way as in bitcoin, so, `value` is also calculated by different way
         inputs = self.nodes[1].listunspent()
-        value = sum(inp["amount"] for inp in inputs) - Decimal("0.00002200")
+        # Deduce exact fee to produce a changeless transaction
+        # Using 2 inputs in Dash vs 1 in Bitcoin, so adjusting tx_size  
+        tx_size = 150  # Approximate tx size for 2 inputs
+        value = sum(inp["amount"] for inp in inputs) - get_fee(tx_size, self.min_relay_tx_fee)
         outputs = {self.nodes[0].getnewaddress():value}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         # fund a transaction that does not require a new key for the change output

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -553,7 +553,6 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # This test is not meant to exercise fee estimation. Making sure all txs are sent at a consistent fee rate.
         self.nodes[1].settxfee(self.min_relay_tx_fee)
-        
         self.nodes[1].encryptwallet("test")
 
         if self.options.descriptors:
@@ -578,7 +577,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # bnb doesn't work same way as in bitcoin, so, `value` is also calculated by different way
         inputs = self.nodes[1].listunspent()
         # Deduce exact fee to produce a changeless transaction
-        # Using 2 inputs in Dash vs 1 in Bitcoin, so adjusting tx_size  
+        # Using 2 inputs in Dash vs 1 in Bitcoin, so adjusting tx_size
         tx_size = 150  # Approximate tx size for 2 inputs
         value = sum(inp["amount"] for inp in inputs) - get_fee(tx_size, self.min_relay_tx_fee)
         outputs = {self.nodes[0].getnewaddress():value}

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -19,7 +19,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     count_bytes,
     find_vout_for_address,
-    get_fee,
     satoshi_round,
 )
 from test_framework.wallet_util import bytes_to_wif
@@ -579,7 +578,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Deduce exact fee to produce a changeless transaction
         # Using 2 inputs in Dash vs 1 in Bitcoin, so adjusting tx_size
         tx_size = 150  # Approximate tx size for 2 inputs
-        value = sum(inp["amount"] for inp in inputs) - get_fee(tx_size, self.min_relay_tx_fee)
+        value = sum(inp["amount"] for inp in inputs) - (tx_size * self.min_relay_tx_fee / 1000)
         outputs = {self.nodes[0].getnewaddress():value}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         # fund a transaction that does not require a new key for the change output


### PR DESCRIPTION
Backports bitcoin/bitcoin#28232

Original commit: aadaa5625eda8d3ae5493ad264d9ccd709bd9f55

Backported from Bitcoin Core v0.26