### PR TITLE
Merge bitcoin-core/gui#119: Replace send-to-self with dual send+receive entries

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -422,6 +422,7 @@ struct WalletTx
     CTransactionRef tx;
     std::vector<wallet::isminetype> txin_is_mine;
     std::vector<wallet::isminetype> txout_is_mine;
+    std::vector<bool> txout_is_change;
     std::vector<CTxDestination> txout_address;
     std::vector<wallet::isminetype> txout_address_is_mine;
     CAmount credit;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -15,7 +15,6 @@
 
 #include <QDateTime>
 
-using wallet::ISMINE_ALL;
 using wallet::ISMINE_SPENDABLE;
 using wallet::ISMINE_WATCH_ONLY;
 using wallet::isminetype;
@@ -43,17 +42,93 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
     std::map<std::string, std::string> mapValue = wtx.value_map;
     auto& coinJoinOptions = node.coinJoinOptions();
 
-    if (nNet > 0 || wtx.is_coinbase || wtx.is_platform_transfer)
-    {
-        //
-        // Credit
-        //
+    bool involvesWatchAddress = false;
+    isminetype fAllFromMe = ISMINE_SPENDABLE;
+    bool any_from_me = false;
+    if (wtx.is_coinbase || wtx.is_platform_transfer) {
+        fAllFromMe = isminetype(0);
+    } else {
+        for (const isminetype mine : wtx.txin_is_mine)
+        {
+            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+            if(fAllFromMe > mine) fAllFromMe = mine;
+            if (mine) any_from_me = true;
+        }
+    }
+
+    // Handle CoinJoin denominate transactions separately
+    if(wtx.is_denominate) {
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::CoinJoinMixing, "", -nDebit, nCredit));
+        parts.last().involvesWatchAddress = false;   // maybe pass to TransactionRecord as constructor argument
+        return parts;
+    }
+
+    if (fAllFromMe || !any_from_me) {
+        for (const isminetype mine : wtx.txout_is_mine)
+        {
+            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+        }
+
+        CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
         for(unsigned int i = 0; i < wtx.tx->vout.size(); i++)
         {
             const CTxOut& txout = wtx.tx->vout[i];
+
+            if (fAllFromMe) {
+                // Change is only really possible if we're the sender
+                // Otherwise, someone just sent bitcoins to a change address, which should be shown
+                if (wtx.txout_is_change[i]) {
+                    continue;
+                }
+
+                //
+                // Debit
+                //
+
+                TransactionRecord sub(hash, nTime);
+                sub.idx = i;
+                sub.involvesWatchAddress = involvesWatchAddress;
+
+                if (!std::get_if<CNoDestination>(&wtx.txout_address[i]))
+                {
+                    // Sent to Dash Address
+                    sub.type = TransactionRecord::SendToAddress;
+                    sub.strAddress = EncodeDestination(wtx.txout_address[i]);
+                    sub.txDest = wtx.txout_address[i];
+                    sub.updateLabel(wallet);
+                }
+                else
+                {
+                    // Sent to IP, or other non-address transaction like OP_EVAL
+                    sub.type = TransactionRecord::SendToOther;
+                    sub.strAddress = mapValue["to"];
+                    sub.txDest = DecodeDestination(sub.strAddress);
+                }
+
+                if(mapValue["DS"] == "1")
+                {
+                    sub.type = TransactionRecord::CoinJoinSend;
+                }
+
+                CAmount nValue = txout.nValue;
+                /* Add fee to first output */
+                if (nTxFee > 0)
+                {
+                    nValue += nTxFee;
+                    nTxFee = 0;
+                }
+                sub.debit = -nValue;
+
+                parts.append(sub);
+            }
+
             isminetype mine = wtx.txout_is_mine[i];
             if(mine)
             {
+                //
+                // Credit
+                //
+
                 TransactionRecord sub(hash, nTime);
                 sub.idx = i; // vout index
                 sub.credit = txout.nValue;
@@ -87,180 +162,74 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
                 parts.append(sub);
             }
         }
-    }
-    else
-    {
-        bool involvesWatchAddress = false;
-        isminetype fAllFromMe = ISMINE_SPENDABLE;
-        for (const isminetype mine : wtx.txin_is_mine)
-        {
-            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllFromMe > mine) fAllFromMe = mine;
-        }
 
