### PR TITLE
Merge bitcoin/bitcoin#26291: Update MANDATORY_SCRIPT_VERIFY_FLAGS

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -64,20 +64,31 @@ static constexpr unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT{101};
  */
 static constexpr unsigned int EXTRA_DESCENDANT_TX_SIZE_LIMIT{10000};
 /**
+ * Mandatory script verification flags that all new transactions must comply with for
+ * them to be valid. Failing one of these tests may trigger a DoS ban;
+ * see CheckInputScripts() for details.
+ *
+ * Note that this does not affect consensus validity; see GetBlockScriptFlags()
+ * for that.
+ */
+static constexpr unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY_P2SH |
+                                                             SCRIPT_VERIFY_DERSIG |
+                                                             SCRIPT_VERIFY_NULLDUMMY |
+                                                             SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
+                                                             SCRIPT_VERIFY_CHECKSEQUENCEVERIFY};
+
+/**
  * Standard script verification flags that standard transactions will comply
- * with. However scripts violating these flags may still be present in valid
- * blocks and we must accept those blocks.
+ * with. However we do not ban/disconnect nodes that forward txs violating
+ * the additional (non-mandatory) rules here, to improve forwards and
+ * backwards compatability.
  */
 static constexpr unsigned int STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRIPT_VERIFY_FLAGS |
-                                                             SCRIPT_VERIFY_DERSIG |
                                                              SCRIPT_VERIFY_STRICTENC |
                                                              SCRIPT_VERIFY_MINIMALDATA |
-                                                             SCRIPT_VERIFY_NULLDUMMY |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
                                                              SCRIPT_VERIFY_CLEANSTACK |
                                                              SCRIPT_VERIFY_NULLFAIL |
-                                                             SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
-                                                             SCRIPT_VERIFY_CHECKSEQUENCEVERIFY |
                                                              SCRIPT_VERIFY_LOW_S |
                                                              SCRIPT_VERIFY_CONST_SCRIPTCODE};
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -45,15 +45,6 @@ extern bool fAcceptDatacarrier;
 /** Maximum size of TxoutType::NULL_DATA scripts that this node considers standard. */
 extern unsigned nMaxDatacarrierBytes;
 
-/**
- * Mandatory script verification flags that all new blocks must comply with for
- * them to be valid. (but old blocks may not comply with) Currently just P2SH,
- * but in the future other flags may be added.
- *
- * Failing one of these tests may trigger a DoS ban - see CheckInputScripts() for
- * details.
- */
-static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;
 
 enum class TxoutType
 {

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -161,11 +161,11 @@ class BIP65Test(BitcoinTestFramework):
             cltv_invalidate(spendtx, i)
 
             expected_cltv_reject_reason = [
-                "non-mandatory-script-verify-flag (Operation not valid with the current stack size)",
-                "non-mandatory-script-verify-flag (Negative locktime)",
-                "non-mandatory-script-verify-flag (Locktime requirement not satisfied)",
-                "non-mandatory-script-verify-flag (Locktime requirement not satisfied)",
-                "non-mandatory-script-verify-flag (Locktime requirement not satisfied)",
+                "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)",
+                "mandatory-script-verify-flag-failed (Negative locktime)",
+                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)",
+                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)",
+                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)",
             ][i]
             # First we show that this tx is valid except for CLTV by getting it
             # rejected from the mempool for exactly that reason.

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -418,9 +418,9 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
         self.send_blocks([self.create_test_block([bip112tx_special_v1])], success=False,
-                         reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
+                         reject_reason='mandatory-script-verify-flag-failed (Negative locktime)')
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v1])], success=False,
-                         reject_reason='non-mandatory-script-verify-flag (Operation not valid with the current stack size)')
+                         reject_reason='mandatory-script-verify-flag-failed (Operation not valid with the current stack size)')
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 1 txs should still pass
 
         success_txs = [tx['tx'] for tx in bip112txs_vary_OP_CSV_v1 if tx['sdf']]
