### PR TITLE
Merge bitcoin/bitcoin#28865: test: migrate to some per-symbol ubsan suppressions

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,9 +1,7 @@
+# Suppressions should use `sanitize-type:ClassName::MethodName`.
+
 # -fsanitize=undefined suppressions
 # =================================
-# The suppressions would be `sanitize-type:ClassName::MethodName`,
-# however due to a bug in clang the symbolizer is disabled and thus no symbol
-# names can be used.
-# See https://github.com/google/sanitizers/issues/1364
 
 # -fsanitize=integer suppressions
 # ===============================
@@ -11,8 +9,7 @@
 # ------------
 # Suppressions in dependencies that are developed outside this repository.
 unsigned-integer-overflow:*/include/c++/
-# unsigned-integer-overflow in FuzzedDataProvider's ConsumeIntegralInRange
-unsigned-integer-overflow:FuzzedDataProvider.h
+unsigned-integer-overflow:FuzzedDataProvider::ConsumeIntegralInRange
 unsigned-integer-overflow:leveldb/
 unsigned-integer-overflow:minisketch/
 unsigned-integer-overflow:secp256k1/
@@ -41,49 +38,37 @@ shift-base:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 # contains files in which we expect unsigned integer overflows to occur. The
 # list is used to suppress -fsanitize=integer warnings when running our CI UBSan
 # job.
-unsigned-integer-overflow:addrman.cpp
 unsigned-integer-overflow:arith_uint256.h
-unsigned-integer-overflow:common/bloom.cpp
-unsigned-integer-overflow:coins.cpp
-unsigned-integer-overflow:compressor.cpp
+unsigned-integer-overflow:CBloomFilter::Hash
+unsigned-integer-overflow:CRollingBloomFilter::insert
+unsigned-integer-overflow:RollingBloomHash
+unsigned-integer-overflow:CCoinsViewCache::AddCoin
+unsigned-integer-overflow:CCoinsViewCache::BatchWrite
+unsigned-integer-overflow:CCoinsViewCache::DynamicMemoryUsage
+unsigned-integer-overflow:CCoinsViewCache::SpendCoin
+unsigned-integer-overflow:CCoinsViewCache::Uncache
+unsigned-integer-overflow:CompressAmount
+unsigned-integer-overflow:DecompressAmount
 unsigned-integer-overflow:crypto/
-unsigned-integer-overflow:hash.cpp
-unsigned-integer-overflow:policy/fees.cpp
+unsigned-integer-overflow:MurmurHash3
+unsigned-integer-overflow:CBlockPolicyEstimator::processBlockTx
+unsigned-integer-overflow:TxConfirmStats::EstimateMedianVal
 unsigned-integer-overflow:prevector.h
-unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
-unsigned-integer-overflow:txmempool.cpp
-unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h
-implicit-integer-sign-change:addrman.h
-implicit-integer-sign-change:bech32.cpp
-implicit-integer-sign-change:compat/stdin.cpp
+implicit-integer-sign-change:SetStdinEcho
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/
-implicit-integer-sign-change:key.cpp
-implicit-integer-sign-change:policy/fees.cpp
+implicit-integer-sign-change:TxConfirmStats::removeTx
 implicit-integer-sign-change:prevector.h
-implicit-integer-sign-change:script/bitcoinconsensus.cpp
-implicit-integer-sign-change:script/interpreter.cpp
+implicit-integer-sign-change:verify_flags
+implicit-integer-sign-change:EvalScript
 implicit-integer-sign-change:serialize.h
-implicit-integer-sign-change:txmempool.cpp
-implicit-integer-sign-change:util/strencodings.cpp
-implicit-integer-sign-change:util/strencodings.h
-implicit-integer-sign-change:validation.cpp
-implicit-signed-integer-truncation,implicit-integer-sign-change:test/skiplist_tests.cpp
-implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:crypto/
 implicit-unsigned-integer-truncation:crypto/
-shift-base:xoroshiro128plusplus.h
-shift-base:nanobench.h
 shift-base:arith_uint256.cpp
 shift-base:crypto/
-shift-base:hash.cpp
+shift-base:ROTL32
 shift-base:streams.h
-shift-base:util/bip32.cpp
-vptr:bls/bls.h
-
-# -fsanitize=float-cast-overflow suppressions
-# ===============================
-# See QTBUG-133261
-float-cast-overflow:qRound
+shift-base:FormatHDKeypath
+shift-base:xoroshiro128plusplus.h


### PR DESCRIPTION
Backports bitcoin/bitcoin#28865

Original commit: a73715e5a4

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sanitizer suppression entries to use more precise method-level specifications instead of broad file-level suppressions.
  * Removed obsolete and unnecessary suppression entries.
  * Clarified the suppression naming convention in documentation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->