### PR TITLE
Merge bitcoin/bitcoin#28291: rpc: removed StrFormatInternalBug quote delimitation

### DIFF
--- a/src/util/check.h
+++ b/src/util/check.h
@@ -21,7 +21,7 @@ class NonFatalCheckError : public std::runtime_error
 };
 
 #define format_internal_error(msg, file, line, func, report)                                    \
-    strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\n"                                     \
+    strprintf("Internal bug detected: %s\n%s:%d (%s)\n"                                     \
               "%s %s\n"                                                                           \
               "Please report this issue here: %s\n",                                             \
               msg, file, line, func, PACKAGE_NAME, FormatFullVersion(), report)

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -27,7 +27,7 @@ class RpcMiscTest(BitcoinTestFramework):
         self.log.info("test CHECK_NONFATAL")
         assert_raises_rpc_error(
             -1,
-            'Internal bug detected: "request.params[9].get_str() != "trigger_internal_bug""',
+            'Internal bug detected: request.params[9].get_str() != "trigger_internal_bug"',
             lambda: node.echo(arg9='trigger_internal_bug'),
         )
 

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -274,6 +274,11 @@ def check_host(args) -> int:
     if args.download_binary:
         platforms = {
             'aarch64-*-linux*': 'aarch64-linux-gnu',
+<<<<<<< HEAD
+=======
+            'powerpc64le-*-linux-*': 'powerpc64le-linux-gnu',
+            'riscv64-*-linux*': 'riscv64-linux-gnu',
+>>>>>>> 1348454d82 (Merge bitcoin/bitcoin#28352: test: Support powerpc64le in get_previous_releases.py)
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',
             'aarch64-apple-darwin*': 'arm64-apple-darwin',

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -274,11 +274,8 @@ def check_host(args) -> int:
     if args.download_binary:
         platforms = {
             'aarch64-*-linux*': 'aarch64-linux-gnu',
-<<<<<<< HEAD
-=======
             'powerpc64le-*-linux-*': 'powerpc64le-linux-gnu',
             'riscv64-*-linux*': 'riscv64-linux-gnu',
->>>>>>> 1348454d82 (Merge bitcoin/bitcoin#28352: test: Support powerpc64le in get_previous_releases.py)
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',
             'aarch64-apple-darwin*': 'arm64-apple-darwin',


### PR DESCRIPTION
Backports bitcoin/bitcoin#28291

Original commit: 337d6f35a2

This PR removes unnecessary quotes from internal bug error messages. In Dash, this change is applied to the `format_internal_error` macro in `src/util/check.h` since Dash doesn't have the `StrFormatInternalBug` function that Bitcoin uses.

## Changes:
- Removed quotes around `%s` in the `format_internal_error` macro
- Updated test expectations in `test/functional/rpc_misc.py` to match the new format

The backport adapts the change to Dash's architecture while maintaining the same functional outcome.

Backported from Bitcoin Core v0.26