### PR TITLE
Merge bitcoin/bitcoin#28814: test: symbolizer improvements

### DIFF
--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -16,3 +16,4 @@ export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address,undefined,integer CC='clang-18 -ftrivial-auto-var-init=pattern' CXX='clang++-18 -ftrivial-auto-var-init=pattern' --with-boost-process"
+export LLVM_SYMBOLIZER_PATH="/usr/bin/llvm-symbolizer-18"

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -16,11 +16,14 @@ import sys
 
 
 def get_fuzz_env(*, target, source_dir):
+    symbolizer = os.environ.get('LLVM_SYMBOLIZER_PATH', "/usr/bin/llvm-symbolizer")
     return {
         'FUZZ': target,
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
+        'UBSAN_SYMBOLIZER_PATH':symbolizer,
         "ASAN_OPTIONS": "detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
+        'ASAN_SYMBOLIZER_PATH':symbolizer,
     }
 
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28814

Original commit: b5d8f001a8

This PR adds LLVM symbolizer path configuration to improve debugging capabilities in fuzz testing environments. The changes ensure that both ASAN and UBSAN can properly symbolize stack traces when running fuzz tests.

Changes:
- Added `LLVM_SYMBOLIZER_PATH` export to CI fuzz environment (adapted for clang-18)
- Modified `test_runner.py` to use symbolizer path from environment

Backported from Bitcoin Core v0.27

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment setup to explicitly define the LLVM symbolizer path for fuzz testing.
  * Improved configuration of sanitizer tools to ensure correct symbolizer path is used during fuzz testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->