### PR TITLE
Merge bitcoin/bitcoin#29272: wallet: fix coin selection tracing to return -1 when no change pos

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1051,7 +1051,7 @@ std::optional<CreatedTransactionResult> CreateTransaction(
 
     std::optional<CreatedTransactionResult> txr_ungrouped = CreateTransactionInternal(wallet, vecSend, change_pos, error, coin_control, fee_calc_out, sign, nExtraPayloadSize);
     TRACE4(coin_selection, normal_create_tx_internal, wallet.GetName().c_str(), txr_ungrouped.has_value(),
-           txr_ungrouped.has_value() ? txr_ungrouped->fee : 0, txr_ungrouped.has_value() ? txr_ungrouped->change_pos : 0);
+           txr_ungrouped.has_value() ? txr_ungrouped->fee : 0, txr_ungrouped.has_value() ? txr_ungrouped->change_pos : -1);
     if (!txr_ungrouped) return std::nullopt;
     // try with avoidpartialspends unless it's enabled already
     if (txr_ungrouped->fee > 0 /* 0 means non-functional fee rate estimation */ && wallet.m_max_aps_fee > -1 && !coin_control.m_avoid_partial_spends) {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -845,7 +845,12 @@ static std::optional<CreatedTransactionResult> CreateTransactionInternal(
         }
         return std::nullopt;
     }
-    TRACE5(coin_selection, selected_coins, wallet.GetName().c_str(), GetAlgorithmName(result->m_algo).c_str(), result->m_target, result->GetWaste(), result->GetSelectedValue());
+    TRACE5(coin_selection, selected_coins,
+           wallet.GetName().c_str(),
+           GetAlgorithmName(result->m_algo).c_str(),
+           result->m_target,
+           result->GetWaste(),
+           result->GetSelectedValue());
 
     // Always make a change output
     // We will reduce the fee from this change output later, and remove the output if it is too small.
@@ -1050,8 +1055,11 @@ std::optional<CreatedTransactionResult> CreateTransaction(
     LOCK(wallet.cs_wallet);
 
     std::optional<CreatedTransactionResult> txr_ungrouped = CreateTransactionInternal(wallet, vecSend, change_pos, error, coin_control, fee_calc_out, sign, nExtraPayloadSize);
-    TRACE4(coin_selection, normal_create_tx_internal, wallet.GetName().c_str(), txr_ungrouped.has_value(),
-           txr_ungrouped.has_value() ? txr_ungrouped->fee : 0, txr_ungrouped.has_value() ? txr_ungrouped->change_pos : -1);
+    TRACE4(coin_selection, normal_create_tx_internal,
+           wallet.GetName().c_str(),
+           txr_ungrouped.has_value(),
+           txr_ungrouped.has_value() ? txr_ungrouped->fee : 0,
+           txr_ungrouped.has_value() && txr_ungrouped->change_pos.has_value() ? int32_t(*txr_ungrouped->change_pos) : -1);
     if (!txr_ungrouped) return std::nullopt;
     // try with avoidpartialspends unless it's enabled already
     if (txr_ungrouped->fee > 0 /* 0 means non-functional fee rate estimation */ && wallet.m_max_aps_fee > -1 && !coin_control.m_avoid_partial_spends) {
@@ -1072,7 +1080,12 @@ std::optional<CreatedTransactionResult> CreateTransaction(
             const bool use_aps = txr_grouped->fee <= txr_ungrouped->fee + wallet.m_max_aps_fee;
             wallet.WalletLogPrintf("Fee non-grouped = %lld, grouped = %lld, using %s\n",
                 txr_ungrouped->fee, txr_grouped->fee, use_aps ? "grouped" : "non-grouped");
-            TRACE5(coin_selection, aps_create_tx_internal, wallet.GetName().c_str(), use_aps, true, txr_grouped->fee, txr_grouped->change_pos.has_value() ? int32_t(*txr_grouped->change_pos) : -1);
+            TRACE5(coin_selection, aps_create_tx_internal,
+                   wallet.GetName().c_str(),
+                   use_aps,
+                   true,
+                   txr_grouped->fee,
+                   txr_grouped->change_pos.has_value() ? int32_t(*txr_grouped->change_pos) : -1);
             if (use_aps) return txr_grouped;
         }
     }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1072,7 +1072,7 @@ std::optional<CreatedTransactionResult> CreateTransaction(
             const bool use_aps = txr_grouped->fee <= txr_ungrouped->fee + wallet.m_max_aps_fee;
             wallet.WalletLogPrintf("Fee non-grouped = %lld, grouped = %lld, using %s\n",
                 txr_ungrouped->fee, txr_grouped->fee, use_aps ? "grouped" : "non-grouped");
-            TRACE5(coin_selection, aps_create_tx_internal, wallet.GetName().c_str(), use_aps, true, txr_grouped->fee, txr_grouped->change_pos);
+            TRACE5(coin_selection, aps_create_tx_internal, wallet.GetName().c_str(), use_aps, true, txr_grouped->fee, txr_grouped->change_pos.has_value() ? int32_t(*txr_grouped->change_pos) : -1);
             if (use_aps) return txr_grouped;
         }
     }

--- a/test/functional/interface_usdt_coinselection.py
+++ b/test/functional/interface_usdt_coinselection.py
@@ -201,6 +201,29 @@ class CoinSelectionTracepointTest(BitcoinTestFramework):
         assert_equal(success, True)
         assert_equal(use_aps, None)
 
+        self.log.info("Change position is -1 if no change is created with APS when APS was initially not used")
+        # We should have 2 tracepoints in the order:
+        # 1. selected_coins (type 1)
+        # 2. normal_create_tx_internal (type 2)
+        # 3. attempting_aps_create_tx (type 3)
+        # 4. selected_coins (type 1)
+        # 5. aps_create_tx_internal (type 4)
+        wallet.sendtoaddress(address=wallet.getnewaddress(), amount=wallet.getbalance(), subtractfeefromamount=True, avoid_reuse=False)
+        events = self.get_tracepoints([1, 2, 3, 1, 4])
+        success, use_aps, algo, waste, change_pos = self.determine_selection_from_usdt(events)
+        assert_equal(success, True)
+        assert_equal(change_pos, -1)
+
+        self.log.info("Change position is -1 if no change is created normally and APS is not used")
+        # We should have 2 tracepoints in the order:
+        # 1. selected_coins (type 1)
+        # 2. normal_create_tx_internal (type 2)
+        wallet.sendtoaddress(address=wallet.getnewaddress(), amount=wallet.getbalance(), subtractfeefromamount=True)
+        events = self.get_tracepoints([1, 2])
+        success, use_aps, algo, waste, change_pos = self.determine_selection_from_usdt(events)
+        assert_equal(success, True)
+        assert_equal(change_pos, -1)
+
         self.bpf.cleanup()
 
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29272

Original commit: 7cb7759b25

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging clarity by ensuring that when no change output is created, the trace logs display a value of -1 for change position instead of 0.

* **Tests**
  * Added new test cases to verify that transactions without change outputs correctly report a change position of -1 in trace logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->