### PR TITLE
Merge bitcoin/bitcoin#29186: ci, iwyu: Drop backported mappings

### DIFF
--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -1,6 +1,3 @@
 # Fixups / upstreamed changes
 [
-  { include: [ "<bits/termios-c_lflag.h>", private, "<termios.h>", public ] },
-  { include: [ "<bits/termios-struct.h>", private, "<termios.h>", public ] },
-  { include: [ "<bits/termios-tcflow.h>", private, "<termios.h>", public ] },
 ]


### PR DESCRIPTION
Backports bitcoin/bitcoin#29186

Original commit: 014f52550b

Backported from Bitcoin Core v0.27