### PR TITLE
Merge bitcoin-core/gui#764: Remove legacy wallet creation

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -113,10 +113,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     {
         /** Create wallet frame*/
         walletFrame = new WalletFrame(this);
-        connect(walletFrame, &WalletFrame::createWalletButtonClicked, [this] {
-            auto activity = new CreateWalletActivity(getWalletController(), this);
-            activity->create();
-        });
+        connect(walletFrame, &WalletFrame::createWalletButtonClicked, this, &BitcoinGUI::createWallet);
         connect(walletFrame, &WalletFrame::message, [this](const QString& title, const QString& message, unsigned int style) {
             this->message(title, message, style);
         });
@@ -574,12 +571,7 @@ void BitcoinGUI::createActions()
         connect(m_close_wallet_action, &QAction::triggered, [this] {
             m_wallet_controller->closeWallet(walletFrame->currentWalletModel(), this);
         });
-        connect(m_create_wallet_action, &QAction::triggered, [this] {
-            auto activity = new CreateWalletActivity(m_wallet_controller, this);
-            connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
-            connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
-            activity->create();
-        });
+        connect(m_create_wallet_action, &QAction::triggered, this, &BitcoinGUI::createWallet);
         connect(m_close_all_wallets_action, &QAction::triggered, [this] {
             m_wallet_controller->closeAllWallets(this);
         });
@@ -1600,6 +1592,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
     progressBar->setToolTip(tooltip);
 }
 
+<<<<<<< HEAD
 void BitcoinGUI::setAdditionalDataSyncProgress(double nSyncProgress)
 {
     if(!clientModel)
@@ -1654,6 +1647,21 @@ void BitcoinGUI::setAdditionalDataSyncProgress(double nSyncProgress)
     labelBlocksIcon->setToolTip(tooltip);
     progressBarLabel->setToolTip(tooltip);
     progressBar->setToolTip(tooltip);
+}
+
+void BitcoinGUI::createWallet()
+{
+#ifdef ENABLE_WALLET
+#ifndef USE_SQLITE
+    // Compiled without sqlite support (required for descriptor wallets)
+    message(tr("Error creating wallet"), tr("Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)"), CClientUIInterface::MSG_ERROR);
+    return;
+#endif // USE_SQLITE
+    auto activity = new CreateWalletActivity(getWalletController(), this);
+    connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
+    connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
+    activity->create();
+#endif // ENABLE_WALLET
 }
 
 void BitcoinGUI::message(const QString& title, QString message, unsigned int style, bool* ret, const QString& detailed_message)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -275,6 +275,8 @@ public Q_SLOTS:
     void setNumBlocks(int count, const QDateTime& blockDate, const QString& blockHash, double nVerificationProgress, bool headers, SynchronizationState sync_state);
     /** Set additional data sync status shown in the UI */
     void setAdditionalDataSyncProgress(double nSyncProgress);
