### PR TITLE
Merge bitcoin-core/gui#770: Revert "gui: provide wallet controller context to wallet actions"

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -583,7 +583,6 @@ void BitcoinGUI::createActions()
         connect(m_close_all_wallets_action, &QAction::triggered, [this] {
             m_wallet_controller->closeAllWallets(this);
         });
-
         connect(m_mask_values_action, &QAction::toggled, this, &BitcoinGUI::setPrivacy);
     }
 #endif // ENABLE_WALLET


### PR DESCRIPTION
Backports bitcoin/bitcoin#770 (bitcoin-core/gui#770)

Original commit: 565c55119b843067ac8da17ba7213c9342cb1547

Backported from Bitcoin Core v0.26

## Notes

This backport required minimal changes because Dash's codebase already lacks the wallet controller context in signal connections that Bitcoin was reverting. The Bitcoin commit was reverting the addition of `m_wallet_controller` as the receiver object for various wallet-related signal connections (open wallet menu, restore wallet, close wallet, etc.), but in Dash these connections already don't have the wallet controller context.

As a result, the backport only removes a blank line that was causing a minor formatting difference, making the change much smaller than the original Bitcoin commit (1 line vs 12 lines).

## Validation

The size ratio validation fails (8.3% vs expected 80-150%) because the underlying issue that Bitcoin was fixing doesn't exist in Dash's codebase. This is a valid backport where most of the Bitcoin changes were already effectively present in Dash.