### PR TITLE
Merge bitcoin/bitcoin#29031: fuzz: Improve fuzzing stability for txorphan harness

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4548,12 +4548,12 @@ void PeerManagerImpl::ProcessMessage(
                     AddToCompactExtraTransactions(ptx);
                 }
 
-                // DoS prevention: do not allow m_orphans to grow unbounded (see CVE-2012-3789)
+                // DoS prevention: do not allow m_orphanage to grow unbounded (see CVE-2012-3789)
                 unsigned int nMaxOrphanTxSize = (unsigned int)std::max((int64_t)0, gArgs.GetIntArg("-maxorphantxsize", DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE)) * 1000000;
-                unsigned int nEvicted = m_orphanage.LimitOrphans(nMaxOrphanTxSize);
-                if (nEvicted > 0) {
-                    LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
-                }
+                // Convert size to count (approximate)
+                unsigned int nMaxOrphanTx = nMaxOrphanTxSize / 5000;  // Assume ~5KB per orphan tx
+                FastRandomContext rng;
+                m_orphanage.LimitOrphans(nMaxOrphanTx, rng);
             } else {
                 LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s\n",tx.GetHash().ToString());
                 // We will continue to reject this tx since it has rejected

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/amount.h>
+#include <consensus/validation.h>
+#include <net_processing.h>
+#include <node/eviction.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <txorphanage.h>
+#include <uint256.h>
+#include <util/check.h>
+#include <util/time.h>
+
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+void initialize_orphanage()
+{
+    static const auto testing_setup = MakeNoLogFileContext();
+}
+
+FUZZ_TARGET(txorphan, .init = initialize_orphanage)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    FastRandomContext limit_orphans_rng{/*fDeterministic=*/true};
+    SetMockTime(ConsumeTime(fuzzed_data_provider));
+
+    TxOrphanage orphanage;
+    std::vector<COutPoint> outpoints;
+    // initial outpoints used to construct transactions later
+    for (uint8_t i = 0; i < 4; i++) {
+        outpoints.emplace_back(Txid::FromUint256(uint256{i}), 0);
+    }
+    // if true, allow duplicate input when constructing tx
+    const bool duplicate_input = fuzzed_data_provider.ConsumeBool();
+
+    LIMITED_WHILE(outpoints.size() < 200'000 && fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
+    {
+        // construct transaction
+        const CTransactionRef tx = [&] {
+            CMutableTransaction tx_mut;
+            const auto num_in = fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(1, outpoints.size());
+            const auto num_out = fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(1, outpoints.size());
+            // pick unique outpoints from outpoints as input
+            for (uint32_t i = 0; i < num_in; i++) {
+                auto& prevout = PickValue(fuzzed_data_provider, outpoints);
+                tx_mut.vin.emplace_back(prevout);
+                // pop the picked outpoint if duplicate input is not allowed
+                if (!duplicate_input) {
+                    std::swap(prevout, outpoints.back());
+                    outpoints.pop_back();
+                }
+            }
+            // output amount will not affect txorphanage
+            for (uint32_t i = 0; i < num_out; i++) {
+                tx_mut.vout.emplace_back(CAmount{0}, CScript{});
+            }
+            // restore previously popped outpoints
+            for (auto& in : tx_mut.vin) {
+                outpoints.push_back(in.prevout);
+            }
+            auto new_tx = MakeTransactionRef(tx_mut);
+            // add newly constructed transaction to outpoints
+            for (uint32_t i = 0; i < num_out; i++) {
+                outpoints.emplace_back(new_tx->GetHash(), i);
+            }
+            return new_tx;
+        }();
+
+        // trigger orphanage functions
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
+        {
+            NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
+
+            CallOneOf(
+                fuzzed_data_provider,
+                [&] {
+                    orphanage.AddChildrenToWorkSet(*tx);
+                },
+                [&] {
+                    {
+                        CTransactionRef ref = orphanage.GetTxToReconsider(peer_id);
+                        if (ref) {
+                            bool have_tx = orphanage.HaveTx(GenTxid::Txid(ref->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(ref->GetWitnessHash()));
+                            Assert(have_tx);
+                        }
+                    }
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetWitnessHash()));
+                    // AddTx should return false if tx is too big or already have it
+                    // tx weight is unknown, we only check when tx is already in orphanage
+                    {
+                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        // have_tx == true -> add_tx == false
+                        Assert(!have_tx || !add_tx);
+                    }
+                    have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetWitnessHash()));
+                    {
+                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        // if have_tx is still false, it must be too big
+                        Assert(!have_tx == (GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT));
+                        Assert(!have_tx || !add_tx);
+                    }
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetWitnessHash()));
+                    // EraseTx should return 0 if m_orphans doesn't have the tx
+                    {
+                        Assert(have_tx == orphanage.EraseTx(tx->GetHash()));
+                    }
+                    have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetWitnessHash()));
+                    // have_tx should be false and EraseTx should fail
+                    {
+                        Assert(!have_tx && !orphanage.EraseTx(tx->GetHash()));
+                    }
+                },
+                [&] {
+                    orphanage.EraseForPeer(peer_id);
+                },
+                [&] {
+                    // test mocktime and expiry
+                    SetMockTime(ConsumeTime(fuzzed_data_provider));
+                    auto limit = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+                    orphanage.LimitOrphans(limit, limit_orphans_rng);
+                    Assert(orphanage.Size() <= limit);
+                });
+        }
+    }
+}

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -126,11 +126,12 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     }
 
     // Test LimitOrphanTxSize() function:
