### PR TITLE
Merge bitcoin/bitcoin#28237: refactor: Enforce C-str fmt strings in WalletLogPrintf()

### DIFF
--- a/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
+++ b/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2023 Bitcoin Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <string>
+
+// Test for bitcoin-unterminated-logprintf
+
+enum LogFlags {
+    NONE
+};
+
+enum Level {
+    None
+};
+
+template <typename... Args>
+static inline void LogPrintf_(const std::string& logging_function, const std::string& source_file, const int source_line, const LogFlags flag, const Level level, const char* fmt, const Args&... args)
+{
+}
+
+#define LogPrintLevel_(category, level, ...) LogPrintf_(__func__, __FILE__, __LINE__, category, level, __VA_ARGS__)
+#define LogPrintf(...) LogPrintLevel_(LogFlags::NONE, Level::None, __VA_ARGS__)
+
+#define LogPrint(category, ...) \
+    do {                        \
+        LogPrintf(__VA_ARGS__); \
+    } while (0)
+
+
+class CWallet
+{
+    std::string GetDisplayName() const
+    {
+        return "default wallet";
+    }
+
+public:
+    template <typename... Params>
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
+    {
+        LogPrintf(("%s " + std::string{fmt}).c_str(), GetDisplayName(), parameters...);
+    };
+};
+
+struct ScriptPubKeyMan
+{
+    std::string GetDisplayName() const
+    {
+        return "default wallet";
+    }
+
+    template <typename... Params>
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
+    {
+        LogPrintf(("%s " + std::string{fmt}).c_str(), GetDisplayName(), parameters...);
+    };
+};
+
+void good_func()
+{
+    LogPrintf("hello world!\n");
+}
+void good_func2()
+{
+    CWallet wallet;
+    wallet.WalletLogPrintf("hi\n");
+    ScriptPubKeyMan spkm;
+    spkm.WalletLogPrintf("hi\n");
+
+    const CWallet& walletref = wallet;
+    walletref.WalletLogPrintf("hi\n");
+
+    auto* walletptr = new CWallet();
+    walletptr->WalletLogPrintf("hi\n");
+    delete walletptr;
+}
+void bad_func()
+{
+    LogPrintf("hello world!");
+}
+void bad_func2()
+{
+    LogPrintf("");
+}
+void bad_func3()
+{
+    // Ending in "..." has no special meaning.
+    LogPrintf("hello world!...");
+}
+void bad_func4_ignored()
+{
+    LogPrintf("hello world!"); // NOLINT(bitcoin-unterminated-logprintf)
+}
+void bad_func5()
+{
+    CWallet wallet;
+    wallet.WalletLogPrintf("hi");
+    ScriptPubKeyMan spkm;
+    spkm.WalletLogPrintf("hi");
+
+    const CWallet& walletref = wallet;
+    walletref.WalletLogPrintf("hi");
+
+    auto* walletptr = new CWallet();
+    walletptr->WalletLogPrintf("hi");
+    delete walletptr;
+}

--- a/contrib/devtools/bitcoin-tidy/logprintf.cpp
+++ b/contrib/devtools/bitcoin-tidy/logprintf.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2023 Bitcoin Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "logprintf.h"
+
+#include <clang/AST/ASTContext.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+
+namespace {
+AST_MATCHER(clang::StringLiteral, unterminated)
+{
+    size_t len = Node.getLength();
+    if (len > 0 && Node.getCodeUnit(len - 1) == '\n') {
+        return false;
+    }
+    return true;
+}
+} // namespace
+
+namespace bitcoin {
+
+void LogPrintfCheck::registerMatchers(clang::ast_matchers::MatchFinder* finder)
+{
+    using namespace clang::ast_matchers;
+
+    /*
+      Logprintf(..., ..., ..., ..., ..., "foo", ...)
+    */
+
+    finder->addMatcher(
+        callExpr(
+            callee(functionDecl(hasName("LogPrintf_"))),
+            hasArgument(5, stringLiteral(unterminated()).bind("logstring"))),
+        this);
+
+    /*
+      auto walletptr = &wallet;
+      wallet.WalletLogPrintf("foo");
+      wallet->WalletLogPrintf("foo");
+    */
+    finder->addMatcher(
+        cxxMemberCallExpr(
+            callee(cxxMethodDecl(hasName("WalletLogPrintf"))),
+            hasArgument(0, stringLiteral(unterminated()).bind("logstring"))),
+        this);
+}
+
+void LogPrintfCheck::check(const clang::ast_matchers::MatchFinder::MatchResult& Result)
+{
+    if (const clang::StringLiteral* lit = Result.Nodes.getNodeAs<clang::StringLiteral>("logstring")) {
+        const clang::ASTContext& ctx = *Result.Context;
+        const auto user_diag = diag(lit->getEndLoc(), "Unterminated format string used with LogPrintf");
+        const auto& loc = lit->getLocationOfByte(lit->getByteLength(), *Result.SourceManager, ctx.getLangOpts(), ctx.getTargetInfo());
+        user_diag << clang::FixItHint::CreateInsertion(loc, "\\n");
+    }
+}
+
+} // namespace bitcoin