-        isminetype fAllToMe = ISMINE_SPENDABLE;
-        for (const isminetype mine : wtx.txout_is_mine)
-        {
-            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllToMe > mine) fAllToMe = mine;
-        }
-
-        if(wtx.is_denominate) {
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::CoinJoinMixing, "", -nDebit, nCredit));
-            parts.last().involvesWatchAddress = false;   // maybe pass to TransactionRecord as constructor argument
-        }
-        else if (fAllFromMe && fAllToMe)
-        {
-            // Payment to self
-            // TODO: this section still not accurate but covers most cases,
-            // might need some additional work however
-
-            TransactionRecord sub(hash, nTime);
-            // Payment to self by default
-            sub.type = TransactionRecord::SendToSelf;
-            sub.strAddress = "";
-            for (auto it = wtx.txout_address.begin(); it != wtx.txout_address.end(); ++it) {
-                if (it != wtx.txout_address.begin()) sub.strAddress += ", ";
-                sub.strAddress += EncodeDestination(*it);
-            }
-
-            if(mapValue["DS"] == "1")
-            {
-                sub.type = TransactionRecord::CoinJoinSend;
-                CTxDestination address;
-                if (ExtractDestination(wtx.tx->vout[0].scriptPubKey, address))
-                {
-                    // Sent to Dash Address
-                    sub.strAddress = EncodeDestination(address);
-                    sub.txDest = address;
-                    sub.updateLabel(wallet);
-                }
-                else
-                {
-                    // Sent to IP, or other non-address transaction like OP_EVAL
-                    sub.strAddress = mapValue["to"];
-                    sub.txDest = DecodeDestination(sub.strAddress);
-                }
-            }
-            else
-            {
-                sub.idx = parts.size();
-                if(wtx.tx->vin.size() == 1 && wtx.tx->vout.size() == 1
-                    && coinJoinOptions.isCollateralAmount(nDebit)
-                    && coinJoinOptions.isCollateralAmount(nCredit)
-                    && coinJoinOptions.isCollateralAmount(-nNet))
-                {
-                    sub.type = TransactionRecord::CoinJoinCollateralPayment;
-                } else {
-                    bool fMakeCollateral{false};
-                    if (wtx.tx->vout.size() == 2) {
-                        CAmount nAmount0 = wtx.tx->vout[0].nValue;
-                        CAmount nAmount1 = wtx.tx->vout[1].nValue;
-                        // <case1>, see CCoinJoinClientSession::MakeCollateralAmounts
-                        fMakeCollateral = (nAmount0 == coinJoinOptions.getMaxCollateralAmount() && !coinJoinOptions.isDenominated(nAmount1) && nAmount1 >= coinJoinOptions.getMinCollateralAmount()) ||
-                                          (nAmount1 == coinJoinOptions.getMaxCollateralAmount() && !coinJoinOptions.isDenominated(nAmount0) && nAmount0 >= coinJoinOptions.getMinCollateralAmount()) ||
-                        // <case2>, see CCoinJoinClientSession::MakeCollateralAmounts
-                                          (nAmount0 == nAmount1 && coinJoinOptions.isCollateralAmount(nAmount0));
-                    } else if (wtx.tx->vout.size() == 1) {
-                        // <case3>, see CCoinJoinClientSession::MakeCollateralAmounts
-                        fMakeCollateral = coinJoinOptions.isCollateralAmount(wtx.tx->vout[0].nValue);
-                    }
-                    if (fMakeCollateral) {
-                        sub.type = TransactionRecord::CoinJoinMakeCollaterals;
-                    } else {
-                        for (const auto& txout : wtx.tx->vout) {
-                            if (coinJoinOptions.isDenominated(txout.nValue)) {
-                                sub.type = TransactionRecord::CoinJoinCreateDenominations;
-                                break; // Done, it's definitely a tx creating mixing denoms, no need to look any further
-                            }
-                        }
-                    }
-                }
-            }
-
-            CAmount nChange = wtx.change;
-
-            sub.debit = -(nDebit - nChange);
-            sub.credit = nCredit - nChange;
-            parts.append(sub);
-            parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
-        }
-        else if (fAllFromMe)
-        {
-            //
-            // Debit
-            //
-            CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
-
-            bool fDone = false;
+        // Handle special Dash-specific CoinJoin transactions that are all from me
+        if (fAllFromMe && nCredit > 0) {
+            // Check for specific CoinJoin transaction types
+            bool fHandled = false;
+            
+            // CoinJoin collateral payment
             if(wtx.tx->vin.size() == 1 && wtx.tx->vout.size() == 1
                 && coinJoinOptions.isCollateralAmount(nDebit)
-                && nCredit == 0 // OP_RETURN
+                && coinJoinOptions.isCollateralAmount(nCredit)
                 && coinJoinOptions.isCollateralAmount(-nNet))
             {
                 TransactionRecord sub(hash, nTime);
-                sub.idx = 0;
                 sub.type = TransactionRecord::CoinJoinCollateralPayment;
-                sub.debit = -nDebit;
-                parts.append(sub);
-                fDone = true;
-            }
-
-            for (unsigned int nOut = 0; nOut < wtx.tx->vout.size() && !fDone; nOut++)
-            {
-                const CTxOut& txout = wtx.tx->vout[nOut];
-                TransactionRecord sub(hash, nTime);
-                sub.idx = nOut;
+                sub.debit = -(nDebit - wtx.change);
+                sub.credit = nCredit - wtx.change;
                 sub.involvesWatchAddress = involvesWatchAddress;
-
-                if(wtx.txout_is_mine[nOut])
-                {
-                    // Ignore parts sent to self, as this is usually the change
-                    // from a transaction sent back to our own address.
-                    continue;
-                }
-
-                if (!std::get_if<CNoDestination>(&wtx.txout_address[nOut]))
-                {
-                    // Sent to Dash Address
-                    sub.type = TransactionRecord::SendToAddress;
-                    sub.strAddress = EncodeDestination(wtx.txout_address[nOut]);
-                    sub.txDest = wtx.txout_address[nOut];
-                    sub.updateLabel(wallet);
-                }
-                else
-                {
-                    // Sent to IP, or other non-address transaction like OP_EVAL
-                    sub.type = TransactionRecord::SendToOther;
-                    sub.strAddress = mapValue["to"];
-                    sub.txDest = DecodeDestination(sub.strAddress);
-                }
-
-                if(mapValue["DS"] == "1")
-                {
-                    sub.type = TransactionRecord::CoinJoinSend;
-                }
-
-                CAmount nValue = txout.nValue;
-                /* Add fee to first output */
-                if (nTxFee > 0)
-                {
-                    nValue += nTxFee;
-                    nTxFee = 0;
-                }
-                sub.debit = -nValue;
-
                 parts.append(sub);
+                fHandled = true;
+            }
+            // Check for CoinJoin make collaterals or create denominations
+            else if (!fHandled) {
+                bool fMakeCollateral = false;
+                bool fCreateDenominations = false;
+                
+                if (wtx.tx->vout.size() == 2) {
+                    CAmount nAmount0 = wtx.tx->vout[0].nValue;
+                    CAmount nAmount1 = wtx.tx->vout[1].nValue;
+                    // <case1>, see CCoinJoinClientSession::MakeCollateralAmounts
+                    fMakeCollateral = (nAmount0 == coinJoinOptions.getMaxCollateralAmount() && !coinJoinOptions.isDenominated(nAmount1) && nAmount1 >= coinJoinOptions.getMinCollateralAmount()) ||
+                                      (nAmount1 == coinJoinOptions.getMaxCollateralAmount() && !coinJoinOptions.isDenominated(nAmount0) && nAmount0 >= coinJoinOptions.getMinCollateralAmount()) ||
+                    // <case2>, see CCoinJoinClientSession::MakeCollateralAmounts
+                                      (nAmount0 == nAmount1 && coinJoinOptions.isCollateralAmount(nAmount0));
+                } else if (wtx.tx->vout.size() == 1) {
+                    // <case3>, see CCoinJoinClientSession::MakeCollateralAmounts
+                    fMakeCollateral = coinJoinOptions.isCollateralAmount(wtx.tx->vout[0].nValue);
+                }
+                
+                if (!fMakeCollateral) {
+                    for (const auto& txout : wtx.tx->vout) {
+                        if (coinJoinOptions.isDenominated(txout.nValue)) {
+                            fCreateDenominations = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (fMakeCollateral || fCreateDenominations) {
+                    TransactionRecord sub(hash, nTime);
+                    sub.type = fMakeCollateral ? TransactionRecord::CoinJoinMakeCollaterals : TransactionRecord::CoinJoinCreateDenominations;
+                    sub.debit = -(nDebit - wtx.change);
+                    sub.credit = nCredit - wtx.change;
+                    sub.involvesWatchAddress = involvesWatchAddress;
+                    parts.append(sub);
+                    fHandled = true;
+                }
+            }
+            
+            if (fHandled) {
+                return parts;
             }
         }
-        else
-        {
-            //
-            // Mixed debit transaction, can't break down payees
-            //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
-            parts.last().involvesWatchAddress = involvesWatchAddress;
-        }
+    } else {
+        //
+        // Mixed debit transaction, can't break down payees
+        //
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
+        parts.last().involvesWatchAddress = involvesWatchAddress;
     }
 
     return parts;
@@ -271,11 +240,21 @@ void TransactionRecord::updateStatus(const interfaces::WalletTxStatus& wtx, cons
     // Determine transaction status
 
     // Sort order, unrecorded transactions sort to the top
-    status.sortKey = strprintf("%010d-%01d-%010u-%03d",
+    int typesort;
+    switch (type) {
+    case SendToAddress: case SendToOther:
+        typesort = 2; break;
+    case RecvWithAddress: case RecvFromOther:
+        typesort = 3; break;
+    default:
+        typesort = 9;
+    }
+    status.sortKey = strprintf("%010d-%01d-%010u-%03d-%d",
         wtx.block_height,
         wtx.is_coinbase ? 1 : 0,
         wtx.time_received,
-        idx);
+        idx,
+        typesort);
     status.countsForBalance = wtx.is_trusted && !(wtx.blocks_to_maturity > 0);
     status.depth = wtx.depth_in_main_chain;
     status.m_cur_block_hash = block_hash;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -78,7 +78,6 @@ public:
         SendToOther,
         RecvWithAddress,
         RecvFromOther,
-        SendToSelf,
         RecvWithCoinJoin,
         CoinJoinMixing,
         CoinJoinCollateralPayment,

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -14,6 +14,7 @@
 
 #include <core_io.h>
 #include <interfaces/handler.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <util/system.h>
 
@@ -423,8 +424,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::SendToAddress:
     case TransactionRecord::SendToOther:
         return tr("Sent to");
-    case TransactionRecord::SendToSelf:
-        return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
     case TransactionRecord::PlatformTransfer:
@@ -476,8 +475,6 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
         return formatAddressLabel(wtx->strAddress, wtx->label, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->strAddress) + watchAddress;
-    case TransactionRecord::SendToSelf:
-        return formatAddressLabel(wtx->strAddress, wtx->label, tooltip) + watchAddress;
     case TransactionRecord::CoinJoinMixing:
     case TransactionRecord::CoinJoinCollateralPayment:
     case TransactionRecord::CoinJoinMakeCollaterals:
@@ -504,7 +501,6 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
             return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BAREADDRESS);
         }
         } break;
-    case TransactionRecord::SendToSelf:
     case TransactionRecord::CoinJoinCreateDenominations:
     case TransactionRecord::CoinJoinMixing:
     case TransactionRecord::CoinJoinMakeCollaterals:
@@ -652,7 +648,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         case Status:
             return QString::fromStdString(rec->status.sortKey);
         case Date:
-            return rec->time;
+            return QString::fromStdString(strprintf("%020s-%s", rec->time, rec->status.sortKey));
         case Type:
             return formatTxType(rec);
         case Watchonly:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -91,7 +91,6 @@ TransactionView::TransactionView(QWidget* parent) :
     typeWidget->addItem(tr("%1 Create Denominations").arg(strCoinJoinName), TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCreateDenominations));
     typeWidget->addItem(tr("%1 Mixing").arg(strCoinJoinName), TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMixing));
     typeWidget->addItem(tr("%1 Collateral Payment").arg(strCoinJoinName), TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCollateralPayment));
