### PR TITLE
Merge bitcoin/bitcoin#28292: ci: Disable cache save for pull requests in GitHub Actions

### DIFF
--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Save depends cache
         uses: actions/cache/save@v4
-        if: steps.restore.outputs.cache-hit != 'true'
+        if: steps.restore.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
         with:
           path: |
             depends/built

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -65,8 +65,8 @@ jobs:
           key: ${{ inputs.depends-key }}
           fail-on-cache-miss: true
 
-      - name: Manage ccache
-        uses: actions/cache@v4
+      - name: Restore ccache
+        uses: actions/cache/restore@v4
         with:
           path: |
             /cache
@@ -120,3 +120,11 @@ jobs:
           compression-level: 0
           overwrite: true
           retention-days: 3
+
+      - name: Save ccache
+        uses: actions/cache/save@v4
+        if: github.event_name != 'pull_request'
+        with:
+          path: |
+            /cache
+          key: ccache-${{ hashFiles('contrib/containers/ci/ci.Dockerfile', 'depends/packages/*') }}-${{ inputs.build-target }}-${{ github.sha }}

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -83,17 +83,17 @@ jobs:
           path: dash
           fetch-depth: 0
 
-      - name: Cache depends sources
-        uses: actions/cache@v4
+      - name: Restore depends sources cache
+        uses: actions/cache/restore@v4
         with:
           path: dash/depends/sources
           key: depends-sources-${{ hashFiles('dash/depends/packages/*') }}
           restore-keys: |
             depends-sources-
 
-      - name: Cache Guix and depends
+      - name: Restore Guix and depends cache
         id: guix-cache-restore
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ${{ github.workspace }}/.cache
@@ -143,3 +143,21 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: ${{ github.workspace }}/dash/guix-build*/output/${{ matrix.build_target }}/*
+
+      - name: Save depends sources cache
+        uses: actions/cache/save@v4
+        if: github.event_name != 'pull_request'
+        with:
+          path: dash/depends/sources
+          key: depends-sources-${{ hashFiles('dash/depends/packages/*') }}
+
+      - name: Save Guix and depends cache
+        uses: actions/cache/save@v3
+        if: github.event_name != 'pull_request' && steps.guix-cache-restore.outputs.cache-hit != 'true'
+        with:
+          path: |
+            ${{ github.workspace }}/.cache
+            ${{ github.workspace }}/dash/depends/built
+            ${{ github.workspace }}/dash/depends/work
+            /gnu/store
+          key: ${{ runner.os }}-guix-${{ matrix.build_target }}-${{ github.sha }}

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           name: ${{ inputs.bundle-key }}
 
-      - name: Manage releases cache
-        uses: actions/cache@v4
+      - name: Restore releases cache
+        uses: actions/cache/restore@v4
         if: inputs.build-target == 'linux64'
         with:
           path: |
@@ -81,3 +81,11 @@ jobs:
           compression-level: 0
           overwrite: true
           retention-days: 1
+
+      - name: Save releases cache
+        uses: actions/cache/save@v4
+        if: inputs.build-target == 'linux64' && github.event_name != 'pull_request'
+        with:
+          path: |
+            releases
+          key: releases-${{ hashFiles('ci/test/00_setup_env_native_qt5.sh', 'test/get_previous_releases.py') }}


### PR DESCRIPTION
Backports bitcoin/bitcoin#28292

Original commit: ded6873340

This adapts Bitcoin's change to disable cache saving for pull requests to Dash's workflow structure. Since Dash uses separate workflow files instead of a single ci.yml, the changes are applied to:
- build-depends.yml: Already had split cache, added PR condition
- build-src.yml: Split cache action and added PR condition  
- test-src.yml: Split cache action and added PR condition
- guix-build.yml: Split cache actions and added PR conditions

This prevents multiple pull requests from filling GitHub Actions cache quota shortly.

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow caching by separating cache restore and save steps in multiple build and test workflows.
  * Updated cache saving to occur only for non-pull request events, enhancing workflow efficiency and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->