### PR TITLE
Merge bitcoin/bitcoin#28969: fuzz: Avoid signed-integer-overflow in wallet_notifications fuzz target

### DIFF
--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Bitcoin Core developers
+// Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -86,7 +86,7 @@ FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
     // The total amount, to be distributed to the wallets a and b in txs
     // without fee. Thus, the balance of the wallets should always equal the
     // total amount.
-    const auto total_amount{ConsumeMoney(fuzzed_data_provider)};
+    const auto total_amount{ConsumeMoney(fuzzed_data_provider, /*max=*/MAX_MONEY / 100000)};
     FuzzedWallet a{"fuzzed_wallet_a"};
     FuzzedWallet b{"fuzzed_wallet_b"};
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28969

Original commit: 7bc8c5312b2272aec0fa185bae7e6cc40b476e1a

Backported from Bitcoin Core v0.27