### PR TITLE
Merge bitcoin/bitcoin#28865: test: migrate to some per-symbol ubsan suppressions

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -43,12 +43,20 @@ shift-base:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 # job.
 unsigned-integer-overflow:addrman.cpp
 unsigned-integer-overflow:arith_uint256.h
-unsigned-integer-overflow:common/bloom.cpp
-unsigned-integer-overflow:coins.cpp
-unsigned-integer-overflow:compressor.cpp
+unsigned-integer-overflow:CBloomFilter::Hash
+unsigned-integer-overflow:CRollingBloomFilter::insert
+unsigned-integer-overflow:RollingBloomHash
+unsigned-integer-overflow:CCoinsViewCache::AddCoin
+unsigned-integer-overflow:CCoinsViewCache::BatchWrite
+unsigned-integer-overflow:CCoinsViewCache::DynamicMemoryUsage
+unsigned-integer-overflow:CCoinsViewCache::SpendCoin
+unsigned-integer-overflow:CCoinsViewCache::Uncache
+unsigned-integer-overflow:CompressAmount
+unsigned-integer-overflow:DecompressAmount
 unsigned-integer-overflow:crypto/
-unsigned-integer-overflow:hash.cpp
-unsigned-integer-overflow:policy/fees.cpp
+unsigned-integer-overflow:MurmurHash3
+unsigned-integer-overflow:CBlockPolicyEstimator::processBlockTx
+unsigned-integer-overflow:TxConfirmStats::EstimateMedianVal
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
@@ -57,14 +65,14 @@ unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h
 implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:bech32.cpp
-implicit-integer-sign-change:compat/stdin.cpp
+implicit-integer-sign-change:SetStdinEcho
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/
 implicit-integer-sign-change:key.cpp
-implicit-integer-sign-change:policy/fees.cpp
+implicit-integer-sign-change:TxConfirmStats::removeTx
 implicit-integer-sign-change:prevector.h
-implicit-integer-sign-change:script/bitcoinconsensus.cpp
-implicit-integer-sign-change:script/interpreter.cpp
+implicit-integer-sign-change:verify_flags
+implicit-integer-sign-change:EvalScript
 implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:txmempool.cpp
 implicit-integer-sign-change:util/strencodings.cpp
@@ -78,9 +86,10 @@ shift-base:xoroshiro128plusplus.h
 shift-base:nanobench.h
 shift-base:arith_uint256.cpp
 shift-base:crypto/
-shift-base:hash.cpp
+shift-base:ROTL32
 shift-base:streams.h
-shift-base:util/bip32.cpp
+shift-base:FormatHDKeypath
+shift-base:xoroshiro128plusplus.h
 vptr:bls/bls.h
 
 # -fsanitize=float-cast-overflow suppressions


### PR DESCRIPTION
Backports bitcoin/bitcoin#28865

Original commit: a73715e5a4

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined sanitizer suppressions for improved precision by targeting specific functions or methods instead of entire files. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->