### PR TITLE
Merge bitcoin/bitcoin#28931: fuzz: Limit fuzz buffer size in script_flags target

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -6,17 +6,30 @@
 #ifndef BITCOIN_SCRIPT_INTERPRETER_H
 #define BITCOIN_SCRIPT_INTERPRETER_H
 
+<<<<<<< HEAD
 #include <script/script_error.h>
+=======
+#include <consensus/amount.h>
+#include <hash.h>
+>>>>>>> 5f9fd11680 (Merge bitcoin/bitcoin#28931: fuzz: Limit fuzz buffer size in script_flags target)
 #include <primitives/transaction.h>
+#include <script/script_error.h> // IWYU pragma: export
+#include <span.h>
+#include <uint256.h>
 
+<<<<<<< HEAD
+=======
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+>>>>>>> 5f9fd11680 (Merge bitcoin/bitcoin#28931: fuzz: Limit fuzz buffer size in script_flags target)
 #include <vector>
-#include <stdint.h>
 
 class CPubKey;
 class CScript;
-class CTransaction;
-class CTxOut;
-class uint256;
+class CScriptNum;
+class XOnlyPubKey;
+struct CScriptWitness;
 
 /** Signature hash types/flags */
 enum

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -3,25 +3,22 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
-#include <pubkey.h>
+#include <primitives/transaction.h>
 #include <script/interpreter.h>
+#include <serialize.h>
 #include <streams.h>
-#include <test/util/script.h>
-#include <version.h>
-
 #include <test/fuzz/fuzz.h>
+#include <test/util/script.h>
+
+#include <cassert>
+#include <ios>
+#include <utility>
+#include <vector>
 
 FUZZ_TARGET(script_flags)
 {
-    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
-    try {
-        int nVersion;
-        ds >> nVersion;
-        ds.SetVersion(nVersion);
-    } catch (const std::ios_base::failure&) {
-        return;
-    }
-
+    if (buffer.size() > 100'000) return;
+    DataStream ds{buffer};
     try {
         const CTransaction tx(deserialize, ds);
         const PrecomputedTransactionData txdata(tx);


### PR DESCRIPTION
Backports bitcoin/bitcoin#28931

Original commit: 5f9fd11680

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dependency management and streamlined type declarations for better maintainability.
  * Simplified and optimized the script flags fuzz testing logic for enhanced efficiency and clarity.

* **Chores**
  * Reorganized and updated header includes in relevant components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->