### PR TITLE
Merge bitcoin/bitcoin#28284: refactor: Remove confusing static_cast in address types

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -8,6 +8,7 @@
 #include <pubkey.h>
 #include <script/script.h>
 
+#include <cassert>
 #include <string>
 
 typedef std::vector<unsigned char> valtype;
@@ -16,17 +17,17 @@ bool fAcceptDatacarrier = DEFAULT_ACCEPT_DATACARRIER;
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
 CScriptID::CScriptID(const CScript& in) : BaseHash(Hash160(in)) {}
-CScriptID::CScriptID(const ScriptHash& in) : BaseHash(static_cast<uint160>(in)) {}
+CScriptID::CScriptID(const ScriptHash& in) : BaseHash{in} {}
 
 ScriptHash::ScriptHash(const CScript& in) : BaseHash(Hash160(in)) {}
-ScriptHash::ScriptHash(const CScriptID& in) : BaseHash(static_cast<uint160>(in)) {}
+ScriptHash::ScriptHash(const CScriptID& in) : BaseHash{in} {}
 
 PKHash::PKHash(const CPubKey& pubkey) : BaseHash(pubkey.GetID()) {}
 PKHash::PKHash(const CKeyID& pubkey_id) : BaseHash(pubkey_id) {}
 
 CKeyID ToKeyID(const PKHash& key_hash)
 {
-    return CKeyID{static_cast<uint160>(key_hash)};
+    return CKeyID{uint160{key_hash}};
 }
 
 std::string GetTxnOutputType(TxoutType t)

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -5,12 +5,18 @@
 
 #include <script/standard.h>
 
+#include <crypto/sha256.h>
 #include <hash.h>
 #include <pubkey.h>
+#include <script/interpreter.h>
 #include <script/script.h>
+#include <uint256.h>
+#include <util/hash_type.h>
 
+#include <algorithm>
 #include <cassert>
 #include <string>
+#include <vector>
 
 typedef std::vector<unsigned char> valtype;
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -5,6 +5,7 @@
 
 #include <script/standard.h>
 
+#include <hash.h>
 #include <pubkey.h>
 #include <script/script.h>
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28284

Original commit: 03a536f1ed

Backported from Bitcoin Core v0.26

## Changes:
- Removes confusing static_cast usage in address type constructors
- Adds missing includes (cassert)
- Note: In Dash, the addresstype code is located in script/standard.cpp rather than addresstype.cpp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the method of type conversion for certain hash-related constructors and functions to use direct initialization instead of explicit casting. No changes to application behavior or logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->