### PR TITLE
Merge bitcoin/bitcoin#29179: test: wallet rescan with reorged parent + IsFromMe child in mempool

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -346,6 +346,7 @@ BASE_SCRIPTS = [
     'wallet_send.py --legacy-wallet',
     'wallet_send.py --descriptors',
     'wallet_create_tx.py --descriptors',
+    'wallet_rescan_unconfirmed.py --descriptors',
     'p2p_fingerprint.py',
     'rpc_external_queue.py',
     'rpc_wipewallettxes.py',

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -21,10 +21,7 @@ happened previously.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.governance import EXPECTED_STDERR_NO_GOV_PRUNE
-from test_framework.address import (
-    AddressType,
-    ADDRESS_BCRT1_UNSPENDABLE,
-)
+from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 from test_framework.util import (
     assert_equal,
     set_node_times,

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -21,6 +21,10 @@ happened previously.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.governance import EXPECTED_STDERR_NO_GOV_PRUNE
+from test_framework.address import (
+    AddressType,
+    ADDRESS_BCRT1_UNSPENDABLE,
+)
 from test_framework.util import (
     assert_equal,
     set_node_times,
@@ -93,7 +97,7 @@ class Variant(collections.namedtuple("Variant", "call data rescan prune")):
 
             address, = [ad for ad in addresses if txid in ad["txids"]]
             assert_equal(address["address"], self.address["address"])
-            assert_equal(address["amount"], self.expected_balance)
+            assert_equal(address["amount"], self.amount_received)
             assert_equal(address["confirmations"], 1 + current_height - confirmation_height)
             # Verify the transaction is correctly marked watchonly depending on
             # whether the transaction pays to an imported public key or
@@ -186,11 +190,11 @@ class ImportRescanTest(BitcoinTestFramework):
             variant.node = self.nodes[2 + IMPORT_NODES.index(ImportNode(variant.prune, expect_rescan))]
             variant.do_import(variant.timestamp)
             if expect_rescan:
-                variant.expected_balance = variant.initial_amount
+                variant.amount_received = variant.initial_amount
                 variant.expected_txs = 1
                 variant.check(variant.initial_txid, variant.initial_amount, variant.confirmation_height)
             else:
-                variant.expected_balance = 0
+                variant.amount_received = 0
                 variant.expected_txs = 0
                 variant.check()
 
@@ -207,13 +211,84 @@ class ImportRescanTest(BitcoinTestFramework):
         # Check the latest results from getbalance and listtransactions.
         for variant in IMPORT_VARIANTS:
             self.log.info('Run check for variant {}'.format(variant))
-            variant.expected_balance += variant.sent_amount
+            variant.amount_received += variant.sent_amount
             variant.expected_txs += 1
             variant.check(variant.sent_txid, variant.sent_amount, variant.confirmation_height)
         for i, import_node in enumerate(IMPORT_NODES, 2):
             if import_node.prune:
                 self.stop_node(i, expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
 
+        self.log.info('Test that the mempool is rescanned as well if the rescan parameter is set to true')
+
+        # The late timestamp and pruned variants are not necessary when testing mempool rescan
+        mempool_variants = [variant for variant in IMPORT_VARIANTS if variant.rescan != Rescan.late_timestamp and not variant.prune]
+        # No further blocks are mined so the timestamp will stay the same
+        timestamp = self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"]
+
+        # Create one transaction on node 0 with a unique amount for
+        # each possible type of wallet import RPC.
+        for i, variant in enumerate(mempool_variants):
+            variant.label = "mempool label {} {}".format(i, variant)
+            variant.address = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress(label=variant.label))
+            variant.key = self.nodes[1].dumpprivkey(variant.address["address"])
+            variant.initial_amount = get_rand_amount() * 2
+            variant.initial_txid = self.nodes[0].sendtoaddress(variant.address["address"], variant.initial_amount)
+            variant.confirmation_height = 0
+            variant.timestamp = timestamp
+
+        # Mine a block so these parents are confirmed
+        assert_equal(len(self.nodes[0].getrawmempool()), len(mempool_variants))
+        self.sync_mempools()
+        block_to_disconnect = self.generate(self.nodes[0], 1)[0]
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+
+        # For each variant, create an unconfirmed child transaction from initial_txid, sending all
+        # the funds to an unspendable address. Importantly, no change output is created so the
+        # transaction can't be recognized using its outputs. The wallet rescan needs to know the
+        # inputs of the transaction to detect it, so the parent must be processed before the child.
+        # An equivalent test for descriptors exists in wallet_rescan_unconfirmed.py.
+        unspent_txid_map = {txin["txid"] : txin for txin in self.nodes[1].listunspent()}
+        for variant in mempool_variants:
+            # Send full amount, subtracting fee from outputs, to ensure no change is created.
+            child = self.nodes[1].send(
+                add_to_wallet=False,
+                inputs=[unspent_txid_map[variant.initial_txid]],
+                outputs=[{ADDRESS_BCRT1_UNSPENDABLE : variant.initial_amount}],
+                subtract_fee_from_outputs=[0]
+            )
+            variant.child_txid = child["txid"]
+            variant.amount_received = 0
+            self.nodes[0].sendrawtransaction(child["hex"])
+
+        # Mempools should contain the child transactions for each variant.
+        assert_equal(len(self.nodes[0].getrawmempool()), len(mempool_variants))
+        self.sync_mempools()
+
+        # Mock a reorg so the parent transactions are added back to the mempool
+        for node in self.nodes:
+            node.invalidateblock(block_to_disconnect)
+            # Mempools should now contain the parent and child for each variant.
+            assert_equal(len(node.getrawmempool()), 2 * len(mempool_variants))
+
+        # For each variation of wallet key import, invoke the import RPC and
+        # check the results from getbalance and listtransactions.
+        for variant in mempool_variants:
+            self.log.info('Run import for mempool variant {}'.format(variant))
+            expect_rescan = variant.rescan == Rescan.yes
+            variant.node = self.nodes[2 + IMPORT_NODES.index(ImportNode(variant.prune, expect_rescan))]
+            variant.do_import(variant.timestamp)
+            if expect_rescan:
+                # Ensure both transactions were rescanned. This would raise a JSONRPCError if the
+                # transactions were not identified as belonging to the wallet.
+                assert_equal(variant.node.gettransaction(variant.initial_txid)['confirmations'], 0)
+                assert_equal(variant.node.gettransaction(variant.child_txid)['confirmations'], 0)
+                variant.amount_received = variant.initial_amount
+                variant.expected_txs = 1
+                variant.check(variant.initial_txid, variant.initial_amount, 0)
+            else:
+                variant.amount_received = 0
+                variant.expected_txs = 0
+                variant.check()
 
 
 if __name__ == "__main__":

--- a/test/functional/wallet_rescan_unconfirmed.py
+++ b/test/functional/wallet_rescan_unconfirmed.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that descriptor wallets rescan mempool transactions properly when importing."""
+
+from test_framework.address import (
+    address_to_scriptpubkey,
+    ADDRESS_BCRT1_UNSPENDABLE,
+)
+from test_framework.messages import COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+from test_framework.wallet_util import test_address
+
+
+class WalletRescanUnconfirmed(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, legacy=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def run_test(self):
+        self.log.info("Create wallets and mine initial chain")
+        node = self.nodes[0]
+        tester_wallet = MiniWallet(node)
+
+        node.createwallet(wallet_name='w0', disable_private_keys=False)
+        w0 = node.get_wallet_rpc('w0')
+
+        self.log.info("Create a parent tx and mine it in a block that will later be disconnected")
+        parent_address = w0.getnewaddress()
+        tx_parent_to_reorg = tester_wallet.send_to(
+            from_node=node,
+            scriptPubKey=address_to_scriptpubkey(parent_address),
+            amount=COIN,
+        )
+        assert tx_parent_to_reorg["txid"] in node.getrawmempool()
+        block_to_reorg = self.generate(tester_wallet, 1)[0]
+        assert_equal(len(node.getrawmempool()), 0)
+        node.syncwithvalidationinterfacequeue()
+        assert_equal(w0.gettransaction(tx_parent_to_reorg["txid"])["confirmations"], 1)
+
+        # Create an unconfirmed child transaction from the parent tx, sending all
+        # the funds to an unspendable address. Importantly, no change output is created so the
+        # transaction can't be recognized using its outputs. The wallet rescan needs to know the
+        # inputs of the transaction to detect it, so the parent must be processed before the child.
+        w0_utxos = w0.listunspent()
+
+        self.log.info("Create a child tx and wait for it to propagate to all mempools")
+        # The only UTXO available to spend is tx_parent_to_reorg.
+        assert_equal(len(w0_utxos), 1)
+        assert_equal(w0_utxos[0]["txid"], tx_parent_to_reorg["txid"])
+        tx_child_unconfirmed_sweep = w0.sendall([ADDRESS_BCRT1_UNSPENDABLE])
+        assert tx_child_unconfirmed_sweep["txid"] in node.getrawmempool()
+        node.syncwithvalidationinterfacequeue()
+
+        self.log.info("Mock a reorg, causing parent to re-enter mempools after its child")
+        node.invalidateblock(block_to_reorg)
+        assert tx_parent_to_reorg["txid"] in node.getrawmempool()
+
+        self.log.info("Import descriptor wallet on another node")
+        descriptors_to_import = [{"desc": w0.getaddressinfo(parent_address)['parent_desc'], "timestamp": 0, "label": "w0 import"}]
+
+        node.createwallet(wallet_name="w1", disable_private_keys=True)
+        w1 = node.get_wallet_rpc("w1")
+        w1.importdescriptors(descriptors_to_import)
+
+        self.log.info("Check that the importing node has properly rescanned mempool transactions")
+        # Check that parent address is correctly determined as ismine
+        test_address(w1, parent_address, solvable=True, ismine=True)
+        # This would raise a JSONRPCError if the transactions were not identified as belonging to the wallet.
+        assert_equal(w1.gettransaction(tx_parent_to_reorg["txid"])["confirmations"], 0)
+        assert_equal(w1.gettransaction(tx_child_unconfirmed_sweep["txid"])["confirmations"], 0)
+
+if __name__ == '__main__':
+    WalletRescanUnconfirmed().main()

--- a/test/functional/wallet_rescan_unconfirmed.py
+++ b/test/functional/wallet_rescan_unconfirmed.py
@@ -4,10 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test that descriptor wallets rescan mempool transactions properly when importing."""
 
-from test_framework.address import (
-    address_to_scriptpubkey,
-    ADDRESS_BCRT1_UNSPENDABLE,
-)
+from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
+from test_framework.wallet import address_to_scriptpubkey
 from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -16,9 +14,6 @@ from test_framework.wallet_util import test_address
 
 
 class WalletRescanUnconfirmed(BitcoinTestFramework):
-    def add_options(self, parser):
-        self.add_wallet_options(parser, legacy=False)
-
     def set_test_params(self):
         self.num_nodes = 1
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29179

Original commit: 27d935f58b9ef5560ddd5914547a6de7884c41e6

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new test verifying wallet behavior when rescanning unconfirmed mempool transactions during descriptor imports.
  * Enhanced existing tests to cover wallet rescanning of mempool transactions during import operations, including blockchain reorganization scenarios.

* **Tests**
  * Updated test scripts to improve tracking and validation of wallet balances and transaction detection during rescan scenarios.
  * Added the new test to the default functional test suite for automatic execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->