### PR TITLE
Merge bitcoin/bitcoin#29055: tests, bench: Fix issue with CWallet::LoadWallet() being called in the wrong places

### DIFF
--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -29,7 +29,6 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
         wallet.SetupDescriptorScriptPubKeyMans("", "");
-        if (wallet.LoadWallet() != DBErrors::LOAD_OK) assert(false);
     }
     auto handler = test_setup->m_node.chain->handleNotifications({&wallet, [](CWallet*) {}});
 

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -29,6 +29,7 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
         wallet.SetupDescriptorScriptPubKeyMans("", "");
+        if (wallet.LoadWallet() != DBErrors::LOAD_OK) assert(false);
     }
     auto handler = test_setup->m_node.chain->handleNotifications({&wallet, [](CWallet*) {}});
 

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -16,7 +16,6 @@
 
 using wallet::CreateMockWalletDatabase;
 using wallet::CWallet;
-using wallet::DBErrors;
 using wallet::WALLET_FLAG_DESCRIPTORS;
 
 static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_mine, const uint32_t epoch_iters)
@@ -29,7 +28,6 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
         wallet.SetupDescriptorScriptPubKeyMans("", "");
-        if (wallet.LoadWallet() != DBErrors::LOAD_OK) assert(false);
     }
     auto handler = test_setup->m_node.chain->handleNotifications({&wallet, [](CWallet*) {}});
 

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -23,7 +23,6 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, interfaces
         LOCK(wallet->cs_wallet);
         wallet->SetLastBlockProcessed(cchain.Height(), cchain.Tip()->GetBlockHash());
     }
-    wallet->LoadWallet();
     {
         LOCK(wallet->cs_wallet);
         wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2154,6 +2154,8 @@ DBErrors CWallet::LoadWallet()
 {
     LOCK(cs_wallet);
 
+    Assert(m_spk_managers.empty());
+    Assert(m_wallet_flags == 0);
     DBErrors nLoadWalletRet = WalletBatch(GetDatabase()).LoadWallet(this);
     if (nLoadWalletRet == DBErrors::NEED_REWRITE)
     {


### PR DESCRIPTION
Backports bitcoin/bitcoin#29055

Original commit: 60f677375e52832536a599afae3226f8e2155d88

Backported from Bitcoin Core v0.27

## Changes:
- Removed incorrect `LoadWallet()` call from wallet test utilities
- Added assertions in `CWallet::LoadWallet()` to ensure it's not called after wallet initialization

## Note:
The file `src/bench/wallet_create_tx.cpp` that Bitcoin modified does not exist in Dash, so those changes were skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet loading process to ensure correct initialization and prevent potential issues during wallet setup. 

* **Chores**
  * Enhanced internal checks during wallet loading for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->