### PR TITLE
Merge bitcoin/bitcoin#28605: Fix typos

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -61,5 +61,5 @@ in order.
 ### Cache
 
 In order to avoid rebuilding all dependencies for each build, the binaries are
-cached and re-used when possible. Changes in the dependency-generator will
+cached and reused when possible. Changes in the dependency-generator will
 trigger cache-invalidation and rebuilds as necessary.

--- a/depends/description.md
+++ b/depends/description.md
@@ -27,7 +27,7 @@ etc), and as well as a hash of the same data for each recursive dependency. If
 any portion of a package's build recipe changes, it will be rebuilt as well as
 any other package that depends on it. If any of the main makefiles (Makefile,
 funcs.mk, etc) are changed, all packages will be rebuilt. After building, the
-results are cached into a tarball that can be re-used and distributed.
+results are cached into a tarball that can be reused and distributed.
 
 ### Package build results are (relatively) deterministic.
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2913,7 +2913,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
         // of transactions relevant to them, without having to download the
         // entire memory pool.
         // Also, other nodes can use these messages to automatically request a
-        // transaction from some other peer that annnounced it, and stop
+        // transaction from some other peer that announced it, and stop
         // waiting for us to respond.
         // In normal operation, we often send NOTFOUND messages for parents of
         // transactions that we relay; if a peer is missing a parent, they may
@@ -3783,7 +3783,7 @@ void PeerManagerImpl::ProcessMessage(
             return;
         }
 
-        // Log succesful connections unconditionally for outbound, but not for inbound as those
+        // Log successful connections unconditionally for outbound, but not for inbound as those
         // can be triggered by an attacker at high rate.
         if (!pfrom.IsInboundConn() || LogAcceptCategory(BCLog::NET, BCLog::Level::Debug)) {
             LogPrintf("New %s %s peer connected: version: %d, blocks=%d, peer=%d%s\n",

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -237,7 +237,7 @@ public:
 
             // If a status update is needed (blocks came in since last check),
             // try to update the status of this transaction from the wallet.
-            // Otherwise, simply re-use the cached status.
+            // Otherwise, simply reuse the cached status.
             interfaces::WalletTxStatus wtx;
             int numBlocks;
             int64_t block_time;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -427,7 +427,7 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     }
     // Process expected parameters. If any parameters were left unspecified in
     // the request before a parameter that was specified, null values need to be
-    // inserted at the unspecifed parameter positions, and the "hole" variable
+    // inserted at the unspecified parameter positions, and the "hole" variable
     // below tracks the number of null values that need to be inserted.
     // The "initial_hole_size" variable stores the size of the initial hole,
     // i.e. how many initial positional arguments were left unspecified. This is

--- a/src/test/fuzz/FuzzedDataProvider.h
+++ b/src/test/fuzz/FuzzedDataProvider.h
@@ -158,7 +158,7 @@ FuzzedDataProvider::ConsumeRandomLengthString(size_t max_length) {
   // picking its contents.
   std::string result;
 
-  // Reserve the anticipated capaticity to prevent several reallocations.
+  // Reserve the anticipated capacity to prevent several reallocations.
   result.reserve(std::min(max_length, remaining_bytes_));
   for (size_t i = 0; i < max_length && remaining_bytes_ != 0; ++i) {
     char next = ConvertUnsignedToSigned<char>(data_ptr_[0]);

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -108,8 +108,14 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
             tx.vin[j].prevout.n = j;
             tx.vin[j].prevout.hash = txPrev->GetHash();
         }
+<<<<<<< HEAD
         BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL));
         // Re-use same signature for other inputs
