### PR TITLE
Merge bitcoin/bitcoin#28671: test: Fix failing time check in rpc_net.py

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2020 The Bitcoin Core developers
+# Copyright (c) 2017-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test RPC calls related to net.

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -15,6 +15,7 @@ from test_framework.messages import (
 )
 
 from itertools import product
+import time
 
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
@@ -342,6 +343,8 @@ class NetTest(DashTestFramework):
         assert_equal(node.getnodeaddresses(count=0), [])
 
         self.log.debug("Test that adding a valid address to the tried table succeeds")
+        self.addr_time = int(time.time())
+        node.setmocktime(self.addr_time)
         assert_equal(node.addpeeraddress(address="1.2.3.4", tried=True, port=8333), {"success": True})
         with node.assert_debug_log(expected_msgs=["CheckAddrman: new 0, tried 1, total 1 started"]):
             addrs = node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks


### PR DESCRIPTION
Backports bitcoin/bitcoin#28671

Original commit: f4049eaf08

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by synchronizing the node's internal time with the system time during peer address addition tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->