### PR TITLE
Merge bitcoin/bitcoin#28295: ci: Add missing amd64 to win64-cross task

### DIFF
--- a/ci/test/00_setup_env_android.sh
+++ b/ci/test/00_setup_env_android.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-present The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export HOST=aarch64-linux-android
+export PACKAGES="unzip openjdk-8-jdk gradle"
+export CONTAINER_NAME=ci_android
+export CI_IMAGE_NAME_TAG="docker.io/amd64/ubuntu:22.04"
+
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
+
+export ANDROID_API_LEVEL=28
+export ANDROID_BUILD_TOOLS_VERSION=28.0.3
+export ANDROID_NDK_VERSION=23.2.8568313
+export ANDROID_TOOLS_URL=https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
+export ANDROID_HOME="${DEPENDS_DIR}/SDKs/android"
+export ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}"
+export DEP_OPTS="ANDROID_SDK=${ANDROID_HOME} ANDROID_NDK=${ANDROID_NDK_HOME} ANDROID_API_LEVEL=${ANDROID_API_LEVEL} ANDROID_TOOLCHAIN_BIN=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/"
+
+export BITCOIN_CONFIG="--disable-tests --enable-gui-tests --disable-bench --disable-fuzz-binary --without-utils --without-libs --without-daemon"

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -7,6 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_win64
+export CI_IMAGE_NAME_TAG="docker.io/amd64/ubuntu:22.04"  # Check that Jammy can cross-compile to win64
 export HOST=x86_64-w64-mingw32
 export DPKG_ADD_ARCH="i386"
 export PACKAGES="python3 nsis g++-mingw-w64-x86-64-posix wine-binfmt wine64 wine32 file"


### PR DESCRIPTION
Backports bitcoin/bitcoin#28295

Original commit: 9b066da8af

Backported from Bitcoin Core v0.26

Notes: 
- The android CI file modification from Bitcoin was omitted as Dash does not have this CI file
- Only the win64 CI configuration change was applied