--- a/contrib/devtools/bitcoin-tidy/logprintf.h
+++ b/contrib/devtools/bitcoin-tidy/logprintf.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 Bitcoin Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef LOGPRINTF_CHECK_H
+#define LOGPRINTF_CHECK_H
+
+#include <clang-tidy/ClangTidyCheck.h>
+
+namespace bitcoin {
+
+// Warn about any use of LogPrintf that does not end with a newline.
+class LogPrintfCheck final : public clang::tidy::ClangTidyCheck
+{
+public:
+    LogPrintfCheck(clang::StringRef Name, clang::tidy::ClangTidyContext* Context)
+        : clang::tidy::ClangTidyCheck(Name, Context) {}
+
+    bool isLanguageVersionSupported(const clang::LangOptions& LangOpts) const override
+    {
+        return LangOpts.CPlusPlus;
+    }
+    void registerMatchers(clang::ast_matchers::MatchFinder* Finder) override;
+    void check(const clang::ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
+} // namespace bitcoin
+
+#endif // LOGPRINTF_CHECK_H

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,14 +1,23 @@
 Checks: '
 -*,
+bitcoin-*,
 bugprone-argument-comment,
+bugprone-use-after-move,
+misc-unused-using-decls,
+modernize-use-default-member-init,
+modernize-use-noexcept,
 modernize-use-nullptr,
+performance-*,
+-performance-inefficient-string-concatenation,
+-performance-no-int-to-ptr,
+-performance-noexcept-move-constructor,
+-performance-unnecessary-value-param,
 readability-const-return-type,
 readability-redundant-declaration,
 readability-redundant-string-init,
 '
-WarningsAsErrors: '
-bugprone-argument-comment,
-modernize-use-nullptr,
-readability-redundant-declaration,
-readability-redundant-string-init,
-'
+WarningsAsErrors: '*'
+CheckOptions:
+ - key: performance-move-const-arg.CheckTriviallyCopyableMove
+   value: false
+HeaderFilterRegex: '.'

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -220,9 +220,10 @@ public:
     virtual uint256 GetID() const { return uint256(); }
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template<typename... Params>
-    void WalletLogPrintf(std::string fmt, Params... parameters) const {
-        LogPrintf(("%s " + fmt).c_str(), m_storage.GetDisplayName(), parameters...);
+    template <typename... Params>
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
+    {
+        LogPrintf(("%s " + std::string{fmt}).c_str(), m_storage.GetDisplayName(), parameters...);
     };
 
     /** Watch-only address added */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2107,7 +2107,7 @@ bool CWallet::SignGovernanceVote(const CKeyID& keyID, CGovernanceVote& vote) con
 void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm)
 {
     LOCK(cs_wallet);
-    WalletLogPrintf("CommitTransaction:\n%s", tx->ToString()); /* Continued */
+    WalletLogPrintf("CommitTransaction:\n%s", tx->ToString()); // NOLINT(bitcoin-unterminated-logprintf)
 
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -967,9 +967,10 @@ public:
     };
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template<typename... Params>
-    void WalletLogPrintf(std::string fmt, Params... parameters) const {
-        LogPrintf(("%s " + fmt).c_str(), GetDisplayName(), parameters...);
+    template <typename... Params>
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
+    {
+        LogPrintf(("%s " + std::string{fmt}).c_str(), GetDisplayName(), parameters...);
     };
 
     /** Upgrade the wallet */

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -24,12 +24,11 @@ FALSE_POSITIVES = [
     ("src/stacktraces.cpp", "strprintf(fmtStr, i, si.pc, lstr, fstr)"),
     ("src/util/system.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/validationinterface.cpp", "LogPrint(BCLog::VALIDATION, fmt \"\\n\", __VA_ARGS__)"),
-    ("src/wallet/wallet.h",  "WalletLogPrintf(std::string fmt, Params... parameters)"),
-    ("src/wallet/wallet.h", "LogPrintf((\"%s \" + fmt).c_str(), GetDisplayName(), parameters...)"),
-    ("src/wallet/scriptpubkeyman.h",  "WalletLogPrintf(std::string fmt, Params... parameters)"),
-    ("src/wallet/scriptpubkeyman.h", "LogPrintf((\"%s \" + fmt).c_str(), m_storage.GetDisplayName(), parameters...)"),
-    ("src/logging.h", "LogPrintf(const char* fmt, const Args&... args)"),
-    ("src/wallet/scriptpubkeyman.h", "WalletLogPrintf(const std::string& fmt, const Params&... parameters)"),
+    ("src/wallet/wallet.h", "WalletLogPrintf(const char* fmt, Params... parameters)"),
+    ("src/wallet/wallet.h", "LogPrintf((\"%s \" + std::string{fmt}).c_str(), GetDisplayName(), parameters...)"),
+    ("src/wallet/scriptpubkeyman.h", "WalletLogPrintf(const char* fmt, Params... parameters)"),
+    ("src/wallet/scriptpubkeyman.h", "LogPrintf((\"%s \" + std::string{fmt}).c_str(), m_storage.GetDisplayName(), parameters...)"),
+    ("src/logging.h", "LogPrintf(const char* fmt, const Args&... args)")
 ]
 
 def parse_function_calls(function_name, source_code):


### PR DESCRIPTION
Backports bitcoin/bitcoin#28237

Original commit: 7bf078f2b7

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an automated check that warns when log messages are missing a terminating newline character.
* **Bug Fixes**
  * Improved logging methods to ensure consistent handling of format string types in wallet-related logging.
* **Chores**
  * Updated linting configuration and test scripts to support the new log message formatting check and reflect updated function signatures.
* **Documentation**
  * Added example code demonstrating both correct and incorrect usage of logging functions for static analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->