### PR TITLE
Merge bitcoin/bitcoin#28123: Bugfix: RPC: Remove quotes from non-string oneline descriptions

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -564,7 +564,7 @@ static RPCHelpMan getblocktemplate()
                         },
                         },
                 },
-                "\"template_request\""},
+                "template_request"},
         },
         {
             RPCResult{"If the proposal was accepted with mode=='proposal'", RPCResult::Type::NONE, "", ""},

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -20,6 +20,8 @@
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
 const std::string EXAMPLE_ADDRESS[2] = {"XunLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPw0", "XwQQkwA4FYkq2XERzMY2CiAZhJTEDAbtc0"};
 
+static const bool DEFAULT_RPC_DOC_CHECK = false;
+
 std::string GetAllOutputTypes()
 {
     std::vector<std::string> ret;
@@ -900,7 +902,16 @@ std::string RPCArg::ToStringObj(const bool oneline) const
 
 std::string RPCArg::ToString(const bool oneline) const
 {
-    if (oneline && !m_oneline_description.empty()) return m_oneline_description;
+    if (oneline && !m_oneline_description.empty()) {
+        if (m_oneline_description[0] == '\"' && m_type != Type::STR_HEX && m_type != Type::STR && gArgs.GetBoolArg("-rpcdoccheck", DEFAULT_RPC_DOC_CHECK)) {
+            throw std::runtime_error{
+                strprintf("Internal bug detected: non-string RPC arg \"%s\" quotes oneline_description:\n%s\n%s %s\nPlease report this issue here: %s\n",
+                          m_names, m_oneline_description,
+                          PACKAGE_NAME, FormatFullVersion(),
+                          PACKAGE_BUGREPORT)};
+        }
+        return m_oneline_description;
+    }
 
     switch (m_type) {
     case Type::STR_HEX:

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1514,12 +1514,12 @@ RPCHelpMan importmulti()
                         },
                     },
                 },
-                "\"requests\""},
+                "requests"},
             {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG, "",
                 {
                     {"rescan", RPCArg::Type::BOOL, RPCArg::Default{true}, "Stating if should rescan the blockchain after all imports"},
                 },
-                "\"options\""},
+                "options"},
         },
         RPCResult{
                 RPCResult::Type::ARR, "", "Response is an array with the same size as the input that has the execution result",
@@ -1826,7 +1826,7 @@ RPCHelpMan importdescriptors() {
                                 },
                             },
                         },
-                        "\"requests\""},
+                        "requests"},
                 },
                 RPCResult{
                     RPCResult::Type::ARR, "", "Response is an array with the same size as the input that has the execution result",


### PR DESCRIPTION
Backports bitcoin/bitcoin#28123

Original commit: ecb20563b6

Backported from Bitcoin Core v0.26

## Summary
This PR removes quotes from non-string oneline descriptions in RPC parameters, fixing a documentation bug where object/array parameters had incorrect quoted descriptions.

## Changes
- Remove quotes from "requests" and "options" oneline descriptions in wallet RPC commands
- Add validation check in util.cpp to detect and error on quoted oneline descriptions for non-string types
- Add DEFAULT_RPC_DOC_CHECK constant to control this validation

## Notes
- Skipped changes to src/rpc/blockchain.cpp as the scanblocks function doesn't exist in Dash
- Skipped changes to test/functional/mining_basic.py as they were for segwit testing which doesn't apply to Dash
- Adapted changes to Dash's codebase structure (m_oneline_description vs Bitcoin's m_opts.oneline_description)