### PR TITLE
Merge bitcoin/bitcoin#28857: test, refactor: Magic bytes array followup

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -738,10 +738,8 @@ bool CNode::ReceiveMsgBytes(Span<const uint8_t> msg_bytes, bool& complete)
 }
 
 V1Transport::V1Transport(const NodeId node_id, int nTypeIn, int nVersionIn) noexcept :
-    m_node_id(node_id), hdrbuf(nTypeIn, nVersionIn), vRecv(nTypeIn, nVersionIn)
+    m_magic_bytes{Params().MessageStart()}, m_node_id(node_id), hdrbuf(nTypeIn, nVersionIn), vRecv(nTypeIn, nVersionIn)
 {
-    assert(std::size(Params().MessageStart()) == std::size(m_magic_bytes));
-    std::copy(std::begin(Params().MessageStart()), std::end(Params().MessageStart()), m_magic_bytes);
     LOCK(m_recv_mutex);
     Reset();
 }

--- a/src/net.h
+++ b/src/net.h
@@ -396,7 +396,7 @@ public:
 class V1Transport final : public Transport
 {
 private:
-    CMessageHeader::MessageStartChars m_magic_bytes;
+    const MessageStartChars m_magic_bytes;
     const NodeId m_node_id; // Only for logging
     mutable Mutex m_recv_mutex; //!< Lock for receive state
     mutable CHash256 hasher GUARDED_BY(m_recv_mutex);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -210,9 +210,8 @@ const static std::string netMessageTypesViolateBlocksOnly[] = {
 const static std::set<std::string> netMessageTypesViolateBlocksOnlySet(std::begin(netMessageTypesViolateBlocksOnly), std::end(netMessageTypesViolateBlocksOnly));
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
+    : pchMessageStart{pchMessageStartIn}
 {
-    memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
-
     // Copy the command name
     size_t i = 0;
     for (; i < COMMAND_SIZE && pszCommand[i] != 0; ++i) pchCommand[i] = pszCommand[i];

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -9,6 +9,7 @@
 #include <util/strencodings.h>
 
 #include <stdint.h>
+#include <array>
 
 #include <boost/test/unit_test.hpp>
 
@@ -84,6 +85,8 @@ BOOST_AUTO_TEST_CASE(sizes)
     BOOST_CHECK_EQUAL(GetSerializeSize(int64_t(0), 0), 8U);
     BOOST_CHECK_EQUAL(GetSerializeSize(uint64_t(0), 0), 8U);
     BOOST_CHECK_EQUAL(GetSerializeSize(bool(0), 0), 1U);
+    BOOST_CHECK_EQUAL(GetSerializeSize(std::array<uint8_t, 1>{0}, 0), 1U);
+    BOOST_CHECK_EQUAL(GetSerializeSize(std::array<uint8_t, 2>{0, 0}, 0), 2U);
 }
 
 BOOST_AUTO_TEST_CASE(varints)
@@ -176,6 +179,16 @@ BOOST_AUTO_TEST_CASE(vector_bool)
 
     BOOST_CHECK(vec1 == std::vector<uint8_t>(vec2.begin(), vec2.end()));
     BOOST_CHECK(SerializeHash(vec1) == SerializeHash(vec2));
+}
+
+BOOST_AUTO_TEST_CASE(array)
+{
+    std::array<uint8_t, 32> array1{1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1};
+    DataStream ds;
+    ds << array1;
+    std::array<uint8_t, 32> array2;
+    ds >> array2;
+    BOOST_CHECK(array1 == array2);
 }
 
 BOOST_AUTO_TEST_CASE(noncanonical)


### PR DESCRIPTION
Backports bitcoin/bitcoin#28857

Original commit: 8992a34ee4

This is a followup-PR for bitcoin#28423

* Initialize magic bytes in constructor
* Add a small unit test for serializing arrays.

Backported from Bitcoin Core v0.27