### PR TITLE
Merge bitcoin/bitcoin#27511: rpc: Add test-only RPC getaddrmaninfo for new/tried table address count

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1112,6 +1112,55 @@ static RPCHelpMan setmnthreadactive()
     };
 }
 
+static RPCHelpMan getaddrmaninfo()
+{
+    return RPCHelpMan{"getaddrmaninfo",
+                      "\nProvides information about the node's address manager by returning the number of "
+                      "addresses in the `new` and `tried` tables and their sum for all networks.\n"
+                      "This RPC is for testing only.\n",
+                      {},
+                      RPCResult{
+                              RPCResult::Type::OBJ_DYN, "", "json object with network type as keys",
+                              {
+                                      {RPCResult::Type::OBJ, "network", "the network (" + Join(GetNetworkNames(), ", ") + ")",
+                                       {
+                                               {RPCResult::Type::NUM, "new", "number of addresses in the new table, which represent potential peers the node has discovered but hasn't yet successfully connected to."},
+                                               {RPCResult::Type::NUM, "tried", "number of addresses in the tried table, which represent peers the node has successfully connected to in the past."},
+                                               {RPCResult::Type::NUM, "total", "total number of addresses in both new/tried tables"},
+                                       }},
+                              }
+                      },
+                      RPCExamples{
+                              HelpExampleCli("getaddrmaninfo", "")
+                              + HelpExampleRpc("getaddrmaninfo", "")
+                      },
+                      [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+                      {
+                          NodeContext& node = EnsureAnyNodeContext(request.context);
+                          if (!node.addrman) {
+                              throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Address manager functionality missing or disabled");
+                          }
+
+                          UniValue ret(UniValue::VOBJ);
+                          for (int n = 0; n < NET_MAX; ++n) {
+                              enum Network network = static_cast<enum Network>(n);
+                              if (network == NET_UNROUTABLE || network == NET_INTERNAL) continue;
+                              UniValue obj(UniValue::VOBJ);
+                              obj.pushKV("new", node.addrman->Size(network, true));
+                              obj.pushKV("tried", node.addrman->Size(network, false));
+                              obj.pushKV("total", node.addrman->Size(network));
+                              ret.pushKV(GetNetworkName(network), obj);
+                          }
+                          UniValue obj(UniValue::VOBJ);
+                          obj.pushKV("new", node.addrman->Size(std::nullopt, true));
+                          obj.pushKV("tried", node.addrman->Size(std::nullopt, false));
+                          obj.pushKV("total", node.addrman->Size());
+                          ret.pushKV("all_networks", obj);
+                          return ret;
+                      },
+    };
+}
+
 void RegisterNetRPCCommands(CRPCTable &t)
 {
 // clang-format off
@@ -1136,6 +1185,7 @@ static const CRPCCommand commands[] =
     { "hidden",              &addconnection,           },
     { "hidden",              &addpeeraddress,          },
     { "hidden",              &sendmsgtopeer            },
+    { "hidden",              &getaddrmaninfo           },
     { "hidden",              &setmnthreadactive        },
 };
 // clang-format on

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -107,6 +107,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "generate",
     "generateblock",
     "getaddednodeinfo",
+    "getaddrmaninfo",
     "getbestblockhash",
     "getblock",
     "getblockchaininfo",

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -68,6 +68,7 @@ class NetTest(DashTestFramework):
         self.test_getnodeaddresses()
         self.test_addpeeraddress()
         self.test_sendmsgtopeer()
+        self.test_getaddrmaninfo()
 
     def test_connection_count(self):
         self.log.info("Test getconnectioncount")
@@ -394,6 +395,28 @@ class NetTest(DashTestFramework):
         node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=zero_byte_string.hex())
         self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
 
+    def test_getaddrmaninfo(self):
+        self.log.info("Test getaddrmaninfo")
+        node = self.nodes[1]
+
+        self.log.debug("Test that getaddrmaninfo is a hidden RPC")
+        # It is hidden from general help, but its detailed help may be called directly.
+        assert "getaddrmaninfo" not in node.help()
+        assert "getaddrmaninfo" in node.help("getaddrmaninfo")
+
+        # current count of ipv4 addresses in addrman is {'new':1, 'tried':1}
+        self.log.info("Test that count of addresses in addrman match expected values")
+        res = node.getaddrmaninfo()
+        assert_equal(res["ipv4"]["new"], 1)
+        assert_equal(res["ipv4"]["tried"], 1)
+        assert_equal(res["ipv4"]["total"], 2)
+        assert_equal(res["all_networks"]["new"], 1)
+        assert_equal(res["all_networks"]["tried"], 1)
+        assert_equal(res["all_networks"]["total"], 2)
+        for net in ["ipv6", "onion", "i2p", "cjdns"]:
+            assert_equal(res[net]["new"], 0)
+            assert_equal(res[net]["tried"], 0)
+            assert_equal(res[net]["total"], 0)
 
 if __name__ == '__main__':
     NetTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#27511

Original commit: ff564c75e7

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a hidden RPC command to provide detailed statistics about the node's address manager, including address counts by network type.
* **Tests**
  * Added new tests to verify the behavior and output of the new RPC command, ensuring accurate reporting of address manager information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->