### PR TITLE
Merge bitcoin/bitcoin#28136: refactor: move GetServicesNames from rpc/util.{h,cpp} to rpc/net.cpp

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -7,6 +7,8 @@
 #include <chainparams.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
+#include <logging.h>
+#include <netaddress.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <util/strencodings.h>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -27,6 +27,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <util/check.h>
+#include <util/strencodings.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -14,6 +14,10 @@
 #include <rpc/util.h>
 #include <txmempool.h>
 #include <univalue.h>
+#include <util/fs.h>
+#include <util/moneystr.h>
+#include <util/strencodings.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <instantsend/instantsend.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -16,6 +16,7 @@
 #include <netbase.h>
 #include <node/context.h>
 #include <policy/settings.h>
+#include <protocol.h>
 #include <rpc/blockchain.h>
 #include <rpc/protocol.h>
 #include <rpc/server_util.h>
@@ -93,6 +94,18 @@ static RPCHelpMan ping()
     return NullUniValue;
 },
     };
+}
+
+/** Returns, given services flags, a list of humanly readable (known) network services */
+static UniValue GetServicesNames(ServiceFlags services)
+{
+    UniValue servicesNames(UniValue::VARR);
+
+    for (const auto& flag : serviceFlagsToStr(services)) {
+        servicesNames.push_back(flag);
+    }
+
+    return servicesNames;
 }
 
 static RPCHelpMan getpeerinfo()

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -991,16 +991,6 @@ UniValue JSONRPCTransactionError(TransactionError terr, const std::string& err_s
     }
 }
 
-UniValue GetServicesNames(ServiceFlags services)
-{
-    UniValue servicesNames(UniValue::VARR);
-
-    for (const auto& flag : serviceFlagsToStr(services)) {
-        servicesNames.push_back(flag);
-    }
-
-    return servicesNames;
-}
 
 std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, FlatSigningProvider& provider)
 {

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -7,7 +7,7 @@
 
 #include <node/coinstats.h>
 #include <node/transaction.h>
-#include <protocol.h>
+#include <outputtype.h>
 #include <pubkey.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
@@ -35,7 +35,6 @@ extern const std::string UNIX_EPOCH_TIME;
  */
 extern const std::string EXAMPLE_ADDRESS[2];
 
-class FillableSigningProvider;
 class FillableSigningProvider;
 class CPubKey;
 class CScript;
@@ -114,9 +113,6 @@ UniValue DescribeAddress(const CTxDestination& dest);
 
 //! Parse a confirm target option and raise an RPC error if it is invalid.
 unsigned int ParseConfirmTarget(const UniValue& value, unsigned int max_target);
-
-/** Returns, given services flags, a list of humanly readable (known) network services */
-UniValue GetServicesNames(ServiceFlags services);
 
 //! Parse a JSON range specified as int64, or [int64, int64]
 std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value);


### PR DESCRIPTION
Backports bitcoin/bitcoin#28136

Original commit: e77339632e

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization by relocating a helper function related to service flag names.
  * Updated file dependencies to ensure proper functionality and maintainability.

No user-facing features or visible changes are introduced in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->