+=======
+        SignatureData empty;
+        BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL, empty));
+        // Reuse same signature for other inputs
+>>>>>>> 22025d06e5 (Merge bitcoin/bitcoin#28605: Fix typos)
         // (they don't have to be valid for this test)
         for (unsigned int j = 1; j < tx.vin.size(); j++)
             tx.vin[j].scriptSig = tx.vin[0].scriptSig;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1049,7 +1049,7 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
-    keys.push_back(key2); keys.push_back(key2); // Can't re-use sig
+    keys.push_back(key2); keys.push_back(key2); // Can't reuse sig
     CScript badsig1 = sign_multisig(scriptPubKey23, keys, CTransaction(txTo23));
     BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey23, gFlags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
         uint32_t chain_all_vbits{0};
         for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++i) {
             const auto dep = static_cast<Consensus::DeploymentPos>(i);
-            // Check that no bits are re-used (within the same chain). This is
+            // Check that no bits are reused (within the same chain). This is
             // disallowed because the transition to FAILED (on timeout) does
             // not take precedence over STARTED/LOCKED_IN. So all softforks on
             // the same bit might overlap, even when non-overlapping start-end

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -249,7 +249,7 @@ std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
             /**
              * Unescape value. Per https://spec.torproject.org/control-spec section 2.1.1:
              *
-             *   For future-proofing, controller implementors MAY use the following
+             *   For future-proofing, controller implementers MAY use the following
              *   rules to be compatible with buggy Tor implementations and with
              *   future ones that implement the spec as intended:
              *

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -622,7 +622,7 @@ public:
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** After reorg, filter the entries that would no longer be valid in the next block, and update
      * the entries' cached LockPoints if needed.  The mempool does not have any knowledge of
-     * consensus rules. It just appplies the callable function and removes the ones for which it
+     * consensus rules. It just applies the callable function and removes the ones for which it
      * returns true.
      * @param[in]   filter_final_and_mature   Predicate that checks the relevant validation rules
      *                                        and updates an entry's LockPoints.

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1005,7 +1005,7 @@ static std::optional<CreatedTransactionResult> CreateTransactionInternal(
     }
 
     // Before we return success, we assume any change key will be used to prevent
-    // accidental re-use.
+    // accidental reuse.
     reservedest.KeepDestination();
     fee_calc_out = feeCalc;
 
@@ -1053,8 +1053,13 @@ std::optional<CreatedTransactionResult> CreateTransaction(
         tmp_cc.m_avoid_partial_spends = true;
         bilingual_str error2; // fired and forgotten; if an error occurs, we discard the results
 
+<<<<<<< HEAD
         // Re-use the change destination from the first creation attempt to avoid skipping BIP44 indexes
         const int ungrouped_change_pos = txr_ungrouped->change_pos;
+=======
+        // Reuse the change destination from the first creation attempt to avoid skipping BIP44 indexes
+        const int ungrouped_change_pos = txr_ungrouped.change_pos;
+>>>>>>> 22025d06e5 (Merge bitcoin/bitcoin#28605: Fix typos)
         if (ungrouped_change_pos != -1) {
             ExtractDestination(txr_ungrouped->tx->vout[ungrouped_change_pos].scriptPubKey, tmp_cc.destChange);
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -165,7 +165,7 @@ extern const std::map<uint64_t,std::string> WALLET_FLAG_CAVEATS;
  * Instantiating a ReserveDestination does not reserve an address. To do so,
  * GetReservedDestination() needs to be called on the object. Once an address has been
  * reserved, call KeepDestination() on the ReserveDestination object to make sure it is not
- * returned. Call ReturnDestination() to return the address so it can be re-used (for
+ * returned. Call ReturnDestination() to return the address so it can be reused (for
  * example, if the address was used in a new transaction
  * and that transaction was not completed and needed to be aborted).
  *

--- a/test/functional/test_framework/blockfilter.py
+++ b/test/functional/test_framework/blockfilter.py
@@ -29,7 +29,7 @@ def bip158_basic_element_hash(script_pub_key, N, block_hash):
 
 
 def bip158_relevant_scriptpubkeys(node, block_hash):
-    """ Determines the basic filter relvant scriptPubKeys as defined in BIP158:
+    """ Determines the basic filter relevant scriptPubKeys as defined in BIP158:
 
     'A basic filter MUST contain exactly the following items for each transaction in a block:
        - The previous output script (the script being spent) for each input, except for

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -4,6 +4,7 @@ blockin
 cachable
 creat
 crypted
+debbugs
 fo
 fpr
 hights


### PR DESCRIPTION
Backports bitcoin/bitcoin#28605

Original commit: 22025d06e5

Backported from Bitcoin Core v0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple typographical errors and improved wording in comments and documentation across the codebase.
  * Standardized the usage of "reused" instead of "re-used" in various documentation and comments.
  * Added "debbugs" to the spelling ignore list.
* **Style**
  * Resolved a minor code style issue related to member access in transaction creation logic.
* **Tests**
  * Updated test comments for clarity and fixed minor typos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->