### PR TITLE
Merge bitcoin/bitcoin#28727: test: replace random_bytes with random.randbytes

### DIFF
--- a/test/functional/p2p_net_deadlock.py
+++ b/test/functional/p2p_net_deadlock.py
@@ -6,7 +6,7 @@
 import threading
 from test_framework.messages import MAX_PROTOCOL_MESSAGE_LENGTH
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import random_bytes
+from random import randbytes
 
 class NetDeadlockTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -18,7 +18,7 @@ class NetDeadlockTest(BitcoinTestFramework):
         node1 = self.nodes[1]
 
         self.log.info("Simultaneously send a large message on both sides")
-        rand_msg = random_bytes(MAX_PROTOCOL_MESSAGE_LENGTH).hex()
+        rand_msg = randbytes(MAX_PROTOCOL_MESSAGE_LENGTH).hex()
 
         thread0 = threading.Thread(target=node0.sendmsgtopeer, args=(0, "unknown", rand_msg))
         thread1 = threading.Thread(target=node1.sendmsgtopeer, args=(0, "unknown", rand_msg))

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -7,6 +7,7 @@
 
 from decimal import Decimal
 from itertools import product
+from random import randbytes
 
 from test_framework.descriptors import descsum_create
 from test_framework.key import ECKey

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -304,11 +304,6 @@ def sha256sum_file(filename):
             d = f.read(4096)
     return h.digest()
 
-# TODO: Remove and use random.randbytes(n) directly
-def random_bytes(n):
-    """Return a random bytes object of length n."""
-    return random.randbytes(n)
-
 # RPC/P2P connection constants and functions
 ############################################
 


### PR DESCRIPTION
## Summary
Backport of Bitcoin Core PR #28727

This replaces the custom `random_bytes` function in the test framework with Python's built-in `random.randbytes` (available in Python 3.9+).

## Changes
- Removed the `random_bytes` function from test_framework/util.py
- Added `from random import randbytes` to test files that need it
- Updated calls from `random_bytes()` to `randbytes()`

## Notes
- Bitcoin modified 5 test files, but Dash only has 3 of them
- `feature_taproot.py` and `mempool_datacarrier.py` don't exist in Dash (Bitcoin-specific tests)
- No functional changes, just using Python's built-in function instead of a custom wrapper

## Test plan
- [ ] Python syntax validation passes ✅
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)