### PR TITLE
Merge bitcoin/bitcoin#27935: fuzz: call lookup functions before calling `Ban`

### DIFF
--- a/ci/test/00_setup_env_mac_native.sh
+++ b/ci/test/00_setup_env_mac_native.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export HOST=x86_64-apple-darwin
+export PIP_PACKAGES="zmq"
+export GOAL="install"
+export BITCOIN_CONFIG="--with-gui --enable-reduce-exports --disable-miner --with-boost-process"
+export CI_OS_NAME="macos"
+export NO_DEPENDS=1
+export OSX_SDK=""
+export CCACHE_MAXSIZE=400M
+export RUN_FUZZ_TESTS=true

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -5,6 +5,7 @@
 #include <banman.h>
 #include <fs.h>
 #include <netaddress.h>
+#include <netbase.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -16,6 +17,7 @@
 #include <cassert>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -63,17 +65,28 @@ FUZZ_TARGET(banman, .init = initialize_banman)
         // The complexity is O(N^2), where N is the input size, because each call
         // might call DumpBanlist (or other methods that are at least linear
         // complexity of the input size).
+        bool contains_invalid{false};
         LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 300)
         {
             CallOneOf(
                 fuzzed_data_provider,
                 [&] {
-                    ban_man.Ban(ConsumeNetAddr(fuzzed_data_provider),
-                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                    CNetAddr net_addr{ConsumeNetAddr(fuzzed_data_provider)};
+                    const std::optional<CNetAddr>& addr{LookupHost(net_addr.ToStringAddr(), /*fAllowLookup=*/false)};
+                    if (addr.has_value() && addr->IsValid()) {
+                        net_addr = *addr;
+                    } else {
+                        contains_invalid = true;
+                    }
+                    ban_man.Ban(net_addr, ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },
                 [&] {
-                    ban_man.Ban(ConsumeSubNet(fuzzed_data_provider),
-                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                    CSubNet subnet{ConsumeSubNet(fuzzed_data_provider)};
+                    subnet = LookupSubNet(subnet.ToString());
+                    if (!subnet.IsValid()) {
+                        contains_invalid = true;
+                    }
+                    ban_man.Ban(subnet, ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },
                 [&] {
                     ban_man.ClearBanned();
@@ -109,7 +122,9 @@ FUZZ_TARGET(banman, .init = initialize_banman)
             BanMan ban_man_read{banlist_file, /*client_interface=*/nullptr, /*default_ban_time=*/0};
             banmap_t banmap_read;
             ban_man_read.GetBanned(banmap_read);
-            assert(banmap == banmap_read);
+            if (!contains_invalid) {
+                assert(banmap == banmap_read);
+            }
         }
     }
     fs::remove(fs::PathToString(banlist_file + ".json"));


### PR DESCRIPTION
Backports bitcoin/bitcoin#27935

Original commit: e862bceb17

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved fuzz testing for ban management to better handle invalid network addresses and subnets, reducing false failures during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->