### PR TITLE
Merge bitcoin/bitcoin#28729: addrman: log AS only when using asmap

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -614,8 +614,9 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, std::c
             ClearNew(nUBucket, nUBucketPos);
             pinfo->nRefCount++;
             vvNew[nUBucket][nUBucketPos] = nId;
-            LogPrint(BCLog::ADDRMAN, "Added %s mapped to AS%i to new[%i][%i]\n",
-                     addr.ToStringAddrPort(), m_netgroupman.GetMappedAS(addr), nUBucket, nUBucketPos);
+            const auto mapped_as{m_netgroupman.GetMappedAS(addr)};
+            LogPrint(BCLog::ADDRMAN, "Added %s%s to new[%i][%i]\n",
+                     addr.ToStringAddrPort(), (mapped_as ? strprintf(" mapped to AS%i", mapped_as) : ""), nUBucket, nUBucketPos);
         } else {
             if (pinfo->nRefCount == 0) {
                 Delete(nId);
@@ -675,11 +676,11 @@ bool AddrManImpl::Good_(const CService& addr, bool test_before_evict, NodeSecond
     } else {
         // move nId to the tried tables
         MakeTried(info, nId);
+        const auto mapped_as{m_netgroupman.GetMappedAS(addr)};
         if (fLogIPs) {
-            LogPrint(BCLog::ADDRMAN, "Moved %s mapped to AS%i to tried[%i][%i]\n",
-                     addr.ToStringAddrPort(), m_netgroupman.GetMappedAS(addr), tried_bucket, tried_bucket_pos);
-        }
-        return true;
+            LogPrint(BCLog::ADDRMAN, "Moved %s%s to tried[%i][%i]\n",
+                     addr.ToStringAddrPort(), (mapped_as ? strprintf(" mapped to AS%i", mapped_as) : ""), tried_bucket, tried_bucket_pos);
+        }        return true;
     }
 }
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28729

Original commit: 4733de3242

This PR changes the log to just print the ASN when using asmap, making it consistent with other logs in the codebase. The AS number is only logged when asmap is actually being used (when mapped_as is non-zero).

**Changes:**
- Modified `AddrManImpl::Good_()` to conditionally log AS information
- Preserved Dash's `fLogIPs` check while incorporating Bitcoin's conditional AS logging

**Note:** The test changes from the Bitcoin commit were not applicable to Dash as the `test_addrv2` methods don't exist in our codebase.

Backported from Bitcoin Core v0.27