-    typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Platform Transfer"), TransactionFilterProxy::TYPE(TransactionRecord::PlatformTransfer));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -72,6 +72,7 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     result.txout_address_is_mine.reserve(wtx.tx->vout.size());
     for (const auto& txout : wtx.tx->vout) {
         result.txout_is_mine.emplace_back(wallet.IsMine(txout));
+        result.txout_is_change.push_back(OutputIsChange(wallet, txout));
         result.txout_address.emplace_back();
         result.txout_address_is_mine.emplace_back(ExtractDestination(txout.scriptPubKey, result.txout_address.back()) ?
                                                       wallet.IsMine(result.txout_address.back()) :


### PR DESCRIPTION
Backports bitcoin/bitcoin#119

Original commit: b000ed5ee5

Backported from Bitcoin Core v0.26

This PR replaces send-to-self transactions with dual send+receive entries in the GUI transaction list, making it more consistent with the RPC interface and clearer overall.

## Changes:
- Removes the SendToSelf transaction type
- Shows send-to-self transactions as separate send and receive entries
- Uses "any from me" as the criteria for deciding whether a transaction is a send or receive
- Preserves Dash-specific CoinJoin transaction types and handling

## Dash Adaptations:
- Kept all CoinJoin-specific transaction types (CoinJoinMixing, CoinJoinCollateralPayment, etc.)
- Preserved special handling for CoinJoin denominate transactions
- Maintained platform transfer transaction type
- Removed ISMINE_NO usage (not available in Dash)