### PR TITLE
Merge bitcoin/bitcoin#28354: test: default acceptnonstdtxn=0 on all chains

### DIFF
--- a/doc/release-notes-28354.md
+++ b/doc/release-notes-28354.md
@@ -1,0 +1,6 @@
+Tests
+-----
+
+- Non-standard transactions are now disabled by default on testnet
+  for relay and mempool acceptance. The previous behaviour can be
+  re-enabled by setting `-acceptnonstdtxn=1`. (#28354)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -280,7 +280,6 @@ public:
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_400_85;
 
         fDefaultConsistencyChecks = false;
-        fRequireStandard = true;
         fRequireRoutableExternalIP = true;
         m_is_test_chain = false;
         fAllowMultipleAddressesFromGroup = false;
@@ -472,7 +471,6 @@ public:
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_50_60;
 
         fDefaultConsistencyChecks = false;
-        fRequireStandard = false;
         fRequireRoutableExternalIP = true;
         m_is_test_chain = true;
         fAllowMultipleAddressesFromGroup = false;
@@ -655,7 +653,6 @@ public:
         UpdateDevnetPowTargetSpacingFromArgs(args);
 
         fDefaultConsistencyChecks = false;
-        fRequireStandard = false;
         fRequireRoutableExternalIP = true;
         m_is_test_chain = true;
         fAllowMultipleAddressesFromGroup = true;
@@ -856,7 +853,6 @@ public:
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
 
         fDefaultConsistencyChecks = true;
-        fRequireStandard = true;
         fRequireRoutableExternalIP = false;
         m_is_test_chain = true;
         fAllowMultipleAddressesFromGroup = true;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -100,8 +100,6 @@ public:
     const CBlock& DevNetGenesisBlock() const { return devnetGenesis; }
     /** Default value for -checkmempool and -checkblockindex argument */
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
-    /** Policy: Filter transactions that do not match well-defined patterns */
-    bool RequireStandard() const { return fRequireStandard; }
     /** Require addresses specified with "-externalip" parameter to be routable */
     bool RequireRoutableExternalIP() const { return fRequireRoutableExternalIP; }
     /** If this chain allows time to be mocked */
@@ -170,7 +168,6 @@ protected:
     CBlock devnetGenesis;
     std::vector<uint8_t> vFixedSeeds;
     bool fDefaultConsistencyChecks;
-    bool fRequireStandard;
     bool fRequireRoutableExternalIP;
     bool m_is_test_chain;
     bool fAllowMultipleAddressesFromGroup;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -740,7 +740,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-masternodeblsprivkey=<hex>", "Set the masternode BLS private key and enable the client to act as a masternode", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::MASTERNODE);
     argsman.AddArg("-deprecated-platform-user=<user>", "Set the username for the \"platform user\", a restricted user intended to be used by Dash Platform, to the specified username.", ArgsManager::ALLOW_ANY, OptionsCategory::MASTERNODE);
 
-    argsman.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", !testnetChainParams->RequireStandard()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (test networks only; default: %u)", 0), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-dustrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to define dust, the value of an output such that it will cost more than its value in fees at this fee rate to spend it. (default: %s)", CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to define cost of relay, used for mempool limiting and BIP 125 replacement. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
@@ -1334,7 +1334,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         }
     }
 
-    fRequireStandard = !args.GetBoolArg("-acceptnonstdtxn", !chainparams.RequireStandard());
+    fRequireStandard = !args.GetBoolArg("-acceptnonstdtxn", 0);
     if (!chainparams.IsTestChain() && !fRequireStandard) {
         return InitError(strprintf(Untranslated("acceptnonstdtxn is not currently supported for %s chain"), chainparams.NetworkIDString()));
     }


### PR DESCRIPTION
Backports bitcoin/bitcoin#28354

Original commit: 5175ae482e

This PR changes `-acceptnonstdtxn` to default to 0 on all chains, including testnet. Previously testnet defaulted to 1 (accepting non-standard transactions).

Key changes:
- Changed the default value in `-acceptnonstdtxn` help text from chainparams-dependent to hardcoded 0
- Removed `fRequireStandard` field from chainparams as it's no longer needed
- Updated init.cpp to use the hardcoded default instead of querying chainparams

Note: Dash doesn't have the kernel/ subdirectory structure, so changes to Bitcoin's kernel/chainparams.* and kernel/mempool_options.h were applied to the equivalent Dash files.

Backported from Bitcoin Core v0.26