### PR TITLE
Merge bitcoin/bitcoin#29035: test: fix `addnode` functional test failure on OpenBSD

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -15,6 +15,7 @@ from test_framework.messages import (
 )
 
 from itertools import product
+import platform
 
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
@@ -240,8 +241,10 @@ class NetTest(DashTestFramework):
         ip_port = "127.0.0.1:{}".format(p2p_port(2))
         self.nodes[0].addnode(node=ip_port, command='add')
         # try to add an equivalent ip
-        ip_port2 = "127.1:{}".format(p2p_port(2))
-        assert_raises_rpc_error(-23, "Node already added", self.nodes[0].addnode, node=ip_port2, command='add')
+        # (note that OpenBSD doesn't support the IPv4 shorthand notation with omitted zero-bytes)
+        if platform.system() != "OpenBSD":
+            ip_port2 = "127.1:{}".format(p2p_port(2))
+            assert_raises_rpc_error(-23, "Node already added", self.nodes[0].addnode, node=ip_port2, command='add')
         # check that the node has indeed been added
         added_nodes = self.nodes[0].getaddednodeinfo()
         assert_equal(len(added_nodes), 1)


### PR DESCRIPTION
Backports bitcoin/bitcoin#29035

Original commit: 09ab9d4fa7

Backported from Bitcoin Core v0.27