### PR TITLE
Merge bitcoin/bitcoin#29065: bench: wallet, fix change position out of range error

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -67,7 +67,7 @@ UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vecto
     // Send
     bilingual_str error;
     FeeCalculation fee_calc_out;
-    std::optional<CreatedTransactionResult> txr = CreateTransaction(wallet, recipients, RANDOM_CHANGE_POSITION, error, coin_control, fee_calc_out, true);
+    std::optional<CreatedTransactionResult> txr = CreateTransaction(wallet, recipients, /*change_pos=*/std::nullopt, error, coin_control, fee_calc_out, true);
     if (!txr) {
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, error.original);
     }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -192,6 +192,7 @@ static RPCHelpMan getwalletinfo()
                                      {RPCResult::Type::NUM, "progress", "scanning progress percentage [0.0, 1.0]"},
                                 }},
                             {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for scriptPubKey management"},
+                            {RPCResult::Type::NUM_TIME, "birthtime", /*optional=*/true, "The start time for blocks scanning. It could be modified by (re)importing any descriptor with an earlier timestamp."},
                         },
                 },
                 RPCExamples{
@@ -269,6 +270,9 @@ static RPCHelpMan getwalletinfo()
         obj.pushKV("scanning", false);
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+    if (int64_t birthtime = pwallet->GetBirthTime(); birthtime != UNKNOWN_TIME) {
+        obj.pushKV("birthtime", birthtime);
+    }
     return obj;
 },
     };

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -818,7 +818,7 @@ void LegacyScriptPubKeyMan::UpdateTimeFirstKey(int64_t nCreateTime)
         // Cannot determine birthday information, so set the wallet birthday to
         // the beginning of time.
         nTimeFirstKey = 1;
-    } else if (!nTimeFirstKey || nCreateTime < nTimeFirstKey) {
+    } else if (nTimeFirstKey == UNKNOWN_TIME || nCreateTime < nTimeFirstKey) {
         nTimeFirstKey = nCreateTime;
     }
 }

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -53,6 +53,9 @@ public:
     virtual void KeepDestinationCallback(bool erased) = 0;
 };
 
+//! Constant representing an unknown spkm creation time
+static constexpr int64_t UNKNOWN_TIME = std::numeric_limits<int64_t>::max();
+
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 
@@ -252,7 +255,8 @@ private:
     WatchKeyMap mapWatchKeys GUARDED_BY(cs_KeyStore);
     HDPubKeyMap mapHdPubKeys GUARDED_BY(cs_KeyStore); ///<! memory map of HD extended pubkeys
 
