### PR TITLE
Merge bitcoin/bitcoin#28980: rpc: encryptwallet help, mention HD seed rotation and backup requirement

### DIFF
--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -220,7 +220,11 @@ RPCHelpMan encryptwallet()
         "After this, any calls that interact with private keys such as sending or signing \n"
         "will require the passphrase to be set prior the making these calls.\n"
         "Use the walletpassphrase call for this, and then walletlock call.\n"
-        "If the wallet is already encrypted, use the walletpassphrasechange call.\n",
+        "If the wallet is already encrypted, use the walletpassphrasechange call.\n"
+        "** IMPORTANT **\n"
+        "For security reasons, the encryption process will generate a new HD seed, resulting\n"
+        "in the creation of a fresh set of active descriptors. Therefore, it is crucial to\n"
+        "securely back up the newly generated wallet file using the backupwallet RPC.\n",
         {
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::NO, "The pass phrase to encrypt the wallet with. It must be at least 1 character, but should be long."},
         },
@@ -263,10 +267,7 @@ RPCHelpMan encryptwallet()
         throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Error: Failed to encrypt the wallet.");
     }
 
-    if (pwallet->IsHDEnabled()) {
-        return "wallet encrypted; If you forget the passphrase, you will lose access to your funds. Make sure that you have backup of your seed or mnemonic.";
-    }
-    return "wallet encrypted; The keypool has been flushed. You need to make a new backup.";
+    return "wallet encrypted; The keypool has been flushed and a new HD seed was generated. You need to make a new backup with the backupwallet RPC.";
 },
     };
 }


### PR DESCRIPTION
Backports bitcoin/bitcoin#28980

Original commit: ca09415e630f0f7de9160cab234bd5ba6968ff2d

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the help text for the wallet encryption command to highlight the need for a new backup after encryption.
* **Enhancements**
  * Simplified the success message after wallet encryption to always indicate that a new backup is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->