### PR TITLE
Merge bitcoin/bitcoin#28157: test doc: tests `acceptstalefeeestimates` option is only supported on regtest chain

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -560,7 +560,6 @@ CBlockPolicyEstimator::CBlockPolicyEstimator()
     shortStats = std::make_unique<TxConfirmStats>(buckets, bucketMap, SHORT_BLOCK_PERIODS, SHORT_DECAY, SHORT_SCALE);
     longStats = std::make_unique<TxConfirmStats>(buckets, bucketMap, LONG_BLOCK_PERIODS, LONG_DECAY, LONG_SCALE);
 
-    // If the fee estimation file is present, read recorded estimations
     fs::path est_filepath = gArgs.GetDataDirNet() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_file(fsbridge::fopen(est_filepath, "rb"), SER_DISK, CLIENT_VERSION);
     if (est_file.IsNull() || !Read(est_file)) {

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -19,6 +19,18 @@
 #include <string>
 #include <vector>
 
+// How often to flush fee estimates to fee_estimates.dat.
+static constexpr std::chrono::hours FEE_FLUSH_INTERVAL{1};
+
+/** fee_estimates.dat that are more than 60 hours (2.5 days) old will not be read,
+ * as fee estimates are based on historical data and may be inaccurate if
+ * network activity has changed.
+ */
+static constexpr std::chrono::hours MAX_FILE_AGE{60};
+
+// Whether we allow importing a fee_estimates file older than MAX_FILE_AGE.
+static constexpr bool DEFAULT_ACCEPT_STALE_FEE_ESTIMATES{false};
+
 class CAutoFile;
 class CTxMemPoolEntry;
 class TxConfirmStats;

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -267,6 +267,15 @@ class ConfArgsTest(BitcoinTestFramework):
                     unexpected_msgs=seednode_ignored):
                 self.restart_node(0, extra_args=[connect_arg, '-seednode=fakeaddress2'])
 
+
+    def test_acceptstalefeeestimates_arg_support(self):
+        self.log.info("Test -acceptstalefeeestimates option support")
+        conf_file = self.nodes[0].datadir_path / "dash.conf"
+        for chain, chain_name in {("main", ""), ("test", "testnet3")}:
+            util.write_config(conf_file, n=0, chain=chain_name, extra_config='acceptstalefeeestimates=1\n')
+            self.nodes[0].assert_start_raises_init_error(expected_msg=f'Error: acceptstalefeeestimates is not supported on {chain} chain.')
+        util.write_config(conf_file, n=0, chain="regtest")  # Reset to regtest
+
     def run_test(self):
         self.test_log_buffer()
         self.test_args_log()
@@ -277,6 +286,7 @@ class ConfArgsTest(BitcoinTestFramework):
 
         self.test_config_file_parser()
         self.test_invalid_command_line_options()
+        self.test_acceptstalefeeestimates_arg_support()
 
         # Remove the -datadir argument so it doesn't override the config file
         self.nodes[0].args = [arg for arg in self.nodes[0].args if not arg.startswith("-datadir")]


### PR DESCRIPTION
Backports bitcoin/bitcoin#28157

Original commit: a84dade1f9df747bb440bedb474ea629d2d6ff34

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new configuration parameters for fee estimate file handling, including flush interval, maximum file age, and default acceptance of stale fee estimates.

* **Tests**
  * Added tests to verify that the `acceptstalefeeestimates` configuration option is properly rejected on unsupported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->