### PR TITLE
Merge bitcoin/bitcoin#28673: docs: Add reference to total.coverage report

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -484,7 +484,9 @@ To enable LCOV report generation during test runs:
 make
 make cov
 
-# A coverage report will now be accessible at `./test_dash.coverage/index.html`.
+# A coverage report will now be accessible at `./test_dash.coverage/index.html`,
+# which covers unit tests, and `./total.coverage/index.html`, which covers
+# unit and functional tests.
 ```
 
 ### Performance profiling with perf


### PR DESCRIPTION
Backports bitcoin/bitcoin#28673

Original commit: 106ab20f121f14d021725c8a657999079dbabfc1

Backported from Bitcoin Core v0.26

This is a simple documentation update that adds a reference to the total.coverage report in the developer notes. The original Bitcoin commit added information about two coverage reports:
- test_bitcoin.coverage/index.html (unit tests only)
- total.coverage/index.html (unit and functional tests)

The backport adapted this to use Dash naming (test_dash.coverage instead of test_bitcoin.coverage).