-    int64_t nTimeFirstKey GUARDED_BY(cs_KeyStore) = 0;
+    // By default, do not scan any block until keys/scripts are generated/imported
+    int64_t nTimeFirstKey GUARDED_BY(cs_KeyStore) = UNKNOWN_TIME;
 
     bool HaveKeyInner(const CKeyID &address) const;
     bool AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -816,13 +816,6 @@ static std::optional<CreatedTransactionResult> CreateTransactionInternal(
     const CAmount not_input_fees = coin_selection_params.m_effective_feerate.GetFee(coin_selection_params.tx_noinputs_size);
     CAmount selection_target = recipients_sum + not_input_fees;
 
-    // This can only happen if feerate is 0, and requested destinations are value of 0 (e.g. OP_RETURN)
-    // and no pre-selected inputs. This will result in 0-input transaction, which is consensus-invalid anyways
-    if (selection_target == 0 && !coin_control.HasSelected()) {
-        error = _("Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input");
-        return std::nullopt;
-    }
-
     // Get available coins
     auto res_available_coins = AvailableCoins(wallet,
                                               &coin_control,
@@ -1030,7 +1023,7 @@ static std::optional<CreatedTransactionResult> CreateTransactionInternal(
 std::optional<CreatedTransactionResult> CreateTransaction(
         CWallet& wallet,
         const std::vector<CRecipient>& vecSend,
-        int change_pos,
+        std::optional<int> change_pos,
         bilingual_str& error,
         const CCoinControl& coin_control,
         FeeCalculation& fee_calc_out,
@@ -1049,7 +1042,7 @@ std::optional<CreatedTransactionResult> CreateTransaction(
 
     LOCK(wallet.cs_wallet);
 
-    std::optional<CreatedTransactionResult> txr_ungrouped = CreateTransactionInternal(wallet, vecSend, change_pos, error, coin_control, fee_calc_out, sign, nExtraPayloadSize);
+    std::optional<CreatedTransactionResult> txr_ungrouped = CreateTransactionInternal(wallet, vecSend, change_pos.value_or(-1), error, coin_control, fee_calc_out, sign, nExtraPayloadSize);
     TRACE4(coin_selection, normal_create_tx_internal, wallet.GetName().c_str(), txr_ungrouped.has_value(),
            txr_ungrouped.has_value() ? txr_ungrouped->fee : 0, txr_ungrouped.has_value() ? txr_ungrouped->change_pos : 0);
     if (!txr_ungrouped) return std::nullopt;
@@ -1066,7 +1059,7 @@ std::optional<CreatedTransactionResult> CreateTransaction(
             ExtractDestination(txr_ungrouped->tx->vout[ungrouped_change_pos].scriptPubKey, tmp_cc.destChange);
         }
 
-        std::optional<CreatedTransactionResult> txr_grouped = CreateTransactionInternal(wallet, vecSend, change_pos, error2, tmp_cc, fee_calc_out, sign, nExtraPayloadSize);
+        std::optional<CreatedTransactionResult> txr_grouped = CreateTransactionInternal(wallet, vecSend, change_pos.value_or(-1), error2, tmp_cc, fee_calc_out, sign, nExtraPayloadSize);
         if (txr_grouped) {
             // if fee of this alternative one is within the range of the max fee, we use this one
             const bool use_aps = txr_grouped->fee <= txr_ungrouped->fee + wallet.m_max_aps_fee;
@@ -1162,7 +1155,7 @@ bool GenBudgetSystemCollateralTx(CWallet& wallet, CTransactionRef& tx, uint256 h
 
     bilingual_str error;
     FeeCalculation fee_calc_out;
-    auto txr{CreateTransaction(wallet, vecSend, RANDOM_CHANGE_POSITION, error, coinControl, fee_calc_out)};
+    auto txr{CreateTransaction(wallet, vecSend, /*change_pos=*/std::nullopt, error, coinControl, fee_calc_out)};
     if (!txr.has_value()) {
         wallet.WalletLogPrintf("%s -- Error: %s\n", __func__, error.original);
         return false;

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -108,9 +108,9 @@ struct CreatedTransactionResult
 /**
  * Create a new transaction paying the recipients with a set of coins
  * selected by SelectCoins(); Also create the change output, when needed
- * @note passing change_pos as -1 will result in setting a random position
+ * @note passing change_pos as std::nullopt will result in setting a random position
  */
-std::optional<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, int change_pos, bilingual_str& error, const CCoinControl& coin_control, FeeCalculation& fee_calc_out, bool sign = true, int nExtraPayloadSize = 0);
+std::optional<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, std::optional<int> change_pos, bilingual_str& error, const CCoinControl& coin_control, FeeCalculation& fee_calc_out, bool sign = true, int nExtraPayloadSize = 0);
 
 /**
  * Insert additional inputs into the transaction by

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -31,7 +31,7 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
         coin_control.m_feerate.emplace(10000);
         coin_control.fOverrideFeeRate = true;
         FeeCalculation fee_calc;
-        std::optional<CreatedTransactionResult> txr = CreateTransaction(*wallet, {recipient}, RANDOM_CHANGE_POSITION, error, coin_control, fee_calc);
+        std::optional<CreatedTransactionResult> txr = CreateTransaction(*wallet, {recipient}, /*change_pos=*/std::nullopt, error, coin_control, fee_calc);
         BOOST_CHECK(txr.has_value());
         BOOST_CHECK_EQUAL(txr->tx->vout.size(), 1);
         BOOST_CHECK_EQUAL(txr->tx->vout[0].nValue, recipient.nAmount + leftover_input_amount - txr->fee);
@@ -56,6 +56,51 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
     // -123). This overpays the recipient instead of overpaying the miner more
     // than double the neccesary fee.
     BOOST_CHECK_EQUAL(fee, check_tx(fee + 123));
+}
+
+BOOST_FIXTURE_TEST_CASE(wallet_duplicated_preset_inputs_test, TestChain100Setup)
+{
+    // Verify that the wallet's Coin Selection process does not include pre-selected inputs twice in a transaction.
+
+    // Add 4 spendable UTXO, 50 BTC each, to the wallet (total balance 200 BTC)
+    for (int i = 0; i < 4; i++) CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+    auto wallet = CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
+
+    LOCK(wallet->cs_wallet);
+    auto available_coins = AvailableCoins(*wallet);
+    std::vector<COutput> coins = available_coins.All();
+    // Preselect the first 3 UTXO (150 BTC total)
+    std::set<COutPoint> preset_inputs = {coins[0].outpoint, coins[1].outpoint, coins[2].outpoint};
+
+    // Try to create a tx that spends more than what preset inputs + wallet selected inputs are covering for.
+    // The wallet can cover up to 200 BTC, and the tx target is 299 BTC.
+    std::vector<CRecipient> recipients{{*Assert(wallet->GetNewDestination(OutputType::BECH32, "dummy")),
+                                           /*nAmount=*/299 * COIN, /*fSubtractFeeFromAmount=*/true}};
+    CCoinControl coin_control;
+    coin_control.m_allow_other_inputs = true;
+    for (const auto& outpoint : preset_inputs) {
+        coin_control.Select(outpoint);
+    }
+
+    // Attempt to send 299 BTC from a wallet that only has 200 BTC. The wallet should exclude
+    // the preset inputs from the pool of available coins, realize that there is not enough
+    // money to fund the 299 BTC payment, and fail with "Insufficient funds".
+    //
+    // Even with SFFO, the wallet can only afford to send 200 BTC.
+    // If the wallet does not properly exclude preset inputs from the pool of available coins
+    // prior to coin selection, it may create a transaction that does not fund the full payment
+    // amount or, through SFFO, incorrectly reduce the recipient's amount by the difference
+    // between the original target and the wrongly counted inputs (in this case 99 BTC)
+    // so that the recipient's amount is no longer equal to the user's selected target of 299 BTC.
+
+    // First case, use 'subtract_fee_from_outputs=true'
+    util::Result<CreatedTransactionResult> res_tx = CreateTransaction(*wallet, recipients, /*change_pos=*/std::nullopt, coin_control);
+    BOOST_CHECK(!res_tx.has_value());
+
+    // Second case, don't use 'subtract_fee_from_outputs'.
+    recipients[0].fSubtractFeeFromAmount = false;
+    res_tx = CreateTransaction(*wallet, recipients, /*change_pos=*/std::nullopt, coin_control);
+    BOOST_CHECK(!res_tx.has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -558,7 +558,7 @@ public:
         CCoinControl dummy;
         FeeCalculation fee_calc_out;
         {
-            std::optional<CreatedTransactionResult> txr = CreateTransaction(*wallet, {recipient}, RANDOM_CHANGE_POSITION, error, dummy, fee_calc_out);
+            std::optional<CreatedTransactionResult> txr = CreateTransaction(*wallet, {recipient}, /*change_pos=*/std::nullopt, error, dummy, fee_calc_out);
             BOOST_CHECK(txr.has_value());
             tx = txr->tx;
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -941,6 +941,9 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
         wtx.nTimeSmart = ComputeTimeSmart(wtx, rescanning_old_block);
         AddToSpends(wtx, &batch);
         candidates = AddWalletUTXOs(wtx.tx, /*ret_dups=*/true);
+
+        // Update birth time when tx time is older than it.
+        MaybeUpdateBirthTime(wtx.GetTxTime());
     }
 
     if (!fInsertedNew)
@@ -1047,6 +1050,10 @@ bool CWallet::LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx
             }
         }
     }
+
+    // Update birth time when tx time is older than it.
+    MaybeUpdateBirthTime(wtx.GetTxTime());
+
     return true;
 }
 
@@ -1638,6 +1645,14 @@ bool CWallet::ImportScriptPubKeys(const std::string& label, const std::set<CScri
         }
     }
     return true;
+}
+
+void CWallet::MaybeUpdateBirthTime(int64_t time)
+{
+    int64_t birthtime = m_birth_time.load();
+    if (time < birthtime) {
+        m_birth_time = time;
+    }
 }
 
 /**
@@ -3049,6 +3064,14 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
+    // Cache the first key time
+    std::optional<int64_t> time_first_key;
+    for (auto spk_man : walletInstance->GetAllScriptPubKeyMans()) {
+        int64_t time = spk_man->GetTimeFirstKey();
+        if (!time_first_key || time < *time_first_key) time_first_key = time;
+    }
+    if (time_first_key) walletInstance->MaybeUpdateBirthTime(*time_first_key);
+
     if (chain && !AttachChain(walletInstance, *chain, error, warnings)) {
         return nullptr;
     }
@@ -3737,6 +3760,16 @@ LegacyScriptPubKeyMan* CWallet::GetOrCreateLegacyScriptPubKeyMan()
     return GetLegacyScriptPubKeyMan();
 }
 
+void CWallet::AddScriptPubKeyMan(const uint256& id, std::unique_ptr<ScriptPubKeyMan> spkm_man)
+{
+    // Add spkm_man to m_spk_managers before calling any method
+    // that might access it.
+    const auto& spkm = m_spk_managers[id] = std::move(spkm_man);
+
+    // Update birth time if needed
+    MaybeUpdateBirthTime(spkm->GetTimeFirstKey());
+}
+
 void CWallet::SetupLegacyScriptPubKeyMan()
 {
     if (m_internal_spk_managers || m_external_spk_managers || !m_spk_managers.empty() || IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
@@ -3765,6 +3798,7 @@ void CWallet::ConnectScriptPubKeyManNotifiers()
     for (const auto& spk_man : GetActiveScriptPubKeyMans()) {
         spk_man->NotifyWatchonlyChanged.connect(NotifyWatchonlyChanged);
         spk_man->NotifyCanGetAddressesChanged.connect(NotifyCanGetAddressesChanged);
+        spk_man->NotifyFirstKeyTimeChanged.connect(std::bind(&CWallet::MaybeUpdateBirthTime, this, std::placeholders::_2));
     }
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -278,6 +278,9 @@ private:
     bool fBroadcastTransactions = false;
     // Local time that the tip block was received. Used to schedule wallet rebroadcasts.
     std::atomic<int64_t> m_best_block_time {0};
+    // The birth time of the wallet. Can be used to skip blocks prior to this time.
+    // Set to the UNIX epoch time if there is no valid timestamp.
+    std::atomic<int64_t> m_birth_time{std::numeric_limits<int64_t>::max()};
 
     mutable bool fAnonymizableTallyCached = false;
     mutable std::vector<CompactTallyItem> vecAnonymizableTallyCached;
@@ -721,6 +724,8 @@ public:
     bool ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool ImportScriptPubKeys(const std::string& label, const std::set<CScript>& script_pub_keys, const bool have_solving_data, const bool apply_label, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    /** Updates wallet birth time if 'time' is below it */
