### PR TITLE
Merge bitcoin/bitcoin#28579: refactor: Remove redundant checks in compat/assumptions.h

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_SERIALIZE_H
 #define BITCOIN_SERIALIZE_H
 
+#include <compat/assumptions.h> // IWYU pragma: keep
 #include <compat/endian.h>
 
 #include <algorithm>


### PR DESCRIPTION
Backports bitcoin/bitcoin#28579

Original commit: 16b5b4b674

Backported from Bitcoin Core v0.27

This is a simple refactoring commit that removes redundant checks from compat/assumptions.h. In Dash:
- The NDEBUG and __cplusplus checks were already removed from compat/assumptions.h
- The comment removal from util/check.h includes was already done
- src/common/system.{cpp,h} don't exist in Dash

The only change needed was adding `#include <compat/assumptions.h> // IWYU pragma: keep` to src/serialize.h.