### PR TITLE
Merge bitcoin/bitcoin#29009: fuzz: p2p: Detect peer deadlocks

### DIFF
--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -83,13 +83,23 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     const auto mock_time = ConsumeTime(fuzzed_data_provider);
     SetMockTime(mock_time);
 
+    CSerializedNetMsg net_msg;
+    net_msg.m_type = random_message_type;
     // fuzzed_data_provider is fully consumed after this call, don't use it
-    CDataStream random_bytes_data_stream{fuzzed_data_provider.ConsumeRemainingBytes<unsigned char>(), SER_NETWORK, PROTOCOL_VERSION};
-    try {
-        g_setup->m_node.peerman->ProcessMessage(p2p_node, random_message_type, random_bytes_data_stream, GetTime<std::chrono::microseconds>(), std::atomic<bool>{false});
-    } catch (const std::ios_base::failure& e) {
+    net_msg.data = fuzzed_data_provider.ConsumeRemainingBytes<unsigned char>();
+
+    connman.FlushSendBuffer(p2p_node);
+    (void)connman.ReceiveMsgFrom(p2p_node, std::move(net_msg));
+
+    bool more_work{true};
+    while (more_work) {
+        p2p_node.fPauseSend = false;
+        try {
+            more_work = connman.ProcessMessagesOnce(p2p_node);
+        } catch (const std::ios_base::failure&) {
+        }
+        g_setup->m_node.peerman->SendMessages(&p2p_node);
     }
-    g_setup->m_node.peerman->SendMessages(&p2p_node);
     SyncWithValidationInterfaceQueue();
     g_setup->m_node.connman->StopNodes();
 }

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -69,13 +69,17 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
 
         connman.FlushSendBuffer(random_node);
         (void)connman.ReceiveMsgFrom(random_node, std::move(net_msg));
-        random_node.fPauseSend = false;
 
-        try {
-            connman.ProcessMessagesOnce(random_node);
-        } catch (const std::ios_base::failure&) {
+        bool more_work{true};
+        while (more_work) { // Ensure that every message is eventually processed in some way or another
+            random_node.fPauseSend = false;
+
+            try {
+                more_work = connman.ProcessMessagesOnce(random_node);
+            } catch (const std::ios_base::failure&) {
+            }
+            g_setup->m_node.peerman->SendMessages(&random_node);
         }
-        g_setup->m_node.peerman->SendMessages(&random_node);
     }
     SyncWithValidationInterfaceQueue();
     g_setup->m_node.connman->StopNodes();

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -70,7 +70,10 @@ struct ConnmanTestMsg : public CConnman {
                    bool relay_txs)
         EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
 
-    void ProcessMessagesOnce(CNode& node) EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex) { m_msgproc->ProcessMessages(&node, flagInterruptMsgProc); }
+    bool ProcessMessagesOnce(CNode& node) EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
+    {
+        return m_msgproc->ProcessMessages(&node, flagInterruptMsgProc);
+    }
 
     void NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const;
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29009

Original commit: 255004fc5e7febb1fbe2b0cdcbab3e0a5207acd9

This PR improves the fuzz testing infrastructure by adding deadlock detection to the p2p message processing tests. The changes ensure that the fuzz harness can detect when peer connections deadlock, which can happen due to software bugs.

Key changes:
- Modified `process_message.cpp` to use `ReceiveMsgFrom` and `ProcessMessagesOnce` instead of directly calling `ProcessMessage`, allowing detection of deadlocks
- Similar improvements to `process_messages.cpp` 
- Updated `src/test/util/net.h` with supporting changes

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the simulation of message processing in testing to more closely resemble real-world scenarios, ensuring all messages are processed and responses are sent before completion.
  * Enhanced the message handling loop for more thorough processing and error handling during tests.

* **Tests**
  * Updated test logic to provide more comprehensive coverage of message receipt, processing, and response cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->