@@ -435,15 +435,15 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v1 if not tx['sdf']]
         for tx in fail_txs:
             self.send_blocks([self.create_test_block([tx])], success=False,
-                             reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+                             reject_reason='mandatory-script-verify-flag-failed (Locktime requirement not satisfied)')
 
         self.log.info("Test version 2 txs")
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
         self.send_blocks([self.create_test_block([bip112tx_special_v2])], success=False,
-                         reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
+                         reject_reason='mandatory-script-verify-flag-failed (Negative locktime)')
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v2])], success=False,
-                         reject_reason='non-mandatory-script-verify-flag (Operation not valid with the current stack size)')
+                         reject_reason='mandatory-script-verify-flag-failed (Operation not valid with the current stack size)')
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 2 txs should pass (all sequence locks are met)
         success_txs = [tx['tx'] for tx in bip112txs_vary_OP_CSV_v2 if tx['sdf']]
@@ -459,20 +459,20 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v2 if not tx['sdf']]
         for tx in fail_txs:
             self.send_blocks([self.create_test_block([tx])], success=False,
-                             reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+                             reject_reason='mandatory-script-verify-flag-failed (Locktime requirement not satisfied)')
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in nSequence, tx should fail
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if tx['sdf']]
         for tx in fail_txs:
             self.send_blocks([self.create_test_block([tx])], success=False,
-                             reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+                             reject_reason='mandatory-script-verify-flag-failed (Locktime requirement not satisfied)')
 
         # If sequencelock types mismatch, tx should fail
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if not tx['sdf'] and tx['stf']]
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_v2 if not tx['sdf'] and tx['stf']]
         for tx in fail_txs:
             self.send_blocks([self.create_test_block([tx])], success=False,
-                             reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+                             reject_reason='mandatory-script-verify-flag-failed (Locktime requirement not satisfied)')
 
         # Remaining txs should pass, just test masking works properly
         success_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if not tx['sdf'] and not tx['stf']]

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -17,7 +17,6 @@ from test_framework.script import CScript
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_raises_rpc_error,
 )
 from test_framework.wallet import (
     MiniWallet,

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -122,14 +122,22 @@ class BIP66Test(BitcoinTestFramework):
 
         # First we show that this tx is valid except for DERSIG by getting it
         # rejected from the mempool for exactly that reason.
-        assert_raises_rpc_error(-26, 'non-mandatory-script-verify-flag (Non-canonical DER signature)', self.nodes[0].sendrawtransaction, spendtx.serialize().hex(), 0)
+        assert_equal(
+            [{
+                'txid': spendtx.hash,
+                'wtxid': spendtx.getwtxid(),
+                'allowed': False,
+                'reject-reason': 'mandatory-script-verify-flag-failed (Non-canonical DER signature)',
+            }],
+            self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
+        )
 
         # Now we verify that a block with this transaction is also invalid.
         block.vtx.append(spendtx)
         block.hashMerkleRoot = block.calc_merkle_root()
         block.solve()
 
-        with self.nodes[0].assert_debug_log(expected_msgs=[f'CheckInputScripts on {block.vtx[-1].hash} failed with non-mandatory-script-verify-flag (Non-canonical DER signature)']):
+        with self.nodes[0].assert_debug_log(expected_msgs=[f'CheckInputScripts on {block.vtx[-1].hash} failed with mandatory-script-verify-flag-failed (Non-canonical DER signature)']):
             peer.send_and_ping(msg_block(block))
             assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
             peer.sync_with_ping()

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -30,7 +30,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 
-NULLDUMMY_ERROR = "non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
+NULLDUMMY_ERROR = "mandatory-script-verify-flag-failed (Dummy CHECKMULTISIG argument must be zero)"
 
 
 def invalidate_nulldummy_tx(tx):


### PR DESCRIPTION
Backports bitcoin/bitcoin#26291

Original commit: 8ff90d9dcf

Backported from Bitcoin Core v0.26

This PR updates the MANDATORY_SCRIPT_VERIFY_FLAGS to include post-p2sh soft forks that are enforced as consensus rules. The effect is that validation will report TX_CONSENSUS failures for txs that fail dersig/csv/cltv/nulldummy checks, instead of TX_NOT_STANDARD.

Note: Segwit and taproot-related flags have been excluded as they are not applicable to Dash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messages for script verification failures to clearly distinguish between mandatory and non-mandatory script verification flag failures.
  * Adjusted tests to expect new error messages for CHECKLOCKTIMEVERIFY, CHECKSEQUENCEVERIFY, DERSIG, and NULLDUMMY violations.

* **Chores**
  * Reorganized script verification flags to separate mandatory flags from standard flags for improved clarity in policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->