+    void MaybeUpdateBirthTime(int64_t time);
     CFeeRate m_pay_tx_fee{DEFAULT_PAY_TX_FEE};
     unsigned int m_confirm_target{DEFAULT_TX_CONFIRM_TARGET};
     /** Allow Coin Selection to pick unconfirmed UTXOs that were sent from our own wallet if it
@@ -932,6 +937,9 @@ public:
     /** Returns a vector containing pointers to the governance objects in m_gobjects */
     std::vector<const Governance::Object*> GetGovernanceObjects() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    /* Returns the time of the first created key or, in case of an import, it could be the time of the first received transaction */
+    int64_t GetBirthTime() const { return m_birth_time; }
+
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current
      * chain at the time this function is entered
@@ -1005,6 +1013,9 @@ public:
 
     //! Make a LegacyScriptPubKeyMan and set it for all types, internal, and external.
     void SetupLegacyScriptPubKeyMan();
+
+    //! Add a ScriptPubKeyMan to the wallet
+    void AddScriptPubKeyMan(const uint256& id, std::unique_ptr<ScriptPubKeyMan> spkm_man);
 
     bool WithEncryptionKey(std::function<bool (const CKeyingMaterial&)> cb) const override;
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -193,6 +193,8 @@ BASE_SCRIPTS = [
     'wallet_listtransactions.py --descriptors',
     'wallet_watchonly.py --legacy-wallet',
     'wallet_watchonly.py --usecli --legacy-wallet',
+    'wallet_reindex.py --legacy-wallet',
+    'wallet_reindex.py --descriptors',
     'interface_http.py',
     'interface_rpc.py',
     'interface_usdt_coinselection.py',

--- a/test/functional/wallet_reindex.py
+++ b/test/functional/wallet_reindex.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+"""Test wallet-reindex interaction"""
+
+import time
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+BLOCK_TIME = 60 * 10
+
+class WalletReindexTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def advance_time(self, node, secs):
+        self.node_time += secs
+        node.setmocktime(self.node_time)
+
+    # Verify the wallet updates the birth time accordingly when it detects a transaction
+    # with a time older than the oldest descriptor timestamp.
+    # This could happen when the user blindly imports a descriptor with 'timestamp=now'.
+    def birthtime_test(self, node, miner_wallet):
+        self.log.info("Test birth time update during tx scanning")
+        # Fund address to test
+        wallet_addr = miner_wallet.getnewaddress()
+        tx_id = miner_wallet.sendtoaddress(wallet_addr, 2)
+
+        # Generate 50 blocks, one every 10 min to surpass the 2 hours rescan window the wallet has
+        for _ in range(50):
+            self.generate(node, 1)
+            self.advance_time(node, BLOCK_TIME)
+
+        # Now create a new wallet, and import the descriptor
+        node.createwallet(wallet_name='watch_only', disable_private_keys=True, load_on_startup=True)
+        wallet_watch_only = node.get_wallet_rpc('watch_only')
+        # Blank wallets don't have a birth time
+        assert 'birthtime' not in wallet_watch_only.getwalletinfo()
+
+        # For a descriptors wallet: Import address with timestamp=now.
+        # For legacy wallet: There is no way of importing a script/address with a custom time. The wallet always imports it with birthtime=1.
+        # In both cases, disable rescan to not detect the transaction.
+        wallet_watch_only.importaddress(wallet_addr, rescan=False)
+        assert_equal(len(wallet_watch_only.listtransactions()), 0)
+
+        # Depending on the wallet type, the birth time changes.
+        wallet_birthtime = wallet_watch_only.getwalletinfo()['birthtime']
+        if self.options.descriptors:
+            # As blocks were generated every 10 min, the chain MTP timestamp is node_time - 60 min.
+            assert_equal(self.node_time - BLOCK_TIME * 6, wallet_birthtime)
+        else:
+            # No way of importing scripts/addresses with a custom time on a legacy wallet.
+            # It's always set to the beginning of time.
+            assert_equal(wallet_birthtime, 1)
+
+        # Rescan the wallet to detect the missing transaction
+        wallet_watch_only.rescanblockchain()
+        assert_equal(wallet_watch_only.gettransaction(tx_id)['confirmations'], 50)
+        assert_equal(wallet_watch_only.getbalances()['mine' if self.options.descriptors else 'watchonly']['trusted'], 2)
+
+        # Reindex and wait for it to finish
+        with node.assert_debug_log(expected_msgs=["initload thread exit"]):
+            self.restart_node(0, extra_args=['-reindex=1', f'-mocktime={self.node_time}'])
+        node.syncwithvalidationinterfacequeue()
+
+        # Verify the transaction is still 'confirmed' after reindex
+        wallet_watch_only = node.get_wallet_rpc('watch_only')
+        tx_info = wallet_watch_only.gettransaction(tx_id)
+        assert_equal(tx_info['confirmations'], 50)
+
+        # Depending on the wallet type, the birth time changes.
+        if self.options.descriptors:
+            # For descriptors, verify the wallet updated the birth time to the transaction time
+            assert_equal(tx_info['time'], wallet_watch_only.getwalletinfo()['birthtime'])
+        else:
+            # For legacy, as the birth time was set to the beginning of time, verify it did not change
+            assert_equal(wallet_birthtime, 1)
+
+        wallet_watch_only.unloadwallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.node_time = int(time.time())
+        node.setmocktime(self.node_time)
+
+        # Fund miner
+        node.createwallet(wallet_name='miner', load_on_startup=True)
+        miner_wallet = node.get_wallet_rpc('miner')
+        self.generatetoaddress(node, COINBASE_MATURITY + 10, miner_wallet.getnewaddress())
+
+        # Tests
+        self.birthtime_test(node, miner_wallet)
+
+
+if __name__ == '__main__':
+    WalletReindexTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#29065

Original commit: 9f0f83d650

Backported from Bitcoin Core v0.27

## Summary
- Fixes change position out of range error in wallet benchmarks and tests
- Updates CreateTransaction API to use std::nullopt instead of -1 for random change position
- Updates documentation to reflect the new API

## Notes
- Files src/bench/wallet_create_tx.cpp and src/wallet/feebumper.cpp don't exist in Dash
- Additional test case wallet_duplicated_preset_inputs_test was included from conflict resolution
- Changes to src/wallet/spend.cpp were required to update the function signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction creation to better handle cases with pre-selected wallet inputs, ensuring accurate detection of insufficient funds and preventing double counting.
* **Tests**
  * Added a new test to verify that pre-selected wallet inputs are not double-counted during transaction creation.
  * Updated existing tests to use a more flexible way of specifying change output positions during transaction creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->