### PR TITLE
Merge bitcoin-core/gui#765: Fix wallet list hover crash on shutdown

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -517,7 +517,7 @@ void BitcoinGUI::createActions()
         connect(usedSendingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedSendingAddresses);
         connect(usedReceivingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedReceivingAddresses);
         connect(openAction, &QAction::triggered, this, &BitcoinGUI::openClicked);
-        connect(m_open_wallet_menu, &QMenu::aboutToShow, [this] {
+        connect(m_open_wallet_menu, &QMenu::aboutToShow, m_wallet_controller, [this] {
             m_open_wallet_menu->clear();
             for (const std::pair<const std::string, bool>& i : m_wallet_controller->listWalletDir()) {
                 const std::string& path = i.first;
@@ -533,7 +533,7 @@ void BitcoinGUI::createActions()
                     continue;
                 }
 
-                connect(action, &QAction::triggered, [this, path] {
+                connect(action, &QAction::triggered, m_wallet_controller, [this, path] {
                     auto activity = new OpenWalletActivity(m_wallet_controller, this);
                     connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet, Qt::QueuedConnection);
                     connect(activity, &OpenWalletActivity::opened, rpcConsole, &RPCConsole::setCurrentWallet, Qt::QueuedConnection);
@@ -545,7 +545,7 @@ void BitcoinGUI::createActions()
                 action->setEnabled(false);
             }
         });
-        connect(m_restore_wallet_action, &QAction::triggered, [this] {
+        connect(m_restore_wallet_action, &QAction::triggered, m_wallet_controller, [this] {
             //: Name of the wallet data file format.
             QString name_data_file = tr("Wallet Data");
 
@@ -571,19 +571,18 @@ void BitcoinGUI::createActions()
             auto backup_file_path = fs::PathFromString(backup_file.toStdString());
             activity->restore(backup_file_path, wallet_name.toStdString());
         });
-        connect(m_close_wallet_action, &QAction::triggered, [this] {
+        connect(m_close_wallet_action, &QAction::triggered, m_wallet_controller, [this] {
             m_wallet_controller->closeWallet(walletFrame->currentWalletModel(), this);
         });
-        connect(m_create_wallet_action, &QAction::triggered, [this] {
+        connect(m_create_wallet_action, &QAction::triggered, m_wallet_controller, [this] {
             auto activity = new CreateWalletActivity(m_wallet_controller, this);
             connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
             connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
             activity->create();
         });
-        connect(m_close_all_wallets_action, &QAction::triggered, [this] {
+        connect(m_close_all_wallets_action, &QAction::triggered, m_wallet_controller, [this] {
             m_wallet_controller->closeAllWallets(this);
         });
-
         connect(m_mask_values_action, &QAction::toggled, this, &BitcoinGUI::setPrivacy);
     }
 #endif // ENABLE_WALLET
@@ -889,7 +888,8 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
             connect(optionsModel, &OptionsModel::coinJoinEnabledChanged, this, &BitcoinGUI::updateCoinJoinVisibility);
         }
     } else {
-        if(trayIconMenu)
+        // Shutdown requested, disable menus
+        if (trayIconMenu)
         {
             // Disable context menu on tray icon
             trayIconMenu->clear();
@@ -911,6 +911,8 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
             dockIconMenu->clear();
         }
 #endif
+        // Disable top bar menu actions
+        appMenuBar->clear();
     }
 
     updateCoinJoinVisibility();


### PR DESCRIPTION
$(cat <<'EOF'
Backports bitcoin/bitcoin-core/gui#765

Original commit: 92704535f6

**Note**: This PR was later reverted in bitcoin-core/gui#770

This PR fixes a crash that occurs when the user hovers over the wallets list during shutdown. The fix adds proper lifetime management by passing `m_wallet_controller` as context to lambdas that access wallet-related functionality, and clears the application menu bar during shutdown to prevent access to invalidated objects.

Backported from Bitcoin Core v0.26
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of wallet-related menu actions for enhanced stability.

* **Bug Fixes**
  * The main menu bar is now properly disabled during shutdown, providing clearer feedback when the application is closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->