### PR TITLE
Merge bitcoin/bitcoin#28639: refactor: Remove unused nchaintx from SnapshotMetadata constructor, fix test, add test

### DIFF
--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -26,8 +26,7 @@ public:
     SnapshotMetadata() { }
     SnapshotMetadata(
         const uint256& base_blockhash,
-        uint64_t coins_count,
-        unsigned int nchaintx) :
+        uint64_t coins_count) :
             m_base_blockhash(base_blockhash),
             m_coins_count(coins_count) { }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2749,14 +2749,8 @@ UniValue CreateUTXOSnapshot(
     result.pushKV("base_height", tip->nHeight);
 
     result.pushKV("path", path.utf8string());
-    result.pushKV("txoutset_hash", stats.hashSerialized.ToString());
-    // Cast required because univalue doesn't have serialization specified for
-    // `unsigned int`, nChainTx's type.
-    result.pushKV("nchaintx", uint64_t{tip->nChainTx});
+    result.pushKV("txoutset_hash", stats.hashSerialized.ToString());    result.pushKV("nchaintx", tip->nChainTx);
 
-    result.pushKV("path", path.u8string());
-    result.pushKV("txoutset_hash", maybe_stats->hashSerialized.ToString());
-    result.pushKV("nchaintx", tip->nChainTx);
 
     return result;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2722,7 +2722,7 @@ UniValue CreateUTXOSnapshot(
         tip->nHeight, tip->GetBlockHash().ToString(),
         fs::PathToString(path), fs::PathToString(temppath)));
 
-    SnapshotMetadata metadata{tip->GetBlockHash(), stats.coins_count, tip->nChainTx};
+    SnapshotMetadata metadata{tip->GetBlockHash(), stats.coins_count};
 
     afile << metadata;
 
@@ -2747,11 +2747,17 @@ UniValue CreateUTXOSnapshot(
     result.pushKV("coins_written", stats.coins_count);
     result.pushKV("base_hash", tip->GetBlockHash().ToString());
     result.pushKV("base_height", tip->nHeight);
+
     result.pushKV("path", path.utf8string());
     result.pushKV("txoutset_hash", stats.hashSerialized.ToString());
     // Cast required because univalue doesn't have serialization specified for
     // `unsigned int`, nChainTx's type.
     result.pushKV("nchaintx", uint64_t{tip->nChainTx});
+
+    result.pushKV("path", path.u8string());
+    result.pushKV("txoutset_hash", maybe_stats->hashSerialized.ToString());
+    result.pushKV("nchaintx", tip->nChainTx);
+
     return result;
 }
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28639

Original commit: 448790c00a

Backported from Bitcoin Core v0.26

## Summary
This PR removes the unused `nchaintx` parameter from the SnapshotMetadata constructor. Since Dash doesn't support assumeutxo functionality, the test file `test/functional/feature_assumeutxo.py` was appropriately not included in this backport.

## Changes
- Removed unused `nchaintx` parameter from SnapshotMetadata constructor
- Simplified RPC code that creates snapshot metadata
- Removed unnecessary cast for `nChainTx` in RPC response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved redundant entries in the output of the `dumptxoutset` RPC command, ensuring cleaner and more accurate information display.

* **Refactor**
  * Updated internal handling of UTXO snapshot metadata for improved consistency. No impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->