### PR TITLE
Merge bitcoin/bitcoin#28230: rpc: Add MaybeArg() and Arg() default helper

### DIFF
--- a/job_logs.txt
+++ b/job_logs.txt
@@ -1,0 +1,2038 @@
+﻿2025-07-28T03:42:33.6276099Z Current runner version: '2.326.0'
+2025-07-28T03:42:33.6307750Z ##[group]Runner Image Provisioner
+2025-07-28T03:42:33.6308994Z Hosted Compute Agent
+2025-07-28T03:42:33.6309863Z Version: 20250711.363
+2025-07-28T03:42:33.6310818Z Commit: 6785254374ce925a23743850c1cb91912ce5c14c
+2025-07-28T03:42:33.6311866Z Build Date: 2025-07-11T20:04:25Z
+2025-07-28T03:42:33.6312932Z ##[endgroup]
+2025-07-28T03:42:33.6313732Z ##[group]Operating System
+2025-07-28T03:42:33.6314938Z Ubuntu
+2025-07-28T03:42:33.6315650Z 24.04.2
+2025-07-28T03:42:33.6316397Z LTS
+2025-07-28T03:42:33.6317300Z ##[endgroup]
+2025-07-28T03:42:33.6318072Z ##[group]Runner Image
+2025-07-28T03:42:33.6318905Z Image: ubuntu-24.04
+2025-07-28T03:42:33.6319628Z Version: 20250720.1.0
+2025-07-28T03:42:33.6321443Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250720.1/images/ubuntu/Ubuntu2404-Readme.md
+2025-07-28T03:42:33.6324170Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250720.1
+2025-07-28T03:42:33.6325940Z ##[endgroup]
+2025-07-28T03:42:33.6327687Z ##[group]GITHUB_TOKEN Permissions
+2025-07-28T03:42:33.6330224Z Contents: read
+2025-07-28T03:42:33.6331079Z Metadata: read
+2025-07-28T03:42:33.6331944Z Packages: write
+2025-07-28T03:42:33.6332747Z ##[endgroup]
+2025-07-28T03:42:33.6336180Z Secret source: Actions
+2025-07-28T03:42:33.6337290Z Prepare workflow directory
+2025-07-28T03:42:33.7081720Z Prepare all required actions
+2025-07-28T03:42:33.7134937Z Getting action download info
+2025-07-28T03:42:33.9555771Z ##[group]Download immutable action package 'actions/checkout@v4'
+2025-07-28T03:42:33.9556757Z Version: 4.2.2
+2025-07-28T03:42:33.9557800Z Digest: sha256:ccb2698953eaebd21c7bf6268a94f9c26518a7e38e27e0b83c1fe1ad049819b1
+2025-07-28T03:42:33.9559041Z Source commit SHA: 11bd71901bbe5b1630ceea73d27597364c9af683
+2025-07-28T03:42:33.9559727Z ##[endgroup]
+2025-07-28T03:42:34.0678418Z ##[group]Download immutable action package 'actions/cache@v4'
+2025-07-28T03:42:34.0679159Z Version: 4.2.3
+2025-07-28T03:42:34.0679890Z Digest: sha256:c8a3bb963e1f1826d8fcc8d1354f0dd29d8ac1db1d4f6f20247055ae11b81ed9
+2025-07-28T03:42:34.0680961Z Source commit SHA: 5a3ec84eff668545956fd18022155c47e93e2684
+2025-07-28T03:42:34.0681608Z ##[endgroup]
+2025-07-28T03:42:34.2899635Z ##[group]Download immutable action package 'actions/upload-artifact@v4'
+2025-07-28T03:42:34.2900415Z Version: 4.6.2
+2025-07-28T03:42:34.2901199Z Digest: sha256:290722aa3281d5caf23d0acdc3dbeb3424786a1a01a9cc97e72f147225e37c38
+2025-07-28T03:42:34.2902117Z Source commit SHA: ea165f8d65b6e75b540449e92b4886f43607fa02
+2025-07-28T03:42:34.2902830Z ##[endgroup]
+2025-07-28T03:42:34.4851095Z Uses: DashCoreAutoGuix/dash/.github/workflows/build-src.yml@refs/heads/backport-0.26-batch-469-pr-28230 (d7489329b91ee7d179382933bdd1aca951aaa44e)
+2025-07-28T03:42:34.4855941Z ##[group] Inputs
+2025-07-28T03:42:34.4856413Z   build-target: linux64
+2025-07-28T03:42:34.4857240Z   container-path: ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-469-pr-28230
+2025-07-28T03:42:34.4859430Z   depends-key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-28T03:42:34.4861214Z ##[endgroup]
+2025-07-28T03:42:34.4861631Z Complete job name: linux64-build / Build source
+2025-07-28T03:42:34.5306933Z ##[group]Checking docker version
+2025-07-28T03:42:34.5319718Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2025-07-28T03:42:34.5913639Z '1.48'
+2025-07-28T03:42:34.5937945Z Docker daemon API version: '1.48'
+2025-07-28T03:42:34.5939149Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2025-07-28T03:42:34.6146899Z '1.48'
+2025-07-28T03:42:34.6169091Z Docker client API version: '1.48'
+2025-07-28T03:42:34.6174982Z ##[endgroup]
+2025-07-28T03:42:34.6179948Z ##[group]Clean up resources from previous jobs
+2025-07-28T03:42:34.6186764Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=ee50f2"
+2025-07-28T03:42:34.6376864Z ##[command]/usr/bin/docker network prune --force --filter "label=ee50f2"
+2025-07-28T03:42:34.6570658Z ##[endgroup]
+2025-07-28T03:42:34.6571402Z ##[group]Create local container network
+2025-07-28T03:42:34.6585173Z ##[command]/usr/bin/docker network create --label ee50f2 github_network_77fcdfaa515a4f78ba21d9d19c7d9447
+2025-07-28T03:42:34.7239623Z 95848c37f18ec0cd1e199a6ed84512c341b9ab5b655431992ba022d58f9ec7f9
+2025-07-28T03:42:34.7259713Z ##[endgroup]
+2025-07-28T03:42:34.7282407Z ##[group]Starting job container
+2025-07-28T03:42:34.7310665Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_e6e2d7dd-96ec-4566-8316-cd2245e9af99 login ghcr.io -u DashCoreAutoGuix --password-stdin
+2025-07-28T03:42:34.8737809Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_e6e2d7dd-96ec-4566-8316-cd2245e9af99 pull ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-469-pr-28230
+2025-07-28T03:42:35.1052254Z backport-0.26-batch-469-pr-28230: Pulling from dashcoreautoguix/dash/dashcore-ci-runner
+2025-07-28T03:42:35.1463872Z 32f112e3802c: Pulling fs layer
+2025-07-28T03:42:35.1464992Z 3c418bbf5534: Pulling fs layer
+2025-07-28T03:42:35.1465692Z 824b5144f7af: Pulling fs layer
+2025-07-28T03:42:35.1466463Z bb9f5c709011: Pulling fs layer
+2025-07-28T03:42:35.1467178Z c31b5eed60b6: Pulling fs layer
+2025-07-28T03:42:35.1467856Z da96180e845f: Pulling fs layer
+2025-07-28T03:42:35.1468543Z f28d6a4cf5de: Pulling fs layer
+2025-07-28T03:42:35.1469275Z 49cbdb9e902d: Pulling fs layer
+2025-07-28T03:42:35.1469954Z 247fd41058fa: Pulling fs layer
+2025-07-28T03:42:35.1470635Z d6a01b6e446c: Pulling fs layer
+2025-07-28T03:42:35.1471314Z 4f4fb700ef54: Pulling fs layer
+2025-07-28T03:42:35.1471978Z 1382f2390a1c: Pulling fs layer
+2025-07-28T03:42:35.1472666Z be38403a389e: Pulling fs layer
+2025-07-28T03:42:35.1473365Z 409781d99354: Pulling fs layer
+2025-07-28T03:42:35.1474266Z c418b82685d0: Pulling fs layer
+2025-07-28T03:42:35.1474991Z bb9f5c709011: Waiting
+2025-07-28T03:42:35.1475667Z d6a01b6e446c: Waiting
+2025-07-28T03:42:35.1476322Z c31b5eed60b6: Waiting
+2025-07-28T03:42:35.1476977Z 4f4fb700ef54: Waiting
+2025-07-28T03:42:35.1477607Z 1382f2390a1c: Waiting
+2025-07-28T03:42:35.1478246Z be38403a389e: Waiting
+2025-07-28T03:42:35.1478877Z da96180e845f: Waiting
+2025-07-28T03:42:35.1479503Z 247fd41058fa: Waiting
+2025-07-28T03:42:35.1480157Z 409781d99354: Waiting
+2025-07-28T03:42:35.1480827Z f28d6a4cf5de: Waiting
+2025-07-28T03:42:35.1481497Z c418b82685d0: Waiting
+2025-07-28T03:42:35.1482718Z 49cbdb9e902d: Waiting
+2025-07-28T03:42:35.2301824Z 824b5144f7af: Verifying Checksum
+2025-07-28T03:42:35.2303515Z 824b5144f7af: Download complete
+2025-07-28T03:42:35.2496274Z 3c418bbf5534: Verifying Checksum
+2025-07-28T03:42:35.2499556Z 3c418bbf5534: Download complete
+2025-07-28T03:42:35.2782342Z 32f112e3802c: Verifying Checksum
+2025-07-28T03:42:35.2784270Z 32f112e3802c: Download complete
+2025-07-28T03:42:35.4955665Z c31b5eed60b6: Verifying Checksum
+2025-07-28T03:42:35.4963049Z c31b5eed60b6: Download complete
+2025-07-28T03:42:35.5388513Z da96180e845f: Verifying Checksum
+2025-07-28T03:42:35.5398980Z da96180e845f: Download complete
+2025-07-28T03:42:35.5630092Z f28d6a4cf5de: Download complete
+2025-07-28T03:42:35.6062126Z 49cbdb9e902d: Verifying Checksum
+2025-07-28T03:42:35.6065348Z 49cbdb9e902d: Download complete
+2025-07-28T03:42:35.6517803Z d6a01b6e446c: Verifying Checksum
+2025-07-28T03:42:35.6522352Z d6a01b6e446c: Download complete
+2025-07-28T03:42:35.7009790Z 4f4fb700ef54: Verifying Checksum
+2025-07-28T03:42:35.7015322Z 4f4fb700ef54: Download complete
+2025-07-28T03:42:35.7324388Z bb9f5c709011: Verifying Checksum
+2025-07-28T03:42:35.7325067Z bb9f5c709011: Download complete
+2025-07-28T03:42:36.2448195Z be38403a389e: Verifying Checksum
+2025-07-28T03:42:36.2448949Z be38403a389e: Download complete
+2025-07-28T03:42:36.3272730Z 409781d99354: Verifying Checksum
+2025-07-28T03:42:36.3273331Z 409781d99354: Download complete
+2025-07-28T03:42:36.3875715Z c418b82685d0: Verifying Checksum
+2025-07-28T03:42:36.3877105Z c418b82685d0: Download complete
+2025-07-28T03:42:36.4342663Z 247fd41058fa: Verifying Checksum
+2025-07-28T03:42:36.4343701Z 247fd41058fa: Download complete
+2025-07-28T03:42:36.8952656Z 32f112e3802c: Pull complete
+2025-07-28T03:42:38.1636085Z 1382f2390a1c: Verifying Checksum
+2025-07-28T03:42:38.1636620Z 1382f2390a1c: Download complete
+2025-07-28T03:42:40.5945366Z 3c418bbf5534: Pull complete
+2025-07-28T03:42:40.7396775Z 824b5144f7af: Pull complete
+2025-07-28T03:42:44.8382513Z bb9f5c709011: Pull complete
+2025-07-28T03:42:48.3396983Z c31b5eed60b6: Pull complete
+2025-07-28T03:42:49.3693182Z da96180e845f: Pull complete
+2025-07-28T03:42:49.4266900Z f28d6a4cf5de: Pull complete
+2025-07-28T03:42:49.4717666Z 49cbdb9e902d: Pull complete
+2025-07-28T03:42:55.4917365Z 247fd41058fa: Pull complete
+2025-07-28T03:42:55.5161849Z d6a01b6e446c: Pull complete
+2025-07-28T03:42:55.5302852Z 4f4fb700ef54: Pull complete
+2025-07-28T03:43:10.3850256Z 1382f2390a1c: Pull complete
+2025-07-28T03:43:14.1861462Z be38403a389e: Pull complete
+2025-07-28T03:43:14.2845977Z 409781d99354: Pull complete
+2025-07-28T03:43:14.3037080Z c418b82685d0: Pull complete
+2025-07-28T03:43:14.3096710Z Digest: sha256:98318d90de6b26cdb45dc6eda94df435f0b6fc679a90718a99cb36cc996953ee
+2025-07-28T03:43:14.3113195Z Status: Downloaded newer image for ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-469-pr-28230
+2025-07-28T03:43:14.3127836Z ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-469-pr-28230
+2025-07-28T03:43:14.3208725Z ##[command]/usr/bin/docker create --name ae769c4d4db949fc90cc49122e63579d_ghcriodashcoreautoguixdashdashcorecirunnerbackport026batch469pr28230_1bd3a3 --label ee50f2 --workdir /__w/dash/dash --network github_network_77fcdfaa515a4f78ba21d9d19c7d9447 --user root -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" -v "/home/runner/actions-runner/cached/externals":"/__e":ro -v "/home/runner/work/_temp":"/__w/_temp" -v "/home/runner/work/_actions":"/__w/_actions" -v "/opt/hostedtoolcache":"/__t" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.26-batch-469-pr-28230 "-f" "/dev/null"
+2025-07-28T03:43:14.3516000Z c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7
+2025-07-28T03:43:14.3538058Z ##[command]/usr/bin/docker start c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7
+2025-07-28T03:43:14.5253247Z c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7
+2025-07-28T03:43:14.5273141Z ##[command]/usr/bin/docker ps --all --filter id=c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7 --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2025-07-28T03:43:14.5387493Z c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7 Up Less than a second
+2025-07-28T03:43:14.5405928Z ##[command]/usr/bin/docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7
+2025-07-28T03:43:14.5524810Z HOME=/github/home
+2025-07-28T03:43:14.5525196Z GITHUB_ACTIONS=true
+2025-07-28T03:43:14.5525508Z CI=true
+2025-07-28T03:43:14.5526885Z PATH=/opt/shellcheck:/usr/local/pyenv/shims:/usr/local/pyenv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+2025-07-28T03:43:14.5527903Z DEBIAN_FRONTEND=noninteractive
+2025-07-28T03:43:14.5528265Z TZ=Europe/London
+2025-07-28T03:43:14.5528659Z APT_ARGS=-y --no-install-recommends --no-upgrade
+2025-07-28T03:43:14.5529112Z PYENV_ROOT=/usr/local/pyenv
+2025-07-28T03:43:14.5529485Z LD_LIBRARY_PATH=/usr/lib/llvm-18/lib
+2025-07-28T03:43:14.5546729Z ##[endgroup]
+2025-07-28T03:43:14.5555967Z ##[group]Waiting for all services to be ready
+2025-07-28T03:43:14.5557692Z ##[endgroup]
+2025-07-28T03:43:14.5786144Z ##[group]Run actions/checkout@v4
+2025-07-28T03:43:14.5786663Z with:
+2025-07-28T03:43:14.5786847Z   fetch-depth: 50
+2025-07-28T03:43:14.5787260Z   repository: DashCoreAutoGuix/dash
+2025-07-28T03:43:14.5787647Z   token: ***
+2025-07-28T03:43:14.5787822Z   ssh-strict: true
+2025-07-28T03:43:14.5788009Z   ssh-user: git
+2025-07-28T03:43:14.5788192Z   persist-credentials: true
+2025-07-28T03:43:14.5788408Z   clean: true
+2025-07-28T03:43:14.5788598Z   sparse-checkout-cone-mode: true
+2025-07-28T03:43:14.5788818Z   fetch-tags: false
+2025-07-28T03:43:14.5789005Z   show-progress: true
+2025-07-28T03:43:14.5789181Z   lfs: false
+2025-07-28T03:43:14.5789345Z   submodules: false
+2025-07-28T03:43:14.5789522Z   set-safe-directory: true
+2025-07-28T03:43:14.5789935Z ##[endgroup]
+2025-07-28T03:43:14.5904546Z ##[command]/usr/bin/docker exec  c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-28T03:43:14.8005024Z Syncing repository: DashCoreAutoGuix/dash
+2025-07-28T03:43:14.8006924Z ##[group]Getting Git version info
+2025-07-28T03:43:14.8007446Z Working directory is '/__w/dash/dash'
+2025-07-28T03:43:14.8008277Z [command]/usr/bin/git version
+2025-07-28T03:43:14.8008711Z git version 2.43.0
+2025-07-28T03:43:14.8030830Z ##[endgroup]
+2025-07-28T03:43:14.8044797Z Temporarily overriding HOME='/__w/_temp/8fa6bd76-60d1-4fa8-945b-2c45f512a007' before making global git config changes
+2025-07-28T03:43:14.8045640Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-28T03:43:14.8051116Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-28T03:43:14.8089458Z Deleting the contents of '/__w/dash/dash'
+2025-07-28T03:43:14.8093712Z ##[group]Initializing the repository
+2025-07-28T03:43:14.8097465Z [command]/usr/bin/git init /__w/dash/dash
+2025-07-28T03:43:14.8127164Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-07-28T03:43:14.8128459Z hint: is subject to change. To configure the initial branch name to use in all
+2025-07-28T03:43:14.8129984Z hint: of your new repositories, which will suppress this warning, call:
+2025-07-28T03:43:14.8130636Z hint: 
+2025-07-28T03:43:14.8131086Z hint: 	git config --global init.defaultBranch <name>
+2025-07-28T03:43:14.8131573Z hint: 
+2025-07-28T03:43:14.8132044Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-07-28T03:43:14.8132823Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-07-28T03:43:14.8133457Z hint: 
+2025-07-28T03:43:14.8133749Z hint: 	git branch -m <name>
+2025-07-28T03:43:14.8135246Z Initialized empty Git repository in /__w/dash/dash/.git/
+2025-07-28T03:43:14.8146900Z [command]/usr/bin/git remote add origin https://github.com/DashCoreAutoGuix/dash
+2025-07-28T03:43:14.8174814Z ##[endgroup]
+2025-07-28T03:43:14.8175167Z ##[group]Disabling automatic garbage collection
+2025-07-28T03:43:14.8179636Z [command]/usr/bin/git config --local gc.auto 0
+2025-07-28T03:43:14.8206603Z ##[endgroup]
+2025-07-28T03:43:14.8207215Z ##[group]Setting up auth
+2025-07-28T03:43:14.8213798Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-28T03:43:14.8241425Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-28T03:43:14.8446760Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-28T03:43:14.8473548Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-28T03:43:14.8672198Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-07-28T03:43:14.8704756Z ##[endgroup]
+2025-07-28T03:43:14.8705385Z ##[group]Fetching the repository
+2025-07-28T03:43:14.8713707Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=50 origin +d7489329b91ee7d179382933bdd1aca951aaa44e:refs/remotes/origin/backport-0.26-batch-469-pr-28230
+2025-07-28T03:43:16.8326141Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-28T03:43:16.8327043Z  * [new ref]         d7489329b91ee7d179382933bdd1aca951aaa44e -> origin/backport-0.26-batch-469-pr-28230
+2025-07-28T03:43:16.8350315Z ##[endgroup]
+2025-07-28T03:43:16.8350672Z ##[group]Determining the checkout info
+2025-07-28T03:43:16.8353264Z ##[endgroup]
+2025-07-28T03:43:16.8358383Z [command]/usr/bin/git sparse-checkout disable
+2025-07-28T03:43:16.8394634Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-07-28T03:43:16.8421788Z ##[group]Checking out the ref
+2025-07-28T03:43:16.8426820Z [command]/usr/bin/git checkout --progress --force -B backport-0.26-batch-469-pr-28230 refs/remotes/origin/backport-0.26-batch-469-pr-28230
+2025-07-28T03:43:17.2278925Z Switched to a new branch 'backport-0.26-batch-469-pr-28230'
+2025-07-28T03:43:17.2279780Z branch 'backport-0.26-batch-469-pr-28230' set up to track 'origin/backport-0.26-batch-469-pr-28230'.
+2025-07-28T03:43:17.2304455Z ##[endgroup]
+2025-07-28T03:43:17.2341858Z [command]/usr/bin/git log -1 --format=%H
+2025-07-28T03:43:17.2363093Z d7489329b91ee7d179382933bdd1aca951aaa44e
+2025-07-28T03:43:17.2585770Z ##[group]Run git config --global --add safe.directory "$PWD"
+2025-07-28T03:43:17.2586223Z [36;1mgit config --global --add safe.directory "$PWD"[0m
+2025-07-28T03:43:17.2586560Z [36;1mgit fetch -fu origin develop:develop[0m
+2025-07-28T03:43:17.2586829Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-28T03:43:17.2587060Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-28T03:43:17.2587314Z [36;1mecho "HOST=${HOST}" >> $GITHUB_OUTPUT[0m
+2025-07-28T03:43:17.2587593Z [36;1mecho "PR_BASE_SHA=" >> $GITHUB_OUTPUT[0m
+2025-07-28T03:43:17.2591531Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-28T03:43:17.2591832Z ##[endgroup]
+2025-07-28T03:43:17.4672147Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-28T03:43:17.4672703Z  * [new branch]      develop    -> develop
+2025-07-28T03:43:17.4673228Z  * [new branch]      develop    -> origin/develop
+2025-07-28T03:43:17.4739613Z Setting specific values in env
+2025-07-28T03:43:17.4740235Z Fallback to default values in env (if not yet set)
+2025-07-28T03:43:17.5233638Z ##[group]Run actions/cache/restore@v4
+2025-07-28T03:43:17.5234158Z with:
+2025-07-28T03:43:17.5234409Z   path: depends/built
+depends/x86_64-pc-linux-gnu
+
+2025-07-28T03:43:17.5235410Z   key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-28T03:43:17.5236371Z   fail-on-cache-miss: true
+2025-07-28T03:43:17.5236588Z   enableCrossOsArchive: false
+2025-07-28T03:43:17.5236801Z   lookup-only: false
+2025-07-28T03:43:17.5236988Z ##[endgroup]
+2025-07-28T03:43:17.5240360Z ##[command]/usr/bin/docker exec  c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-28T03:43:17.8705181Z Cache hit for: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-28T03:43:18.4142087Z Received 90046447 of 90046447 (100.0%), 169.4 MBs/sec
+2025-07-28T03:43:18.4145043Z Cache Size: ~86 MB (90046447 B)
+2025-07-28T03:43:18.4172684Z [command]/usr/bin/tar -xf /__w/_temp/0ebed2b5-68b0-4ec1-8e09-d18ac980aef6/cache.tzst -P -C /__w/dash/dash --use-compress-program unzstd
+2025-07-28T03:43:19.7170227Z Cache restored successfully
+2025-07-28T03:43:19.7409664Z Cache restored from key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-28T03:43:19.9068103Z ##[group]Run actions/cache@v4
+2025-07-28T03:43:19.9068353Z with:
+2025-07-28T03:43:19.9068525Z   path: /cache
+
+2025-07-28T03:43:19.9069219Z   key: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-d7489329b91ee7d179382933bdd1aca951aaa44e
+2025-07-28T03:43:19.9069983Z   restore-keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-
+
+2025-07-28T03:43:19.9070430Z   enableCrossOsArchive: false
+2025-07-28T03:43:19.9070649Z   fail-on-cache-miss: false
+2025-07-28T03:43:19.9070862Z   lookup-only: false
+2025-07-28T03:43:19.9071046Z   save-always: false
+2025-07-28T03:43:19.9071227Z ##[endgroup]
+2025-07-28T03:43:19.9074753Z ##[command]/usr/bin/docker exec  c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-28T03:43:20.2280477Z Cache not found for input keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-d7489329b91ee7d179382933bdd1aca951aaa44e, ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64-
+2025-07-28T03:43:20.2374974Z ##[group]Run CCACHE_SIZE="400M"
+2025-07-28T03:43:20.2375292Z [36;1mCCACHE_SIZE="400M"[0m
+2025-07-28T03:43:20.2375516Z [36;1mCACHE_DIR="/cache"[0m
+2025-07-28T03:43:20.2375728Z [36;1mmkdir /output[0m
+2025-07-28T03:43:20.2375937Z [36;1mBASE_OUTDIR="/output"[0m
+2025-07-28T03:43:20.2376154Z [36;1mBUILD_TARGET="linux64"[0m
+2025-07-28T03:43:20.2376391Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-28T03:43:20.2376624Z [36;1m./ci/dash/build_src.sh[0m
+2025-07-28T03:43:20.2376849Z [36;1mccache -X 9[0m
+2025-07-28T03:43:20.2377038Z [36;1mccache -c[0m
+2025-07-28T03:43:20.2377379Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-28T03:43:20.2377652Z ##[endgroup]
+2025-07-28T03:43:20.2935465Z Setting specific values in env
+2025-07-28T03:43:20.2935954Z Fallback to default values in env (if not yet set)
+2025-07-28T03:43:20.3308982Z Setting specific values in env
+2025-07-28T03:43:20.3309326Z Fallback to default values in env (if not yet set)
+2025-07-28T03:43:20.4065303Z Statistics zeroed
+2025-07-28T03:43:20.4065748Z Set cache size limit to 400.0 MB
+2025-07-28T03:43:25.2870832Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-28T03:43:25.2871577Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-28T03:43:25.3155198Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-28T03:43:25.3155977Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-28T03:43:25.3450109Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-28T03:43:25.3775095Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-28T03:43:25.4109120Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-28T03:43:25.4430634Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-28T03:43:27.4674783Z configure.ac:38: installing 'build-aux/compile'
+2025-07-28T03:43:27.4692288Z configure.ac:12: installing 'build-aux/config.guess'
+2025-07-28T03:43:27.4710427Z configure.ac:12: installing 'build-aux/config.sub'
+2025-07-28T03:43:27.4728329Z configure.ac:17: installing 'build-aux/install-sh'
+2025-07-28T03:43:27.4746746Z configure.ac:17: installing 'build-aux/missing'
+2025-07-28T03:43:27.5374866Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-28T03:43:29.8741131Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-28T03:43:29.8741848Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-28T03:43:29.8979207Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-28T03:43:29.8979931Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-28T03:43:29.9182343Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-28T03:43:29.9389075Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-28T03:43:29.9596675Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-28T03:43:29.9806008Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-28T03:43:31.4250406Z configure.ac:39: installing 'build-aux/ar-lib'
+2025-07-28T03:43:31.4268015Z configure.ac:37: installing 'build-aux/compile'
+2025-07-28T03:43:31.4286317Z configure.ac:24: installing 'build-aux/config.guess'
+2025-07-28T03:43:31.4304259Z configure.ac:24: installing 'build-aux/config.sub'
+2025-07-28T03:43:31.4321620Z configure.ac:27: installing 'build-aux/install-sh'
+2025-07-28T03:43:31.4340514Z configure.ac:27: installing 'build-aux/missing'
+2025-07-28T03:43:31.4674978Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-28T03:43:31.5009203Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-28T03:43:31.5930205Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-28T03:43:31.5930929Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-28T03:43:31.6192281Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-28T03:43:31.6192763Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-28T03:43:31.6612725Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-28T03:43:31.7044236Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-28T03:43:31.7471915Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-28T03:43:31.7901792Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-28T03:43:34.3628742Z configure.ac:105: installing 'build-aux/compile'
+2025-07-28T03:43:34.3646005Z configure.ac:48: installing 'build-aux/config.guess'
+2025-07-28T03:43:34.3664454Z configure.ac:48: installing 'build-aux/config.sub'
+2025-07-28T03:43:34.3681423Z configure.ac:55: installing 'build-aux/install-sh'
+2025-07-28T03:43:34.3699806Z configure.ac:55: installing 'build-aux/missing'
+2025-07-28T03:43:34.6147273Z src/Makefile.am: installing 'build-aux/depcomp'
+2025-07-28T03:43:37.1475015Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-28T03:43:37.3321769Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-28T03:43:37.3396921Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-28T03:43:37.3410773Z checking pkg-config is at least version 0.9.0... yes
+2025-07-28T03:43:37.3857529Z checking build system type... x86_64-pc-linux-gnu
+2025-07-28T03:43:37.3905615Z checking host system type... x86_64-pc-linux-gnu
+2025-07-28T03:43:37.3986390Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-28T03:43:37.4015149Z checking whether build environment is sane... yes
+2025-07-28T03:43:37.4074702Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-28T03:43:37.4096674Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-28T03:43:37.4101533Z checking for gawk... gawk
+2025-07-28T03:43:37.4165638Z checking whether make sets $(MAKE)... yes
+2025-07-28T03:43:37.4221115Z checking whether make supports nested variables... yes
+2025-07-28T03:43:37.4266078Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-28T03:43:37.4268848Z checking whether make supports nested variables... (cached) yes
+2025-07-28T03:43:37.4818830Z checking whether the C++ compiler works... yes
+2025-07-28T03:43:37.4819443Z checking for C++ compiler default output file name... a.out
+2025-07-28T03:43:37.5142611Z checking for suffix of executables... 
+2025-07-28T03:43:37.5590450Z checking whether we are cross compiling... no
+2025-07-28T03:43:37.5754761Z checking for suffix of object files... o
+2025-07-28T03:43:37.5895853Z checking whether the compiler supports GNU C++... yes
+2025-07-28T03:43:37.6054387Z checking whether g++ -m64 accepts -g... yes
+2025-07-28T03:43:37.8833719Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-28T03:43:37.9304688Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-28T03:43:37.9379304Z checking whether make supports the include directive... yes (GNU style)
+2025-07-28T03:43:37.9382998Z checking dependency style of g++ -m64... none
+2025-07-28T03:43:38.0168748Z checking whether g++ -m64 supports C++20 features with -std=c++20... yes
+2025-07-28T03:43:38.0171023Z checking for x86_64-pc-linux-gnu-g++... g++ -m64 -std=c++20
+2025-07-28T03:43:38.0462792Z checking whether the compiler supports GNU Objective C++... no
+2025-07-28T03:43:38.0734824Z checking whether g++ -m64 -std=c++20 accepts -g... no
+2025-07-28T03:43:38.0737551Z checking dependency style of g++ -m64 -std=c++20... none
+2025-07-28T03:43:38.0762700Z checking how to print strings... printf
+2025-07-28T03:43:38.0765417Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-28T03:43:38.1145887Z checking whether the compiler supports GNU C... yes
+2025-07-28T03:43:38.1296520Z checking whether gcc -m64 accepts -g... yes
+2025-07-28T03:43:38.1646862Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-28T03:43:38.1911057Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-28T03:43:38.1914571Z checking dependency style of gcc -m64... none
+2025-07-28T03:43:38.1954221Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-28T03:43:38.1985143Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-28T03:43:38.2000791Z checking for egrep... /usr/bin/grep -E
+2025-07-28T03:43:38.2016785Z checking for fgrep... /usr/bin/grep -F
+2025-07-28T03:43:38.2064207Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-28T03:43:38.2088969Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-28T03:43:38.2091220Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-28T03:43:38.2372453Z checking the name lister (nm) interface... BSD nm
+2025-07-28T03:43:38.2373024Z checking whether ln -s works... yes
+2025-07-28T03:43:38.2417945Z checking the maximum length of command line arguments... 3145728
+2025-07-28T03:43:38.2445985Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-28T03:43:38.2447452Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-28T03:43:38.2448415Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-28T03:43:38.2454583Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-28T03:43:38.2459654Z checking for file... file
+2025-07-28T03:43:38.2465010Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:43:38.2470219Z checking for objdump... objdump
+2025-07-28T03:43:38.2474622Z checking how to recognize dependent libraries... pass_all
+2025-07-28T03:43:38.2479838Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-28T03:43:38.2507227Z checking for dlltool... no
+2025-07-28T03:43:38.2507807Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-28T03:43:38.2508429Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:43:38.2833116Z checking for archiver @FILE support... @
+2025-07-28T03:43:38.2833802Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-28T03:43:38.2837393Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-28T03:43:38.3498240Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-28T03:43:38.3514625Z checking for sysroot... no
+2025-07-28T03:43:38.3558145Z checking for a working dd... /usr/bin/dd
+2025-07-28T03:43:38.3596294Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-28T03:43:38.3697662Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-28T03:43:38.3702624Z checking for mt... no
+2025-07-28T03:43:38.3733552Z checking if : is a manifest tool... no
+2025-07-28T03:43:38.3876582Z checking for stdio.h... yes
+2025-07-28T03:43:38.4035760Z checking for stdlib.h... yes
+2025-07-28T03:43:38.4203092Z checking for string.h... yes
+2025-07-28T03:43:38.4374569Z checking for inttypes.h... yes
+2025-07-28T03:43:38.4545222Z checking for stdint.h... yes
+2025-07-28T03:43:38.4719781Z checking for strings.h... yes
+2025-07-28T03:43:38.4898576Z checking for sys/stat.h... yes
+2025-07-28T03:43:38.5079871Z checking for sys/types.h... yes
+2025-07-28T03:43:38.5281218Z checking for unistd.h... yes
+2025-07-28T03:43:38.5485649Z checking for dlfcn.h... yes
+2025-07-28T03:43:38.5523594Z checking for objdir... .libs
+2025-07-28T03:43:38.6109048Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-28T03:43:38.6110043Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:43:38.6244287Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:43:38.6811570Z checking if gcc -m64 static flag -static works... yes
+2025-07-28T03:43:38.7023569Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-28T03:43:38.7024409Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-28T03:43:38.7117855Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:43:38.7321685Z checking whether -lc should be explicitly linked in... no
+2025-07-28T03:43:38.7805509Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-28T03:43:38.7806469Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:43:38.7823471Z checking whether stripping libraries is possible... yes
+2025-07-28T03:43:38.7825027Z checking if libtool supports shared libraries... yes
+2025-07-28T03:43:38.7825562Z checking whether to build shared libraries... yes
+2025-07-28T03:43:38.7826355Z checking whether to build static libraries... yes
+2025-07-28T03:43:38.8084403Z checking how to run the C++ preprocessor... g++ -m64 -std=c++20 -E
+2025-07-28T03:43:38.8821279Z checking for ld used by g++ -m64 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-28T03:43:38.8846182Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-28T03:43:38.8915752Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:43:38.9507724Z checking for g++ -m64 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:43:38.9656448Z checking if g++ -m64 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:43:39.0244111Z checking if g++ -m64 -std=c++20 static flag -static works... yes
+2025-07-28T03:43:39.0470823Z checking if g++ -m64 -std=c++20 supports -c -o file.o... yes
+2025-07-28T03:43:39.0471399Z checking if g++ -m64 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-28T03:43:39.0472061Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:43:39.0519511Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-28T03:43:39.0521262Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:43:39.0529278Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-28T03:43:39.0536402Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-28T03:43:39.0541041Z checking for gcov... /usr/bin/gcov
+2025-07-28T03:43:39.0546375Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-28T03:43:39.0551659Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-28T03:43:39.0556593Z checking for lcov... no
+2025-07-28T03:43:39.0560314Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-28T03:43:39.0565634Z checking for genhtml... no
+2025-07-28T03:43:39.0569632Z checking for git... /usr/bin/git
+2025-07-28T03:43:39.0573223Z checking for ccache... /usr/bin/ccache
+2025-07-28T03:43:39.0578111Z checking for xgettext... /usr/bin/xgettext
+2025-07-28T03:43:39.0581924Z checking for hexdump... /usr/bin/hexdump
+2025-07-28T03:43:39.0587287Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-28T03:43:39.0592196Z checking for objcopy... /usr/bin/objcopy
+2025-07-28T03:43:39.0596750Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:43:39.0600880Z checking for objdump... /usr/bin/objdump
+2025-07-28T03:43:39.0605973Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-28T03:43:39.0611016Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-28T03:43:39.0616084Z checking for doxygen... no
+2025-07-28T03:43:39.0769883Z checking whether C++ compiler accepts -Werror... yes
+2025-07-28T03:43:39.1122839Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-28T03:43:39.1553279Z checking for execinfo.h... yes
+2025-07-28T03:43:39.1907933Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-28T03:43:39.2103672Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-28T03:43:39.2278173Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-28T03:43:39.2449878Z checking whether C++ compiler accepts -Wattributes... yes
+2025-07-28T03:43:39.2619925Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-28T03:43:39.2791338Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-28T03:43:39.2966142Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-28T03:43:39.3151493Z checking whether C++ compiler accepts -Wall... yes
+2025-07-28T03:43:39.3328459Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-28T03:43:39.3466516Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-28T03:43:39.3641285Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-28T03:43:39.3812538Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-28T03:43:39.3987806Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-28T03:43:39.4163041Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-28T03:43:39.4362792Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-28T03:43:39.4553755Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-28T03:43:39.4729356Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-28T03:43:39.4975504Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-28T03:43:39.5149248Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-28T03:43:39.5411273Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-28T03:43:39.5583818Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-28T03:43:39.5756801Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-28T03:43:39.5927370Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-28T03:43:39.6097391Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-28T03:43:39.6267606Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-28T03:43:39.6436640Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-28T03:43:39.6606491Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-28T03:43:39.6800480Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-28T03:43:39.6974079Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-28T03:43:39.7146262Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-28T03:43:39.7318057Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-28T03:43:39.7463185Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-28T03:43:39.7634537Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-28T03:43:39.7805073Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-28T03:43:39.7980860Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-28T03:43:39.8153308Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-28T03:43:40.2792297Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-28T03:43:40.3236256Z checking for SSE4.2 intrinsics... yes
+2025-07-28T03:43:40.7561970Z checking for SSE4.1 intrinsics... yes
+2025-07-28T03:43:41.1793038Z checking for AVX2 intrinsics... yes
+2025-07-28T03:43:41.6194427Z checking for x86 SHA-NI intrinsics... yes
+2025-07-28T03:43:41.6363585Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-28T03:43:41.6519147Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-28T03:43:41.6659570Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-28T03:43:41.6806274Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-28T03:43:41.7621235Z checking whether byte ordering is bigendian... no
+2025-07-28T03:43:41.7838838Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-28T03:43:41.8137073Z checking whether gcc -m64 is Clang... no
+2025-07-28T03:43:41.8586283Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-28T03:43:41.8931894Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-28T03:43:41.8932998Z checking whether more special flags are required for pthreads... no
+2025-07-28T03:43:41.9288589Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-28T03:43:42.7495016Z checking whether std::atomic can be used without link library... yes
+2025-07-28T03:43:42.7502925Z checking for special C compiler options needed for large files... no
+2025-07-28T03:43:42.7697624Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-28T03:43:42.8016109Z checking for g++ -m64 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-28T03:43:42.8511224Z checking whether strerror_r is declared... yes
+2025-07-28T03:43:42.8733006Z checking whether strerror_r returns char *... yes
+2025-07-28T03:43:42.8882220Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-28T03:43:42.9033315Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-28T03:43:42.9182015Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-28T03:43:42.9333126Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-28T03:43:42.9507449Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-28T03:43:42.9591878Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-28T03:43:42.9675754Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-28T03:43:42.9925318Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-28T03:43:43.0172271Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-28T03:43:43.0421562Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-28T03:43:43.0670002Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-28T03:43:43.1043654Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-28T03:43:43.1417001Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-28T03:43:43.1788834Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-28T03:43:43.2157218Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-28T03:43:43.2580761Z checking for sys/select.h... yes
+2025-07-28T03:43:43.3001616Z checking for sys/prctl.h... yes
+2025-07-28T03:43:43.3320694Z checking for vm/vm_param.h... no
+2025-07-28T03:43:43.3632776Z checking for sys/vmmeter.h... no
+2025-07-28T03:43:43.3942048Z checking for sys/resources.h... no
+2025-07-28T03:43:43.4219437Z checking whether getifaddrs is declared... yes
+2025-07-28T03:43:43.4662774Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-28T03:43:43.4954400Z checking whether freeifaddrs is declared... yes
+2025-07-28T03:43:43.5400257Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-28T03:43:43.5916753Z checking whether fork is declared... yes
+2025-07-28T03:43:43.6422650Z checking whether setsid is declared... yes
+2025-07-28T03:43:43.6921564Z checking whether pipe2 is declared... yes
+2025-07-28T03:43:43.7152197Z checking for mallopt M_ARENA_MAX... yes
+2025-07-28T03:43:43.7388121Z checking for getmemoryinfo... yes
+2025-07-28T03:43:43.7585192Z checking for posix_fallocate... yes
+2025-07-28T03:43:43.7731315Z checking for default visibility attribute... yes
+2025-07-28T03:43:43.7880578Z checking for dllexport attribute... no
+2025-07-28T03:43:44.2655540Z checking for thread_local support... yes
+2025-07-28T03:43:44.2937874Z checking for Linux getrandom syscall... yes
+2025-07-28T03:43:44.3251127Z checking for getentropy via random.h... yes
+2025-07-28T03:43:44.3444507Z checking for sysctl... no
+2025-07-28T03:43:44.3637098Z checking for sysctl KERN_ARND... no
+2025-07-28T03:43:44.4001843Z checking for library containing backtrace... none required
+2025-07-28T03:43:44.4244514Z checking for fdatasync... yes
+2025-07-28T03:43:44.4449439Z checking for F_FULLFSYNC... no
+2025-07-28T03:43:44.4657566Z checking for O_CLOEXEC... yes
+2025-07-28T03:43:44.4814261Z checking for __builtin_prefetch... yes
+2025-07-28T03:43:44.5217749Z checking for _mm_prefetch... yes
+2025-07-28T03:43:44.5418387Z checking for strong getauxval support in the system headers... yes
+2025-07-28T03:43:44.5685082Z checking for sockaddr_un... yes
+2025-07-28T03:43:44.6158571Z checking for std::system... yes
+2025-07-28T03:43:44.6442321Z checking for ::_wsystem... no
+2025-07-28T03:43:44.6608848Z checking for Qt5Core >= 5.11.3... yes
+2025-07-28T03:43:44.6717160Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-28T03:43:44.6827524Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-28T03:43:44.6935622Z checking for Qt5Network >= 5.11.3... yes
+2025-07-28T03:43:44.7043523Z checking for Qt5Test >= 5.11.3... yes
+2025-07-28T03:43:44.7150610Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-28T03:43:44.9232701Z checking for static Qt... yes
+2025-07-28T03:43:44.9348011Z checking for Qt5AccessibilitySupport... yes
+2025-07-28T03:43:44.9456407Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-28T03:43:44.9566109Z checking for Qt5EdidSupport... yes
+2025-07-28T03:43:44.9679141Z checking for Qt5EventDispatcherSupport... yes
+2025-07-28T03:43:44.9790711Z checking for Qt5FbSupport... yes
+2025-07-28T03:43:44.9901723Z checking for Qt5FontDatabaseSupport... yes
+2025-07-28T03:43:45.0013232Z checking for Qt5ThemeSupport... yes
+2025-07-28T03:43:45.0125875Z checking for Qt5InputSupport... yes
+2025-07-28T03:43:45.0239791Z checking for Qt5ServiceSupport... yes
+2025-07-28T03:43:45.0366783Z checking for Qt5XcbQpa... yes
+2025-07-28T03:43:45.0479586Z checking for Qt5XkbCommonSupport... yes
+2025-07-28T03:43:47.0005568Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-28T03:43:49.0570304Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-28T03:43:49.2664802Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-28T03:43:49.2677479Z checking for moc-qt5... no
+2025-07-28T03:43:49.2678214Z checking for moc5... no
+2025-07-28T03:43:49.2679875Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-28T03:43:49.2682927Z checking for uic-qt5... no
+2025-07-28T03:43:49.2683355Z checking for uic5... no
+2025-07-28T03:43:49.2686645Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-28T03:43:49.2688223Z checking for rcc-qt5... no
+2025-07-28T03:43:49.2690097Z checking for rcc5... no
+2025-07-28T03:43:49.2692171Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-28T03:43:49.2693136Z checking for lrelease-qt5... no
+2025-07-28T03:43:49.2695395Z checking for lrelease5... no
+2025-07-28T03:43:49.2697434Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-28T03:43:49.2699245Z checking for lupdate-qt5... no
+2025-07-28T03:43:49.2700265Z checking for lupdate5... no
+2025-07-28T03:43:49.2702476Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-28T03:43:49.2704790Z checking for lconvert-qt5... no
+2025-07-28T03:43:49.2705593Z checking for lconvert5... no
+2025-07-28T03:43:49.2707608Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-28T03:43:49.2738522Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-28T03:43:49.2739818Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-28T03:43:50.1211154Z checking for Berkeley DB C++ headers... default
+2025-07-28T03:43:50.1604654Z checking for main in -ldb_cxx-4.8... yes
+2025-07-28T03:43:50.1753790Z checking for sqlite3 >= 3.7.17... yes
+2025-07-28T03:43:50.1755168Z checking whether to build wallet with support for sqlite... yes
+2025-07-28T03:43:50.1947951Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-28T03:43:50.2424054Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-28T03:43:50.2831966Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-28T03:43:50.3282545Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-28T03:43:50.3321625Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-28T03:43:50.3798583Z checking for miniupnpc/upnperrors.h... yes
+2025-07-28T03:43:50.3837014Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-28T03:43:50.3917833Z checking whether miniUPnPc API version is supported... yes
+2025-07-28T03:43:50.4400631Z checking for natpmp.h... yes
+2025-07-28T03:43:50.4753185Z checking for initnatpmp in -lnatpmp... yes
+2025-07-28T03:43:50.4828386Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-28T03:43:50.4831176Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-28T03:43:50.4832425Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-28T03:43:50.4833482Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-28T03:43:50.4834894Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-28T03:43:50.4974375Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-28T03:43:50.5259721Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-28T03:43:53.3354862Z checking for Boost Process... yes
+2025-07-28T03:43:53.3571483Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-28T03:43:53.3948406Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-28T03:43:53.4209355Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-28T03:43:53.4328526Z checking for libevent >= 2.1.8... yes
+2025-07-28T03:43:53.4442049Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-28T03:43:53.4777422Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-28T03:43:53.4903052Z checking for libqrencode... yes
+2025-07-28T03:43:53.5017026Z checking for libzmq >= 4... yes
+2025-07-28T03:43:53.5589822Z checking for gmp.h... yes
+2025-07-28T03:43:53.5950904Z checking for __gmpz_init in -lgmp... yes
+2025-07-28T03:43:53.6065846Z checking for libmultiprocess... no
+2025-07-28T03:43:53.6146746Z checking whether to build dashd... yes
+2025-07-28T03:43:53.6148172Z checking whether to build dash-cli... yes
+2025-07-28T03:43:53.6148797Z checking whether to build dash-tx... yes
+2025-07-28T03:43:53.6150880Z checking whether to build dash-wallet... yes
+2025-07-28T03:43:53.6151376Z checking whether to build libraries... no
+2025-07-28T03:43:53.6154189Z checking if ccache should be used... yes
+2025-07-28T03:43:53.6427048Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-28T03:43:53.6541344Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-28T03:43:53.6543679Z checking if wallet should be enabled... yes
+2025-07-28T03:43:53.6545866Z checking whether to build with support for UPnP... yes
+2025-07-28T03:43:53.6546825Z checking whether to build with support for NAT-PMP... yes
+2025-07-28T03:43:53.6549224Z checking whether to build GUI with support for D-Bus... yes
+2025-07-28T03:43:53.6551377Z checking whether to build GUI with support for QR codes... yes
+2025-07-28T03:43:53.6552140Z checking whether to build test_dash-qt... yes
+2025-07-28T03:43:53.6552642Z checking whether to build test_dash... yes
+2025-07-28T03:43:53.6553286Z checking whether to reduce exports... yes
+2025-07-28T03:43:53.6686468Z checking whether dsymutil needs -flat... yes
+2025-07-28T03:43:53.6686852Z 
+2025-07-28T03:43:53.7124612Z checking that generated files are newer than configure... done
+2025-07-28T03:43:53.7131160Z configure: creating ./config.status
+2025-07-28T03:43:54.3565413Z config.status: creating Makefile
+2025-07-28T03:43:54.3689033Z config.status: creating src/Makefile
+2025-07-28T03:43:54.4259782Z config.status: creating doc/man/Makefile
+2025-07-28T03:43:54.4421347Z config.status: creating share/setup.nsi
+2025-07-28T03:43:54.4585006Z config.status: creating share/qt/Info.plist
+2025-07-28T03:43:54.4751671Z config.status: creating test/config.ini
+2025-07-28T03:43:54.4911490Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-28T03:43:54.5080954Z config.status: creating src/config/bitcoin-config.h
+2025-07-28T03:43:54.5251330Z config.status: linking ../contrib/filter-lcov.py to contrib/filter-lcov.py
+2025-07-28T03:43:54.5316126Z config.status: linking ../src/.bear-tidy-config to src/.bear-tidy-config
+2025-07-28T03:43:54.5381863Z config.status: linking ../src/.clang-tidy to src/.clang-tidy
+2025-07-28T03:43:54.5458000Z config.status: linking ../test/functional/test_runner.py to test/functional/test_runner.py
+2025-07-28T03:43:54.5533579Z config.status: linking ../test/fuzz/test_runner.py to test/fuzz/test_runner.py
+2025-07-28T03:43:54.5609373Z config.status: linking ../test/util/test_runner.py to test/util/test_runner.py
+2025-07-28T03:43:54.5674794Z config.status: linking ../test/util/rpcauth-test.py to test/util/rpcauth-test.py
+2025-07-28T03:43:54.5705975Z config.status: executing depfiles commands
+2025-07-28T03:43:54.5720238Z config.status: executing libtool commands
+2025-07-28T03:43:54.5835525Z === configuring in src/dashbls (/__w/dash/dash/build-ci/src/dashbls)
+2025-07-28T03:43:54.5891747Z configure: running /bin/bash ../../../src/dashbls/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/dashbls
+2025-07-28T03:43:54.7057286Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-28T03:43:54.7534430Z checking build system type... x86_64-pc-linux-gnu
+2025-07-28T03:43:54.7581489Z checking host system type... x86_64-pc-linux-gnu
+2025-07-28T03:43:54.7658273Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-28T03:43:54.7686613Z checking whether build environment is sane... yes
+2025-07-28T03:43:54.7746236Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-28T03:43:54.7767033Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-28T03:43:54.7770627Z checking for gawk... gawk
+2025-07-28T03:43:54.7833596Z checking whether make sets $(MAKE)... yes
+2025-07-28T03:43:54.7889642Z checking whether make supports nested variables... yes
+2025-07-28T03:43:54.7934194Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-28T03:43:54.7935099Z checking whether make supports nested variables... (cached) yes
+2025-07-28T03:43:54.7938243Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-28T03:43:54.8480359Z checking whether the C compiler works... yes
+2025-07-28T03:43:54.8480861Z checking for C compiler default output file name... a.out
+2025-07-28T03:43:54.8761988Z checking for suffix of executables... 
+2025-07-28T03:43:54.9118182Z checking whether we are cross compiling... no
+2025-07-28T03:43:54.9273390Z checking for suffix of object files... o
+2025-07-28T03:43:54.9412237Z checking whether the compiler supports GNU C... yes
+2025-07-28T03:43:54.9560307Z checking whether gcc -m64 accepts -g... yes
+2025-07-28T03:43:54.9902661Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-28T03:43:55.0162892Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-28T03:43:55.0235876Z checking whether make supports the include directive... yes (GNU style)
+2025-07-28T03:43:55.0239665Z checking dependency style of gcc -m64... none
+2025-07-28T03:43:55.0573015Z checking whether the compiler supports GNU C++... yes
+2025-07-28T03:43:55.0735116Z checking whether g++ -m64 accepts -g... yes
+2025-07-28T03:43:55.3545971Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-28T03:43:55.4015566Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-28T03:43:55.4018150Z checking dependency style of g++ -m64... none
+2025-07-28T03:43:55.4404338Z checking whether g++ -m64 supports C++14 features with -std=c++14... yes
+2025-07-28T03:43:55.4428552Z checking how to print strings... printf
+2025-07-28T03:43:55.4467015Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-28T03:43:55.4497197Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-28T03:43:55.4512679Z checking for egrep... /usr/bin/grep -E
+2025-07-28T03:43:55.4527840Z checking for fgrep... /usr/bin/grep -F
+2025-07-28T03:43:55.4574601Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-28T03:43:55.4598403Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-28T03:43:55.4600418Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-28T03:43:55.4880354Z checking the name lister (nm) interface... BSD nm
+2025-07-28T03:43:55.4880909Z checking whether ln -s works... yes
+2025-07-28T03:43:55.4921511Z checking the maximum length of command line arguments... 3145728
+2025-07-28T03:43:55.4947323Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-28T03:43:55.4948502Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-28T03:43:55.4949364Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-28T03:43:55.4953619Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-28T03:43:55.4958143Z checking for file... file
+2025-07-28T03:43:55.4962358Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:43:55.4966918Z checking for objdump... objdump
+2025-07-28T03:43:55.4971038Z checking how to recognize dependent libraries... pass_all
+2025-07-28T03:43:55.4975704Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-28T03:43:55.4980354Z checking for dlltool... no
+2025-07-28T03:43:55.4981819Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-28T03:43:55.4983870Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:43:55.5311360Z checking for archiver @FILE support... @
+2025-07-28T03:43:55.5312695Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-28T03:43:55.5315734Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-28T03:43:55.5973109Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-28T03:43:55.5989057Z checking for sysroot... no
+2025-07-28T03:43:55.6030774Z checking for a working dd... /usr/bin/dd
+2025-07-28T03:43:55.6068911Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-28T03:43:55.6167198Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-28T03:43:55.6171654Z checking for mt... no
+2025-07-28T03:43:55.6201863Z checking if : is a manifest tool... no
+2025-07-28T03:43:55.6344693Z checking for stdio.h... yes
+2025-07-28T03:43:55.6505052Z checking for stdlib.h... yes
+2025-07-28T03:43:55.6671760Z checking for string.h... yes
+2025-07-28T03:43:55.6846639Z checking for inttypes.h... yes
+2025-07-28T03:43:55.7016084Z checking for stdint.h... yes
+2025-07-28T03:43:55.7188078Z checking for strings.h... yes
+2025-07-28T03:43:55.7365275Z checking for sys/stat.h... yes
+2025-07-28T03:43:55.7546218Z checking for sys/types.h... yes
+2025-07-28T03:43:55.7749389Z checking for unistd.h... yes
+2025-07-28T03:43:55.7954208Z checking for dlfcn.h... yes
+2025-07-28T03:43:55.7988539Z checking for objdir... .libs
+2025-07-28T03:43:55.8568255Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-28T03:43:55.8570121Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:43:55.8703046Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:43:55.9261541Z checking if gcc -m64 static flag -static works... yes
+2025-07-28T03:43:55.9474872Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-28T03:43:55.9475972Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-28T03:43:55.9568981Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:43:56.0051121Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-28T03:43:56.0052413Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:43:56.0073056Z checking whether stripping libraries is possible... yes
+2025-07-28T03:43:56.0074518Z checking if libtool supports shared libraries... yes
+2025-07-28T03:43:56.0074967Z checking whether to build shared libraries... no
+2025-07-28T03:43:56.0075312Z checking whether to build static libraries... yes
+2025-07-28T03:43:56.0329184Z checking how to run the C++ preprocessor... g++ -m64 -std=c++14 -E
+2025-07-28T03:43:56.1064309Z checking for ld used by g++ -m64 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-28T03:43:56.1089287Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-28T03:43:56.1159759Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:43:56.1752204Z checking for g++ -m64 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:43:56.1901613Z checking if g++ -m64 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:43:56.2485263Z checking if g++ -m64 -std=c++14 static flag -static works... yes
+2025-07-28T03:43:56.2710141Z checking if g++ -m64 -std=c++14 supports -c -o file.o... yes
+2025-07-28T03:43:56.2710895Z checking if g++ -m64 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-28T03:43:56.2713061Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:43:56.2758898Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-28T03:43:56.2760162Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:43:56.2768025Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-28T03:43:56.2773857Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-28T03:43:56.2776070Z checking for ranlib... (cached) ranlib
+2025-07-28T03:43:56.2781296Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-28T03:43:56.2783210Z checking for strip... (cached) strip
+2025-07-28T03:43:56.2787211Z checking dependency style of gcc -m64... none
+2025-07-28T03:43:56.2930986Z checking whether C compiler accepts -Werror... yes
+2025-07-28T03:43:56.3181979Z checking for gmp.h... yes
+2025-07-28T03:43:56.3502224Z checking for __gmpz_init in -lgmp... yes
+2025-07-28T03:43:56.3678593Z checking gmp version >= 6.2... yes
+2025-07-28T03:43:56.3706889Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-28T03:43:56.3718435Z checking pkg-config is at least version 0.9.0... yes
+2025-07-28T03:43:56.3807152Z checking if gcc -m64 supports -pipe... yes
+2025-07-28T03:43:56.3903642Z checking if gcc -m64 supports -fomit-frame-pointer... yes
+2025-07-28T03:43:56.4149655Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-28T03:43:56.4448755Z checking whether gcc -m64 is Clang... no
+2025-07-28T03:43:56.4886429Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-28T03:43:56.5234678Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-28T03:43:56.5235508Z checking whether more special flags are required for pthreads... no
+2025-07-28T03:43:56.5587735Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-28T03:43:56.5918289Z checking for library containing clock_gettime... none required
+2025-07-28T03:43:56.6090573Z checking whether C compiler accepts -fPIC... yes
+2025-07-28T03:43:56.6256697Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-28T03:43:56.6400967Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-28T03:43:56.6567509Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-28T03:43:56.6727494Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-28T03:43:56.6885751Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-28T03:43:56.7102357Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-28T03:43:56.7319048Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-28T03:43:56.7536933Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-28T03:43:56.7753669Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-28T03:43:56.8065180Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-28T03:43:56.8373834Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-28T03:43:56.8691445Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-28T03:43:56.9000904Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-28T03:43:56.9177396Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-28T03:43:56.9179457Z checking whether to build runtest... yes
+2025-07-28T03:43:56.9180073Z checking whether to build runbench... yes
+2025-07-28T03:43:56.9408810Z checking that generated files are newer than configure... done
+2025-07-28T03:43:56.9413660Z configure: creating ./config.status
+2025-07-28T03:43:57.4747833Z config.status: creating Makefile
+2025-07-28T03:43:57.4961344Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-28T03:43:57.5101829Z config.status: executing depfiles commands
+2025-07-28T03:43:57.5114988Z config.status: executing libtool commands
+2025-07-28T03:43:57.5241652Z 
+2025-07-28T03:43:57.5242109Z Options used to compile and link:
+2025-07-28T03:43:57.5242645Z   target os           = linux
+2025-07-28T03:43:57.5243009Z   backend             = gmp
+2025-07-28T03:43:57.5243358Z   build bench         = yes
+2025-07-28T03:43:57.5243726Z   build test          = yes
+2025-07-28T03:43:57.5244285Z   use debug           = no
+2025-07-28T03:43:57.5244561Z   use hardening       = yes
+2025-07-28T03:43:57.5244770Z   use optimizations   = yes
+2025-07-28T03:43:57.5244920Z 
+2025-07-28T03:43:57.5245107Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-28T03:43:57.5246372Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-28T03:43:57.5247503Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-28T03:43:57.5248504Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-28T03:43:57.5249182Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-28T03:43:57.5249363Z 
+2025-07-28T03:43:57.5598516Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/src/secp256k1)
+2025-07-28T03:43:57.5653304Z configure: running /bin/bash ../../../src/secp256k1/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/secp256k1
+2025-07-28T03:43:57.6800994Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-28T03:43:57.7300028Z checking build system type... x86_64-pc-linux-gnu
+2025-07-28T03:43:57.7347754Z checking host system type... x86_64-pc-linux-gnu
+2025-07-28T03:43:57.7425686Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-28T03:43:57.7452807Z checking whether build environment is sane... yes
+2025-07-28T03:43:57.7512660Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-28T03:43:57.7533308Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-28T03:43:57.7537357Z checking for gawk... gawk
+2025-07-28T03:43:57.7598476Z checking whether make sets $(MAKE)... yes
+2025-07-28T03:43:57.7650069Z checking whether make supports nested variables... yes
+2025-07-28T03:43:57.7691383Z checking whether make supports nested variables... (cached) yes
+2025-07-28T03:43:57.7694774Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-28T03:43:57.8236254Z checking whether the C compiler works... yes
+2025-07-28T03:43:57.8237206Z checking for C compiler default output file name... a.out
+2025-07-28T03:43:57.8519982Z checking for suffix of executables... 
+2025-07-28T03:43:57.8876897Z checking whether we are cross compiling... no
+2025-07-28T03:43:57.9033461Z checking for suffix of object files... o
+2025-07-28T03:43:57.9167053Z checking whether the compiler supports GNU C... yes
+2025-07-28T03:43:57.9314847Z checking whether gcc -m64 accepts -g... yes
+2025-07-28T03:43:57.9661227Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-28T03:43:57.9923603Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-28T03:43:57.9996132Z checking whether make supports the include directive... yes (GNU style)
+2025-07-28T03:43:57.9998424Z checking dependency style of gcc -m64... none
+2025-07-28T03:43:58.0002224Z checking dependency style of gcc -m64... none
+2025-07-28T03:43:58.0004738Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:43:58.0263235Z checking the archiver (ar) interface... ar
+2025-07-28T03:43:58.0285844Z checking how to print strings... printf
+2025-07-28T03:43:58.0325013Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-28T03:43:58.0353560Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-28T03:43:58.0368914Z checking for egrep... /usr/bin/grep -E
+2025-07-28T03:43:58.0383832Z checking for fgrep... /usr/bin/grep -F
+2025-07-28T03:43:58.0429790Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-28T03:43:58.0452988Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-28T03:43:58.0455177Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-28T03:43:58.0725772Z checking the name lister (nm) interface... BSD nm
+2025-07-28T03:43:58.0726328Z checking whether ln -s works... yes
+2025-07-28T03:43:58.0767200Z checking the maximum length of command line arguments... 3145728
+2025-07-28T03:43:58.0793322Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-28T03:43:58.0794829Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-28T03:43:58.0795702Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-28T03:43:58.0800327Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-28T03:43:58.0804789Z checking for file... file
+2025-07-28T03:43:58.0809151Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:43:58.0814120Z checking for objdump... objdump
+2025-07-28T03:43:58.0817954Z checking how to recognize dependent libraries... pass_all
+2025-07-28T03:43:58.0822301Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-28T03:43:58.0826962Z checking for dlltool... no
+2025-07-28T03:43:58.0828464Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-28T03:43:58.0830461Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:43:58.1171549Z checking for archiver @FILE support... @
+2025-07-28T03:43:58.1173676Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-28T03:43:58.1174817Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-28T03:43:58.1846912Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-28T03:43:58.1863551Z checking for sysroot... no
+2025-07-28T03:43:58.1905178Z checking for a working dd... /usr/bin/dd
+2025-07-28T03:43:58.1943534Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-28T03:43:58.2044878Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-28T03:43:58.2049098Z checking for mt... no
+2025-07-28T03:43:58.2079806Z checking if : is a manifest tool... no
+2025-07-28T03:43:58.2229147Z checking for stdio.h... yes
+2025-07-28T03:43:58.2393403Z checking for stdlib.h... yes
+2025-07-28T03:43:58.2560255Z checking for string.h... yes
+2025-07-28T03:43:58.2736369Z checking for inttypes.h... yes
+2025-07-28T03:43:58.2910955Z checking for stdint.h... yes
+2025-07-28T03:43:58.3092182Z checking for strings.h... yes
+2025-07-28T03:43:58.3272585Z checking for sys/stat.h... yes
+2025-07-28T03:43:58.3451783Z checking for sys/types.h... yes
+2025-07-28T03:43:58.3657145Z checking for unistd.h... yes
+2025-07-28T03:43:58.3863118Z checking for dlfcn.h... yes
+2025-07-28T03:43:58.3902075Z checking for objdir... .libs
+2025-07-28T03:43:58.4492378Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-28T03:43:58.4493341Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:43:58.4629589Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:43:58.5191830Z checking if gcc -m64 static flag -static works... yes
+2025-07-28T03:43:58.5402858Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-28T03:43:58.5403489Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-28T03:43:58.5497752Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:43:58.5977368Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-28T03:43:58.5978126Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:43:58.5994715Z checking whether stripping libraries is possible... yes
+2025-07-28T03:43:58.5995484Z checking if libtool supports shared libraries... yes
+2025-07-28T03:43:58.5996298Z checking whether to build shared libraries... no
+2025-07-28T03:43:58.5997305Z checking whether to build static libraries... yes
+2025-07-28T03:43:58.6101581Z checking if gcc -m64 supports -Werror... yes
+2025-07-28T03:43:58.6197171Z checking if gcc -m64 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-28T03:43:58.6289329Z checking if gcc -m64 supports -Wno-overlength-strings... yes
+2025-07-28T03:43:58.6381207Z checking if gcc -m64 supports -Wall... yes
+2025-07-28T03:43:58.6471972Z checking if gcc -m64 supports -Wno-unused-function... yes
+2025-07-28T03:43:58.6561965Z checking if gcc -m64 supports -Wextra... yes
+2025-07-28T03:43:58.6654161Z checking if gcc -m64 supports -Wcast-align... yes
+2025-07-28T03:43:58.6745003Z checking if gcc -m64 supports -Wcast-align=strict... yes
+2025-07-28T03:43:58.6980619Z checking if gcc -m64 supports -Wconditional-uninitialized... no
+2025-07-28T03:43:58.7183709Z checking if gcc -m64 supports -Wreserved-identifier... no
+2025-07-28T03:43:58.7275558Z checking if gcc -m64 supports -fvisibility=hidden... yes
+2025-07-28T03:43:58.7418337Z checking for valgrind support... 
+2025-07-28T03:43:58.7749250Z checking for x86_64 assembly availability... yes
+2025-07-28T03:43:58.7973797Z checking that generated files are newer than configure... done
+2025-07-28T03:43:58.7977181Z configure: creating ./config.status
+2025-07-28T03:43:59.1895487Z config.status: creating Makefile
+2025-07-28T03:43:59.2020756Z config.status: creating libsecp256k1.pc
+2025-07-28T03:43:59.2128881Z config.status: executing depfiles commands
+2025-07-28T03:43:59.2142828Z config.status: executing libtool commands
+2025-07-28T03:43:59.2229533Z 
+2025-07-28T03:43:59.2229750Z Build Options:
+2025-07-28T03:43:59.2230082Z   with external callbacks = no
+2025-07-28T03:43:59.2230481Z   with benchmarks         = no
+2025-07-28T03:43:59.2230837Z   with tests              = yes
+2025-07-28T03:43:59.2231187Z   with ctime tests        = no
+2025-07-28T03:43:59.2231569Z   with coverage           = no
+2025-07-28T03:43:59.2231942Z   with examples           = no
+2025-07-28T03:43:59.2232258Z   module ecdh             = no
+2025-07-28T03:43:59.2232574Z   module recovery         = yes
+2025-07-28T03:43:59.2232938Z   module extrakeys        = yes
+2025-07-28T03:43:59.2233326Z   module schnorrsig       = yes
+2025-07-28T03:43:59.2233685Z   module ellswift         = yes
+2025-07-28T03:43:59.2234103Z 
+2025-07-28T03:43:59.2234223Z   asm                     = x86_64
+2025-07-28T03:43:59.2234596Z   ecmult window size      = 15
+2025-07-28T03:43:59.2234895Z   ecmult gen prec. bits   = 4
+2025-07-28T03:43:59.2235058Z 
+2025-07-28T03:43:59.2235134Z   valgrind                = no
+2025-07-28T03:43:59.2235364Z   CC                      = gcc -m64
+2025-07-28T03:43:59.2235718Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-28T03:43:59.2236899Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-28T03:43:59.2238367Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-28T03:43:59.2238790Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-28T03:43:59.2540541Z 
+2025-07-28T03:43:59.2540771Z Options used to compile and link:
+2025-07-28T03:43:59.2541212Z   boost process       = yes
+2025-07-28T03:43:59.2541586Z   multiprocess        = no
+2025-07-28T03:43:59.2541934Z   with libs           = no
+2025-07-28T03:43:59.2542229Z   with wallet         = yes
+2025-07-28T03:43:59.2542552Z     with sqlite       = yes
+2025-07-28T03:43:59.2543177Z     with bdb          = yes
+2025-07-28T03:43:59.2543553Z   with gui / qt       = yes
+2025-07-28T03:43:59.2544326Z     with qr           = yes
+2025-07-28T03:43:59.2544673Z   with zmq            = yes
+2025-07-28T03:43:59.2547309Z   with test           = yes
+2025-07-28T03:43:59.2547796Z   with fuzz binary    = no
+2025-07-28T03:43:59.2548138Z   with bench          = yes
+2025-07-28T03:43:59.2548469Z   with upnp           = yes
+2025-07-28T03:43:59.2548758Z   with natpmp         = yes
+2025-07-28T03:43:59.2548969Z   USDT tracing        = yes
+2025-07-28T03:43:59.2549179Z   sanitizers          = 
+2025-07-28T03:43:59.2549390Z   debug enabled       = no
+2025-07-28T03:43:59.2549599Z   stacktraces enabled = yes
+2025-07-28T03:43:59.2549805Z   crash hooks enabled = no
+2025-07-28T03:43:59.2549994Z   miner enabled       = yes
+2025-07-28T03:43:59.2550194Z   gprof enabled       = no
+2025-07-28T03:43:59.2550387Z   werror              = yes
+2025-07-28T03:43:59.2550509Z 
+2025-07-28T03:43:59.2550587Z   target os           = linux-gnu
+2025-07-28T03:43:59.2550825Z   build os            = linux-gnu
+2025-07-28T03:43:59.2550980Z 
+2025-07-28T03:43:59.2551079Z   CC                  = /usr/bin/ccache gcc -m64
+2025-07-28T03:43:59.2551451Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-28T03:43:59.2552221Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-28T03:43:59.2552921Z   CXX                 = /usr/bin/ccache g++ -m64 -std=c++20
+2025-07-28T03:43:59.2555965Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-28T03:43:59.2560212Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-28T03:43:59.2561203Z   AR                  = ar
+2025-07-28T03:43:59.2561552Z   ARFLAGS             = cr
+2025-07-28T03:43:59.2561788Z 
+2025-07-28T03:43:59.3151215Z make  distdir-am
+2025-07-28T03:43:59.3205542Z make[1]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-28T03:43:59.3206635Z if test -d "dashcore-linux64"; then find "dashcore-linux64" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "dashcore-linux64" || { sleep 5 && rm -rf "dashcore-linux64"; }; else :; fi
+2025-07-28T03:43:59.3220255Z test -d "dashcore-linux64" || mkdir "dashcore-linux64"
+2025-07-28T03:43:59.5352394Z  (cd src && make  top_distdir=../dashcore-linux64 distdir=../dashcore-linux64/src \
+2025-07-28T03:43:59.5353161Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-28T03:43:59.5601321Z make[2]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-28T03:43:59.5602005Z make  distdir-am
+2025-07-28T03:43:59.6910088Z make[3]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-28T03:43:59.7745955Z Generated bench/data/block813851.raw.h
+2025-07-28T03:43:59.7964465Z Generated test/data/blockfilters.json.h
+2025-07-28T03:43:59.8045146Z Generated test/data/base58_encode_decode.json.h
+2025-07-28T03:43:59.8133069Z Generated test/data/bip39_vectors.json.h
+2025-07-28T03:43:59.8223351Z Generated test/data/key_io_valid.json.h
+2025-07-28T03:43:59.8305040Z Generated test/data/key_io_invalid.json.h
+2025-07-28T03:43:59.8385763Z Generated test/data/proposals_valid.json.h
+2025-07-28T03:43:59.8467271Z Generated test/data/proposals_invalid.json.h
+2025-07-28T03:43:59.8813136Z Generated test/data/script_tests.json.h
+2025-07-28T03:43:59.9095843Z Generated test/data/sighash.json.h
+2025-07-28T03:43:59.9188075Z Generated test/data/trivially_invalid.json.h
+2025-07-28T03:43:59.9289408Z Generated test/data/trivially_valid.json.h
+2025-07-28T03:43:59.9408374Z Generated test/data/tx_invalid.json.h
+2025-07-28T03:43:59.9531662Z Generated test/data/tx_valid.json.h
+2025-07-28T03:43:59.9611345Z Generated test/data/asmap.raw.h
+2025-07-28T03:44:02.4522013Z  (cd secp256k1 && make  top_distdir=../../dashcore-linux64 distdir=../../dashcore-linux64/src/secp256k1 \
+2025-07-28T03:44:02.4523041Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-28T03:44:02.4560915Z make[4]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-28T03:44:02.4561485Z make  distdir-am
+2025-07-28T03:44:02.4675746Z make[5]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-28T03:44:02.4676284Z :
+2025-07-28T03:44:02.4676711Z test -d "../../dashcore-linux64/src/secp256k1" || mkdir "../../dashcore-linux64/src/secp256k1"
+2025-07-28T03:44:02.6846457Z test -n ":" \
+2025-07-28T03:44:02.6847043Z || find "../../dashcore-linux64/src/secp256k1" -type d ! -perm -755 \
+2025-07-28T03:44:02.6847701Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-28T03:44:02.6848219Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-28T03:44:02.6848761Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-28T03:44:02.6849545Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/src/secp256k1/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-28T03:44:02.6850331Z || chmod -R a+r "../../dashcore-linux64/src/secp256k1"
+2025-07-28T03:44:02.6861438Z make[5]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-28T03:44:02.6864580Z make[4]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-28T03:44:02.6870233Z make[3]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-28T03:44:02.6880142Z make[2]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-28T03:44:02.7144312Z  (cd doc/man && make  top_distdir=../../dashcore-linux64 distdir=../../dashcore-linux64/doc/man \
+2025-07-28T03:44:02.7145208Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-28T03:44:02.7166699Z make[2]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-28T03:44:02.7167210Z make  distdir-am
+2025-07-28T03:44:02.7199070Z make[3]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-28T03:44:02.7369662Z make[3]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-28T03:44:02.7371528Z make[2]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-28T03:44:02.7375719Z make  \
+2025-07-28T03:44:02.7376291Z   top_distdir="dashcore-linux64" distdir="dashcore-linux64" \
+2025-07-28T03:44:02.7376856Z   dist-hook
+2025-07-28T03:44:02.7409304Z make[2]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-28T03:44:02.7410132Z /usr/bin/git archive --format=tar HEAD -- src/clientversion.cpp | ${TAR-tar} -C dashcore-linux64 -xf -
+2025-07-28T03:44:02.7438638Z fatal: pathspec 'src/clientversion.cpp' did not match any files
+2025-07-28T03:44:02.7440839Z tar: This does not look like a tar archive
+2025-07-28T03:44:02.7441664Z tar: Exiting with failure status due to previous errors
+2025-07-28T03:44:02.7445458Z make[2]: [Makefile:1225: dist-hook] Error 2 (ignored)
+2025-07-28T03:44:02.7446028Z make[2]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-28T03:44:02.7447240Z test -n "" \
+2025-07-28T03:44:02.7447531Z || find "dashcore-linux64" -type d ! -perm -755 \
+2025-07-28T03:44:02.7448073Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-28T03:44:02.7448554Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-28T03:44:02.7448915Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-28T03:44:02.7449325Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-28T03:44:02.7449717Z || chmod -R a+r "dashcore-linux64"
+2025-07-28T03:44:02.7665452Z make[1]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-28T03:44:02.8712122Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-28T03:44:02.8789191Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-28T03:44:02.8801571Z checking pkg-config is at least version 0.9.0... yes
+2025-07-28T03:44:02.9245606Z checking build system type... x86_64-pc-linux-gnu
+2025-07-28T03:44:02.9293141Z checking host system type... x86_64-pc-linux-gnu
+2025-07-28T03:44:02.9373091Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-28T03:44:02.9401669Z checking whether build environment is sane... yes
+2025-07-28T03:44:02.9461690Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-28T03:44:02.9482273Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-28T03:44:02.9487019Z checking for gawk... gawk
+2025-07-28T03:44:02.9548811Z checking whether make sets $(MAKE)... yes
+2025-07-28T03:44:02.9600607Z checking whether make supports nested variables... yes
+2025-07-28T03:44:02.9641491Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-28T03:44:02.9643792Z checking whether make supports nested variables... (cached) yes
+2025-07-28T03:44:03.0184450Z checking whether the C++ compiler works... yes
+2025-07-28T03:44:03.0184936Z checking for C++ compiler default output file name... a.out
+2025-07-28T03:44:03.0509576Z checking for suffix of executables... 
+2025-07-28T03:44:03.0951234Z checking whether we are cross compiling... no
+2025-07-28T03:44:03.1118718Z checking for suffix of object files... o
+2025-07-28T03:44:03.1262554Z checking whether the compiler supports GNU C++... yes
+2025-07-28T03:44:03.1417518Z checking whether g++ -m64 accepts -g... yes
+2025-07-28T03:44:03.4194964Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-28T03:44:03.4674936Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-28T03:44:03.4741924Z checking whether make supports the include directive... yes (GNU style)
+2025-07-28T03:44:03.4745377Z checking dependency style of g++ -m64... none
+2025-07-28T03:44:03.5525925Z checking whether g++ -m64 supports C++20 features with -std=c++20... yes
+2025-07-28T03:44:03.5528428Z checking for x86_64-pc-linux-gnu-g++... g++ -m64 -std=c++20
+2025-07-28T03:44:03.5815150Z checking whether the compiler supports GNU Objective C++... no
+2025-07-28T03:44:03.6087297Z checking whether g++ -m64 -std=c++20 accepts -g... no
+2025-07-28T03:44:03.6090871Z checking dependency style of g++ -m64 -std=c++20... none
+2025-07-28T03:44:03.6114561Z checking how to print strings... printf
+2025-07-28T03:44:03.6117333Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-28T03:44:03.6499413Z checking whether the compiler supports GNU C... yes
+2025-07-28T03:44:03.6655849Z checking whether gcc -m64 accepts -g... yes
+2025-07-28T03:44:03.7001854Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-28T03:44:03.7268858Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-28T03:44:03.7272560Z checking dependency style of gcc -m64... none
+2025-07-28T03:44:03.7310998Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-28T03:44:03.7341572Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-28T03:44:03.7357418Z checking for egrep... /usr/bin/grep -E
+2025-07-28T03:44:03.7372515Z checking for fgrep... /usr/bin/grep -F
+2025-07-28T03:44:03.7419058Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-28T03:44:03.7442688Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-28T03:44:03.7445174Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-28T03:44:03.7725668Z checking the name lister (nm) interface... BSD nm
+2025-07-28T03:44:03.7726844Z checking whether ln -s works... yes
+2025-07-28T03:44:03.7768603Z checking the maximum length of command line arguments... 3145728
+2025-07-28T03:44:03.7796012Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-28T03:44:03.7797438Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-28T03:44:03.7800829Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-28T03:44:03.7802673Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-28T03:44:03.7807491Z checking for file... file
+2025-07-28T03:44:03.7811912Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:44:03.7816616Z checking for objdump... objdump
+2025-07-28T03:44:03.7820344Z checking how to recognize dependent libraries... pass_all
+2025-07-28T03:44:03.7825073Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-28T03:44:03.7829374Z checking for dlltool... no
+2025-07-28T03:44:03.7831587Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-28T03:44:03.7833794Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:44:03.8161754Z checking for archiver @FILE support... @
+2025-07-28T03:44:03.8162991Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-28T03:44:03.8166326Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-28T03:44:03.8822197Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-28T03:44:03.8838562Z checking for sysroot... no
+2025-07-28T03:44:03.8881167Z checking for a working dd... /usr/bin/dd
+2025-07-28T03:44:03.8919987Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-28T03:44:03.9018237Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-28T03:44:03.9022664Z checking for mt... no
+2025-07-28T03:44:03.9053718Z checking if : is a manifest tool... no
+2025-07-28T03:44:03.9196820Z checking for stdio.h... yes
+2025-07-28T03:44:03.9351978Z checking for stdlib.h... yes
+2025-07-28T03:44:03.9518820Z checking for string.h... yes
+2025-07-28T03:44:03.9688261Z checking for inttypes.h... yes
+2025-07-28T03:44:03.9857265Z checking for stdint.h... yes
+2025-07-28T03:44:04.0029448Z checking for strings.h... yes
+2025-07-28T03:44:04.0204812Z checking for sys/stat.h... yes
+2025-07-28T03:44:04.0383810Z checking for sys/types.h... yes
+2025-07-28T03:44:04.0592701Z checking for unistd.h... yes
+2025-07-28T03:44:04.0796586Z checking for dlfcn.h... yes
+2025-07-28T03:44:04.0834211Z checking for objdir... .libs
+2025-07-28T03:44:04.1408949Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-28T03:44:04.1410385Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:44:04.1544393Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:44:04.2097927Z checking if gcc -m64 static flag -static works... yes
+2025-07-28T03:44:04.2309187Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-28T03:44:04.2309830Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-28T03:44:04.2402033Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:44:04.2610004Z checking whether -lc should be explicitly linked in... no
+2025-07-28T03:44:04.3096425Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-28T03:44:04.3097808Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:44:04.3114821Z checking whether stripping libraries is possible... yes
+2025-07-28T03:44:04.3116062Z checking if libtool supports shared libraries... yes
+2025-07-28T03:44:04.3116648Z checking whether to build shared libraries... yes
+2025-07-28T03:44:04.3117006Z checking whether to build static libraries... yes
+2025-07-28T03:44:04.3368709Z checking how to run the C++ preprocessor... g++ -m64 -std=c++20 -E
+2025-07-28T03:44:04.4089007Z checking for ld used by g++ -m64 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-28T03:44:04.4112389Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-28T03:44:04.4181725Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:44:04.4762233Z checking for g++ -m64 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:44:04.4914676Z checking if g++ -m64 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:44:04.5514568Z checking if g++ -m64 -std=c++20 static flag -static works... yes
+2025-07-28T03:44:04.5742696Z checking if g++ -m64 -std=c++20 supports -c -o file.o... yes
+2025-07-28T03:44:04.5743556Z checking if g++ -m64 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-28T03:44:04.5744534Z checking whether the g++ -m64 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:44:04.5791882Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-28T03:44:04.5792971Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:44:04.5800350Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-28T03:44:04.5806576Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-28T03:44:04.5810856Z checking for gcov... /usr/bin/gcov
+2025-07-28T03:44:04.5815811Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-28T03:44:04.5820454Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-28T03:44:04.5824403Z checking for lcov... no
+2025-07-28T03:44:04.5827930Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-28T03:44:04.5831586Z checking for genhtml... no
+2025-07-28T03:44:04.5835594Z checking for git... /usr/bin/git
+2025-07-28T03:44:04.5839366Z checking for ccache... /usr/bin/ccache
+2025-07-28T03:44:04.5843285Z checking for xgettext... /usr/bin/xgettext
+2025-07-28T03:44:04.5847222Z checking for hexdump... /usr/bin/hexdump
+2025-07-28T03:44:04.5851564Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-28T03:44:04.5856235Z checking for objcopy... /usr/bin/objcopy
+2025-07-28T03:44:04.5860349Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:44:04.5864762Z checking for objdump... /usr/bin/objdump
+2025-07-28T03:44:04.5869028Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-28T03:44:04.5873477Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-28T03:44:04.5877612Z checking for doxygen... no
+2025-07-28T03:44:04.6030036Z checking whether C++ compiler accepts -Werror... yes
+2025-07-28T03:44:04.6381541Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-28T03:44:04.6809823Z checking for execinfo.h... yes
+2025-07-28T03:44:04.7163401Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-28T03:44:04.7356388Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-28T03:44:04.7527886Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-28T03:44:04.7696121Z checking whether C++ compiler accepts -Wattributes... yes
+2025-07-28T03:44:04.7864599Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-28T03:44:04.8033023Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-28T03:44:04.8201034Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-28T03:44:04.8372161Z checking whether C++ compiler accepts -Wall... yes
+2025-07-28T03:44:04.8542387Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-28T03:44:04.8678264Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-28T03:44:04.8849655Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-28T03:44:04.9019739Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-28T03:44:04.9189096Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-28T03:44:04.9361872Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-28T03:44:04.9558550Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-28T03:44:04.9749028Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-28T03:44:04.9923370Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-28T03:44:05.0168651Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-28T03:44:05.0341986Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-28T03:44:05.0603135Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-28T03:44:05.0777489Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-28T03:44:05.0951264Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-28T03:44:05.1124624Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-28T03:44:05.1296779Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-28T03:44:05.1467827Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-28T03:44:05.1641538Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-28T03:44:05.1812734Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-28T03:44:05.2009508Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-28T03:44:05.2185207Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-28T03:44:05.2368043Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-28T03:44:05.2553245Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-28T03:44:05.2708908Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-28T03:44:05.2893089Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-28T03:44:05.3082209Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-28T03:44:05.3271262Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-28T03:44:05.3454785Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-28T03:44:05.8030978Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-28T03:44:05.8469979Z checking for SSE4.2 intrinsics... yes
+2025-07-28T03:44:06.2801023Z checking for SSE4.1 intrinsics... yes
+2025-07-28T03:44:06.7005669Z checking for AVX2 intrinsics... yes
+2025-07-28T03:44:07.1348688Z checking for x86 SHA-NI intrinsics... yes
+2025-07-28T03:44:07.1518570Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-28T03:44:07.1672451Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-28T03:44:07.1811066Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-28T03:44:07.1957555Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-28T03:44:07.2773811Z checking whether byte ordering is bigendian... no
+2025-07-28T03:44:07.2990200Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-28T03:44:07.3284916Z checking whether gcc -m64 is Clang... no
+2025-07-28T03:44:07.3730986Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-28T03:44:07.4081376Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-28T03:44:07.4082155Z checking whether more special flags are required for pthreads... no
+2025-07-28T03:44:07.4433152Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-28T03:44:08.2588327Z checking whether std::atomic can be used without link library... yes
+2025-07-28T03:44:08.2600547Z checking for special C compiler options needed for large files... no
+2025-07-28T03:44:08.2792709Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-28T03:44:08.3110212Z checking for g++ -m64 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-28T03:44:08.3605722Z checking whether strerror_r is declared... yes
+2025-07-28T03:44:08.3823083Z checking whether strerror_r returns char *... yes
+2025-07-28T03:44:08.3973388Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-28T03:44:08.4124089Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-28T03:44:08.4270920Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-28T03:44:08.4412956Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-28T03:44:08.4578753Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-28T03:44:08.4660304Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-28T03:44:08.4741870Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-28T03:44:08.4997962Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-28T03:44:08.5253711Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-28T03:44:08.5504367Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-28T03:44:08.5753256Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-28T03:44:08.6120785Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-28T03:44:08.6490664Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-28T03:44:08.6869773Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-28T03:44:08.7243564Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-28T03:44:08.7663870Z checking for sys/select.h... yes
+2025-07-28T03:44:08.8084812Z checking for sys/prctl.h... yes
+2025-07-28T03:44:08.8400466Z checking for vm/vm_param.h... no
+2025-07-28T03:44:08.8708616Z checking for sys/vmmeter.h... no
+2025-07-28T03:44:08.9018558Z checking for sys/resources.h... no
+2025-07-28T03:44:08.9299651Z checking whether getifaddrs is declared... yes
+2025-07-28T03:44:08.9737630Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-28T03:44:09.0022783Z checking whether freeifaddrs is declared... yes
+2025-07-28T03:44:09.0462002Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-28T03:44:09.0975898Z checking whether fork is declared... yes
+2025-07-28T03:44:09.1481852Z checking whether setsid is declared... yes
+2025-07-28T03:44:09.1984307Z checking whether pipe2 is declared... yes
+2025-07-28T03:44:09.2213250Z checking for mallopt M_ARENA_MAX... yes
+2025-07-28T03:44:09.2451797Z checking for getmemoryinfo... yes
+2025-07-28T03:44:09.2655206Z checking for posix_fallocate... yes
+2025-07-28T03:44:09.2803099Z checking for default visibility attribute... yes
+2025-07-28T03:44:09.2954384Z checking for dllexport attribute... no
+2025-07-28T03:44:09.7747748Z checking for thread_local support... yes
+2025-07-28T03:44:09.8027312Z checking for Linux getrandom syscall... yes
+2025-07-28T03:44:09.8339019Z checking for getentropy via random.h... yes
+2025-07-28T03:44:09.8531232Z checking for sysctl... no
+2025-07-28T03:44:09.8721999Z checking for sysctl KERN_ARND... no
+2025-07-28T03:44:09.9093391Z checking for library containing backtrace... none required
+2025-07-28T03:44:09.9334133Z checking for fdatasync... yes
+2025-07-28T03:44:09.9536169Z checking for F_FULLFSYNC... no
+2025-07-28T03:44:09.9737930Z checking for O_CLOEXEC... yes
+2025-07-28T03:44:09.9894550Z checking for __builtin_prefetch... yes
+2025-07-28T03:44:10.0293436Z checking for _mm_prefetch... yes
+2025-07-28T03:44:10.0489160Z checking for strong getauxval support in the system headers... yes
+2025-07-28T03:44:10.0756988Z checking for sockaddr_un... yes
+2025-07-28T03:44:10.1227958Z checking for std::system... yes
+2025-07-28T03:44:10.1515011Z checking for ::_wsystem... no
+2025-07-28T03:44:10.1678125Z checking for Qt5Core >= 5.11.3... yes
+2025-07-28T03:44:10.1785805Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-28T03:44:10.1897429Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-28T03:44:10.2006907Z checking for Qt5Network >= 5.11.3... yes
+2025-07-28T03:44:10.2115000Z checking for Qt5Test >= 5.11.3... yes
+2025-07-28T03:44:10.2221658Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-28T03:44:10.4299507Z checking for static Qt... yes
+2025-07-28T03:44:10.4412838Z checking for Qt5AccessibilitySupport... yes
+2025-07-28T03:44:10.4521655Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-28T03:44:10.4629521Z checking for Qt5EdidSupport... yes
+2025-07-28T03:44:10.4739882Z checking for Qt5EventDispatcherSupport... yes
+2025-07-28T03:44:10.4851143Z checking for Qt5FbSupport... yes
+2025-07-28T03:44:10.4962209Z checking for Qt5FontDatabaseSupport... yes
+2025-07-28T03:44:10.5071968Z checking for Qt5ThemeSupport... yes
+2025-07-28T03:44:10.5184499Z checking for Qt5InputSupport... yes
+2025-07-28T03:44:10.5299512Z checking for Qt5ServiceSupport... yes
+2025-07-28T03:44:10.5426678Z checking for Qt5XcbQpa... yes
+2025-07-28T03:44:10.5538922Z checking for Qt5XkbCommonSupport... yes
+2025-07-28T03:44:12.5061292Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-28T03:44:14.5561305Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-28T03:44:14.7664492Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-28T03:44:14.7676188Z checking for moc-qt5... no
+2025-07-28T03:44:14.7677527Z checking for moc5... no
+2025-07-28T03:44:14.7679705Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-28T03:44:14.7680750Z checking for uic-qt5... no
+2025-07-28T03:44:14.7682748Z checking for uic5... no
+2025-07-28T03:44:14.7684520Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-28T03:44:14.7687628Z checking for rcc-qt5... no
+2025-07-28T03:44:14.7688045Z checking for rcc5... no
+2025-07-28T03:44:14.7690192Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-28T03:44:14.7692033Z checking for lrelease-qt5... no
+2025-07-28T03:44:14.7694041Z checking for lrelease5... no
+2025-07-28T03:44:14.7695669Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-28T03:44:14.7697467Z checking for lupdate-qt5... no
+2025-07-28T03:44:14.7699007Z checking for lupdate5... no
+2025-07-28T03:44:14.7700982Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-28T03:44:14.7702418Z checking for lconvert-qt5... no
+2025-07-28T03:44:14.7704775Z checking for lconvert5... no
+2025-07-28T03:44:14.7706397Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-28T03:44:14.7739137Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-28T03:44:14.7740088Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-28T03:44:15.6150001Z checking for Berkeley DB C++ headers... default
+2025-07-28T03:44:15.6539398Z checking for main in -ldb_cxx-4.8... yes
+2025-07-28T03:44:15.6687587Z checking for sqlite3 >= 3.7.17... yes
+2025-07-28T03:44:15.6688366Z checking whether to build wallet with support for sqlite... yes
+2025-07-28T03:44:15.6881388Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-28T03:44:15.7361355Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-28T03:44:15.7769029Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-28T03:44:15.8216772Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-28T03:44:15.8255394Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-28T03:44:15.8699935Z checking for miniupnpc/upnperrors.h... yes
+2025-07-28T03:44:15.8739032Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-28T03:44:15.8819523Z checking whether miniUPnPc API version is supported... yes
+2025-07-28T03:44:15.9298521Z checking for natpmp.h... yes
+2025-07-28T03:44:15.9656278Z checking for initnatpmp in -lnatpmp... yes
+2025-07-28T03:44:15.9731791Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-28T03:44:15.9735468Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-28T03:44:15.9736556Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-28T03:44:15.9737892Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-28T03:44:15.9738930Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-28T03:44:15.9876120Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-28T03:44:16.0159305Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-28T03:44:18.8313078Z checking for Boost Process... yes
+2025-07-28T03:44:18.8535316Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-28T03:44:18.8918018Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-28T03:44:18.9187575Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-28T03:44:18.9306928Z checking for libevent >= 2.1.8... yes
+2025-07-28T03:44:18.9419407Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-28T03:44:18.9752787Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-28T03:44:18.9878874Z checking for libqrencode... yes
+2025-07-28T03:44:18.9993033Z checking for libzmq >= 4... yes
+2025-07-28T03:44:19.0574512Z checking for gmp.h... yes
+2025-07-28T03:44:19.0934519Z checking for __gmpz_init in -lgmp... yes
+2025-07-28T03:44:19.1048358Z checking for libmultiprocess... no
+2025-07-28T03:44:19.1127808Z checking whether to build dashd... yes
+2025-07-28T03:44:19.1129462Z checking whether to build dash-cli... yes
+2025-07-28T03:44:19.1129970Z checking whether to build dash-tx... yes
+2025-07-28T03:44:19.1130728Z checking whether to build dash-wallet... yes
+2025-07-28T03:44:19.1132167Z checking whether to build libraries... no
+2025-07-28T03:44:19.1134877Z checking if ccache should be used... yes
+2025-07-28T03:44:19.1232196Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-28T03:44:19.1346368Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-28T03:44:19.1349017Z checking if wallet should be enabled... yes
+2025-07-28T03:44:19.1349956Z checking whether to build with support for UPnP... yes
+2025-07-28T03:44:19.1351320Z checking whether to build with support for NAT-PMP... yes
+2025-07-28T03:44:19.1354561Z checking whether to build GUI with support for D-Bus... yes
+2025-07-28T03:44:19.1355376Z checking whether to build GUI with support for QR codes... yes
+2025-07-28T03:44:19.1355989Z checking whether to build test_dash-qt... yes
+2025-07-28T03:44:19.1356782Z checking whether to build test_dash... yes
+2025-07-28T03:44:19.1357846Z checking whether to reduce exports... yes
+2025-07-28T03:44:19.1489213Z checking whether dsymutil needs -flat... yes
+2025-07-28T03:44:19.1489828Z 
+2025-07-28T03:44:19.1927910Z checking that generated files are newer than configure... done
+2025-07-28T03:44:19.1934098Z configure: creating ./config.status
+2025-07-28T03:44:19.8323162Z config.status: creating Makefile
+2025-07-28T03:44:19.8445413Z config.status: creating src/Makefile
+2025-07-28T03:44:19.9004350Z config.status: creating doc/man/Makefile
+2025-07-28T03:44:19.9152878Z config.status: creating share/setup.nsi
+2025-07-28T03:44:19.9306041Z config.status: creating share/qt/Info.plist
+2025-07-28T03:44:19.9456548Z config.status: creating test/config.ini
+2025-07-28T03:44:19.9608066Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-28T03:44:19.9767645Z config.status: creating src/config/bitcoin-config.h
+2025-07-28T03:44:20.0219479Z config.status: executing depfiles commands
+2025-07-28T03:44:20.0233374Z config.status: executing libtool commands
+2025-07-28T03:44:20.0350126Z === configuring in src/dashbls (/__w/dash/dash/build-ci/dashcore-linux64/src/dashbls)
+2025-07-28T03:44:20.0393576Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-28T03:44:20.1555099Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-28T03:44:20.2041674Z checking build system type... x86_64-pc-linux-gnu
+2025-07-28T03:44:20.2089082Z checking host system type... x86_64-pc-linux-gnu
+2025-07-28T03:44:20.2167430Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-28T03:44:20.2196596Z checking whether build environment is sane... yes
+2025-07-28T03:44:20.2256534Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-28T03:44:20.2276966Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-28T03:44:20.2281190Z checking for gawk... gawk
+2025-07-28T03:44:20.2344548Z checking whether make sets $(MAKE)... yes
+2025-07-28T03:44:20.2397479Z checking whether make supports nested variables... yes
+2025-07-28T03:44:20.2438944Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-28T03:44:20.2441007Z checking whether make supports nested variables... (cached) yes
+2025-07-28T03:44:20.2442949Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-28T03:44:20.3003608Z checking whether the C compiler works... yes
+2025-07-28T03:44:20.3004433Z checking for C compiler default output file name... a.out
+2025-07-28T03:44:20.3296831Z checking for suffix of executables... 
+2025-07-28T03:44:20.3682352Z checking whether we are cross compiling... no
+2025-07-28T03:44:20.3841324Z checking for suffix of object files... o
+2025-07-28T03:44:20.3976168Z checking whether the compiler supports GNU C... yes
+2025-07-28T03:44:20.4124307Z checking whether gcc -m64 accepts -g... yes
+2025-07-28T03:44:20.4467435Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-28T03:44:20.4731018Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-28T03:44:20.4804587Z checking whether make supports the include directive... yes (GNU style)
+2025-07-28T03:44:20.4807651Z checking dependency style of gcc -m64... none
+2025-07-28T03:44:20.5142882Z checking whether the compiler supports GNU C++... yes
+2025-07-28T03:44:20.5297700Z checking whether g++ -m64 accepts -g... yes
+2025-07-28T03:44:20.8100926Z checking for g++ -m64 option to enable C++11 features... unsupported
+2025-07-28T03:44:20.8572593Z checking for g++ -m64 option to enable C++98 features... none needed
+2025-07-28T03:44:20.8575529Z checking dependency style of g++ -m64... none
+2025-07-28T03:44:20.8964726Z checking whether g++ -m64 supports C++14 features with -std=c++14... yes
+2025-07-28T03:44:20.8989227Z checking how to print strings... printf
+2025-07-28T03:44:20.9027002Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-28T03:44:20.9056930Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-28T03:44:20.9071995Z checking for egrep... /usr/bin/grep -E
+2025-07-28T03:44:20.9087287Z checking for fgrep... /usr/bin/grep -F
+2025-07-28T03:44:20.9134237Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-28T03:44:20.9157382Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-28T03:44:20.9159287Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-28T03:44:20.9436191Z checking the name lister (nm) interface... BSD nm
+2025-07-28T03:44:20.9437044Z checking whether ln -s works... yes
+2025-07-28T03:44:20.9480903Z checking the maximum length of command line arguments... 3145728
+2025-07-28T03:44:20.9506692Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-28T03:44:20.9508695Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-28T03:44:20.9509596Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-28T03:44:20.9513877Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-28T03:44:20.9518037Z checking for file... file
+2025-07-28T03:44:20.9522173Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:44:20.9526841Z checking for objdump... objdump
+2025-07-28T03:44:20.9530894Z checking how to recognize dependent libraries... pass_all
+2025-07-28T03:44:20.9535341Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-28T03:44:20.9539535Z checking for dlltool... no
+2025-07-28T03:44:20.9541129Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-28T03:44:20.9543019Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:44:20.9871660Z checking for archiver @FILE support... @
+2025-07-28T03:44:20.9872390Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-28T03:44:20.9875742Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-28T03:44:21.0530422Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-28T03:44:21.0546955Z checking for sysroot... no
+2025-07-28T03:44:21.0588139Z checking for a working dd... /usr/bin/dd
+2025-07-28T03:44:21.0626540Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-28T03:44:21.0729430Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-28T03:44:21.0741803Z checking for mt... no
+2025-07-28T03:44:21.0780134Z checking if : is a manifest tool... no
+2025-07-28T03:44:21.0923874Z checking for stdio.h... yes
+2025-07-28T03:44:21.1082636Z checking for stdlib.h... yes
+2025-07-28T03:44:21.1246614Z checking for string.h... yes
+2025-07-28T03:44:21.1414107Z checking for inttypes.h... yes
+2025-07-28T03:44:21.1583821Z checking for stdint.h... yes
+2025-07-28T03:44:21.1756554Z checking for strings.h... yes
+2025-07-28T03:44:21.1934980Z checking for sys/stat.h... yes
+2025-07-28T03:44:21.2113060Z checking for sys/types.h... yes
+2025-07-28T03:44:21.2311819Z checking for unistd.h... yes
+2025-07-28T03:44:21.2516033Z checking for dlfcn.h... yes
+2025-07-28T03:44:21.2549883Z checking for objdir... .libs
+2025-07-28T03:44:21.3128321Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-28T03:44:21.3129116Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:44:21.3261454Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:44:21.3811444Z checking if gcc -m64 static flag -static works... yes
+2025-07-28T03:44:21.4023329Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-28T03:44:21.4024395Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-28T03:44:21.4118836Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:44:21.4605585Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-28T03:44:21.4606533Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:44:21.4623330Z checking whether stripping libraries is possible... yes
+2025-07-28T03:44:21.4624528Z checking if libtool supports shared libraries... yes
+2025-07-28T03:44:21.4625123Z checking whether to build shared libraries... no
+2025-07-28T03:44:21.4625739Z checking whether to build static libraries... yes
+2025-07-28T03:44:21.4882801Z checking how to run the C++ preprocessor... g++ -m64 -std=c++14 -E
+2025-07-28T03:44:21.5616648Z checking for ld used by g++ -m64 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-28T03:44:21.5640248Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-28T03:44:21.5709861Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:44:21.6298040Z checking for g++ -m64 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:44:21.6445154Z checking if g++ -m64 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:44:21.7040223Z checking if g++ -m64 -std=c++14 static flag -static works... yes
+2025-07-28T03:44:21.7264614Z checking if g++ -m64 -std=c++14 supports -c -o file.o... yes
+2025-07-28T03:44:21.7265354Z checking if g++ -m64 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-28T03:44:21.7267070Z checking whether the g++ -m64 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:44:21.7312930Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-28T03:44:21.7315672Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:44:21.7322446Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-28T03:44:21.7327555Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-28T03:44:21.7329987Z checking for ranlib... (cached) ranlib
+2025-07-28T03:44:21.7334380Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-28T03:44:21.7337431Z checking for strip... (cached) strip
+2025-07-28T03:44:21.7340230Z checking dependency style of gcc -m64... none
+2025-07-28T03:44:21.7484488Z checking whether C compiler accepts -Werror... yes
+2025-07-28T03:44:21.7728565Z checking for gmp.h... yes
+2025-07-28T03:44:21.8049712Z checking for __gmpz_init in -lgmp... yes
+2025-07-28T03:44:21.8223167Z checking gmp version >= 6.2... yes
+2025-07-28T03:44:21.8252067Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-28T03:44:21.8263785Z checking pkg-config is at least version 0.9.0... yes
+2025-07-28T03:44:21.8351281Z checking if gcc -m64 supports -pipe... yes
+2025-07-28T03:44:21.8448025Z checking if gcc -m64 supports -fomit-frame-pointer... yes
+2025-07-28T03:44:21.8694411Z checking how to run the C preprocessor... gcc -m64 -E
+2025-07-28T03:44:21.8995199Z checking whether gcc -m64 is Clang... no
+2025-07-28T03:44:21.9435466Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-28T03:44:21.9782439Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-28T03:44:21.9783255Z checking whether more special flags are required for pthreads... no
+2025-07-28T03:44:22.0135226Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-28T03:44:22.0459345Z checking for library containing clock_gettime... none required
+2025-07-28T03:44:22.0629161Z checking whether C compiler accepts -fPIC... yes
+2025-07-28T03:44:22.0796886Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-28T03:44:22.0940349Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-28T03:44:22.1108075Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-28T03:44:22.1268759Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-28T03:44:22.1429091Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-28T03:44:22.1648748Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-28T03:44:22.1865844Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-28T03:44:22.2084404Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-28T03:44:22.2303716Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-28T03:44:22.2615297Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-28T03:44:22.2928819Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-28T03:44:22.3240835Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-28T03:44:22.3548646Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-28T03:44:22.3730731Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-28T03:44:22.3731477Z checking whether to build runtest... yes
+2025-07-28T03:44:22.3731961Z checking whether to build runbench... yes
+2025-07-28T03:44:22.3962487Z checking that generated files are newer than configure... done
+2025-07-28T03:44:22.3967298Z configure: creating ./config.status
+2025-07-28T03:44:22.9277787Z config.status: creating Makefile
+2025-07-28T03:44:22.9490909Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-28T03:44:22.9623623Z config.status: executing depfiles commands
+2025-07-28T03:44:22.9637605Z config.status: executing libtool commands
+2025-07-28T03:44:22.9767920Z 
+2025-07-28T03:44:22.9768178Z Options used to compile and link:
+2025-07-28T03:44:22.9768608Z   target os           = linux
+2025-07-28T03:44:22.9769168Z   backend             = gmp
+2025-07-28T03:44:22.9769564Z   build bench         = yes
+2025-07-28T03:44:22.9769917Z   build test          = yes
+2025-07-28T03:44:22.9770573Z   use debug           = no
+2025-07-28T03:44:22.9770928Z   use hardening       = yes
+2025-07-28T03:44:22.9771286Z   use optimizations   = yes
+2025-07-28T03:44:22.9771493Z 
+2025-07-28T03:44:22.9771791Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-28T03:44:22.9773060Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-28T03:44:22.9774370Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-28T03:44:22.9775488Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-28T03:44:22.9776594Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-28T03:44:22.9776898Z 
+2025-07-28T03:44:23.0125782Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/dashcore-linux64/src/secp256k1)
+2025-07-28T03:44:23.0168020Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--with-libs=no' '--enable-reduce-exports' '--disable-fuzz-binary' 'LDFLAGS=-static-libstdc++' '--with-boost-process' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-28T03:44:23.1322916Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-28T03:44:23.1821841Z checking build system type... x86_64-pc-linux-gnu
+2025-07-28T03:44:23.1869890Z checking host system type... x86_64-pc-linux-gnu
+2025-07-28T03:44:23.1947360Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-28T03:44:23.1975466Z checking whether build environment is sane... yes
+2025-07-28T03:44:23.2035370Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-28T03:44:23.2055627Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-28T03:44:23.2059575Z checking for gawk... gawk
+2025-07-28T03:44:23.2121332Z checking whether make sets $(MAKE)... yes
+2025-07-28T03:44:23.2174144Z checking whether make supports nested variables... yes
+2025-07-28T03:44:23.2215973Z checking whether make supports nested variables... (cached) yes
+2025-07-28T03:44:23.2217880Z checking for x86_64-pc-linux-gnu-gcc... gcc -m64
+2025-07-28T03:44:23.2765516Z checking whether the C compiler works... yes
+2025-07-28T03:44:23.2766276Z checking for C compiler default output file name... a.out
+2025-07-28T03:44:23.3056880Z checking for suffix of executables... 
+2025-07-28T03:44:23.3412579Z checking whether we are cross compiling... no
+2025-07-28T03:44:23.3570136Z checking for suffix of object files... o
+2025-07-28T03:44:23.3703680Z checking whether the compiler supports GNU C... yes
+2025-07-28T03:44:23.3852542Z checking whether gcc -m64 accepts -g... yes
+2025-07-28T03:44:23.4196038Z checking for gcc -m64 option to enable C11 features... none needed
+2025-07-28T03:44:23.4473223Z checking whether gcc -m64 understands -c and -o together... yes
+2025-07-28T03:44:23.4545820Z checking whether make supports the include directive... yes (GNU style)
+2025-07-28T03:44:23.4549766Z checking dependency style of gcc -m64... none
+2025-07-28T03:44:23.4553134Z checking dependency style of gcc -m64... none
+2025-07-28T03:44:23.4555959Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:44:23.4816360Z checking the archiver (ar) interface... ar
+2025-07-28T03:44:23.4839062Z checking how to print strings... printf
+2025-07-28T03:44:23.4877027Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-28T03:44:23.4906466Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-28T03:44:23.4921660Z checking for egrep... /usr/bin/grep -E
+2025-07-28T03:44:23.4936346Z checking for fgrep... /usr/bin/grep -F
+2025-07-28T03:44:23.4982457Z checking for ld used by gcc -m64... /usr/bin/ld
+2025-07-28T03:44:23.5006862Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-28T03:44:23.5009132Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-28T03:44:23.5282678Z checking the name lister (nm) interface... BSD nm
+2025-07-28T03:44:23.5283216Z checking whether ln -s works... yes
+2025-07-28T03:44:23.5324190Z checking the maximum length of command line arguments... 3145728
+2025-07-28T03:44:23.5349875Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-28T03:44:23.5351023Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-28T03:44:23.5353199Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-28T03:44:23.5356549Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-28T03:44:23.5360761Z checking for file... file
+2025-07-28T03:44:23.5366062Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-28T03:44:23.5370520Z checking for objdump... objdump
+2025-07-28T03:44:23.5373859Z checking how to recognize dependent libraries... pass_all
+2025-07-28T03:44:23.5378633Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-28T03:44:23.5383301Z checking for dlltool... no
+2025-07-28T03:44:23.5384801Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-28T03:44:23.5386625Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-28T03:44:23.5713189Z checking for archiver @FILE support... @
+2025-07-28T03:44:23.5713815Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-28T03:44:23.5717324Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-28T03:44:23.6362221Z checking command to parse nm output from gcc -m64 object... ok
+2025-07-28T03:44:23.6378034Z checking for sysroot... no
+2025-07-28T03:44:23.6419097Z checking for a working dd... /usr/bin/dd
+2025-07-28T03:44:23.6456866Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-28T03:44:23.6555049Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-28T03:44:23.6559521Z checking for mt... no
+2025-07-28T03:44:23.6589412Z checking if : is a manifest tool... no
+2025-07-28T03:44:23.6735095Z checking for stdio.h... yes
+2025-07-28T03:44:23.6892739Z checking for stdlib.h... yes
+2025-07-28T03:44:23.7059682Z checking for string.h... yes
+2025-07-28T03:44:23.7227759Z checking for inttypes.h... yes
+2025-07-28T03:44:23.7398438Z checking for stdint.h... yes
+2025-07-28T03:44:23.7569633Z checking for strings.h... yes
+2025-07-28T03:44:23.7746428Z checking for sys/stat.h... yes
+2025-07-28T03:44:23.7926142Z checking for sys/types.h... yes
+2025-07-28T03:44:23.8129091Z checking for unistd.h... yes
+2025-07-28T03:44:23.8331184Z checking for dlfcn.h... yes
+2025-07-28T03:44:23.8369006Z checking for objdir... .libs
+2025-07-28T03:44:23.8954136Z checking if gcc -m64 supports -fno-rtti -fno-exceptions... no
+2025-07-28T03:44:23.8955849Z checking for gcc -m64 option to produce PIC... -fPIC -DPIC
+2025-07-28T03:44:23.9086711Z checking if gcc -m64 PIC flag -fPIC -DPIC works... yes
+2025-07-28T03:44:23.9653824Z checking if gcc -m64 static flag -static works... yes
+2025-07-28T03:44:23.9863741Z checking if gcc -m64 supports -c -o file.o... yes
+2025-07-28T03:44:23.9864569Z checking if gcc -m64 supports -c -o file.o... (cached) yes
+2025-07-28T03:44:23.9957566Z checking whether the gcc -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-28T03:44:24.0436763Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-28T03:44:24.0437533Z checking how to hardcode library paths into programs... immediate
+2025-07-28T03:44:24.0454597Z checking whether stripping libraries is possible... yes
+2025-07-28T03:44:24.0455243Z checking if libtool supports shared libraries... yes
+2025-07-28T03:44:24.0456984Z checking whether to build shared libraries... no
+2025-07-28T03:44:24.0457605Z checking whether to build static libraries... yes
+2025-07-28T03:44:24.0561959Z checking if gcc -m64 supports -Werror... yes
+2025-07-28T03:44:24.0656480Z checking if gcc -m64 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-28T03:44:24.0749290Z checking if gcc -m64 supports -Wno-overlength-strings... yes
+2025-07-28T03:44:24.0844172Z checking if gcc -m64 supports -Wall... yes
+2025-07-28T03:44:24.0935904Z checking if gcc -m64 supports -Wno-unused-function... yes
+2025-07-28T03:44:24.1027711Z checking if gcc -m64 supports -Wextra... yes
+2025-07-28T03:44:24.1121100Z checking if gcc -m64 supports -Wcast-align... yes
+2025-07-28T03:44:24.1215320Z checking if gcc -m64 supports -Wcast-align=strict... yes
+2025-07-28T03:44:24.1452546Z checking if gcc -m64 supports -Wconditional-uninitialized... no
+2025-07-28T03:44:24.1654496Z checking if gcc -m64 supports -Wreserved-identifier... no
+2025-07-28T03:44:24.1746756Z checking if gcc -m64 supports -fvisibility=hidden... yes
+2025-07-28T03:44:24.1894753Z checking for valgrind support... 
+2025-07-28T03:44:24.2225527Z checking for x86_64 assembly availability... yes
+2025-07-28T03:44:24.2449723Z checking that generated files are newer than configure... done
+2025-07-28T03:44:24.2452679Z configure: creating ./config.status
+2025-07-28T03:44:24.6296934Z config.status: creating Makefile
+2025-07-28T03:44:24.6421916Z config.status: creating libsecp256k1.pc
+2025-07-28T03:44:24.6527371Z config.status: executing depfiles commands
+2025-07-28T03:44:24.6541728Z config.status: executing libtool commands
+2025-07-28T03:44:24.6625928Z 
+2025-07-28T03:44:24.6626271Z Build Options:
+2025-07-28T03:44:24.6626615Z   with external callbacks = no
+2025-07-28T03:44:24.6627006Z   with benchmarks         = no
+2025-07-28T03:44:24.6627375Z   with tests              = yes
+2025-07-28T03:44:24.6627911Z   with ctime tests        = no
+2025-07-28T03:44:24.6628301Z   with coverage           = no
+2025-07-28T03:44:24.6629028Z   with examples           = no
+2025-07-28T03:44:24.6629402Z   module ecdh             = no
+2025-07-28T03:44:24.6629758Z   module recovery         = yes
+2025-07-28T03:44:24.6630142Z   module extrakeys        = yes
+2025-07-28T03:44:24.6630527Z   module schnorrsig       = yes
+2025-07-28T03:44:24.6630878Z   module ellswift         = yes
+2025-07-28T03:44:24.6631103Z 
+2025-07-28T03:44:24.6631227Z   asm                     = x86_64
+2025-07-28T03:44:24.6631585Z   ecmult window size      = 15
+2025-07-28T03:44:24.6631949Z   ecmult gen prec. bits   = 4
+2025-07-28T03:44:24.6632181Z 
+2025-07-28T03:44:24.6632309Z   valgrind                = no
+2025-07-28T03:44:24.6632595Z   CC                      = gcc -m64
+2025-07-28T03:44:24.6632937Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-28T03:44:24.6633866Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-28T03:44:24.6635039Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-28T03:44:24.6635426Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-28T03:44:24.6943095Z 
+2025-07-28T03:44:24.6943457Z Options used to compile and link:
+2025-07-28T03:44:24.6944040Z   boost process       = yes
+2025-07-28T03:44:24.6944417Z   multiprocess        = no
+2025-07-28T03:44:24.6944759Z   with libs           = no
+2025-07-28T03:44:24.6945099Z   with wallet         = yes
+2025-07-28T03:44:24.6945429Z     with sqlite       = yes
+2025-07-28T03:44:24.6945759Z     with bdb          = yes
+2025-07-28T03:44:24.6946082Z   with gui / qt       = yes
+2025-07-28T03:44:24.6946409Z     with qr           = yes
+2025-07-28T03:44:24.6947360Z   with zmq            = yes
+2025-07-28T03:44:24.6947721Z   with test           = yes
+2025-07-28T03:44:24.6948056Z   with fuzz binary    = no
+2025-07-28T03:44:24.6948388Z   with bench          = yes
+2025-07-28T03:44:24.6948713Z   with upnp           = yes
+2025-07-28T03:44:24.6949041Z   with natpmp         = yes
+2025-07-28T03:44:24.6949388Z   USDT tracing        = yes
+2025-07-28T03:44:24.6949721Z   sanitizers          = 
+2025-07-28T03:44:24.6950338Z   debug enabled       = no
+2025-07-28T03:44:24.6950676Z   stacktraces enabled = yes
+2025-07-28T03:44:24.6951016Z   crash hooks enabled = no
+2025-07-28T03:44:24.6951343Z   miner enabled       = yes
+2025-07-28T03:44:24.6951680Z   gprof enabled       = no
+2025-07-28T03:44:24.6952006Z   werror              = yes
+2025-07-28T03:44:24.6952214Z 
+2025-07-28T03:44:24.6952342Z   target os           = linux-gnu
+2025-07-28T03:44:24.6952711Z   build os            = linux-gnu
+2025-07-28T03:44:24.6952950Z 
+2025-07-28T03:44:24.6953110Z   CC                  = /usr/bin/ccache gcc -m64
+2025-07-28T03:44:24.6953686Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-28T03:44:24.6954945Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-28T03:44:24.6955833Z   CXX                 = /usr/bin/ccache g++ -m64 -std=c++20
+2025-07-28T03:44:24.6958625Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-28T03:44:24.6962852Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -static-libstdc++
+2025-07-28T03:44:24.6963879Z   AR                  = ar
+2025-07-28T03:44:24.6964752Z   ARFLAGS             = cr
+2025-07-28T03:44:24.6964993Z 
+2025-07-28T03:44:24.7596514Z Making install in src
+2025-07-28T03:44:24.7829993Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:44:24.8099898Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:44:24.8134783Z   CXX      dashd-bitcoind.o
+2025-07-28T03:44:24.8135206Z   CXX      libbitcoin_node_a-addrdb.o
+2025-07-28T03:44:24.8172162Z   CXX      libbitcoin_node_a-addressindex.o
+2025-07-28T03:44:24.8188220Z   CXX      libbitcoin_node_a-addrman.o
+2025-07-28T03:44:26.8680828Z   CXX      libbitcoin_node_a-banman.o
+2025-07-28T03:44:28.2946045Z   CXX      libbitcoin_node_a-batchedlogger.o
+2025-07-28T03:44:29.7461112Z   CXX      libbitcoin_node_a-bip324.o
+2025-07-28T03:44:30.5042855Z   CXX      libbitcoin_node_a-blockencodings.o
+2025-07-28T03:44:30.5517359Z   CXX      libbitcoin_node_a-blockfilter.o
+2025-07-28T03:44:32.2666868Z   CXX      libbitcoin_node_a-chain.o
+2025-07-28T03:44:32.6898059Z   CXX      libbitcoin_node_a-dbwrapper.o
+2025-07-28T03:44:33.1642704Z   CXX      libbitcoin_node_a-deploymentstatus.o
+2025-07-28T03:44:34.9527638Z   CXX      libbitcoin_node_a-dsnotificationinterface.o
+2025-07-28T03:44:35.3459745Z   CXX      libbitcoin_node_a-flatfile.o
+2025-07-28T03:44:36.7849698Z   CXX      libbitcoin_node_a-httprpc.o
+2025-07-28T03:44:36.7880124Z   CXX      libbitcoin_node_a-httpserver.o
+2025-07-28T03:44:38.6492794Z   CXX      libbitcoin_node_a-i2p.o
+2025-07-28T03:44:42.2108641Z   CXX      libbitcoin_node_a-init.o
+2025-07-28T03:44:42.5866267Z   CXX      libbitcoin_node_a-mapport.o
+2025-07-28T03:44:43.7872209Z   CXX      libbitcoin_node_a-net.o
+2025-07-28T03:44:44.5016503Z   CXX      libbitcoin_node_a-netfulfilledman.o
+2025-07-28T03:44:46.6972728Z   CXX      libbitcoin_node_a-netgroup.o
+2025-07-28T03:44:49.0315495Z   CXX      libbitcoin_node_a-net_processing.o
+2025-07-28T03:44:49.5804302Z   CXX      libbitcoin_node_a-noui.o
+2025-07-28T03:44:53.4426455Z   CXX      libbitcoin_node_a-pow.o
+2025-07-28T03:44:55.4909957Z   CXX      libbitcoin_node_a-rest.o
+2025-07-28T03:45:02.6172286Z   CXX      libbitcoin_node_a-shutdown.o
+2025-07-28T03:45:04.7489118Z   CXX      libbitcoin_node_a-spork.o
+2025-07-28T03:45:05.1366395Z   CXX      libbitcoin_node_a-timedata.o
+2025-07-28T03:45:05.2872786Z   CXX      libbitcoin_node_a-torcontrol.o
+2025-07-28T03:45:08.6338900Z   CXX      libbitcoin_node_a-txdb.o
+2025-07-28T03:45:11.5607048Z   CXX      libbitcoin_node_a-txmempool.o
+2025-07-28T03:45:14.1270045Z   CXX      libbitcoin_node_a-txorphanage.o
+2025-07-28T03:45:14.5623565Z   CXX      libbitcoin_node_a-validation.o
+2025-07-28T03:45:18.9690165Z   CXX      libbitcoin_node_a-validationinterface.o
+2025-07-28T03:45:18.9801036Z   CXX      libbitcoin_node_a-versionbits.o
+2025-07-28T03:45:21.1892292Z   CXX      coinjoin/libbitcoin_wallet_a-client.o
+2025-07-28T03:45:24.2217722Z   CXX      coinjoin/libbitcoin_wallet_a-interfaces.o
+2025-07-28T03:45:26.0184623Z   CXX      coinjoin/libbitcoin_wallet_a-util.o
+2025-07-28T03:45:31.2898731Z   CXX      wallet/libbitcoin_wallet_a-bip39.o
+2025-07-28T03:45:33.4968472Z   CXX      wallet/libbitcoin_wallet_a-coinjoin.o
+2025-07-28T03:45:34.5793334Z   CXX      wallet/libbitcoin_wallet_a-coincontrol.o
+2025-07-28T03:45:37.1722881Z   CXX      wallet/libbitcoin_wallet_a-context.o
+2025-07-28T03:45:37.4292721Z   CXX      wallet/libbitcoin_wallet_a-crypter.o
+2025-07-28T03:45:37.8821226Z   CXX      wallet/libbitcoin_wallet_a-db.o
+2025-07-28T03:45:38.3563645Z   CXX      wallet/libbitcoin_wallet_a-dump.o
+2025-07-28T03:45:40.7945503Z   CXX      wallet/libbitcoin_wallet_a-fees.o
+2025-07-28T03:45:41.9227542Z   CXX      wallet/libbitcoin_wallet_a-hdchain.o
+2025-07-28T03:45:43.6767427Z   CXX      wallet/libbitcoin_wallet_a-interfaces.o
+2025-07-28T03:45:45.7295793Z   CXX      wallet/libbitcoin_wallet_a-load.o
+2025-07-28T03:45:46.5716709Z   CXX      wallet/libbitcoin_wallet_a-receive.o
+2025-07-28T03:45:48.0091967Z   CXX      wallet/libbitcoin_wallet_a-scriptpubkeyman.o
+2025-07-28T03:45:54.0080344Z   CXX      wallet/libbitcoin_wallet_a-spend.o
+2025-07-28T03:45:54.2447307Z   CXX      wallet/libbitcoin_wallet_a-transaction.o
+2025-07-28T03:45:55.8410630Z   CXX      wallet/libbitcoin_wallet_a-wallet.o
+2025-07-28T03:45:58.9875725Z   CXX      wallet/libbitcoin_wallet_a-walletdb.o
+2025-07-28T03:46:03.5293498Z   CXX      wallet/libbitcoin_wallet_a-walletutil.o
+2025-07-28T03:46:05.9574570Z   CXX      wallet/libbitcoin_wallet_a-coinselection.o
+2025-07-28T03:46:06.2133582Z   CXX      wallet/libbitcoin_wallet_a-sqlite.o
+2025-07-28T03:46:11.2611261Z   CXX      wallet/libbitcoin_wallet_a-bdb.o
+2025-07-28T03:46:11.6237196Z   CXX      wallet/libbitcoin_wallet_a-salvage.o
+2025-07-28T03:46:13.3712726Z   CXX      libbitcoin_common_a-base58.o
+2025-07-28T03:46:15.1436126Z   CXX      libbitcoin_common_a-bech32.o
+2025-07-28T03:46:16.0207163Z   CXX      libbitcoin_common_a-chainparams.o
+2025-07-28T03:46:16.6463861Z   CXX      libbitcoin_common_a-coins.o
+2025-07-28T03:46:20.1883154Z   CXX      libbitcoin_common_a-compressor.o
+2025-07-28T03:46:20.9962255Z   CXX      libbitcoin_common_a-core_read.o
+2025-07-28T03:46:21.2921450Z   CXX      libbitcoin_common_a-core_write.o
+2025-07-28T03:46:21.6242552Z   CXX      libbitcoin_common_a-deploymentinfo.o
+2025-07-28T03:46:22.2418931Z   CXX      evo/libbitcoin_common_a-core_write.o
+2025-07-28T03:46:22.3338705Z   CXX      evo/libbitcoin_common_a-netinfo.o
+2025-07-28T03:46:24.6707513Z   CXX      governance/libbitcoin_common_a-common.o
+2025-07-28T03:46:26.4539768Z   CXX      init/libbitcoin_common_a-common.o
+2025-07-28T03:46:26.7067952Z   CXX      libbitcoin_common_a-key.o
+2025-07-28T03:46:27.2801961Z   CXX      libbitcoin_common_a-key_io.o
+2025-07-28T03:46:28.2259396Z   CXX      libbitcoin_common_a-merkleblock.o
+2025-07-28T03:46:29.0308499Z   CXX      libbitcoin_common_a-net_types.o
+2025-07-28T03:46:29.9508331Z   CXX      libbitcoin_common_a-netaddress.o
+2025-07-28T03:46:30.1403168Z   CXX      libbitcoin_common_a-netbase.o
+2025-07-28T03:46:30.8073437Z   CXX      libbitcoin_common_a-net_permissions.o
+2025-07-28T03:46:32.4266813Z   CXX      libbitcoin_common_a-outputtype.o
+2025-07-28T03:46:34.0498291Z   CXX      policy/libbitcoin_common_a-feerate.o
+2025-07-28T03:46:34.0881534Z   CXX      policy/libbitcoin_common_a-policy.o
+2025-07-28T03:46:34.2336505Z   CXX      libbitcoin_common_a-protocol.o
+2025-07-28T03:46:35.1416505Z   CXX      libbitcoin_common_a-psbt.o
+2025-07-28T03:46:35.7193198Z   CXX      rpc/libbitcoin_common_a-evo_util.o
+2025-07-28T03:46:35.7493055Z   CXX      rpc/libbitcoin_common_a-rawtransaction_util.o
+2025-07-28T03:46:37.7457696Z   CXX      rpc/libbitcoin_common_a-util.o
+2025-07-28T03:46:39.7033619Z   CXX      libbitcoin_common_a-saltedhasher.o
+2025-07-28T03:46:40.8582600Z rpc/util.cpp: In member function ‘UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest&) const’:
+2025-07-28T03:46:40.8584264Z rpc/util.cpp:543:28: error: ‘const struct RPCArg’ has no member named ‘MatchesType’
+2025-07-28T03:46:40.8585069Z   543 |         UniValue match{arg.MatchesType(request.params[i])};
+2025-07-28T03:46:40.8585957Z       |                            ^~~~~~~~~~~
+2025-07-28T03:46:40.8587131Z rpc/util.cpp:543:58: error: no matching function for call to ‘UniValue::UniValue(<brace-enclosed initializer list>)’
+2025-07-28T03:46:40.8588032Z   543 |         UniValue match{arg.MatchesType(request.params[i])};
+2025-07-28T03:46:40.8588599Z       |                                                          ^
+2025-07-28T03:46:40.8589092Z In file included from ./rpc/request.h:13,
+2025-07-28T03:46:40.8589536Z                  from ./rpc/util.h:14,
+2025-07-28T03:46:40.8589953Z                  from rpc/util.cpp:10:
+2025-07-28T03:46:40.8592456Z ./univalue/include/univalue.h:31:5: note: candidate: ‘template<class Ref, class T, typename std::enable_if<((((is_floating_point_v<T> || is_same_v<bool, T>) || is_signed_v<T>) || is_unsigned_v<T>) || is_constructible_v<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, T>), bool>::type <anonymous> > UniValue::UniValue(Ref&&)’
+2025-07-28T03:46:40.8594714Z    31 |     UniValue(Ref&& val)
+2025-07-28T03:46:40.8595116Z       |     ^~~~~~~~
+2025-07-28T03:46:40.8595747Z ./univalue/include/univalue.h:31:5: note:   template argument deduction/substitution failed:
+2025-07-28T03:46:40.8597021Z ./univalue/include/univalue.h:24:5: note: candidate: ‘UniValue::UniValue(VType, std::string)’
+2025-07-28T03:46:40.8598027Z    24 |     UniValue(UniValue::VType type, std::string str = {}) : typ{type}, val{std::move(str)} {}
+2025-07-28T03:46:40.8598640Z       |     ^~~~~~~~
+2025-07-28T03:46:40.8599249Z ./univalue/include/univalue.h:24:5: note:   conversion of argument 1 would be ill-formed:
+2025-07-28T03:46:40.8600382Z ./univalue/include/univalue.h:23:5: note: candidate: ‘UniValue::UniValue()’
+2025-07-28T03:46:40.8601020Z    23 |     UniValue() { typ = VNULL; }
+2025-07-28T03:46:40.8601422Z       |     ^~~~~~~~
+2025-07-28T03:46:40.8602012Z ./univalue/include/univalue.h:23:5: note:   candidate expects 0 arguments, 1 provided
+2025-07-28T03:46:40.8603297Z ./univalue/include/univalue.h:19:7: note: candidate: ‘constexpr UniValue::UniValue(const UniValue&)’
+2025-07-28T03:46:40.8604656Z    19 | class UniValue {
+2025-07-28T03:46:40.8605054Z       |       ^~~~~~~~
+2025-07-28T03:46:40.8605678Z ./univalue/include/univalue.h:19:7: note:   conversion of argument 1 would be ill-formed:
+2025-07-28T03:46:40.8606979Z ./univalue/include/univalue.h:19:7: note: candidate: ‘constexpr UniValue::UniValue(UniValue&&)’
+2025-07-28T03:46:40.8607982Z ./univalue/include/univalue.h:19:7: note:   conversion of argument 1 would be ill-formed:
+2025-07-28T03:46:40.8636459Z make[2]: *** [Makefile:9673: rpc/libbitcoin_common_a-util.o] Error 1
+2025-07-28T03:46:40.8640932Z make[2]: *** Waiting for unfinished jobs....
+2025-07-28T03:46:42.2510560Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:46:42.2516919Z make[1]: *** [Makefile:20633: install-recursive] Error 1
+2025-07-28T03:46:42.2519060Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:46:42.2524710Z make: *** [Makefile:788: install-recursive] Error 1
+2025-07-28T03:46:42.2530088Z Build failure. Verbose build follows.
+2025-07-28T03:46:42.2592434Z Making install in src
+2025-07-28T03:46:42.2823517Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:46:42.3089336Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:46:42.3095158Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o init/dashd-bitcoind.o `test -f 'init/bitcoind.cpp' || echo './'`init/bitcoind.cpp
+2025-07-28T03:46:44.6790335Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-coinjoin.o `test -f 'coinjoin/coinjoin.cpp' || echo './'`coinjoin/coinjoin.cpp
+2025-07-28T03:46:50.1180159Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-context.o `test -f 'coinjoin/context.cpp' || echo './'`coinjoin/context.cpp
+2025-07-28T03:46:54.4798594Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o coinjoin/libbitcoin_node_a-server.o `test -f 'coinjoin/server.cpp' || echo './'`coinjoin/server.cpp
+2025-07-28T03:47:01.7909106Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o consensus/libbitcoin_node_a-tx_verify.o `test -f 'consensus/tx_verify.cpp' || echo './'`consensus/tx_verify.cpp
+2025-07-28T03:47:03.6737800Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-assetlocktx.o `test -f 'evo/assetlocktx.cpp' || echo './'`evo/assetlocktx.cpp
+2025-07-28T03:47:07.4376266Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-cbtx.o `test -f 'evo/cbtx.cpp' || echo './'`evo/cbtx.cpp
+2025-07-28T03:47:11.7839122Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-creditpool.o `test -f 'evo/creditpool.cpp' || echo './'`evo/creditpool.cpp
+2025-07-28T03:47:17.3686945Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-chainhelper.o `test -f 'evo/chainhelper.cpp' || echo './'`evo/chainhelper.cpp
+2025-07-28T03:47:19.9113148Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-deterministicmns.o `test -f 'evo/deterministicmns.cpp' || echo './'`evo/deterministicmns.cpp
+2025-07-28T03:47:29.3770974Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-dmnstate.o `test -f 'evo/dmnstate.cpp' || echo './'`evo/dmnstate.cpp
+2025-07-28T03:47:31.7087868Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-evodb.o `test -f 'evo/evodb.cpp' || echo './'`evo/evodb.cpp
+2025-07-28T03:47:34.2366206Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-mnauth.o `test -f 'evo/mnauth.cpp' || echo './'`evo/mnauth.cpp
+2025-07-28T03:47:38.1498725Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-mnhftx.o `test -f 'evo/mnhftx.cpp' || echo './'`evo/mnhftx.cpp
+2025-07-28T03:47:44.0243870Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-providertx.o `test -f 'evo/providertx.cpp' || echo './'`evo/providertx.cpp
+2025-07-28T03:47:46.8126421Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-simplifiedmns.o `test -f 'evo/simplifiedmns.cpp' || echo './'`evo/simplifiedmns.cpp
+2025-07-28T03:47:49.6918147Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-smldiff.o `test -f 'evo/smldiff.cpp' || echo './'`evo/smldiff.cpp
+2025-07-28T03:47:55.3792822Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-specialtx.o `test -f 'evo/specialtx.cpp' || echo './'`evo/specialtx.cpp
+2025-07-28T03:47:56.2499524Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o evo/libbitcoin_node_a-specialtxman.o `test -f 'evo/specialtxman.cpp' || echo './'`evo/specialtxman.cpp
+2025-07-28T03:48:03.5079909Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-classes.o `test -f 'governance/classes.cpp' || echo './'`governance/classes.cpp
+2025-07-28T03:48:08.0151084Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-exceptions.o `test -f 'governance/exceptions.cpp' || echo './'`governance/exceptions.cpp
+2025-07-28T03:48:08.7459156Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-governance.o `test -f 'governance/governance.cpp' || echo './'`governance/governance.cpp
+2025-07-28T03:48:19.7885192Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-object.o `test -f 'governance/object.cpp' || echo './'`governance/object.cpp
+2025-07-28T03:48:25.7523846Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-validators.o `test -f 'governance/validators.cpp' || echo './'`governance/validators.cpp
+2025-07-28T03:48:27.9200527Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-vote.o `test -f 'governance/vote.cpp' || echo './'`governance/vote.cpp
+2025-07-28T03:48:32.0680208Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o governance/libbitcoin_node_a-votedb.o `test -f 'governance/votedb.cpp' || echo './'`governance/votedb.cpp
+2025-07-28T03:48:33.4002742Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o gsl/libbitcoin_node_a-assert.o `test -f 'gsl/assert.cpp' || echo './'`gsl/assert.cpp
+2025-07-28T03:48:34.5949103Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-base.o `test -f 'index/base.cpp' || echo './'`index/base.cpp
+2025-07-28T03:48:38.9476213Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-blockfilterindex.o `test -f 'index/blockfilterindex.cpp' || echo './'`index/blockfilterindex.cpp
+2025-07-28T03:48:42.7738580Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-coinstatsindex.o `test -f 'index/coinstatsindex.cpp' || echo './'`index/coinstatsindex.cpp
+2025-07-28T03:48:47.0841768Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o index/libbitcoin_node_a-txindex.o `test -f 'index/txindex.cpp' || echo './'`index/txindex.cpp
+2025-07-28T03:48:51.0035433Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-db.o `test -f 'instantsend/db.cpp' || echo './'`instantsend/db.cpp
+2025-07-28T03:48:55.1919499Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-instantsend.o `test -f 'instantsend/instantsend.cpp' || echo './'`instantsend/instantsend.cpp
+2025-07-28T03:49:02.8930031Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-lock.o `test -f 'instantsend/lock.cpp' || echo './'`instantsend/lock.cpp
+2025-07-28T03:49:04.1370742Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o instantsend/libbitcoin_node_a-signing.o `test -f 'instantsend/signing.cpp' || echo './'`instantsend/signing.cpp
+2025-07-28T03:49:09.9583767Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-blockprocessor.o `test -f 'llmq/blockprocessor.cpp' || echo './'`llmq/blockprocessor.cpp
+2025-07-28T03:49:17.6596477Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-chainlocks.o `test -f 'llmq/chainlocks.cpp' || echo './'`llmq/chainlocks.cpp
+2025-07-28T03:49:23.5824352Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-clsig.o `test -f 'llmq/clsig.cpp' || echo './'`llmq/clsig.cpp
+2025-07-28T03:49:24.9820530Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-commitment.o `test -f 'llmq/commitment.cpp' || echo './'`llmq/commitment.cpp
+2025-07-28T03:49:30.0411856Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-context.o `test -f 'llmq/context.cpp' || echo './'`llmq/context.cpp
+2025-07-28T03:49:34.7986503Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-debug.o `test -f 'llmq/debug.cpp' || echo './'`llmq/debug.cpp
+2025-07-28T03:49:38.7009070Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsession.o `test -f 'llmq/dkgsession.cpp' || echo './'`llmq/dkgsession.cpp
+2025-07-28T03:49:46.3252807Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsessionhandler.o `test -f 'llmq/dkgsessionhandler.cpp' || echo './'`llmq/dkgsessionhandler.cpp
+2025-07-28T03:49:54.2747922Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-dkgsessionmgr.o `test -f 'llmq/dkgsessionmgr.cpp' || echo './'`llmq/dkgsessionmgr.cpp
+2025-07-28T03:50:00.7232857Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-ehf_signals.o `test -f 'llmq/ehf_signals.cpp' || echo './'`llmq/ehf_signals.cpp
+2025-07-28T03:50:05.0006532Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-options.o `test -f 'llmq/options.cpp' || echo './'`llmq/options.cpp
+2025-07-28T03:50:07.7249194Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-quorums.o `test -f 'llmq/quorums.cpp' || echo './'`llmq/quorums.cpp
+2025-07-28T03:50:18.1666324Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-signing.o `test -f 'llmq/signing.cpp' || echo './'`llmq/signing.cpp
+2025-07-28T03:50:26.1194357Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-signing_shares.o `test -f 'llmq/signing_shares.cpp' || echo './'`llmq/signing_shares.cpp
+2025-07-28T03:50:36.8122459Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-snapshot.o `test -f 'llmq/snapshot.cpp' || echo './'`llmq/snapshot.cpp
+2025-07-28T03:50:42.3373366Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o llmq/libbitcoin_node_a-utils.o `test -f 'llmq/utils.cpp' || echo './'`llmq/utils.cpp
+2025-07-28T03:50:48.7685900Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-node.o `test -f 'masternode/node.cpp' || echo './'`masternode/node.cpp
+2025-07-28T03:50:52.3691439Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-meta.o `test -f 'masternode/meta.cpp' || echo './'`masternode/meta.cpp
+2025-07-28T03:50:55.7250681Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-payments.o `test -f 'masternode/payments.cpp' || echo './'`masternode/payments.cpp
+2025-07-28T03:51:00.6390794Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-sync.o `test -f 'masternode/sync.cpp' || echo './'`masternode/sync.cpp
+2025-07-28T03:51:05.2946638Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o masternode/libbitcoin_node_a-utils.o `test -f 'masternode/utils.cpp' || echo './'`masternode/utils.cpp
+2025-07-28T03:51:10.7932627Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-blockstorage.o `test -f 'node/blockstorage.cpp' || echo './'`node/blockstorage.cpp
+2025-07-28T03:51:16.7099582Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-caches.o `test -f 'node/caches.cpp' || echo './'`node/caches.cpp
+2025-07-28T03:51:19.5832884Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-chainstate.o `test -f 'node/chainstate.cpp' || echo './'`node/chainstate.cpp
+2025-07-28T03:51:23.4996821Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-coin.o `test -f 'node/coin.cpp' || echo './'`node/coin.cpp
+2025-07-28T03:51:26.5645662Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-coinstats.o `test -f 'node/coinstats.cpp' || echo './'`node/coinstats.cpp
+2025-07-28T03:51:30.1513149Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-connection_types.o `test -f 'node/connection_types.cpp' || echo './'`node/connection_types.cpp
+2025-07-28T03:51:30.4655116Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-context.o `test -f 'node/context.cpp' || echo './'`node/context.cpp
+2025-07-28T03:51:35.5008698Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-eviction.o `test -f 'node/eviction.cpp' || echo './'`node/eviction.cpp
+2025-07-28T03:51:37.4270255Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-interfaces.o `test -f 'node/interfaces.cpp' || echo './'`node/interfaces.cpp
+2025-07-28T03:51:44.4751290Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-miner.o `test -f 'node/miner.cpp' || echo './'`node/miner.cpp
+2025-07-28T03:51:51.1573167Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-minisketchwrapper.o `test -f 'node/minisketchwrapper.cpp' || echo './'`node/minisketchwrapper.cpp
+2025-07-28T03:51:52.9315965Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-psbt.o `test -f 'node/psbt.cpp' || echo './'`node/psbt.cpp
+2025-07-28T03:51:54.7178441Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-transaction.o `test -f 'node/transaction.cpp' || echo './'`node/transaction.cpp
+2025-07-28T03:51:58.4209730Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-txreconciliation.o `test -f 'node/txreconciliation.cpp' || echo './'`node/txreconciliation.cpp
+2025-07-28T03:52:00.8760364Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o node/libbitcoin_node_a-interface_ui.o `test -f 'node/interface_ui.cpp' || echo './'`node/interface_ui.cpp
+2025-07-28T03:52:09.0383395Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-fees.o `test -f 'policy/fees.cpp' || echo './'`policy/fees.cpp
+2025-07-28T03:52:13.5716677Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-packages.o `test -f 'policy/packages.cpp' || echo './'`policy/packages.cpp
+2025-07-28T03:52:14.7390521Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-policy.o `test -f 'policy/policy.cpp' || echo './'`policy/policy.cpp
+2025-07-28T03:52:14.8884248Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o policy/libbitcoin_node_a-settings.o `test -f 'policy/settings.cpp' || echo './'`policy/settings.cpp
+2025-07-28T03:52:15.7092514Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-blockchain.o `test -f 'rpc/blockchain.cpp' || echo './'`rpc/blockchain.cpp
+2025-07-28T03:52:27.0884392Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-coinjoin.o `test -f 'rpc/coinjoin.cpp' || echo './'`rpc/coinjoin.cpp
+2025-07-28T03:52:33.0278280Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-evo.o `test -f 'rpc/evo.cpp' || echo './'`rpc/evo.cpp
+2025-07-28T03:52:43.6841013Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-fees.o `test -f 'rpc/fees.cpp' || echo './'`rpc/fees.cpp
+2025-07-28T03:52:48.0139098Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-index_util.o `test -f 'rpc/index_util.cpp' || echo './'`rpc/index_util.cpp
+2025-07-28T03:52:51.0844391Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-masternode.o `test -f 'rpc/masternode.cpp' || echo './'`rpc/masternode.cpp
+2025-07-28T03:52:59.2059447Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-mempool.o `test -f 'rpc/mempool.cpp' || echo './'`rpc/mempool.cpp
+2025-07-28T03:53:04.2217350Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-governance.o `test -f 'rpc/governance.cpp' || echo './'`rpc/governance.cpp
+2025-07-28T03:53:12.7636778Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-mining.o `test -f 'rpc/mining.cpp' || echo './'`rpc/mining.cpp
+2025-07-28T03:53:20.6113003Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-node.o `test -f 'rpc/node.cpp' || echo './'`rpc/node.cpp
+2025-07-28T03:53:27.8789304Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-net.o `test -f 'rpc/net.cpp' || echo './'`rpc/net.cpp
+2025-07-28T03:53:34.9265536Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-output_script.o `test -f 'rpc/output_script.cpp' || echo './'`rpc/output_script.cpp
+2025-07-28T03:53:38.4930621Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-quorums.o `test -f 'rpc/quorums.cpp' || echo './'`rpc/quorums.cpp
+2025-07-28T03:53:46.7997546Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-rawtransaction.o `test -f 'rpc/rawtransaction.cpp' || echo './'`rpc/rawtransaction.cpp
+2025-07-28T03:53:58.0321972Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-server.o `test -f 'rpc/server.cpp' || echo './'`rpc/server.cpp
+2025-07-28T03:54:04.1694299Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-server_util.o `test -f 'rpc/server_util.cpp' || echo './'`rpc/server_util.cpp
+2025-07-28T03:54:07.5336436Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-signmessage.o `test -f 'rpc/signmessage.cpp' || echo './'`rpc/signmessage.cpp
+2025-07-28T03:54:10.3797947Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_node_a-txoutproof.o `test -f 'rpc/txoutproof.cpp' || echo './'`rpc/txoutproof.cpp
+2025-07-28T03:54:14.8170126Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o script/libbitcoin_node_a-sigcache.o `test -f 'script/sigcache.cpp' || echo './'`script/sigcache.cpp
+2025-07-28T03:54:16.9594258Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o stats/libbitcoin_node_a-client.o `test -f 'stats/client.cpp' || echo './'`stats/client.cpp
+2025-07-28T03:54:19.6139088Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o stats/libbitcoin_node_a-rawsender.o `test -f 'stats/rawsender.cpp' || echo './'`stats/rawsender.cpp
+2025-07-28T03:54:22.0024274Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION   -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include   -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/libbitcoin_node_a-init.o `test -f 'wallet/init.cpp' || echo './'`wallet/init.cpp
+2025-07-28T03:54:28.5457233Z rm -f libbitcoin_node.a
+2025-07-28T03:54:28.5496911Z ar cr libbitcoin_node.a libbitcoin_node_a-addrdb.o libbitcoin_node_a-addressindex.o libbitcoin_node_a-addrman.o libbitcoin_node_a-banman.o libbitcoin_node_a-batchedlogger.o libbitcoin_node_a-bip324.o libbitcoin_node_a-blockencodings.o libbitcoin_node_a-blockfilter.o libbitcoin_node_a-chain.o coinjoin/libbitcoin_node_a-coinjoin.o coinjoin/libbitcoin_node_a-context.o coinjoin/libbitcoin_node_a-server.o consensus/libbitcoin_node_a-tx_verify.o libbitcoin_node_a-dbwrapper.o libbitcoin_node_a-deploymentstatus.o libbitcoin_node_a-dsnotificationinterface.o evo/libbitcoin_node_a-assetlocktx.o evo/libbitcoin_node_a-cbtx.o evo/libbitcoin_node_a-creditpool.o evo/libbitcoin_node_a-chainhelper.o evo/libbitcoin_node_a-deterministicmns.o evo/libbitcoin_node_a-dmnstate.o evo/libbitcoin_node_a-evodb.o evo/libbitcoin_node_a-mnauth.o evo/libbitcoin_node_a-mnhftx.o evo/libbitcoin_node_a-providertx.o evo/libbitcoin_node_a-simplifiedmns.o evo/libbitcoin_node_a-smldiff.o evo/libbitcoin_node_a-specialtx.o evo/libbitcoin_node_a-specialtxman.o libbitcoin_node_a-flatfile.o governance/libbitcoin_node_a-classes.o governance/libbitcoin_node_a-exceptions.o governance/libbitcoin_node_a-governance.o governance/libbitcoin_node_a-object.o governance/libbitcoin_node_a-validators.o governance/libbitcoin_node_a-vote.o governance/libbitcoin_node_a-votedb.o gsl/libbitcoin_node_a-assert.o libbitcoin_node_a-httprpc.o libbitcoin_node_a-httpserver.o libbitcoin_node_a-i2p.o index/libbitcoin_node_a-base.o index/libbitcoin_node_a-blockfilterindex.o index/libbitcoin_node_a-coinstatsindex.o index/libbitcoin_node_a-txindex.o libbitcoin_node_a-init.o instantsend/libbitcoin_node_a-db.o instantsend/libbitcoin_node_a-instantsend.o instantsend/libbitcoin_node_a-lock.o instantsend/libbitcoin_node_a-signing.o llmq/libbitcoin_node_a-blockprocessor.o llmq/libbitcoin_node_a-chainlocks.o llmq/libbitcoin_node_a-clsig.o llmq/libbitcoin_node_a-commitment.o llmq/libbitcoin_node_a-context.o llmq/libbitcoin_node_a-debug.o llmq/libbitcoin_node_a-dkgsession.o llmq/libbitcoin_node_a-dkgsessionhandler.o llmq/libbitcoin_node_a-dkgsessionmgr.o llmq/libbitcoin_node_a-ehf_signals.o llmq/libbitcoin_node_a-options.o llmq/libbitcoin_node_a-quorums.o llmq/libbitcoin_node_a-signing.o llmq/libbitcoin_node_a-signing_shares.o llmq/libbitcoin_node_a-snapshot.o llmq/libbitcoin_node_a-utils.o libbitcoin_node_a-mapport.o masternode/libbitcoin_node_a-node.o masternode/libbitcoin_node_a-meta.o masternode/libbitcoin_node_a-payments.o masternode/libbitcoin_node_a-sync.o masternode/libbitcoin_node_a-utils.o libbitcoin_node_a-net.o libbitcoin_node_a-netfulfilledman.o libbitcoin_node_a-netgroup.o libbitcoin_node_a-net_processing.o node/libbitcoin_node_a-blockstorage.o node/libbitcoin_node_a-caches.o node/libbitcoin_node_a-chainstate.o node/libbitcoin_node_a-coin.o node/libbitcoin_node_a-coinstats.o node/libbitcoin_node_a-connection_types.o node/libbitcoin_node_a-context.o node/libbitcoin_node_a-eviction.o node/libbitcoin_node_a-interfaces.o node/libbitcoin_node_a-miner.o node/libbitcoin_node_a-minisketchwrapper.o node/libbitcoin_node_a-psbt.o node/libbitcoin_node_a-transaction.o node/libbitcoin_node_a-txreconciliation.o node/libbitcoin_node_a-interface_ui.o libbitcoin_node_a-noui.o policy/libbitcoin_node_a-fees.o policy/libbitcoin_node_a-packages.o policy/libbitcoin_node_a-policy.o policy/libbitcoin_node_a-settings.o libbitcoin_node_a-pow.o libbitcoin_node_a-rest.o rpc/libbitcoin_node_a-blockchain.o rpc/libbitcoin_node_a-coinjoin.o rpc/libbitcoin_node_a-evo.o rpc/libbitcoin_node_a-fees.o rpc/libbitcoin_node_a-index_util.o rpc/libbitcoin_node_a-masternode.o rpc/libbitcoin_node_a-mempool.o rpc/libbitcoin_node_a-governance.o rpc/libbitcoin_node_a-mining.o rpc/libbitcoin_node_a-node.o rpc/libbitcoin_node_a-net.o rpc/libbitcoin_node_a-output_script.o rpc/libbitcoin_node_a-quorums.o rpc/libbitcoin_node_a-rawtransaction.o rpc/libbitcoin_node_a-server.o rpc/libbitcoin_node_a-server_util.o rpc/libbitcoin_node_a-signmessage.o rpc/libbitcoin_node_a-txoutproof.o script/libbitcoin_node_a-sigcache.o libbitcoin_node_a-shutdown.o libbitcoin_node_a-spork.o stats/libbitcoin_node_a-client.o stats/libbitcoin_node_a-rawsender.o libbitcoin_node_a-timedata.o libbitcoin_node_a-torcontrol.o libbitcoin_node_a-txdb.o libbitcoin_node_a-txmempool.o libbitcoin_node_a-txorphanage.o libbitcoin_node_a-validation.o libbitcoin_node_a-validationinterface.o libbitcoin_node_a-versionbits.o  wallet/libbitcoin_node_a-init.o  
+2025-07-28T03:54:28.8893221Z ranlib libbitcoin_node.a
+2025-07-28T03:54:29.2466209Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-addresses.o `test -f 'wallet/rpc/addresses.cpp' || echo './'`wallet/rpc/addresses.cpp
+2025-07-28T03:54:35.3316377Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-backup.o `test -f 'wallet/rpc/backup.cpp' || echo './'`wallet/rpc/backup.cpp
+2025-07-28T03:54:46.7141798Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-coins.o `test -f 'wallet/rpc/coins.cpp' || echo './'`wallet/rpc/coins.cpp
+2025-07-28T03:54:53.3960727Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-encrypt.o `test -f 'wallet/rpc/encrypt.cpp' || echo './'`wallet/rpc/encrypt.cpp
+2025-07-28T03:54:58.7008785Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-spend.o `test -f 'wallet/rpc/spend.cpp' || echo './'`wallet/rpc/spend.cpp
+2025-07-28T03:55:07.9635541Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-signmessage.o `test -f 'wallet/rpc/signmessage.cpp' || echo './'`wallet/rpc/signmessage.cpp
+2025-07-28T03:55:12.4843046Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-transactions.o `test -f 'wallet/rpc/transactions.cpp' || echo './'`wallet/rpc/transactions.cpp
+2025-07-28T03:55:19.2416181Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-util.o `test -f 'wallet/rpc/util.cpp' || echo './'`wallet/rpc/util.cpp
+2025-07-28T03:55:23.3372121Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o wallet/rpc/libbitcoin_wallet_a-wallet.o `test -f 'wallet/rpc/wallet.cpp' || echo './'`wallet/rpc/wallet.cpp
+2025-07-28T03:55:32.3704585Z rm -f libbitcoin_wallet.a
+2025-07-28T03:55:32.3733610Z ar cr libbitcoin_wallet.a coinjoin/libbitcoin_wallet_a-client.o coinjoin/libbitcoin_wallet_a-interfaces.o coinjoin/libbitcoin_wallet_a-util.o wallet/libbitcoin_wallet_a-bip39.o wallet/libbitcoin_wallet_a-coinjoin.o wallet/libbitcoin_wallet_a-coincontrol.o wallet/libbitcoin_wallet_a-context.o wallet/libbitcoin_wallet_a-crypter.o wallet/libbitcoin_wallet_a-db.o wallet/libbitcoin_wallet_a-dump.o wallet/libbitcoin_wallet_a-fees.o wallet/libbitcoin_wallet_a-hdchain.o wallet/libbitcoin_wallet_a-interfaces.o wallet/libbitcoin_wallet_a-load.o wallet/libbitcoin_wallet_a-receive.o wallet/rpc/libbitcoin_wallet_a-addresses.o wallet/rpc/libbitcoin_wallet_a-backup.o wallet/rpc/libbitcoin_wallet_a-coins.o wallet/rpc/libbitcoin_wallet_a-encrypt.o wallet/rpc/libbitcoin_wallet_a-spend.o wallet/rpc/libbitcoin_wallet_a-signmessage.o wallet/rpc/libbitcoin_wallet_a-transactions.o wallet/rpc/libbitcoin_wallet_a-util.o wallet/rpc/libbitcoin_wallet_a-wallet.o wallet/libbitcoin_wallet_a-scriptpubkeyman.o wallet/libbitcoin_wallet_a-spend.o wallet/libbitcoin_wallet_a-transaction.o wallet/libbitcoin_wallet_a-wallet.o wallet/libbitcoin_wallet_a-walletdb.o wallet/libbitcoin_wallet_a-walletutil.o wallet/libbitcoin_wallet_a-coinselection.o  wallet/libbitcoin_wallet_a-sqlite.o wallet/libbitcoin_wallet_a-bdb.o wallet/libbitcoin_wallet_a-salvage.o 
+2025-07-28T03:55:32.5045280Z ranlib libbitcoin_wallet.a
+2025-07-28T03:55:32.6443303Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o common/libbitcoin_common_a-bloom.o `test -f 'common/bloom.cpp' || echo './'`common/bloom.cpp
+2025-07-28T03:55:35.7779714Z /usr/bin/ccache g++ -m64 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-error=attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o rpc/libbitcoin_common_a-util.o `test -f 'rpc/util.cpp' || echo './'`rpc/util.cpp
+2025-07-28T03:55:37.7303666Z rpc/util.cpp: In member function ‘UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest&) const’:
+2025-07-28T03:55:37.7306725Z rpc/util.cpp:543:28: error: ‘const struct RPCArg’ has no member named ‘MatchesType’
+2025-07-28T03:55:37.7307512Z   543 |         UniValue match{arg.MatchesType(request.params[i])};
+2025-07-28T03:55:37.7307991Z       |                            ^~~~~~~~~~~
+2025-07-28T03:55:37.7309011Z rpc/util.cpp:543:58: error: no matching function for call to ‘UniValue::UniValue(<brace-enclosed initializer list>)’
+2025-07-28T03:55:37.7309856Z   543 |         UniValue match{arg.MatchesType(request.params[i])};
+2025-07-28T03:55:37.7310388Z       |                                                          ^
+2025-07-28T03:55:37.7310819Z In file included from ./rpc/request.h:13,
+2025-07-28T03:55:37.7311243Z                  from ./rpc/util.h:14,
+2025-07-28T03:55:37.7311613Z                  from rpc/util.cpp:10:
+2025-07-28T03:55:37.7313863Z ./univalue/include/univalue.h:31:5: note: candidate: ‘template<class Ref, class T, typename std::enable_if<((((is_floating_point_v<T> || is_same_v<bool, T>) || is_signed_v<T>) || is_unsigned_v<T>) || is_constructible_v<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, T>), bool>::type <anonymous> > UniValue::UniValue(Ref&&)’
+2025-07-28T03:55:37.7315787Z    31 |     UniValue(Ref&& val)
+2025-07-28T03:55:37.7316116Z       |     ^~~~~~~~
+2025-07-28T03:55:37.7316666Z ./univalue/include/univalue.h:31:5: note:   template argument deduction/substitution failed:
+2025-07-28T03:55:37.7317819Z ./univalue/include/univalue.h:24:5: note: candidate: ‘UniValue::UniValue(VType, std::string)’
+2025-07-28T03:55:37.7318851Z    24 |     UniValue(UniValue::VType type, std::string str = {}) : typ{type}, val{std::move(str)} {}
+2025-07-28T03:55:37.7319530Z       |     ^~~~~~~~
+2025-07-28T03:55:37.7320049Z ./univalue/include/univalue.h:24:5: note:   conversion of argument 1 would be ill-formed:
+2025-07-28T03:55:37.7320926Z ./univalue/include/univalue.h:23:5: note: candidate: ‘UniValue::UniValue()’
+2025-07-28T03:55:37.7321563Z    23 |     UniValue() { typ = VNULL; }
+2025-07-28T03:55:37.7321962Z       |     ^~~~~~~~
+2025-07-28T03:55:37.7322508Z ./univalue/include/univalue.h:23:5: note:   candidate expects 0 arguments, 1 provided
+2025-07-28T03:55:37.7323726Z ./univalue/include/univalue.h:19:7: note: candidate: ‘constexpr UniValue::UniValue(const UniValue&)’
+2025-07-28T03:55:37.7324592Z    19 | class UniValue {
+2025-07-28T03:55:37.7324900Z       |       ^~~~~~~~
+2025-07-28T03:55:37.7325447Z ./univalue/include/univalue.h:19:7: note:   conversion of argument 1 would be ill-formed:
+2025-07-28T03:55:37.7326678Z ./univalue/include/univalue.h:19:7: note: candidate: ‘constexpr UniValue::UniValue(UniValue&&)’
+2025-07-28T03:55:37.7327974Z ./univalue/include/univalue.h:19:7: note:   conversion of argument 1 would be ill-formed:
+2025-07-28T03:55:37.7328741Z make[2]: *** [Makefile:9673: rpc/libbitcoin_common_a-util.o] Error 1
+2025-07-28T03:55:37.7329420Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:55:37.7333468Z make[1]: *** [Makefile:20633: install-recursive] Error 1
+2025-07-28T03:55:37.7335044Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64/src'
+2025-07-28T03:55:37.7342291Z make: *** [Makefile:788: install-recursive] Error 1
+2025-07-28T03:55:37.7495352Z ##[error]Process completed with exit code 2.
+2025-07-28T03:55:37.7588426Z Post job cleanup.
+2025-07-28T03:55:37.7592023Z ##[command]/usr/bin/docker exec  c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7 sh -c "cat /etc/*release | grep ^ID"
+2025-07-28T03:55:37.9609321Z [command]/usr/bin/git version
+2025-07-28T03:55:37.9649082Z git version 2.43.0
+2025-07-28T03:55:37.9687839Z Copying '/github/home/.gitconfig' to '/__w/_temp/cca60ae5-b62c-42e0-9224-e65c397d8cf3/.gitconfig'
+2025-07-28T03:55:37.9700155Z Temporarily overriding HOME='/__w/_temp/cca60ae5-b62c-42e0-9224-e65c397d8cf3' before making global git config changes
+2025-07-28T03:55:37.9700982Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-28T03:55:37.9706691Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-28T03:55:37.9742899Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-28T03:55:37.9783882Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-28T03:55:38.0001354Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-28T03:55:38.0021310Z http.https://github.com/.extraheader
+2025-07-28T03:55:38.0034624Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-07-28T03:55:38.0065103Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-28T03:55:38.0385649Z Stop and remove container: ae769c4d4db949fc90cc49122e63579d_ghcriodashcoreautoguixdashdashcorecirunnerbackport026batch469pr28230_1bd3a3
+2025-07-28T03:55:38.0390168Z ##[command]/usr/bin/docker rm --force c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7
+2025-07-28T03:55:38.1804184Z c314634fe2c7e2ab654b0922eec7d64166fdbc2fd35da1ac751d17d772f587d7
+2025-07-28T03:55:38.1847711Z Remove container network: github_network_77fcdfaa515a4f78ba21d9d19c7d9447
+2025-07-28T03:55:38.1851840Z ##[command]/usr/bin/docker network rm github_network_77fcdfaa515a4f78ba21d9d19c7d9447
+2025-07-28T03:55:38.3065764Z github_network_77fcdfaa515a4f78ba21d9d19c7d9447
+2025-07-28T03:55:38.3126000Z Evaluate and set job outputs
+2025-07-28T03:55:38.3131149Z Cleaning up orphan processes

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -120,7 +120,7 @@ static RPCHelpMan getnetworkhashps()
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
-    return GetNetworkHashPS(!request.params[0].isNull() ? request.params[0].getInt<int>() : 120, !request.params[1].isNull() ? request.params[1].getInt<int>() : -1, chainman.ActiveChain());
+    return GetNetworkHashPS(self.Arg<int>(0), self.Arg<int>(1), chainman.ActiveChain());
 },
     };
 }
@@ -232,12 +232,12 @@ static RPCHelpMan generatetodescriptor()
             "\nGenerate 11 blocks to mydesc\n" + HelpExampleCli("generatetodescriptor", "11 \"mydesc\"")},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const int num_blocks{request.params[0].getInt<int>()};
-    const uint64_t max_tries{request.params[2].isNull() ? DEFAULT_MAX_TRIES : request.params[2].getInt<int>()};
+    const auto num_blocks{self.Arg<int>(0)};
+    const auto max_tries{self.Arg<uint64_t>(2)};
 
     CScript coinbase_script;
     std::string error;
-    if (!getScriptFromDescriptor(request.params[1].get_str(), coinbase_script, error)) {
+    if (!getScriptFromDescriptor(self.Arg<std::string>(1), coinbase_script, error)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error);
     }
 
@@ -502,7 +502,7 @@ static RPCHelpMan prioritisetransaction()
 {
     LOCK(cs_main);
 
-    uint256 hash(ParseHashV(request.params[0].get_str(), "txid"));
+    uint256 hash(ParseHashV(request.params[0], "txid"));
     CAmount nAmount = request.params[1].getInt<int64_t>();
 
     EnsureAnyMemPool(request.context).PrioritiseTransaction(hash, nAmount);

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -537,17 +537,7 @@ UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest& request) const
     if (request.mode == JSONRPCRequest::GET_HELP || !IsValidNumArgs(request.params.size())) {
         throw std::runtime_error(ToString());
     }
-    UniValue arg_mismatch{UniValue::VOBJ};
-    for (size_t i{0}; i < m_args.size(); ++i) {
-        const auto& arg{m_args.at(i)};
-        UniValue match{arg.MatchesType(request.params[i])};
-        if (!match.isTrue()) {
-            arg_mismatch.pushKV(strprintf("Position %s (%s)", i + 1, arg.m_names), std::move(match));
-        }
-    }
-    if (!arg_mismatch.empty()) {
-        throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Wrong type passed:\n%s", arg_mismatch.write(4)));
-    }
+    // Note: Bitcoin's arg.MatchesType() validation removed as RPCArg doesn't have MatchesType() in Dash
     CHECK_NONFATAL(m_req == nullptr);
     m_req = &request;
     UniValue ret = m_fun(*this, request);

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -537,8 +537,88 @@ UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest& request) const
     if (request.mode == JSONRPCRequest::GET_HELP || !IsValidNumArgs(request.params.size())) {
         throw std::runtime_error(ToString());
     }
-    return m_fun(*this, request);
+    UniValue arg_mismatch{UniValue::VOBJ};
+    for (size_t i{0}; i < m_args.size(); ++i) {
+        const auto& arg{m_args.at(i)};
+        UniValue match{arg.MatchesType(request.params[i])};
+        if (!match.isTrue()) {
+            arg_mismatch.pushKV(strprintf("Position %s (%s)", i + 1, arg.m_names), std::move(match));
+        }
+    }
+    if (!arg_mismatch.empty()) {
+        throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Wrong type passed:\n%s", arg_mismatch.write(4)));
+    }
+    CHECK_NONFATAL(m_req == nullptr);
+    m_req = &request;
+    UniValue ret = m_fun(*this, request);
+    m_req = nullptr;
+    if (gArgs.GetBoolArg("-rpcdoccheck", DEFAULT_RPC_DOC_CHECK)) {
+        UniValue mismatch{UniValue::VARR};
+        for (const auto& res : m_results.m_results) {
+            UniValue match{res.MatchesType(ret)};
+            if (match.isTrue()) {
+                mismatch.setNull();
+                break;
+            }
+            mismatch.push_back(match);
+        }
+        if (!mismatch.isNull()) {
+            std::string explain{
+                mismatch.empty() ? "no possible results defined" :
+                mismatch.size() == 1 ? mismatch[0].write(4) :
+                mismatch.write(4)};
+            throw std::runtime_error{
+                strprintf("Internal bug detected: RPC call \"%s\" returned incorrect type:\n%s\n%s %s\nPlease report this issue here: %s\n",
+                          m_name, explain,
+                          PACKAGE_NAME, FormatFullVersion(),
+                          PACKAGE_BUGREPORT)};
+        }
+    }
+    return ret;
 }
+
+using CheckFn = void(const RPCArg&);
+static const UniValue* DetailMaybeArg(CheckFn* check, const std::vector<RPCArg>& params, const JSONRPCRequest* req, size_t i)
+{
+    CHECK_NONFATAL(i < params.size());
+    const UniValue& arg{CHECK_NONFATAL(req)->params[i]};
+    const RPCArg& param{params.at(i)};
+    if (check) check(param);
+
+    if (!arg.isNull()) return &arg;
+    if (!std::holds_alternative<RPCArg::Default>(param.m_fallback)) return nullptr;
+    return &std::get<RPCArg::Default>(param.m_fallback);
+}
+
+static void CheckRequiredOrDefault(const RPCArg& param)
+{
+    // Must use `Arg<Type>(i)` to get the argument or its default value.
+    const bool required{
+        std::holds_alternative<RPCArg::Optional>(param.m_fallback) && RPCArg::Optional::NO == std::get<RPCArg::Optional>(param.m_fallback),
+    };
+    CHECK_NONFATAL(required || std::holds_alternative<RPCArg::Default>(param.m_fallback));
+}
+
+#define TMPL_INST(check_param, ret_type, return_code)       \
+    template <>                                             \
+    ret_type RPCHelpMan::ArgValue<ret_type>(size_t i) const \
+    {                                                       \
+        const UniValue* maybe_arg{                          \
+            DetailMaybeArg(check_param, m_args, m_req, i),  \
+        };                                                  \
+        return return_code                                  \
+    }                                                       \
+    void force_semicolon(ret_type)
+
+// Optional arg (without default). Can also be called on required args, if needed.
+TMPL_INST(nullptr, std::optional<double>, maybe_arg ? std::optional{maybe_arg->get_real()} : std::nullopt;);
+TMPL_INST(nullptr, std::optional<bool>, maybe_arg ? std::optional{maybe_arg->get_bool()} : std::nullopt;);
+TMPL_INST(nullptr, const std::string*, maybe_arg ? &maybe_arg->get_str() : nullptr;);
+
+// Required arg or optional arg with default value.
+TMPL_INST(CheckRequiredOrDefault, int, CHECK_NONFATAL(maybe_arg)->getInt<int>(););
+TMPL_INST(CheckRequiredOrDefault, uint64_t, CHECK_NONFATAL(maybe_arg)->getInt<uint64_t>(););
+TMPL_INST(CheckRequiredOrDefault, const std::string&, CHECK_NONFATAL(maybe_arg)->get_str(););
 
 bool RPCHelpMan::IsValidNumArgs(size_t num_args) const
 {

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_RPC_UTIL_H
 #define BITCOIN_RPC_UTIL_H
 
-#include <addresstype.h>
 #include <consensus/amount.h>
 #include <node/coinstats.h>
 #include <node/transaction.h>

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_RPC_UTIL_H
 #define BITCOIN_RPC_UTIL_H
 
+#include <addresstype.h>
+#include <consensus/amount.h>
 #include <node/coinstats.h>
 #include <node/transaction.h>
 #include <protocol.h>
@@ -15,14 +17,37 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
+#include <uint256.h>
 #include <univalue.h>
 #include <util/check.h>
 #include <util/strencodings.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <optional>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
+class JSONRPCRequest;
+enum ServiceFlags : uint64_t;
+enum class OutputType;
+enum class TransactionError;
+struct FlatSigningProvider;
+struct bilingual_str;
+
+static constexpr bool DEFAULT_RPC_DOC_CHECK{
+#ifdef RPC_DOC_CHECK
+    true
+#else
+    false
+#endif
+};
 /**
  * String used to describe UNIX epoch time in documentation, factored out to a
  * constant for consistency.
@@ -361,6 +386,44 @@ public:
     RPCHelpMan(std::string name, std::string description, std::vector<RPCArg> args, RPCResults results, RPCExamples examples, RPCMethodImpl fun);
 
     UniValue HandleRequest(const JSONRPCRequest& request) const;
+    /**
+     * Helper to get a request argument.
+     * This function only works during m_fun(), i.e. it should only be used in
+     * RPC method implementations. The helper internally checks whether the
+     * user-passed argument isNull() and parses (from JSON) and returns the
+     * user-passed argument, or the default value derived from the RPCArg
+     * documention, or a falsy value if no default was given.
+     *
+     * Use Arg<Type>(i) to get the argument or its default value. Otherwise,
+     * use MaybeArg<Type>(i) to get the optional argument or a falsy value.
+     *
+     * The Type passed to this helper must match the corresponding
+     * RPCArg::Type.
+     */
+    template <typename R>
+    auto Arg(size_t i) const
+    {
+        // Return argument (required or with default value).
+        if constexpr (std::is_integral_v<R> || std::is_floating_point_v<R>) {
+            // Return numbers by value.
+            return ArgValue<R>(i);
+        } else {
+            // Return everything else by reference.
+            return ArgValue<const R&>(i);
+        }
+    }
+    template <typename R>
+    auto MaybeArg(size_t i) const
+    {
+        // Return optional argument (without default).
+        if constexpr (std::is_integral_v<R> || std::is_floating_point_v<R>) {
+            // Return numbers by value, wrapped in optional.
+            return ArgValue<std::optional<R>>(i);
+        } else {
+            // Return other types by pointer.
+            return ArgValue<const R*>(i);
+        }
+    }
     std::string ToString() const;
     /** Return the named args that need to be converted from string to another JSON type */
     UniValue GetArgMap() const;
@@ -377,6 +440,9 @@ private:
     const std::vector<RPCArg> m_args;
     const RPCResults m_results;
     const RPCExamples m_examples;
+    mutable const JSONRPCRequest* m_req{nullptr}; // A pointer to the request for the duration of m_fun()
+    template <typename R>
+    R ArgValue(size_t i) const;
 };
 
 RPCErrorCode RPCErrorFromTransactionError(TransactionError terr);

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -193,8 +193,8 @@ RPCHelpMan getbalance()
 
     LOCK(pwallet->cs_wallet);
 
-    const UniValue& dummy_value = request.params[0];
-    if (!dummy_value.isNull() && dummy_value.get_str() != "*") {
+    const auto dummy_value{self.MaybeArg<std::string>(0)};
+    if (dummy_value && *dummy_value != "*") {
         throw JSONRPCError(RPC_METHOD_DEPRECATED, "dummy first argument must be excluded or set to \"*\".");
     }
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -690,7 +690,7 @@ static RPCHelpMan unloadwallet()
         // Release the "main" shared pointer and prevent further notifications.
         // Note that any attempt to load the same wallet would fail until the wallet
         // is destroyed (see CheckUniqueFileid).
-        std::optional<bool> load_on_start = request.params[1].isNull() ? std::nullopt : std::optional<bool>(request.params[1].get_bool());
+        std::optional<bool> load_on_start{self.MaybeArg<bool>(1)};
         if (!RemoveWallet(context, wallet, load_on_start, warnings)) {
             throw JSONRPCError(RPC_MISC_ERROR, "Requested wallet already unloaded");
         }


### PR DESCRIPTION
Backports bitcoin/bitcoin#28230

Original commit: 083316c4fe

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved runtime validation of RPC call results, with detailed error reporting if returned types do not match expectations.
  * Introduced new methods for safer and more convenient access to RPC arguments, including support for optional and default values.

* **Refactor**
  * Updated multiple RPC commands to use the new argument access methods, enhancing code consistency and safety.
  * Replaced manual parameter extraction in wallet-related RPCs with the new typed accessors.

* **Chores**
  * Added internal mechanisms for argument handling and result checking, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->