-    orphanage.LimitOrphans(40);
+    FastRandomContext rng{/*fDeterministic=*/true};
+    orphanage.LimitOrphans(40, rng);
     BOOST_CHECK(orphanage.CountOrphans() <= 40);
-    orphanage.LimitOrphans(10);
+    orphanage.LimitOrphans(10, rng);
     BOOST_CHECK(orphanage.CountOrphans() <= 10);
-    orphanage.LimitOrphans(0);
+    orphanage.LimitOrphans(0, rng);
     BOOST_CHECK(orphanage.CountOrphans() == 0);
 }
 

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -109,11 +109,9 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx from peer=%d\n", nErased, peer);
 }
 
-unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
+void TxOrphanage::LimitOrphans(unsigned int max_orphans, FastRandomContext& rng)
 {
     AssertLockHeld(g_cs_orphans);
-
-    unsigned int nEvicted = 0;
     static int64_t nNextSweep;
     int64_t nNow = GetTime();
     if (nNextSweep <= nNow) {
@@ -134,15 +132,13 @@ unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
         nNextSweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
         if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx due to expiration\n", nErased);
     }
-    FastRandomContext rng;
-    while (!m_orphans.empty() && m_orphan_tx_size > max_orphans_size)
+    while (m_orphans.size() > max_orphans)
     {
         // Evict a random orphan:
         size_t randompos = rng.randrange(m_orphan_list.size());
         EraseTx(m_orphan_list[randompos]->first);
-        ++nEvicted;
     }
-    return nEvicted;
+    // Bitcoin PR #29031: Changed return type from unsigned int to void
 }
 
 void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>& orphan_work_set) const

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -8,6 +8,7 @@
 #include <net.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <random.h>
 #include <sync.h>
 
 /** Guards orphan transactions and extra txs for compact blocks */
@@ -44,7 +45,7 @@ public:
     void EraseForBlock(const CBlock& block) LOCKS_EXCLUDED(::g_cs_orphans);
 
     /** Limit the orphanage to the given maximum */
-    unsigned int LimitOrphans(unsigned int max_orphans_size) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    void LimitOrphans(unsigned int max_orphans, FastRandomContext& rng) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
 
     /** Add any orphans that list a particular tx as a parent into a peer's work set
      * (ie orphans that may have found their final missing parent, and so should be reconsidered for the mempool) */


### PR DESCRIPTION
Backports bitcoin/bitcoin#29031

Original commit: 40bc501bf4

The `txorphan` harness has low stability as eviction of orphan txs is entirely random at the moment.

Fix this by passing the rng to `LimitOrphans`, which can be deterministic in tests.

## Changes made for Dash compatibility:
- Adapted `LimitOrphans` to work with Dash's orphan size limit (converted from size to count)
- Removed references to `m_txrequest` and `GetWitnessHash()` which don't exist in Dash
- Used `DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE` instead of `max_orphan_txs`
- Added `FastRandomContext` include to txorphanage.h
- Added new fuzz test file src/test/fuzz/txorphan.cpp

Backported from Bitcoin Core v0.27