### PR TITLE
Merge bitcoin/bitcoin#28903: refactor: Make CTxMemPoolEntry only explicitly copyable

### DIFF
--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -11,6 +11,7 @@
 #include <txmempool.h>
 
 #include <cstdint>
+#include <list>
 #include <optional>
 #include <string>
 #include <vector>
@@ -39,14 +40,14 @@ FUZZ_TARGET(policy_estimator, .init = initialize_policy_estimator)
                 }
             },
             [&] {
-                std::vector<CTxMemPoolEntry> mempool_entries;
+                std::list<CTxMemPoolEntry> mempool_entries;
                 LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
                     const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
                     if (!mtx) {
                         break;
                     }
                     const CTransaction tx{*mtx};
-                    mempool_entries.push_back(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
+                    mempool_entries.emplace_back(CTxMemPoolEntry::ExplicitCopy, ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
                 }
                 std::vector<const CTxMemPoolEntry*> ptrs;
                 ptrs.reserve(mempool_entries.size());

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -467,7 +467,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     // Add to memory pool without checking anything.
     // Used by AcceptToMemoryPool(), which DOES do
     // all the appropriate checks.
-    indexed_transaction_set::iterator newit = mapTx.insert(entry).first;
+    indexed_transaction_set::iterator newit = mapTx.emplace(CTxMemPoolEntry::ExplicitCopy, entry).first;
 
     // Update transaction for any feeDelta created by PrioritiseTransaction
     CAmount delta{0};

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -104,6 +104,11 @@ public:
     typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> Children;
 
 private:
+    CTxMemPoolEntry(const CTxMemPoolEntry&) = default;
+    struct ExplicitCopyTag {
+        explicit ExplicitCopyTag() = default;
+    };
+
     const CTransactionRef tx;
     mutable Parents m_parents;
     mutable Children m_children;
@@ -135,6 +140,13 @@ public:
                     int64_t time, unsigned int entry_height,
                     bool spends_coinbase,
                     int64_t sigops_count, LockPoints lp);
+
+    CTxMemPoolEntry(ExplicitCopyTag, const CTxMemPoolEntry& entry) : CTxMemPoolEntry(entry) {}
+    CTxMemPoolEntry& operator=(const CTxMemPoolEntry&) = delete;
+    CTxMemPoolEntry(CTxMemPoolEntry&&) = delete;
+    CTxMemPoolEntry& operator=(CTxMemPoolEntry&&) = delete;
+
+    static constexpr ExplicitCopyTag ExplicitCopy{};
 
     const CTransaction& GetTx() const { return *this->tx; }
     CTransactionRef GetSharedTx() const { return this->tx; }


### PR DESCRIPTION
Backports bitcoin/bitcoin#28903

Original commit: 535424a10b

Backported from Bitcoin Core v0.27

## Changes
This refactor makes CTxMemPoolEntry only explicitly copyable to prevent accidental runtime failures when interacting with iterator_to with a copied entry.

### Key changes:
- Added private default copy constructor and ExplicitCopyTag struct
- Added explicit copy constructor using ExplicitCopyTag
- Deleted copy assignment, move constructor, and move assignment operators
- Changed std::vector to std::list in policy_estimator fuzz test
- Updated mapTx.insert() to mapTx.emplace() with ExplicitCopy tag

### Dash-specific adaptations:
- Applied changes to src/txmempool.h instead of src/kernel/mempool_entry.h (Dash doesn't have kernel module structure)
- Removed TX_WITH_WITNESS parameter from ConsumeDeserializable (Dash doesn't have witness support)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of transaction pool entries to enforce explicit copying and restrict assignment and move operations.
  * Updated methods to use explicit copy operations when managing transaction entries.

No user-facing changes or new features are introduced; these updates improve internal consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->