### PR TITLE
Merge bitcoin-core/gui#739: Disable and uncheck blank when private keys are disabled

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -41,9 +41,10 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
         // set to true, enable it when isDisablePrivateKeysChecked is false.
         ui->encrypt_wallet_checkbox->setEnabled(!checked);
 
-        // Wallets without private keys start out blank
+        // Wallets without private keys cannot set blank
+        ui->blank_wallet_checkbox->setEnabled(!checked);
         if (checked) {
-            ui->blank_wallet_checkbox->setChecked(true);
+            ui->blank_wallet_checkbox->setChecked(false);
         }
 
         // When the encrypt_wallet_checkbox is disabled, uncheck it.
@@ -53,8 +54,11 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
     });
 
     connect(ui->blank_wallet_checkbox, &QCheckBox::toggled, [this](bool checked) {
-        if (!checked) {
-          ui->disable_privkeys_checkbox->setChecked(false);
+        // Disable the disable_privkeys_checkbox when blank_wallet_checkbox is checked
+        // as blank-ness only pertains to wallets with private keys.
+        ui->disable_privkeys_checkbox->setEnabled(!checked);
+        if (checked) {
+            ui->disable_privkeys_checkbox->setChecked(false);
         }
     });
 


### PR DESCRIPTION
Backports bitcoin-core/gui#739

Original commit: bce7b087cbd9668f46b5c560f3187db2e878a2df

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the behavior of the "disable private keys" and "blank wallet" checkboxes in the wallet creation dialog to ensure they are now mutually exclusive and update correctly when toggled.

* **Documentation**
  * Updated in-app descriptions to clarify the relationship between "blank wallet" and "disable private keys" options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->