### PR TITLE
Merge bitcoin/bitcoin#29195: build: Fix `-Xclang -internal-isystem` option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -792,7 +792,7 @@ case $host in
          dnl option to system-ify all /usr/local/include paths without adding it to the list
          dnl of search paths in case it's not already there.
          if test "$suppress_external_warnings" != "no"; then
-           AX_CHECK_PREPROC_FLAG([-Xclang -internal-isystem/usr/local/include], [CORE_CPPFLAGS="$CORE_CPPFLAGS -Xclang -internal-isystem/usr/local/include"], [], [$CXXFLAG_WERROR])
+           AX_CHECK_PREPROC_FLAG([-Xclang -internal-isystem -Xclang /usr/local/include/], [CORE_CPPFLAGS="$CORE_CPPFLAGS -Xclang -internal-isystem -Xclang /usr/local/include/"], [], [$CXXFLAG_WERROR])
          fi
 
          if test "$use_bdb" != "no" && $BREW list --versions berkeley-db@4 >/dev/null && test "$BDB_CFLAGS" = "" && test "$BDB_LIBS" = ""; then


### PR DESCRIPTION
Backports bitcoin/bitcoin#29195

Original commit: 9e1306fc88

Backported from Bitcoin Core v0.27

This PR fixes a build issue with newer versions of Clang (LLVM Clang >=16.0 and Apple Clang >=15.0) that no longer recognize the old `-Xclang -internal-isystem/usr/local/include` syntax. The fix splits this into separate `-Xclang -internal-isystem -Xclang /usr/local/include/` arguments.

Note: The Bitcoin commit also included changes to `.github/workflows/ci.yml` which doesn't exist in Dash, so only the `configure.ac` change was backported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the way compiler flags are set for macOS to improve handling of system include paths during configuration. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->