### PR TITLE
Merge bitcoin/bitcoin#26312: Remove Sock::Get() and Sock::Sock()

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -846,6 +846,30 @@ std::vector<CAddress> AddrManImpl::GetAddr_(size_t max_addresses, size_t max_pct
     return addresses;
 }
 
+std::vector<std::pair<AddrInfo, AddressPosition>> AddrManImpl::GetEntries_(bool from_tried) const
+{
+    AssertLockHeld(cs);
+
+    const int bucket_count = from_tried ? ADDRMAN_TRIED_BUCKET_COUNT : ADDRMAN_NEW_BUCKET_COUNT;
+    std::vector<std::pair<AddrInfo, AddressPosition>> infos;
+    for (int bucket = 0; bucket < bucket_count; ++bucket) {
+        for (int position = 0; position < ADDRMAN_BUCKET_SIZE; ++position) {
+            int id = GetEntry(from_tried, bucket, position);
+            if (id >= 0) {
+                AddrInfo info = mapInfo.at(id);
+                AddressPosition location = AddressPosition(
+                    from_tried,
+                    /*multiplicity_in=*/from_tried ? 1 : info.nRefCount,
+                    bucket,
+                    position);
+                infos.push_back(std::make_pair(info, location));
+            }
+        }
+    }
+
+    return infos;
+}
+
 void AddrManImpl::Connected_(const CService& addr, NodeSeconds time)
 {
     AssertLockHeld(cs);
@@ -1218,6 +1242,15 @@ std::vector<CAddress> AddrManImpl::GetAddr(size_t max_addresses, size_t max_pct,
     return addresses;
 }
 
+std::vector<std::pair<AddrInfo, AddressPosition>> AddrManImpl::GetEntries(bool from_tried) const
+{
+    LOCK(cs);
+    Check();
+    auto addrInfos = GetEntries_(from_tried);
+    Check();
+    return addrInfos;
+}
+
 void AddrManImpl::Connected(const CService& addr, NodeSeconds time)
 {
     LOCK(cs);
@@ -1318,6 +1351,11 @@ std::pair<CAddress, NodeSeconds> AddrMan::Select(bool new_only, std::optional<Ne
 std::vector<CAddress> AddrMan::GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network) const
 {
     return m_impl->GetAddr(max_addresses, max_pct, network);
+}
+
+std::vector<std::pair<AddrInfo, AddressPosition>> AddrMan::GetEntries(bool use_tried) const
+{
+    return m_impl->GetEntries(use_tried);
 }
 
 void AddrMan::Connected(const CService& addr, NodeSeconds time)

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -36,11 +36,12 @@ public:
 
 class AddrInfo;
 class AddrManImpl;
+class AddrInfo;
 
 /** Default for -checkaddrman */
 static constexpr int32_t DEFAULT_ADDRMAN_CONSISTENCY_CHECKS{0};
 
-/** Test-only struct, capturing info about an address in AddrMan */
+/** Location information for an address in AddrMan */
 struct AddressPosition {
     // Whether the address is in the new or tried table
     const bool tried;
@@ -181,6 +182,17 @@ public:
      * @return                   A vector of randomly selected addresses from vRandom.
      */
     std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network) const;
+
+    /**
+     * Returns an information-location pair for all addresses in the selected addrman table.
+     * If an address appears multiple times in the new table, an information-location pair
+     * is returned for each occurence. Addresses only ever appear once in the tried table.
+     *
+     * @param[in] from_tried     Selects which table to return entries from.
+     *
+     * @return                   A vector consisting of pairs of AddrInfo and AddressPosition.
+     */
+    std::vector<std::pair<AddrInfo, AddressPosition>> GetEntries(bool from_tried) const;
 
     /** We have successfully connected to this peer. Calling this function
      *  updates the CAddress's nTime, which is used in our IsTerrible()

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -133,6 +133,9 @@ public:
     std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
+    std::vector<std::pair<AddrInfo, AddressPosition>> GetEntries(bool from_tried) const
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
     void Connected(const CService& addr, NodeSeconds time)
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
@@ -263,6 +266,8 @@ private:
     int GetEntry(bool use_tried, size_t bucket, size_t position) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     std::vector<CAddress> GetAddr_(size_t max_addresses, size_t max_pct, std::optional<Network> network) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    std::vector<std::pair<AddrInfo, AddressPosition>> GetEntries_(bool from_tried) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     void Connected_(const CService& addr, NodeSeconds time) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -133,6 +133,8 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getnetworkinfo",
     "getnodeaddresses",
     "getpeerinfo",
+    "getprioritisedtransactions",
+    "getrawaddrman",
     "getrawmempool",
     "getrawtransaction",
     "getrpcinfo",

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(constructor_and_destructor)
 {
     const SOCKET s = CreateSocket();
     Sock* sock = new Sock(s);
-    BOOST_CHECK_EQUAL(sock->Get(), s);
+    BOOST_CHECK(*sock == s);
     BOOST_CHECK(!SocketIsClosed(s));
     delete sock;
     BOOST_CHECK(SocketIsClosed(s));
@@ -51,22 +51,34 @@ BOOST_AUTO_TEST_CASE(move_constructor)
     Sock* sock2 = new Sock(std::move(*sock1));
     delete sock1;
     BOOST_CHECK(!SocketIsClosed(s));
-    BOOST_CHECK_EQUAL(sock2->Get(), s);
+    BOOST_CHECK(*sock2 == s);
     delete sock2;
     BOOST_CHECK(SocketIsClosed(s));
 }
 
 BOOST_AUTO_TEST_CASE(move_assignment)
 {
-    const SOCKET s = CreateSocket();
-    Sock* sock1 = new Sock(s);
-    Sock* sock2 = new Sock();
+    const SOCKET s1 = CreateSocket();
+    const SOCKET s2 = CreateSocket();
+    Sock* sock1 = new Sock(s1);
+    Sock* sock2 = new Sock(s2);
+
+    BOOST_CHECK(!SocketIsClosed(s1));
+    BOOST_CHECK(!SocketIsClosed(s2));
+
     *sock2 = std::move(*sock1);
+    BOOST_CHECK(!SocketIsClosed(s1));
+    BOOST_CHECK(SocketIsClosed(s2));
+    BOOST_CHECK(*sock2 == s1);
+
     delete sock1;
-    BOOST_CHECK(!SocketIsClosed(s));
-    BOOST_CHECK_EQUAL(sock2->Get(), s);
+    BOOST_CHECK(!SocketIsClosed(s1));
+    BOOST_CHECK(SocketIsClosed(s2));
+    BOOST_CHECK(*sock2 == s1);
+
     delete sock2;
-    BOOST_CHECK(SocketIsClosed(s));
+    BOOST_CHECK(SocketIsClosed(s1));
+    BOOST_CHECK(SocketIsClosed(s2));
 }
 
 #ifndef WIN32 // Windows does not have socketpair(2).
@@ -98,7 +110,7 @@ BOOST_AUTO_TEST_CASE(send_and_receive)
     SendAndRecvMessage(*sock0, *sock1);
 
     Sock* sock0moved = new Sock(std::move(*sock0));
-    Sock* sock1moved = new Sock();
+    Sock* sock1moved = new Sock(INVALID_SOCKET);
     *sock1moved = std::move(*sock1);
 
     delete sock0;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -133,10 +133,11 @@ constexpr auto ALL_NETWORKS = std::array{
 class StaticContentsSock : public Sock
 {
 public:
-    explicit StaticContentsSock(const std::string& contents) : m_contents{contents}, m_consumed{0}
+    explicit StaticContentsSock(const std::string& contents)
+        : Sock{INVALID_SOCKET},
+          m_contents{contents},
+          m_consumed{0}
     {
-        // Just a dummy number that is not INVALID_SOCKET.
-        m_socket = INVALID_SOCKET - 1;
     }
 
     ~StaticContentsSock() override { m_socket = INVALID_SOCKET; }
@@ -219,6 +220,11 @@ public:
             (void)sock;
             events.occurred = events.requested;
         }
+        return true;
+    }
+
+    bool IsConnected(std::string&) const override
+    {
         return true;
     }
 

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -43,8 +43,6 @@ static inline bool IsSelectableSocket(const SOCKET& s, bool is_select)
 #endif
 }
 
-Sock::Sock() : m_socket(INVALID_SOCKET) {}
-
 Sock::Sock(SOCKET s) : m_socket(s) {}
 
 Sock::Sock(Sock&& other)
@@ -62,8 +60,6 @@ Sock& Sock::operator=(Sock&& other)
     other.m_socket = INVALID_SOCKET;
     return *this;
 }
-
-SOCKET Sock::Get() const { return m_socket; }
 
 ssize_t Sock::Send(const void* data, size_t len, int flags) const
 {
@@ -566,6 +562,11 @@ void Sock::Close()
     }
     m_socket = INVALID_SOCKET;
 }
+
+bool Sock::operator==(SOCKET s) const
+{
+    return m_socket == s;
+};
 
 std::string NetworkErrorString(int err)
 {

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -123,16 +123,12 @@ constexpr SocketEventsMode SEMFromString(std::string_view str) {
 }
 
 /**
- * RAII helper class that manages a socket. Mimics `std::unique_ptr`, but instead of a pointer it
- * contains a socket and closes it automatically when it goes out of scope.
+ * RAII helper class that manages a socket and closes it automatically when it goes out of scope.
  */
 class Sock
 {
 public:
-    /**
-     * Default constructor, creates an empty object that does nothing when destroyed.
-     */
-    Sock();
+    Sock() = delete;
 
     /**
      * Take ownership of an existent socket.
@@ -165,43 +161,37 @@ public:
     virtual Sock& operator=(Sock&& other);
 
     /**
-     * Get the value of the contained socket.
-     * @return socket or INVALID_SOCKET if empty
-     */
-    [[nodiscard]] virtual SOCKET Get() const;
-
-    /**
-     * send(2) wrapper. Equivalent to `send(this->Get(), data, len, flags);`. Code that uses this
+     * send(2) wrapper. Equivalent to `send(m_socket, data, len, flags);`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual ssize_t Send(const void* data, size_t len, int flags) const;
 
     /**
-     * recv(2) wrapper. Equivalent to `recv(this->Get(), buf, len, flags);`. Code that uses this
+     * recv(2) wrapper. Equivalent to `recv(m_socket, buf, len, flags);`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual ssize_t Recv(void* buf, size_t len, int flags) const;
 
     /**
-     * connect(2) wrapper. Equivalent to `connect(this->Get(), addr, addrlen)`. Code that uses this
+     * connect(2) wrapper. Equivalent to `connect(m_socket, addr, addrlen)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual int Connect(const sockaddr* addr, socklen_t addr_len) const;
 
     /**
-     * bind(2) wrapper. Equivalent to `bind(this->Get(), addr, addr_len)`. Code that uses this
+     * bind(2) wrapper. Equivalent to `bind(m_socket, addr, addr_len)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual int Bind(const sockaddr* addr, socklen_t addr_len) const;
 
     /**
-     * listen(2) wrapper. Equivalent to `listen(this->Get(), backlog)`. Code that uses this
+     * listen(2) wrapper. Equivalent to `listen(m_socket, backlog)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual int Listen(int backlog) const;
 
     /**
-     * accept(2) wrapper. Equivalent to `std::make_unique<Sock>(accept(this->Get(), addr, addr_len))`.
+     * accept(2) wrapper. Equivalent to `std::make_unique<Sock>(accept(m_socket, addr, addr_len))`.
      * Code that uses this wrapper can be unit tested if this method is overridden by a mock Sock
      * implementation.
      * The returned unique_ptr is empty if `accept()` failed in which case errno will be set.
@@ -210,7 +200,7 @@ public:
 
     /**
      * getsockopt(2) wrapper. Equivalent to
-     * `getsockopt(this->Get(), level, opt_name, opt_val, opt_len)`. Code that uses this
+     * `getsockopt(m_socket, level, opt_name, opt_val, opt_len)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual int GetSockOpt(int level,
@@ -220,7 +210,7 @@ public:
 
     /**
      * setsockopt(2) wrapper. Equivalent to
-     * `setsockopt(this->Get(), level, opt_name, opt_val, opt_len)`. Code that uses this
+     * `setsockopt(m_socket, level, opt_name, opt_val, opt_len)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual int SetSockOpt(int level,
@@ -230,7 +220,7 @@ public:
 
     /**
      * getsockname(2) wrapper. Equivalent to
-     * `getsockname(this->Get(), name, name_len)`. Code that uses this
+     * `getsockname(m_socket, name, name_len)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
     [[nodiscard]] virtual int GetSockName(sockaddr* name, socklen_t* name_len) const;
@@ -390,6 +380,11 @@ public:
      * @return true if connected
      */
     [[nodiscard]] virtual bool IsConnected(std::string& errmsg) const;
+
+    /**
+     * Check if the internal socket is equal to `s`. Use only in tests.
+     */
+    bool operator==(SOCKET s) const;
 
 protected:
     /**


### PR DESCRIPTION
Backports bitcoin/bitcoin#26312

Original commit: d0b928b29d80267404eef34f722d3fc9f80673ba

Backported from Bitcoin Core v0.26

## Summary
This PR removes the `Sock::Get()` method and the default constructor `Sock::Sock()` from the socket wrapper class. These changes improve encapsulation by preventing direct access to the underlying socket file descriptor and requiring explicit socket initialization.

## Changes
- Removed `Sock::Get()` method that exposed the raw socket file descriptor
- Removed default constructor `Sock()` - now marked as `delete`
- Updated comments in sock.h to reference `m_socket` directly instead of `Get()`
- Modified test code to use the new `operator==` for socket comparisons
- Adapted FuzzedSock and StaticContentsSock test classes to pass INVALID_SOCKET to base constructor

## Notes
- Dash doesn't have the FuzzedSock implementation in test/fuzz/util/net.cpp, so those changes were skipped
- Minor logging style conflict in i2p.cpp was resolved using Dash's LogPrintLevel style
- The netbase.cpp changes were already implemented differently in Dash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method to retrieve all address entries along with their position information in address tables.

* **Bug Fixes**
  * Improved socket test coverage by verifying socket states and comparisons more thoroughly.

* **Refactor**
  * Updated socket class to remove the default constructor and accessor method, and added direct comparison support with raw socket handles.
  * Clarified documentation and initialization in socket-related classes for better maintainability.

* **Tests**
  * Enhanced socket and network utility tests to ensure correct behavior during construction, move operations, and connectivity checks.
  * Added new RPC commands to the list of commands tested for fuzzing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->