### PR TITLE
Merge bitcoin/bitcoin#29127: Use hardened runtime on macOS release builds.

### DIFF
--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -24,7 +24,7 @@ fi
 rm -rf ${TEMPDIR}
 mkdir -p ${TEMPDIR}
 
-${SIGNAPPLE} sign --hardened-runtime -f --detach "${TEMPDIR}/${OUTROOT}"  "$@" "${BUNDLE}"
+${SIGNAPPLE} sign -f --detach "${TEMPDIR}/${OUTROOT}"  "$@" "${BUNDLE}" --hardened-runtime
 
 tar -C "${TEMPDIR}" -czf "${OUT}" .
 rm -rf "${TEMPDIR}"


### PR DESCRIPTION
Backports bitcoin/bitcoin#29127

Original commit: 522b8370d92a8815537b402f43951b45ed0fe7ad

This commit is already implemented in Dash. The --hardened-runtime flag is already present in contrib/macdeploy/detached-sig-create.sh, just in a different position in the command line arguments.

## Notes
- Bitcoin added `--hardened-runtime` flag at the end of the signapple command
- Dash already has this flag immediately after the `sign` subcommand
- This is effectively a no-op backport as the functionality already exists
- Created empty commit to maintain tracking consistency

Backported from Bitcoin Core v0.27