### PR TITLE
Merge bitcoin/bitcoin#28994: wallet: skip BnB when SFFO is enabled

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -396,8 +396,11 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
     // Note that unlike KnapsackSolver, we do not include the fee for creating a change output as BnB will not create a change output.
     std::vector<OutputGroup> positive_groups = GroupOutputs(wallet, coins, coin_selection_params, eligibility_filter, true /* positive_only */);
     positive_groups.clear(); // Cleared to skip BnB and SRD as they're unaware of mixed coins
-    if (auto bnb_result{SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change)}) {
-        results.push_back(*bnb_result);
+    // SFFO frequently causes issues in the context of changeless input sets: skip BnB when SFFO is active
+    if (!coin_selection_params.m_subtract_fee_outputs) {
+        if (auto bnb_result{SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change)}) {
+            results.push_back(*bnb_result);
+        }
     }
 
     // The knapsack solver has some legacy behavior where it will spend dust outputs. We retain this behavior, so don't filter for positive only here.
@@ -1016,6 +1019,7 @@ static std::optional<CreatedTransactionResult> CreateTransactionInternal(
     reservedest.KeepDestination();
     fee_calc_out = feeCalc;
 
+    wallet.WalletLogPrintf("Coin Selection: Algorithm:%s, Waste Metric Score:%d\n", GetAlgorithmName(result->m_algo).c_str(), result->GetWaste());
     wallet.WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
               nFeeRet, nBytes, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
               feeCalc.est.pass.start, feeCalc.est.pass.end,

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -298,7 +298,6 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         /*tx_noinputs_size=*/ 0,
         /*avoid_partial=*/ false,
     };
-    coin_selection_params_bnb.m_subtract_fee_outputs = true;
 
     {
         std::unique_ptr<CWallet> wallet = std::make_unique<CWallet>(m_node.chain.get(), /*coinjoin_loader=*/nullptr, "", m_args, CreateMockWalletDatabase());
@@ -397,6 +396,55 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         const auto result13 = SelectCoins(*wallet, coins, 10 * CENT, coin_control, coin_selection_params_bnb);
         BOOST_CHECK(EquivalentResult(expected_result, *result13));
     }
+}
+
+BOOST_AUTO_TEST_CASE(bnb_sffo_restriction)
+{
+    // Verify the coin selection process does not produce a BnB solution when SFFO is enabled.
+    // This is currently problematic because it could require a change output. And BnB is specialized on changeless solutions.
+    // NOTE: In Dash, BnB is already disabled by clearing positive_groups, so this test verifies that behavior remains consistent.
+    std::unique_ptr<CWallet> wallet = std::make_unique<CWallet>(m_node.chain.get(), /*coinjoin_loader=*/nullptr, "", m_args, CreateMockWalletDatabase());
+    wallet->LoadWallet();
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        wallet->SetupDescriptorScriptPubKeyMans("", "");
+        wallet->SetLastBlockProcessed(300, uint256{}); // set a high block so internal UTXOs are selectable
+    }
+
+    FastRandomContext rand{};
+    CoinSelectionParams params{
+            rand,
+            /*change_output_size=*/ 31,  // unused value, p2wpkh output size (wallet default change type)
+            /*change_spend_size=*/ 68,   // unused value, p2wpkh input size (high-r signature)
+            /*min_change_target=*/ 0,    // dummy, set later
+            /*effective_feerate=*/ CFeeRate(3000),
+            /*long_term_feerate=*/ CFeeRate(1000),
+            /*discard_feerate=*/ CFeeRate(1000),
+            /*tx_noinputs_size=*/ 0,
+            /*avoid_partial=*/ false,
+    };
+    params.m_subtract_fee_outputs = true;
+    params.m_change_fee = params.m_effective_feerate.GetFee(params.change_output_size);
+    params.m_cost_of_change = params.m_discard_feerate.GetFee(params.change_spend_size) + params.m_change_fee;
+    params.m_min_change_target = params.m_cost_of_change + 1;
+    
+    // Add spendable coin at the BnB selection upper bound
+    std::vector<COutput> coins;
+    add_coin(coins, *wallet, COIN + params.m_cost_of_change, /*feerate=*/params.m_effective_feerate, /*nAge=*/6, /*fIsFromMe=*/true, /*nInput=*/0, /*spendable=*/true);
+    add_coin(coins, *wallet, 0.5 * COIN + params.m_cost_of_change, /*feerate=*/params.m_effective_feerate, /*nAge=*/6, /*fIsFromMe=*/true, /*nInput=*/0, /*spendable=*/true);
+    add_coin(coins, *wallet, 0.5 * COIN, /*feerate=*/params.m_effective_feerate, /*nAge=*/6, /*fIsFromMe=*/true, /*nInput=*/0, /*spendable=*/true);
+    
+    // Knapsack will only find a changeless solution on an exact match to the satoshi, SRD doesn't look for changeless
+    // If BnB were run, it would produce a single input solution with the best waste score
+    // In Dash, BnB is already disabled, so we expect Knapsack
+    CCoinControl coin_control;
+    auto result = SelectCoins(*wallet, coins, COIN, coin_control, params);
+    BOOST_CHECK(result.has_value());
+    // In Dash, BnB is disabled by clearing positive_groups, so it should never be selected
+    BOOST_CHECK_NE(result->GetAlgo(), SelectionAlgorithm::BNB);
+    // Knapsack is the expected algorithm in Dash
+    BOOST_CHECK(result->GetAlgo() == SelectionAlgorithm::KNAPSACK);
 }
 
 BOOST_AUTO_TEST_CASE(knapsack_solver_test)

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -81,7 +81,9 @@ FUZZ_TARGET(coinselection)
     GroupCoins(fuzzed_data_provider, utxo_pool, coin_params, /*positive_only=*/false, group_all);
 
     // Run coinselection algorithms
-    const auto result_bnb = SelectCoinsBnB(group_pos, target, cost_of_change);
+    // SFFO frequently causes issues in the context of changeless input sets: skip BnB when SFFO is active
+    const auto result_bnb = coin_params.m_subtract_fee_outputs ? util::Result<SelectionResult>{util::Error{Untranslated("BnB disabled when SFFO is enabled")}} :
+                            SelectCoinsBnB(group_pos, target, cost_of_change);
 
     auto result_srd = SelectCoinsSRD(group_pos, target, fast_random_context);
     if (result_srd) result_srd->ComputeAndSetWaste(cost_of_change);


### PR DESCRIPTION
Backports bitcoin/bitcoin#28994

Original commit: d646ca35d991e4f694096fdbd2d2ebd8cebf244e

Backported from Bitcoin Core v0.27

## Summary
This PR backports Bitcoin's fix to skip the Branch and Bound (BnB) coin selection algorithm when Subtract Fee From Outputs (SFFO) is enabled. BnB is designed for changeless solutions, which can be problematic when SFFO is active.

## Changes
- Added check to skip BnB when `m_subtract_fee_outputs` is true (though in Dash, BnB is already disabled via `positive_groups.clear()`)
- Added logging for coin selection algorithm and waste metric score
- Added test case to verify BnB is not used with SFFO (adapted for Dash where BnB is already disabled)
- Updated fuzz test to handle SFFO case

## Notes
- In Dash, BnB is already effectively disabled by clearing the positive_groups vector due to mixed coins handling
- The backport adds an additional safeguard that aligns with Bitcoin's approach
- Test expectations were adjusted since BnB never runs in Dash (expects Knapsack algorithm instead)