### PR TITLE
Merge bitcoin/bitcoin#29025: doc: Add link to needs-release-notes label

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -28,6 +28,9 @@ Before every major release:
 * [ ] Update [`src/chainparams.cpp`](/src/chainparams.cpp) `m_assumed_blockchain_size` and `m_assumed_chain_state_size` with the current size plus some overhead (see [this](#how-to-calculate-assumed-blockchain-and-chain-state-size) for information on how to calculate them).
 * [ ] Update [`src/chainparams.cpp`](/src/chainparams.cpp) `chainTxData` with statistics about the transaction count and rate. Use the output of the `getchaintxstats` RPC, see
   [this pull request](https://github.com/dashpay/dash/pull/5692) for an example. Reviewers can verify the results by running `getchaintxstats <window_block_count> <window_last_block_hash>` with the `window_block_count` and `window_last_block_hash` from your output.
+* [ ] Ensure the "Needs release note" label is removed from all relevant pull
+  requests and issues:
+  https://github.com/dashpay/dash/issues?q=label%3A%22Needs+release+note%22
 
 ### First time / New builders
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29025

Original commit: 14d1732602

Backported from Bitcoin Core v0.27