+    /** Launch the wallet creation modal (no-op if wallet is not compiled) **/
+    void createWallet();
 
     /** Notify the user of an event from the core network or transaction handling code.
        @param[in] title             the message box / notification title

--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -57,16 +57,6 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
           ui->disable_privkeys_checkbox->setChecked(false);
         }
     });
-
-#ifndef USE_SQLITE
-    ui->descriptor_checkbox->setToolTip(tr("Compiled without sqlite support (required for descriptor wallets)"));
-    ui->descriptor_checkbox->setEnabled(false);
-    ui->descriptor_checkbox->setChecked(false);
-#endif
-#ifndef USE_BDB
-    ui->descriptor_checkbox->setEnabled(false);
-    ui->descriptor_checkbox->setChecked(true);
-#endif
 }
 
 CreateWalletDialog::~CreateWalletDialog()
@@ -92,9 +82,4 @@ bool CreateWalletDialog::isDisablePrivateKeysChecked() const
 bool CreateWalletDialog::isMakeBlankWalletChecked() const
 {
     return ui->blank_wallet_checkbox->isChecked();
-}
-
-bool CreateWalletDialog::isDescriptorWalletChecked() const
-{
-    return ui->descriptor_checkbox->isChecked();
 }

--- a/src/qt/createwalletdialog.h
+++ b/src/qt/createwalletdialog.h
@@ -27,7 +27,6 @@ public:
     bool isEncryptWalletChecked() const;
     bool isDisablePrivateKeysChecked() const;
     bool isMakeBlankWalletChecked() const;
-    bool isDescriptorWalletChecked() const;
 
 private:
     Ui::CreateWalletDialog *ui;

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>407</width>
-    <height>0</height>
+    <width>371</width>
+    <height>298</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,6 +17,48 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_description">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>You are one step away from creating your new wallet!</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_subdescription">
+     <property name="text">
+      <string>Please provide a name and, if desired, enable any advanced options</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>3</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -75,7 +117,19 @@
      <property name="title">
       <string>Advanced Options</string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_groupbox">
+      <property name="spacing">
+       <number>9</number>
+      </property>
       <item>
        <widget class="QCheckBox" name="disable_privkeys_checkbox">
         <property name="enabled">
@@ -96,16 +150,6 @@
         </property>
         <property name="text">
          <string>Make Blank Wallet</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="descriptor_checkbox">
-        <property name="toolTip">
-         <string>Use descriptors for scriptPubKey management. This feature is well-tested but still considered experimental and not recommended for use yet.</string>
-        </property>
-        <property name="text">
-         <string>Descriptor Wallet (EXPERIMENTAL)</string>
         </property>
        </widget>
       </item>

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -247,14 +247,13 @@ void CreateWalletActivity::createWallet()
 
     std::string name = m_create_wallet_dialog->walletName().toStdString();
     uint64_t flags = 0;
+    // Enable descriptors by default.
+    flags |= WALLET_FLAG_DESCRIPTORS;
     if (m_create_wallet_dialog->isDisablePrivateKeysChecked()) {
         flags |= WALLET_FLAG_DISABLE_PRIVATE_KEYS;
     }
     if (m_create_wallet_dialog->isMakeBlankWalletChecked()) {
         flags |= WALLET_FLAG_BLANK_WALLET;
-    }
-    if (m_create_wallet_dialog->isDescriptorWalletChecked()) {
-        flags |= WALLET_FLAG_DESCRIPTORS;
     }
 
     QTimer::singleShot(500ms, worker(), [this, name, flags] {

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -10,17 +10,25 @@ from itertools import product
 
 from test_framework.descriptors import descsum_create
 from test_framework.key import ECKey
+from test_framework.messages import ser_compact_size
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
     find_output
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import (
+    bytes_to_wif,
+    get_generate_key
+)
 
 import json
 import os
+
+# Dash doesn't have SegWit, so witness scale factor is 1 (no scaling)
+WITNESS_SCALE_FACTOR = 1
 
 # Create one-input, one-output, no-fee transaction:
 class PSBTTest(BitcoinTestFramework):


### PR DESCRIPTION
Backports bitcoin/bitcoin#764

Original commit: d2b8c5e123

Backported from Bitcoin Core v0.26

This commit removes the legacy wallet creation option from the GUI, making descriptor wallets the default. The descriptor wallet checkbox has been removed from the Create Wallet dialog, and descriptor wallets are now always enabled when creating new wallets through the GUI.

Key changes:
- Removed descriptor wallet checkbox from Create Wallet dialog
- Always enable WALLET_FLAG_DESCRIPTORS when creating wallets
- Added error message when SQLite support is not available (required for descriptor wallets)
- Removed isDescriptorWalletChecked() method as it's no longer needed

Note: Legacy wallets can still be created via the createwallet RPC command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved wallet creation dialog with clearer instructions and a more user-friendly layout.

* **Refactor**
  * Centralized wallet creation logic for a more consistent user experience.

* **Style**
  * Updated dialog appearance and layout for better usability.

* **Bug Fixes**
  * Removed the experimental "Descriptor Wallet" option; all new wallets now use descriptors by default. 

* **Chores**
  * Enhanced error handling for unsupported configurations during wallet creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->