### PR TITLE
Merge bitcoin/bitcoin#26859: fuzz: extend ConsumeNetAddr() to return I2P and CJDNS addresses

### DIFF
--- a/linux64_fuzz_logs.txt
+++ b/linux64_fuzz_logs.txt
@@ -1,0 +1,2227 @@
+﻿2025-07-30T13:45:54.3824070Z Current runner version: '2.326.0'
+2025-07-30T13:45:54.3849392Z ##[group]Runner Image Provisioner
+2025-07-30T13:45:54.3850214Z Hosted Compute Agent
+2025-07-30T13:45:54.3850762Z Version: 20250711.363
+2025-07-30T13:45:54.3851570Z Commit: 6785254374ce925a23743850c1cb91912ce5c14c
+2025-07-30T13:45:54.3852283Z Build Date: 2025-07-11T20:04:25Z
+2025-07-30T13:45:54.3852903Z ##[endgroup]
+2025-07-30T13:45:54.3853441Z ##[group]Operating System
+2025-07-30T13:45:54.3854061Z Ubuntu
+2025-07-30T13:45:54.3854502Z 24.04.2
+2025-07-30T13:45:54.3855008Z LTS
+2025-07-30T13:45:54.3855437Z ##[endgroup]
+2025-07-30T13:45:54.3855926Z ##[group]Runner Image
+2025-07-30T13:45:54.3856450Z Image: ubuntu-24.04
+2025-07-30T13:45:54.3857040Z Version: 20250720.1.0
+2025-07-30T13:45:54.3858082Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250720.1/images/ubuntu/Ubuntu2404-Readme.md
+2025-07-30T13:45:54.3859740Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250720.1
+2025-07-30T13:45:54.3860776Z ##[endgroup]
+2025-07-30T13:45:54.3862042Z ##[group]GITHUB_TOKEN Permissions
+2025-07-30T13:45:54.3864145Z Contents: read
+2025-07-30T13:45:54.3864673Z Metadata: read
+2025-07-30T13:45:54.3865252Z Packages: write
+2025-07-30T13:45:54.3865753Z ##[endgroup]
+2025-07-30T13:45:54.3867727Z Secret source: Actions
+2025-07-30T13:45:54.3868786Z Prepare workflow directory
+2025-07-30T13:45:54.4400392Z Prepare all required actions
+2025-07-30T13:45:54.4437372Z Getting action download info
+2025-07-30T13:45:54.8425962Z ##[group]Download immutable action package 'actions/checkout@v4'
+2025-07-30T13:45:54.8427231Z Version: 4.2.2
+2025-07-30T13:45:54.8428313Z Digest: sha256:ccb2698953eaebd21c7bf6268a94f9c26518a7e38e27e0b83c1fe1ad049819b1
+2025-07-30T13:45:54.8429660Z Source commit SHA: 11bd71901bbe5b1630ceea73d27597364c9af683
+2025-07-30T13:45:54.8430434Z ##[endgroup]
+2025-07-30T13:45:54.9369236Z ##[group]Download immutable action package 'actions/cache@v4'
+2025-07-30T13:45:54.9370158Z Version: 4.2.3
+2025-07-30T13:45:54.9371428Z Digest: sha256:c8a3bb963e1f1826d8fcc8d1354f0dd29d8ac1db1d4f6f20247055ae11b81ed9
+2025-07-30T13:45:54.9372651Z Source commit SHA: 5a3ec84eff668545956fd18022155c47e93e2684
+2025-07-30T13:45:54.9373435Z ##[endgroup]
+2025-07-30T13:45:55.0421680Z ##[group]Download immutable action package 'actions/upload-artifact@v4'
+2025-07-30T13:45:55.0422612Z Version: 4.6.2
+2025-07-30T13:45:55.0423514Z Digest: sha256:290722aa3281d5caf23d0acdc3dbeb3424786a1a01a9cc97e72f147225e37c38
+2025-07-30T13:45:55.0424609Z Source commit SHA: ea165f8d65b6e75b540449e92b4886f43607fa02
+2025-07-30T13:45:55.0425435Z ##[endgroup]
+2025-07-30T13:45:55.2441236Z Uses: DashCoreAutoGuix/dash/.github/workflows/build-src.yml@refs/heads/backport-0.27-batch-556-pr-26859 (3edf8361bf6a05778eab7a21802074376a229653)
+2025-07-30T13:45:55.2446231Z ##[group] Inputs
+2025-07-30T13:45:55.2446823Z   build-target: linux64_fuzz
+2025-07-30T13:45:55.2447792Z   container-path: ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:45:55.2450285Z   depends-key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:45:55.2452530Z ##[endgroup]
+2025-07-30T13:45:55.2453022Z Complete job name: linux64_fuzz-build / Build source
+2025-07-30T13:45:55.2924470Z ##[group]Checking docker version
+2025-07-30T13:45:55.2937457Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2025-07-30T13:45:55.3377607Z '1.48'
+2025-07-30T13:45:55.3388476Z Docker daemon API version: '1.48'
+2025-07-30T13:45:55.3389302Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2025-07-30T13:45:55.3556522Z '1.48'
+2025-07-30T13:45:55.3571707Z Docker client API version: '1.48'
+2025-07-30T13:45:55.3578087Z ##[endgroup]
+2025-07-30T13:45:55.3582993Z ##[group]Clean up resources from previous jobs
+2025-07-30T13:45:55.3588892Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=362aa6"
+2025-07-30T13:45:55.3733821Z ##[command]/usr/bin/docker network prune --force --filter "label=362aa6"
+2025-07-30T13:45:55.3867821Z ##[endgroup]
+2025-07-30T13:45:55.3868379Z ##[group]Create local container network
+2025-07-30T13:45:55.3879564Z ##[command]/usr/bin/docker network create --label 362aa6 github_network_f14c4402ce2947a5be80f529f4c1bca9
+2025-07-30T13:45:55.4588609Z 26bc8e09ffe87f826c7b2024a7b744e0896442d17914005d3660e7ed9f90d485
+2025-07-30T13:45:55.4600031Z ##[endgroup]
+2025-07-30T13:45:55.4624379Z ##[group]Starting job container
+2025-07-30T13:45:55.4645813Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_ac15dd22-ed72-40a7-b446-f296dc5589db login ghcr.io -u DashCoreAutoGuix --password-stdin
+2025-07-30T13:45:55.9291058Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_ac15dd22-ed72-40a7-b446-f296dc5589db pull ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:45:57.4126006Z backport-0.27-batch-556-pr-26859: Pulling from dashcoreautoguix/dash/dashcore-ci-runner
+2025-07-30T13:45:57.5122019Z 32f112e3802c: Pulling fs layer
+2025-07-30T13:45:57.5122802Z 3c418bbf5534: Pulling fs layer
+2025-07-30T13:45:57.5123461Z 824b5144f7af: Pulling fs layer
+2025-07-30T13:45:57.5124191Z bb9f5c709011: Pulling fs layer
+2025-07-30T13:45:57.5124880Z c31b5eed60b6: Pulling fs layer
+2025-07-30T13:45:57.5125518Z da96180e845f: Pulling fs layer
+2025-07-30T13:45:57.5126110Z f28d6a4cf5de: Pulling fs layer
+2025-07-30T13:45:57.5126518Z 49cbdb9e902d: Pulling fs layer
+2025-07-30T13:45:57.5126928Z 247fd41058fa: Pulling fs layer
+2025-07-30T13:45:57.5127327Z d6a01b6e446c: Pulling fs layer
+2025-07-30T13:45:57.5127646Z 4f4fb700ef54: Pulling fs layer
+2025-07-30T13:45:57.5127959Z 1382f2390a1c: Pulling fs layer
+2025-07-30T13:45:57.5128288Z be38403a389e: Pulling fs layer
+2025-07-30T13:45:57.5128614Z 409781d99354: Pulling fs layer
+2025-07-30T13:45:57.5129039Z c418b82685d0: Pulling fs layer
+2025-07-30T13:45:57.5129342Z bb9f5c709011: Waiting
+2025-07-30T13:45:57.5129702Z c31b5eed60b6: Waiting
+2025-07-30T13:45:57.5130086Z da96180e845f: Waiting
+2025-07-30T13:45:57.5130355Z 247fd41058fa: Waiting
+2025-07-30T13:45:57.5130752Z d6a01b6e446c: Waiting
+2025-07-30T13:45:57.5131290Z be38403a389e: Waiting
+2025-07-30T13:45:57.5131569Z 4f4fb700ef54: Waiting
+2025-07-30T13:45:57.5131829Z 409781d99354: Waiting
+2025-07-30T13:45:57.5132116Z f28d6a4cf5de: Waiting
+2025-07-30T13:45:57.5132381Z c418b82685d0: Waiting
+2025-07-30T13:45:57.5132647Z 1382f2390a1c: Waiting
+2025-07-30T13:45:57.6543628Z 824b5144f7af: Verifying Checksum
+2025-07-30T13:45:57.6544365Z 824b5144f7af: Download complete
+2025-07-30T13:45:57.6628322Z 3c418bbf5534: Verifying Checksum
+2025-07-30T13:45:57.6628968Z 3c418bbf5534: Download complete
+2025-07-30T13:45:57.9855362Z 32f112e3802c: Verifying Checksum
+2025-07-30T13:45:57.9858554Z 32f112e3802c: Download complete
+2025-07-30T13:45:58.0790289Z c31b5eed60b6: Verifying Checksum
+2025-07-30T13:45:58.0796820Z c31b5eed60b6: Download complete
+2025-07-30T13:45:58.3953227Z f28d6a4cf5de: Verifying Checksum
+2025-07-30T13:45:58.3959931Z f28d6a4cf5de: Download complete
+2025-07-30T13:45:58.4472577Z bb9f5c709011: Verifying Checksum
+2025-07-30T13:45:58.4473715Z bb9f5c709011: Download complete
+2025-07-30T13:45:58.5252313Z 49cbdb9e902d: Verifying Checksum
+2025-07-30T13:45:58.5254957Z 49cbdb9e902d: Download complete
+2025-07-30T13:45:58.5573340Z da96180e845f: Verifying Checksum
+2025-07-30T13:45:58.5574198Z da96180e845f: Download complete
+2025-07-30T13:45:58.6462669Z d6a01b6e446c: Verifying Checksum
+2025-07-30T13:45:58.6463604Z d6a01b6e446c: Download complete
+2025-07-30T13:45:58.7903203Z 4f4fb700ef54: Verifying Checksum
+2025-07-30T13:45:58.7903720Z 4f4fb700ef54: Download complete
+2025-07-30T13:45:59.0676951Z 32f112e3802c: Pull complete
+2025-07-30T13:45:59.8571335Z be38403a389e: Download complete
+2025-07-30T13:46:00.4029078Z 3c418bbf5534: Pull complete
+2025-07-30T13:46:00.7278039Z 409781d99354: Verifying Checksum
+2025-07-30T13:46:00.7278547Z 409781d99354: Download complete
+2025-07-30T13:46:00.8537661Z 824b5144f7af: Pull complete
+2025-07-30T13:46:00.9506336Z c418b82685d0: Verifying Checksum
+2025-07-30T13:46:00.9506830Z c418b82685d0: Download complete
+2025-07-30T13:46:02.9503485Z 247fd41058fa: Verifying Checksum
+2025-07-30T13:46:02.9504172Z 247fd41058fa: Download complete
+2025-07-30T13:46:03.0134700Z 1382f2390a1c: Verifying Checksum
+2025-07-30T13:46:03.0135425Z 1382f2390a1c: Download complete
+2025-07-30T13:46:06.9063236Z bb9f5c709011: Pull complete
+2025-07-30T13:46:10.5116548Z c31b5eed60b6: Pull complete
+2025-07-30T13:46:11.5480296Z da96180e845f: Pull complete
+2025-07-30T13:46:11.6041411Z f28d6a4cf5de: Pull complete
+2025-07-30T13:46:11.6467581Z 49cbdb9e902d: Pull complete
+2025-07-30T13:46:17.7031713Z 247fd41058fa: Pull complete
+2025-07-30T13:46:17.7207463Z d6a01b6e446c: Pull complete
+2025-07-30T13:46:17.7312077Z 4f4fb700ef54: Pull complete
+2025-07-30T13:46:32.6559975Z 1382f2390a1c: Pull complete
+2025-07-30T13:46:36.5080339Z be38403a389e: Pull complete
+2025-07-30T13:46:36.6041457Z 409781d99354: Pull complete
+2025-07-30T13:46:36.6138891Z c418b82685d0: Pull complete
+2025-07-30T13:46:36.6178115Z Digest: sha256:cb77d7b2020ec7db2823fc4528c92549266d05db97a83ceb6c2a222660fd2915
+2025-07-30T13:46:36.6189343Z Status: Downloaded newer image for ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:46:36.6199250Z ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:46:36.6287762Z ##[command]/usr/bin/docker create --name e629db8815984cbf9985d15319787204_ghcriodashcoreautoguixdashdashcorecirunnerbackport027batch556pr26859_57af2c --label 362aa6 --workdir /__w/dash/dash --network github_network_f14c4402ce2947a5be80f529f4c1bca9 --user root -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" -v "/home/runner/actions-runner/cached/externals":"/__e":ro -v "/home/runner/work/_temp":"/__w/_temp" -v "/home/runner/work/_actions":"/__w/_actions" -v "/opt/hostedtoolcache":"/__t" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859 "-f" "/dev/null"
+2025-07-30T13:46:36.6545936Z 2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926
+2025-07-30T13:46:36.6569610Z ##[command]/usr/bin/docker start 2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926
+2025-07-30T13:46:36.8198734Z 2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926
+2025-07-30T13:46:36.8224047Z ##[command]/usr/bin/docker ps --all --filter id=2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926 --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2025-07-30T13:46:36.8344505Z 2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926 Up Less than a second
+2025-07-30T13:46:36.8363874Z ##[command]/usr/bin/docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" 2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926
+2025-07-30T13:46:36.8476530Z HOME=/github/home
+2025-07-30T13:46:36.8476930Z GITHUB_ACTIONS=true
+2025-07-30T13:46:36.8477282Z CI=true
+2025-07-30T13:46:36.8478319Z PATH=/opt/shellcheck:/usr/local/pyenv/shims:/usr/local/pyenv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+2025-07-30T13:46:36.8479854Z DEBIAN_FRONTEND=noninteractive
+2025-07-30T13:46:36.8480319Z TZ=Europe/London
+2025-07-30T13:46:36.8480645Z APT_ARGS=-y --no-install-recommends --no-upgrade
+2025-07-30T13:46:36.8481289Z PYENV_ROOT=/usr/local/pyenv
+2025-07-30T13:46:36.8481590Z LD_LIBRARY_PATH=/usr/lib/llvm-18/lib
+2025-07-30T13:46:36.8495675Z ##[endgroup]
+2025-07-30T13:46:36.8505124Z ##[group]Waiting for all services to be ready
+2025-07-30T13:46:36.8506833Z ##[endgroup]
+2025-07-30T13:46:36.8743352Z ##[group]Run actions/checkout@v4
+2025-07-30T13:46:36.8743889Z with:
+2025-07-30T13:46:36.8744079Z   fetch-depth: 50
+2025-07-30T13:46:36.8744293Z   repository: DashCoreAutoGuix/dash
+2025-07-30T13:46:36.8744997Z   token: ***
+2025-07-30T13:46:36.8745181Z   ssh-strict: true
+2025-07-30T13:46:36.8745370Z   ssh-user: git
+2025-07-30T13:46:36.8745557Z   persist-credentials: true
+2025-07-30T13:46:36.8745782Z   clean: true
+2025-07-30T13:46:36.8745979Z   sparse-checkout-cone-mode: true
+2025-07-30T13:46:36.8746230Z   fetch-tags: false
+2025-07-30T13:46:36.8746421Z   show-progress: true
+2025-07-30T13:46:36.8746606Z   lfs: false
+2025-07-30T13:46:36.8746776Z   submodules: false
+2025-07-30T13:46:36.8746960Z   set-safe-directory: true
+2025-07-30T13:46:36.8747388Z ##[endgroup]
+2025-07-30T13:46:36.8864829Z ##[command]/usr/bin/docker exec  2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T13:46:37.0983922Z Syncing repository: DashCoreAutoGuix/dash
+2025-07-30T13:46:37.0985852Z ##[group]Getting Git version info
+2025-07-30T13:46:37.0986384Z Working directory is '/__w/dash/dash'
+2025-07-30T13:46:37.0987210Z [command]/usr/bin/git version
+2025-07-30T13:46:37.0987658Z git version 2.43.0
+2025-07-30T13:46:37.1002816Z ##[endgroup]
+2025-07-30T13:46:37.1018135Z Temporarily overriding HOME='/__w/_temp/9e87721c-fb22-4c6b-bf0f-52a37c2c2115' before making global git config changes
+2025-07-30T13:46:37.1019401Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-30T13:46:37.1024605Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-30T13:46:37.1060230Z Deleting the contents of '/__w/dash/dash'
+2025-07-30T13:46:37.1064359Z ##[group]Initializing the repository
+2025-07-30T13:46:37.1068025Z [command]/usr/bin/git init /__w/dash/dash
+2025-07-30T13:46:37.1103305Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-07-30T13:46:37.1103898Z hint: is subject to change. To configure the initial branch name to use in all
+2025-07-30T13:46:37.1104419Z hint: of your new repositories, which will suppress this warning, call:
+2025-07-30T13:46:37.1104785Z hint: 
+2025-07-30T13:46:37.1105058Z hint: 	git config --global init.defaultBranch <name>
+2025-07-30T13:46:37.1105366Z hint: 
+2025-07-30T13:46:37.1105681Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-07-30T13:46:37.1106197Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-07-30T13:46:37.1106583Z hint: 
+2025-07-30T13:46:37.1106777Z hint: 	git branch -m <name>
+2025-07-30T13:46:37.1112122Z Initialized empty Git repository in /__w/dash/dash/.git/
+2025-07-30T13:46:37.1123984Z [command]/usr/bin/git remote add origin https://github.com/DashCoreAutoGuix/dash
+2025-07-30T13:46:37.1153079Z ##[endgroup]
+2025-07-30T13:46:37.1153762Z ##[group]Disabling automatic garbage collection
+2025-07-30T13:46:37.1157674Z [command]/usr/bin/git config --local gc.auto 0
+2025-07-30T13:46:37.1185463Z ##[endgroup]
+2025-07-30T13:46:37.1186217Z ##[group]Setting up auth
+2025-07-30T13:46:37.1192747Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-30T13:46:37.1222766Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-30T13:46:37.1433045Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-30T13:46:37.1460588Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-30T13:46:37.1667571Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-07-30T13:46:37.1701997Z ##[endgroup]
+2025-07-30T13:46:37.1702475Z ##[group]Fetching the repository
+2025-07-30T13:46:37.1711020Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=50 origin +3edf8361bf6a05778eab7a21802074376a229653:refs/remotes/origin/backport-0.27-batch-556-pr-26859
+2025-07-30T13:46:39.2645412Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-30T13:46:39.2646414Z  * [new ref]         3edf8361bf6a05778eab7a21802074376a229653 -> origin/backport-0.27-batch-556-pr-26859
+2025-07-30T13:46:39.2671245Z ##[endgroup]
+2025-07-30T13:46:39.2673601Z ##[group]Determining the checkout info
+2025-07-30T13:46:39.2675357Z ##[endgroup]
+2025-07-30T13:46:39.2678287Z [command]/usr/bin/git sparse-checkout disable
+2025-07-30T13:46:39.2713225Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-07-30T13:46:39.2739062Z ##[group]Checking out the ref
+2025-07-30T13:46:39.2743755Z [command]/usr/bin/git checkout --progress --force -B backport-0.27-batch-556-pr-26859 refs/remotes/origin/backport-0.27-batch-556-pr-26859
+2025-07-30T13:46:39.6613595Z Switched to a new branch 'backport-0.27-batch-556-pr-26859'
+2025-07-30T13:46:39.6615158Z branch 'backport-0.27-batch-556-pr-26859' set up to track 'origin/backport-0.27-batch-556-pr-26859'.
+2025-07-30T13:46:39.6641223Z ##[endgroup]
+2025-07-30T13:46:39.6678803Z [command]/usr/bin/git log -1 --format=%H
+2025-07-30T13:46:39.6701746Z 3edf8361bf6a05778eab7a21802074376a229653
+2025-07-30T13:46:39.6922762Z ##[group]Run git config --global --add safe.directory "$PWD"
+2025-07-30T13:46:39.6923288Z [36;1mgit config --global --add safe.directory "$PWD"[0m
+2025-07-30T13:46:39.6923654Z [36;1mgit fetch -fu origin develop:develop[0m
+2025-07-30T13:46:39.6923959Z [36;1mBUILD_TARGET="linux64_fuzz"[0m
+2025-07-30T13:46:39.6924228Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-30T13:46:39.6924522Z [36;1mecho "HOST=${HOST}" >> $GITHUB_OUTPUT[0m
+2025-07-30T13:46:39.6924837Z [36;1mecho "PR_BASE_SHA=" >> $GITHUB_OUTPUT[0m
+2025-07-30T13:46:39.6928939Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-30T13:46:39.6929275Z ##[endgroup]
+2025-07-30T13:46:39.9558590Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-30T13:46:39.9559082Z  * [new branch]      develop    -> develop
+2025-07-30T13:46:39.9559429Z  * [new branch]      develop    -> origin/develop
+2025-07-30T13:46:39.9631471Z Setting specific values in env
+2025-07-30T13:46:39.9632097Z Fallback to default values in env (if not yet set)
+2025-07-30T13:46:40.0132503Z ##[group]Run actions/cache/restore@v4
+2025-07-30T13:46:40.0132787Z with:
+2025-07-30T13:46:40.0133010Z   path: depends/built
+depends/x86_64-pc-linux-gnu
+
+2025-07-30T13:46:40.0134074Z   key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:46:40.0135097Z   fail-on-cache-miss: true
+2025-07-30T13:46:40.0135323Z   enableCrossOsArchive: false
+2025-07-30T13:46:40.0135550Z   lookup-only: false
+2025-07-30T13:46:40.0135749Z ##[endgroup]
+2025-07-30T13:46:40.0139326Z ##[command]/usr/bin/docker exec  2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T13:46:40.3667603Z Cache hit for: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:46:41.3817504Z Received 90051949 of 90051949 (100.0%), 97.9 MBs/sec
+2025-07-30T13:46:41.3818633Z Cache Size: ~86 MB (90051949 B)
+2025-07-30T13:46:41.3844691Z [command]/usr/bin/tar -xf /__w/_temp/e45b9e22-153e-42a9-8ca7-2de5e03c19bf/cache.tzst -P -C /__w/dash/dash --use-compress-program unzstd
+2025-07-30T13:46:42.6605959Z Cache restored successfully
+2025-07-30T13:46:42.6886464Z Cache restored from key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64-5e68e2df712ce28194c6b6d486145262467ca05bc80cf4a4f71520f130839ff3-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:46:42.8523629Z ##[group]Run actions/cache@v4
+2025-07-30T13:46:42.8523912Z with:
+2025-07-30T13:46:42.8524102Z   path: /cache
+
+2025-07-30T13:46:42.8524720Z   key: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_fuzz-3edf8361bf6a05778eab7a21802074376a229653
+2025-07-30T13:46:42.8525892Z   restore-keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_fuzz-
+
+2025-07-30T13:46:42.8526459Z   enableCrossOsArchive: false
+2025-07-30T13:46:42.8526715Z   fail-on-cache-miss: false
+2025-07-30T13:46:42.8526956Z   lookup-only: false
+2025-07-30T13:46:42.8527169Z   save-always: false
+2025-07-30T13:46:42.8527375Z ##[endgroup]
+2025-07-30T13:46:42.8531354Z ##[command]/usr/bin/docker exec  2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T13:46:43.2087428Z Cache not found for input keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_fuzz-3edf8361bf6a05778eab7a21802074376a229653, ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_fuzz-
+2025-07-30T13:46:43.2193730Z ##[group]Run CCACHE_SIZE="400M"
+2025-07-30T13:46:43.2194086Z [36;1mCCACHE_SIZE="400M"[0m
+2025-07-30T13:46:43.2194346Z [36;1mCACHE_DIR="/cache"[0m
+2025-07-30T13:46:43.2194599Z [36;1mmkdir /output[0m
+2025-07-30T13:46:43.2194841Z [36;1mBASE_OUTDIR="/output"[0m
+2025-07-30T13:46:43.2195115Z [36;1mBUILD_TARGET="linux64_fuzz"[0m
+2025-07-30T13:46:43.2195418Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-30T13:46:43.2195698Z [36;1m./ci/dash/build_src.sh[0m
+2025-07-30T13:46:43.2195964Z [36;1mccache -X 9[0m
+2025-07-30T13:46:43.2196189Z [36;1mccache -c[0m
+2025-07-30T13:46:43.2196574Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-30T13:46:43.2196904Z ##[endgroup]
+2025-07-30T13:46:43.2789444Z Setting specific values in env
+2025-07-30T13:46:43.2790166Z Fallback to default values in env (if not yet set)
+2025-07-30T13:46:43.3173515Z Setting specific values in env
+2025-07-30T13:46:43.3174148Z Fallback to default values in env (if not yet set)
+2025-07-30T13:46:43.3931571Z Statistics zeroed
+2025-07-30T13:46:43.3932192Z Set cache size limit to 400.0 MB
+2025-07-30T13:46:48.3448159Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-30T13:46:48.3449470Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-30T13:46:48.3698166Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-30T13:46:48.3699144Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-30T13:46:48.3975017Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-30T13:46:48.4263608Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-30T13:46:48.4550073Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-30T13:46:48.4837739Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-30T13:46:50.5329396Z configure.ac:38: installing 'build-aux/compile'
+2025-07-30T13:46:50.5346632Z configure.ac:12: installing 'build-aux/config.guess'
+2025-07-30T13:46:50.5364900Z configure.ac:12: installing 'build-aux/config.sub'
+2025-07-30T13:46:50.5382960Z configure.ac:17: installing 'build-aux/install-sh'
+2025-07-30T13:46:50.5401497Z configure.ac:17: installing 'build-aux/missing'
+2025-07-30T13:46:50.6015240Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-30T13:46:52.9567374Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-30T13:46:52.9568401Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-30T13:46:52.9804957Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-30T13:46:52.9805606Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-30T13:46:53.0013255Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-30T13:46:53.0230316Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-30T13:46:53.0446666Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-30T13:46:53.0664100Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-30T13:46:54.5421549Z configure.ac:39: installing 'build-aux/ar-lib'
+2025-07-30T13:46:54.5438372Z configure.ac:37: installing 'build-aux/compile'
+2025-07-30T13:46:54.5458068Z configure.ac:24: installing 'build-aux/config.guess'
+2025-07-30T13:46:54.5476761Z configure.ac:24: installing 'build-aux/config.sub'
+2025-07-30T13:46:54.5495189Z configure.ac:27: installing 'build-aux/install-sh'
+2025-07-30T13:46:54.5513341Z configure.ac:27: installing 'build-aux/missing'
+2025-07-30T13:46:54.5857712Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-30T13:46:54.6203800Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-30T13:46:54.7167320Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-30T13:46:54.7168038Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-30T13:46:54.7435528Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-30T13:46:54.7436554Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-30T13:46:54.7878016Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-30T13:46:54.8329648Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-30T13:46:54.8788810Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-30T13:46:54.9240564Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-30T13:46:57.5273992Z configure.ac:105: installing 'build-aux/compile'
+2025-07-30T13:46:57.5290563Z configure.ac:48: installing 'build-aux/config.guess'
+2025-07-30T13:46:57.5308482Z configure.ac:48: installing 'build-aux/config.sub'
+2025-07-30T13:46:57.5326367Z configure.ac:55: installing 'build-aux/install-sh'
+2025-07-30T13:46:57.5344838Z configure.ac:55: installing 'build-aux/missing'
+2025-07-30T13:46:57.7786579Z src/Makefile.am: installing 'build-aux/depcomp'
+2025-07-30T13:47:00.3132084Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-30T13:47:00.5046959Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:47:00.5132353Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:47:00.5147525Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:47:00.5867049Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:00.5916331Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:00.5999843Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:47:00.6029060Z checking whether build environment is sane... yes
+2025-07-30T13:47:00.6090638Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:47:00.6112275Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:47:00.6117089Z checking for gawk... gawk
+2025-07-30T13:47:00.6182621Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:47:00.6237489Z checking whether make supports nested variables... yes
+2025-07-30T13:47:00.6293456Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:47:00.6296309Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:47:00.8030216Z checking whether the C++ compiler works... yes
+2025-07-30T13:47:00.8031216Z checking for C++ compiler default output file name... a.out
+2025-07-30T13:47:00.8876734Z checking for suffix of executables... 
+2025-07-30T13:47:00.9825520Z checking whether we are cross compiling... no
+2025-07-30T13:47:01.0141756Z checking for suffix of object files... o
+2025-07-30T13:47:01.0418986Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:47:01.0689864Z checking whether clang++-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:01.5093319Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++11 features... unsupported
+2025-07-30T13:47:01.5818764Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++98 features... none needed
+2025-07-30T13:47:01.5898536Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:47:01.5903292Z checking dependency style of clang++-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:01.7087552Z checking whether clang++-18 -ftrivial-auto-var-init=pattern supports C++20 features with -std=c++20... yes
+2025-07-30T13:47:01.7091295Z checking for x86_64-pc-linux-gnu-g++... clang++-18 -ftrivial-auto-var-init=pattern -std=c++20
+2025-07-30T13:47:01.8180289Z checking whether the compiler supports GNU Objective C++... yes
+2025-07-30T13:47:01.8444107Z checking whether clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 accepts -g... yes
+2025-07-30T13:47:01.8447085Z checking dependency style of clang++-18 -ftrivial-auto-var-init=pattern -std=c++20... none
+2025-07-30T13:47:01.8472825Z checking how to print strings... printf
+2025-07-30T13:47:01.8474878Z checking for x86_64-pc-linux-gnu-gcc... clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:01.9766689Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:47:02.0022762Z checking whether clang-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:02.0517964Z checking for clang-18 -ftrivial-auto-var-init=pattern option to enable C11 features... none needed
+2025-07-30T13:47:02.1007344Z checking whether clang-18 -ftrivial-auto-var-init=pattern understands -c and -o together... yes
+2025-07-30T13:47:02.1012814Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:02.1054536Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:47:02.1087808Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:47:02.1104067Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:47:02.1119822Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:47:02.1340723Z checking for ld used by clang-18 -ftrivial-auto-var-init=pattern... /usr/bin/ld
+2025-07-30T13:47:02.1367900Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:47:02.1370333Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:47:02.1802407Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:47:02.1803446Z checking whether ln -s works... yes
+2025-07-30T13:47:02.1847297Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:47:02.1876200Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:47:02.1879053Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:47:02.1880573Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:47:02.1915677Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:47:02.1916490Z checking for file... file
+2025-07-30T13:47:02.1917789Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:02.1918676Z checking for objdump... objdump
+2025-07-30T13:47:02.1919276Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:47:02.1920039Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:47:02.1929232Z checking for dlltool... no
+2025-07-30T13:47:02.1930067Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:47:02.1930732Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:02.2397255Z checking for archiver @FILE support... @
+2025-07-30T13:47:02.2397807Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:47:02.2401087Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:47:02.3503134Z checking command to parse nm output from clang-18 -ftrivial-auto-var-init=pattern object... ok
+2025-07-30T13:47:02.3519347Z checking for sysroot... no
+2025-07-30T13:47:02.3564797Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:47:02.3603851Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:47:02.3872083Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:47:02.3877293Z checking for mt... no
+2025-07-30T13:47:02.3908616Z checking if : is a manifest tool... no
+2025-07-30T13:47:02.4208796Z checking for stdio.h... yes
+2025-07-30T13:47:02.4560217Z checking for stdlib.h... yes
+2025-07-30T13:47:02.4883824Z checking for string.h... yes
+2025-07-30T13:47:02.5215518Z checking for inttypes.h... yes
+2025-07-30T13:47:02.5540456Z checking for stdint.h... yes
+2025-07-30T13:47:02.5866296Z checking for strings.h... yes
+2025-07-30T13:47:02.6192833Z checking for sys/stat.h... yes
+2025-07-30T13:47:02.6519076Z checking for sys/types.h... yes
+2025-07-30T13:47:02.6859111Z checking for unistd.h... yes
+2025-07-30T13:47:02.7205489Z checking for dlfcn.h... yes
+2025-07-30T13:47:02.7247639Z checking for objdir... .libs
+2025-07-30T13:47:02.8501198Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fno-rtti -fno-exceptions... yes
+2025-07-30T13:47:02.8502711Z checking for clang-18 -ftrivial-auto-var-init=pattern option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:02.8795895Z checking if clang-18 -ftrivial-auto-var-init=pattern PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:02.9632533Z checking if clang-18 -ftrivial-auto-var-init=pattern static flag -static works... yes
+2025-07-30T13:47:03.0032470Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... yes
+2025-07-30T13:47:03.0034401Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... (cached) yes
+2025-07-30T13:47:03.0277544Z checking whether the clang-18 -ftrivial-auto-var-init=pattern linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:03.0851734Z checking whether -lc should be explicitly linked in... no
+2025-07-30T13:47:03.1922134Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:47:03.1923089Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:03.1941819Z checking whether stripping libraries is possible... yes
+2025-07-30T13:47:03.1942825Z checking if libtool supports shared libraries... yes
+2025-07-30T13:47:03.1943586Z checking whether to build shared libraries... yes
+2025-07-30T13:47:03.1944628Z checking whether to build static libraries... yes
+2025-07-30T13:47:03.2489191Z checking how to run the C++ preprocessor... clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 -E
+2025-07-30T13:47:03.4378198Z checking for ld used by clang++-18 -ftrivial-auto-var-init=pattern -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:47:03.4403564Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:47:03.4792301Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:03.5935022Z checking for clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:03.6253493Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:03.7099541Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 static flag -static works... yes
+2025-07-30T13:47:03.7490551Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 supports -c -o file.o... yes
+2025-07-30T13:47:03.7492070Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-30T13:47:03.7493863Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:03.7539907Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:47:03.7540692Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:03.7548453Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:47:03.7554850Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-30T13:47:03.7559969Z checking for gcov... /usr/bin/gcov
+2025-07-30T13:47:03.7565058Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-30T13:47:03.7570329Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-30T13:47:03.7575520Z checking for lcov... no
+2025-07-30T13:47:03.7580188Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-30T13:47:03.7583963Z checking for genhtml... no
+2025-07-30T13:47:03.7587730Z checking for git... /usr/bin/git
+2025-07-30T13:47:03.7591089Z checking for ccache... /usr/bin/ccache
+2025-07-30T13:47:03.7595639Z checking for xgettext... /usr/bin/xgettext
+2025-07-30T13:47:03.7599604Z checking for hexdump... /usr/bin/hexdump
+2025-07-30T13:47:03.7604914Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-30T13:47:03.7610009Z checking for objcopy... /usr/bin/objcopy
+2025-07-30T13:47:03.7614544Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:03.7618799Z checking for objdump... /usr/bin/objdump
+2025-07-30T13:47:03.7624454Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-30T13:47:03.7629506Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-30T13:47:03.7634770Z checking for doxygen... no
+2025-07-30T13:47:03.7930686Z checking whether C++ compiler accepts -Werror... yes
+2025-07-30T13:47:03.8773422Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-30T13:47:03.9318513Z checking for execinfo.h... yes
+2025-07-30T13:47:04.0180281Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-30T13:47:04.0460592Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-30T13:47:04.0800533Z checking whether C++ compiler accepts -fsanitize=fuzzer,address,undefined,integer... yes
+2025-07-30T13:47:04.2555503Z checking whether the linker accepts -fsanitize=fuzzer,address,undefined,integer... yes
+2025-07-30T13:47:04.2886961Z checking whether C++ compiler accepts -Warray-bounds... no
+2025-07-30T13:47:04.3196309Z checking whether C++ compiler accepts -Wattributes... no
+2025-07-30T13:47:04.3506235Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-30T13:47:04.3807293Z checking whether C++ compiler accepts -Wstringop-overread... no
+2025-07-30T13:47:04.4099384Z checking whether C++ compiler accepts -Wstringop-overflow... no
+2025-07-30T13:47:04.4404184Z checking whether C++ compiler accepts -Wall... yes
+2025-07-30T13:47:04.4707117Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-30T13:47:04.5011840Z checking whether C++ compiler accepts -Wgnu... yes
+2025-07-30T13:47:04.5315737Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-30T13:47:04.5615193Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-30T13:47:04.5913787Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-30T13:47:04.6214872Z checking whether C++ compiler accepts -Wshadow-field... yes
+2025-07-30T13:47:04.6511735Z checking whether C++ compiler accepts -Wthread-safety... yes
+2025-07-30T13:47:04.6810628Z checking whether C++ compiler accepts -Wloop-analysis... yes
+2025-07-30T13:47:04.7111496Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-30T13:47:04.7421934Z checking whether C++ compiler accepts -Wunused-member-function... yes
+2025-07-30T13:47:04.7723040Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-30T13:47:04.8021898Z checking whether C++ compiler accepts -Wconditional-uninitialized... yes
+2025-07-30T13:47:04.8321673Z checking whether C++ compiler accepts -Wduplicated-branches... no
+2025-07-30T13:47:04.8615871Z checking whether C++ compiler accepts -Wduplicated-cond... no
+2025-07-30T13:47:04.8919069Z checking whether C++ compiler accepts -Wlogical-op... no
+2025-07-30T13:47:04.9221187Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-30T13:47:04.9537176Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-30T13:47:04.9862233Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-30T13:47:05.0184601Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-30T13:47:05.0482797Z checking whether C++ compiler accepts -Wdocumentation... yes
+2025-07-30T13:47:05.0814613Z checking whether C++ compiler accepts -Wself-assign... yes
+2025-07-30T13:47:05.1119973Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-30T13:47:05.1431158Z checking whether C++ compiler accepts -fno-extended-identifiers... no
+2025-07-30T13:47:05.1708991Z checking whether C++ compiler accepts -fstack-reuse=none... no
+2025-07-30T13:47:05.2023267Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-30T13:47:05.2337982Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-30T13:47:05.2646990Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-30T13:47:05.2951617Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-30T13:47:05.7754333Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-30T13:47:05.8594553Z checking for SSE4.2 intrinsics... yes
+2025-07-30T13:47:06.3132466Z checking for SSE4.1 intrinsics... yes
+2025-07-30T13:47:06.7725883Z checking for AVX2 intrinsics... yes
+2025-07-30T13:47:07.2300561Z checking for x86 SHA-NI intrinsics... yes
+2025-07-30T13:47:07.2662125Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-30T13:47:07.2963292Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-30T13:47:07.3713092Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-30T13:47:07.4448803Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-30T13:47:07.5696882Z checking whether byte ordering is bigendian... no
+2025-07-30T13:47:07.6198583Z checking how to run the C preprocessor... clang-18 -ftrivial-auto-var-init=pattern -E
+2025-07-30T13:47:07.6918615Z checking whether clang-18 -ftrivial-auto-var-init=pattern is Clang... yes
+2025-07-30T13:47:07.7653028Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:47:07.8920031Z checking whether Clang needs flag to prevent "argument unused" warning when linking with -pthread... no
+2025-07-30T13:47:07.9561086Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:47:07.9562618Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:47:08.0213811Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:47:09.4554943Z checking whether std::atomic can be used without link library... yes
+2025-07-30T13:47:09.4563822Z checking for special C compiler options needed for large files... no
+2025-07-30T13:47:09.4899383Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-30T13:47:09.5513480Z checking for clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-30T13:47:09.6112997Z checking whether strerror_r is declared... yes
+2025-07-30T13:47:09.6471025Z checking whether strerror_r returns char *... yes
+2025-07-30T13:47:09.6758850Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-30T13:47:09.7041027Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-30T13:47:09.7321803Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-30T13:47:09.7589604Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-30T13:47:09.7882919Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:47:09.8102855Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-30T13:47:09.8322431Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-30T13:47:09.8855143Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:47:09.9392034Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:47:09.9938829Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:47:10.0492138Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:47:10.1370465Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:47:10.2258034Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:47:10.3143951Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:47:10.4015126Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:47:10.4557245Z checking for sys/select.h... yes
+2025-07-30T13:47:10.5078381Z checking for sys/prctl.h... yes
+2025-07-30T13:47:10.5635228Z checking for vm/vm_param.h... no
+2025-07-30T13:47:10.6191423Z checking for sys/vmmeter.h... no
+2025-07-30T13:47:10.6742852Z checking for sys/resources.h... no
+2025-07-30T13:47:10.7139693Z checking whether getifaddrs is declared... yes
+2025-07-30T13:47:10.8052311Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:47:10.8466745Z checking whether freeifaddrs is declared... yes
+2025-07-30T13:47:10.9393392Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:47:10.9996781Z checking whether fork is declared... yes
+2025-07-30T13:47:11.0584507Z checking whether setsid is declared... yes
+2025-07-30T13:47:11.1166502Z checking whether pipe2 is declared... yes
+2025-07-30T13:47:11.1517027Z checking for mallopt M_ARENA_MAX... yes
+2025-07-30T13:47:11.1871412Z checking for getmemoryinfo... yes
+2025-07-30T13:47:11.2190778Z checking for posix_fallocate... yes
+2025-07-30T13:47:11.2468033Z checking for default visibility attribute... yes
+2025-07-30T13:47:11.2762334Z checking for dllexport attribute... no
+2025-07-30T13:47:11.9438441Z checking for thread_local support... yes
+2025-07-30T13:47:11.9807127Z checking for Linux getrandom syscall... yes
+2025-07-30T13:47:12.0175142Z checking for getentropy via random.h... yes
+2025-07-30T13:47:12.0518202Z checking for sysctl... no
+2025-07-30T13:47:12.0853372Z checking for sysctl KERN_ARND... no
+2025-07-30T13:47:12.1717447Z checking for library containing backtrace... none required
+2025-07-30T13:47:12.2049656Z checking for fdatasync... yes
+2025-07-30T13:47:12.2379966Z checking for F_FULLFSYNC... no
+2025-07-30T13:47:12.2696577Z checking for O_CLOEXEC... yes
+2025-07-30T13:47:12.2991808Z checking for __builtin_prefetch... yes
+2025-07-30T13:47:12.3742422Z checking for _mm_prefetch... yes
+2025-07-30T13:47:12.4087030Z checking for strong getauxval support in the system headers... yes
+2025-07-30T13:47:12.4481244Z checking for sockaddr_un... yes
+2025-07-30T13:47:12.5454470Z checking for std::system... yes
+2025-07-30T13:47:12.6064842Z checking for ::_wsystem... no
+2025-07-30T13:47:12.6129558Z configure: WARNING: enable-fuzz will disable all other targets and force --enable-fuzz-binary=yes
+2025-07-30T13:47:12.6380614Z checking whether C++ preprocessor accepts -DABORT_ON_FAILED_ASSUME... yes
+2025-07-30T13:47:12.8166488Z checking whether main function is needed for fuzz binary... checking whether the linker accepts ... yes
+2025-07-30T13:47:12.8167292Z no
+2025-07-30T13:47:14.2823283Z checking for Berkeley DB C++ headers... default
+2025-07-30T13:47:14.3739793Z checking for main in -ldb_cxx-4.8... yes
+2025-07-30T13:47:14.3880622Z checking for sqlite3 >= 3.7.17... yes
+2025-07-30T13:47:14.3881503Z checking whether to build wallet with support for sqlite... yes
+2025-07-30T13:47:14.4260374Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-30T13:47:14.4350974Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-30T13:47:14.4352539Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-30T13:47:14.4354027Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-30T13:47:14.4355242Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-30T13:47:14.4356204Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-30T13:47:14.4641590Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-30T13:47:14.5072286Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-30T13:47:18.7435472Z checking for Boost Process... yes
+2025-07-30T13:47:18.7598049Z checking for libevent >= 2.1.8... yes
+2025-07-30T13:47:18.7719695Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-30T13:47:18.8251586Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-30T13:47:18.8956424Z checking for gmp.h... yes
+2025-07-30T13:47:18.9826812Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:47:18.9946800Z checking for libmultiprocess... no
+2025-07-30T13:47:19.0027407Z checking whether to build dashd... no
+2025-07-30T13:47:19.0029039Z checking whether to build dash-cli... no
+2025-07-30T13:47:19.0030172Z checking whether to build dash-tx... no
+2025-07-30T13:47:19.0031545Z checking whether to build dash-wallet... no
+2025-07-30T13:47:19.0032827Z checking whether to build libraries... no
+2025-07-30T13:47:19.0035938Z checking if wallet should be enabled... yes
+2025-07-30T13:47:19.0038529Z checking whether to build with support for UPnP... no
+2025-07-30T13:47:19.0039634Z checking whether to build with support for NAT-PMP... no
+2025-07-30T13:47:19.0042930Z checking whether to build test_dash... no
+2025-07-30T13:47:19.0044047Z checking whether to reduce exports... no
+2025-07-30T13:47:19.0173699Z checking whether dsymutil needs -flat... yes
+2025-07-30T13:47:19.0174833Z 
+2025-07-30T13:47:19.0525932Z checking that generated files are newer than configure... done
+2025-07-30T13:47:19.0532822Z configure: creating ./config.status
+2025-07-30T13:47:19.6235085Z config.status: creating Makefile
+2025-07-30T13:47:19.6358182Z config.status: creating src/Makefile
+2025-07-30T13:47:19.6932237Z config.status: creating doc/man/Makefile
+2025-07-30T13:47:19.7092456Z config.status: creating share/setup.nsi
+2025-07-30T13:47:19.7256864Z config.status: creating share/qt/Info.plist
+2025-07-30T13:47:19.7420573Z config.status: creating test/config.ini
+2025-07-30T13:47:19.7581816Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-30T13:47:19.7752372Z config.status: creating src/config/bitcoin-config.h
+2025-07-30T13:47:19.7928694Z config.status: linking ../contrib/filter-lcov.py to contrib/filter-lcov.py
+2025-07-30T13:47:19.7994584Z config.status: linking ../src/.bear-tidy-config to src/.bear-tidy-config
+2025-07-30T13:47:19.8059355Z config.status: linking ../src/.clang-tidy to src/.clang-tidy
+2025-07-30T13:47:19.8136387Z config.status: linking ../test/functional/test_runner.py to test/functional/test_runner.py
+2025-07-30T13:47:19.8211996Z config.status: linking ../test/fuzz/test_runner.py to test/fuzz/test_runner.py
+2025-07-30T13:47:19.8289669Z config.status: linking ../test/util/test_runner.py to test/util/test_runner.py
+2025-07-30T13:47:19.8356277Z config.status: linking ../test/util/rpcauth-test.py to test/util/rpcauth-test.py
+2025-07-30T13:47:19.8387150Z config.status: executing depfiles commands
+2025-07-30T13:47:19.8401928Z config.status: executing libtool commands
+2025-07-30T13:47:19.8526126Z === configuring in src/dashbls (/__w/dash/dash/build-ci/src/dashbls)
+2025-07-30T13:47:19.8585925Z configure: running /bin/bash ../../../src/dashbls/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--disable-ccache' '--enable-fuzz' '--with-sanitizers=fuzzer,address,undefined,integer' 'CC=clang-18 -ftrivial-auto-var-init=pattern' 'CXX=clang++-18 -ftrivial-auto-var-init=pattern' '--with-boost-process' 'CPPFLAGS=-DDEBUG_LOCKORDER -DARENA_DEBUG' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/dashbls
+2025-07-30T13:47:19.9856102Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:47:20.0589093Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:20.0638919Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:20.0718537Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:47:20.0748003Z checking whether build environment is sane... yes
+2025-07-30T13:47:20.0811154Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:47:20.0832333Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:47:20.0836093Z checking for gawk... gawk
+2025-07-30T13:47:20.0899476Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:47:20.0955185Z checking whether make supports nested variables... yes
+2025-07-30T13:47:20.1000167Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:47:20.1002662Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:47:20.1006021Z checking for x86_64-pc-linux-gnu-gcc... clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:20.2701714Z checking whether the C compiler works... yes
+2025-07-30T13:47:20.2702535Z checking for C compiler default output file name... a.out
+2025-07-30T13:47:20.3309789Z checking for suffix of executables... 
+2025-07-30T13:47:20.3967151Z checking whether we are cross compiling... no
+2025-07-30T13:47:20.4281847Z checking for suffix of object files... o
+2025-07-30T13:47:20.4565838Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:47:20.4841205Z checking whether clang-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:20.5336692Z checking for clang-18 -ftrivial-auto-var-init=pattern option to enable C11 features... none needed
+2025-07-30T13:47:20.5836005Z checking whether clang-18 -ftrivial-auto-var-init=pattern understands -c and -o together... yes
+2025-07-30T13:47:20.5910526Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:47:20.5914876Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:20.7011557Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:47:20.7278677Z checking whether clang++-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:21.1763477Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++11 features... unsupported
+2025-07-30T13:47:21.2539348Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++98 features... none needed
+2025-07-30T13:47:21.2543318Z checking dependency style of clang++-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:21.3147586Z checking whether clang++-18 -ftrivial-auto-var-init=pattern supports C++14 features with -std=c++14... yes
+2025-07-30T13:47:21.3175281Z checking how to print strings... printf
+2025-07-30T13:47:21.3217368Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:47:21.3253481Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:47:21.3271845Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:47:21.3293965Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:47:21.3555904Z checking for ld used by clang-18 -ftrivial-auto-var-init=pattern... /usr/bin/ld
+2025-07-30T13:47:21.3582531Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:47:21.3584574Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:47:21.4048903Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:47:21.4049743Z checking whether ln -s works... yes
+2025-07-30T13:47:21.4093230Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:47:21.4121122Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:47:21.4123321Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:47:21.4124553Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:47:21.4129260Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:47:21.4134541Z checking for file... file
+2025-07-30T13:47:21.4139025Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:21.4143305Z checking for objdump... objdump
+2025-07-30T13:47:21.4146992Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:47:21.4152271Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:47:21.4156768Z checking for dlltool... no
+2025-07-30T13:47:21.4158550Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:47:21.4160388Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:21.4634982Z checking for archiver @FILE support... @
+2025-07-30T13:47:21.4635964Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:47:21.4638549Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:47:21.5850075Z checking command to parse nm output from clang-18 -ftrivial-auto-var-init=pattern object... ok
+2025-07-30T13:47:21.5867626Z checking for sysroot... no
+2025-07-30T13:47:21.5914573Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:47:21.5956159Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:47:21.6246896Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:47:21.6252517Z checking for mt... no
+2025-07-30T13:47:21.6285633Z checking if : is a manifest tool... no
+2025-07-30T13:47:21.6615846Z checking for stdio.h... yes
+2025-07-30T13:47:21.6927187Z checking for stdlib.h... yes
+2025-07-30T13:47:21.7243320Z checking for string.h... yes
+2025-07-30T13:47:21.7561511Z checking for inttypes.h... yes
+2025-07-30T13:47:21.7881441Z checking for stdint.h... yes
+2025-07-30T13:47:21.8205095Z checking for strings.h... yes
+2025-07-30T13:47:21.8540779Z checking for sys/stat.h... yes
+2025-07-30T13:47:21.8875387Z checking for sys/types.h... yes
+2025-07-30T13:47:21.9223226Z checking for unistd.h... yes
+2025-07-30T13:47:21.9583767Z checking for dlfcn.h... yes
+2025-07-30T13:47:21.9621309Z checking for objdir... .libs
+2025-07-30T13:47:22.0834673Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fno-rtti -fno-exceptions... yes
+2025-07-30T13:47:22.0836834Z checking for clang-18 -ftrivial-auto-var-init=pattern option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:22.1127049Z checking if clang-18 -ftrivial-auto-var-init=pattern PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:22.1942875Z checking if clang-18 -ftrivial-auto-var-init=pattern static flag -static works... yes
+2025-07-30T13:47:22.2322742Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... yes
+2025-07-30T13:47:22.2323883Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... (cached) yes
+2025-07-30T13:47:22.2573534Z checking whether the clang-18 -ftrivial-auto-var-init=pattern linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:22.3655768Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:47:22.3656840Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:22.3673909Z checking whether stripping libraries is possible... yes
+2025-07-30T13:47:22.3674698Z checking if libtool supports shared libraries... yes
+2025-07-30T13:47:22.3675399Z checking whether to build shared libraries... no
+2025-07-30T13:47:22.3676050Z checking whether to build static libraries... yes
+2025-07-30T13:47:22.4226712Z checking how to run the C++ preprocessor... clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 -E
+2025-07-30T13:47:22.6072663Z checking for ld used by clang++-18 -ftrivial-auto-var-init=pattern -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:47:22.6096552Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:47:22.6475757Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:22.7594730Z checking for clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:22.7908170Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:22.8737946Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 static flag -static works... yes
+2025-07-30T13:47:22.9124211Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 supports -c -o file.o... yes
+2025-07-30T13:47:22.9125746Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-30T13:47:22.9127169Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:22.9173227Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:47:22.9174454Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:22.9181719Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:47:22.9187525Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-30T13:47:22.9189507Z checking for ranlib... (cached) ranlib
+2025-07-30T13:47:22.9194748Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-30T13:47:22.9197373Z checking for strip... (cached) strip
+2025-07-30T13:47:22.9200554Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:22.9486929Z checking whether C compiler accepts -Werror... yes
+2025-07-30T13:47:22.9923989Z checking for gmp.h... yes
+2025-07-30T13:47:23.0522536Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:47:23.0876779Z checking gmp version >= 6.2... yes
+2025-07-30T13:47:23.0906074Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:47:23.0919042Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:47:23.1163860Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -pipe... yes
+2025-07-30T13:47:23.1411576Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fomit-frame-pointer... yes
+2025-07-30T13:47:23.1935976Z checking how to run the C preprocessor... clang-18 -ftrivial-auto-var-init=pattern -E
+2025-07-30T13:47:23.2637667Z checking whether clang-18 -ftrivial-auto-var-init=pattern is Clang... yes
+2025-07-30T13:47:23.3343553Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:47:23.4585300Z checking whether Clang needs flag to prevent "argument unused" warning when linking with -pthread... no
+2025-07-30T13:47:23.5236972Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:47:23.5238204Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:47:23.5932073Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:47:23.6588983Z checking for library containing clock_gettime... none required
+2025-07-30T13:47:23.6913186Z checking whether C compiler accepts -fPIC... yes
+2025-07-30T13:47:23.7213348Z checking whether C compiler accepts -fstack-reuse=none... no
+2025-07-30T13:47:23.7497183Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-30T13:47:23.7801110Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-30T13:47:23.8108389Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-30T13:47:23.8436991Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:47:23.8946878Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:47:23.9461909Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:47:23.9984157Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:47:24.0486145Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:47:24.1082931Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:47:24.1683602Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:47:24.2278340Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:47:24.2903564Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:47:24.3218342Z checking whether C compiler accepts -fno-extended-identifiers... no
+2025-07-30T13:47:24.3219835Z checking whether to build runtest... yes
+2025-07-30T13:47:24.3221074Z checking whether to build runbench... yes
+2025-07-30T13:47:24.3462247Z checking that generated files are newer than configure... done
+2025-07-30T13:47:24.3467446Z configure: creating ./config.status
+2025-07-30T13:47:24.8980699Z config.status: creating Makefile
+2025-07-30T13:47:24.9196225Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-30T13:47:24.9339174Z config.status: executing depfiles commands
+2025-07-30T13:47:24.9353542Z config.status: executing libtool commands
+2025-07-30T13:47:24.9486918Z 
+2025-07-30T13:47:24.9487574Z Options used to compile and link:
+2025-07-30T13:47:24.9488461Z   target os           = linux
+2025-07-30T13:47:24.9489122Z   backend             = gmp
+2025-07-30T13:47:24.9489729Z   build bench         = yes
+2025-07-30T13:47:24.9490586Z   build test          = yes
+2025-07-30T13:47:24.9491330Z   use debug           = no
+2025-07-30T13:47:24.9491954Z   use hardening       = yes
+2025-07-30T13:47:24.9492532Z   use optimizations   = yes
+2025-07-30T13:47:24.9492921Z 
+2025-07-30T13:47:24.9493339Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-30T13:47:24.9494916Z   CFLAGS              =   -fPIC -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE   
+2025-07-30T13:47:24.9496401Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-30T13:47:24.9497772Z   CXXFLAGS            =   -fPIC -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE   
+2025-07-30T13:47:24.9499214Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-30T13:47:24.9499700Z 
+2025-07-30T13:47:24.9858322Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/src/secp256k1)
+2025-07-30T13:47:24.9919088Z configure: running /bin/bash ../../../src/secp256k1/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--disable-ccache' '--enable-fuzz' '--with-sanitizers=fuzzer,address,undefined,integer' 'CC=clang-18 -ftrivial-auto-var-init=pattern' 'CXX=clang++-18 -ftrivial-auto-var-init=pattern' '--with-boost-process' 'CPPFLAGS=-DDEBUG_LOCKORDER -DARENA_DEBUG' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/secp256k1
+2025-07-30T13:47:25.1189983Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:47:25.1927868Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:25.1976417Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:25.2056198Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:47:25.2084729Z checking whether build environment is sane... yes
+2025-07-30T13:47:25.2146872Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:47:25.2167415Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:47:25.2171886Z checking for gawk... gawk
+2025-07-30T13:47:25.2234879Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:47:25.2289280Z checking whether make supports nested variables... yes
+2025-07-30T13:47:25.2333744Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:47:25.2336980Z checking for x86_64-pc-linux-gnu-gcc... clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:25.3947180Z checking whether the C compiler works... yes
+2025-07-30T13:47:25.3947871Z checking for C compiler default output file name... a.out
+2025-07-30T13:47:25.4512891Z checking for suffix of executables... 
+2025-07-30T13:47:25.5150431Z checking whether we are cross compiling... no
+2025-07-30T13:47:25.5448004Z checking for suffix of object files... o
+2025-07-30T13:47:25.5717891Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:47:25.5973400Z checking whether clang-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:25.6473959Z checking for clang-18 -ftrivial-auto-var-init=pattern option to enable C11 features... none needed
+2025-07-30T13:47:25.6948560Z checking whether clang-18 -ftrivial-auto-var-init=pattern understands -c and -o together... yes
+2025-07-30T13:47:25.7022921Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:47:25.7026779Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:25.7030612Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:25.7032684Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:25.7446606Z checking the archiver (ar) interface... ar
+2025-07-30T13:47:25.7470238Z checking how to print strings... printf
+2025-07-30T13:47:25.7509860Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:47:25.7539798Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:47:25.7555018Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:47:25.7570171Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:47:25.7785661Z checking for ld used by clang-18 -ftrivial-auto-var-init=pattern... /usr/bin/ld
+2025-07-30T13:47:25.7809713Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:47:25.7812383Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:47:25.8255457Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:47:25.8256045Z checking whether ln -s works... yes
+2025-07-30T13:47:25.8295943Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:47:25.8322359Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:47:25.8323951Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:47:25.8324848Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:47:25.8329952Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:47:25.8335074Z checking for file... file
+2025-07-30T13:47:25.8339451Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:25.8344241Z checking for objdump... objdump
+2025-07-30T13:47:25.8348115Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:47:25.8353154Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:47:25.8357387Z checking for dlltool... no
+2025-07-30T13:47:25.8358981Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:47:25.8361452Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:25.8824510Z checking for archiver @FILE support... @
+2025-07-30T13:47:25.8825453Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:47:25.8828594Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:47:25.9967244Z checking command to parse nm output from clang-18 -ftrivial-auto-var-init=pattern object... ok
+2025-07-30T13:47:25.9984404Z checking for sysroot... no
+2025-07-30T13:47:26.0028061Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:47:26.0066661Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:47:26.0329922Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:47:26.0335095Z checking for mt... no
+2025-07-30T13:47:26.0366708Z checking if : is a manifest tool... no
+2025-07-30T13:47:26.0684427Z checking for stdio.h... yes
+2025-07-30T13:47:26.0988858Z checking for stdlib.h... yes
+2025-07-30T13:47:26.1304187Z checking for string.h... yes
+2025-07-30T13:47:26.1657909Z checking for inttypes.h... yes
+2025-07-30T13:47:26.1989287Z checking for stdint.h... yes
+2025-07-30T13:47:26.2318482Z checking for strings.h... yes
+2025-07-30T13:47:26.2659358Z checking for sys/stat.h... yes
+2025-07-30T13:47:26.3010529Z checking for sys/types.h... yes
+2025-07-30T13:47:26.3352111Z checking for unistd.h... yes
+2025-07-30T13:47:26.3698502Z checking for dlfcn.h... yes
+2025-07-30T13:47:26.3737416Z checking for objdir... .libs
+2025-07-30T13:47:26.4914028Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fno-rtti -fno-exceptions... yes
+2025-07-30T13:47:26.4915567Z checking for clang-18 -ftrivial-auto-var-init=pattern option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:26.5219859Z checking if clang-18 -ftrivial-auto-var-init=pattern PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:26.6056838Z checking if clang-18 -ftrivial-auto-var-init=pattern static flag -static works... yes
+2025-07-30T13:47:26.6455232Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... yes
+2025-07-30T13:47:26.6457119Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... (cached) yes
+2025-07-30T13:47:26.6717870Z checking whether the clang-18 -ftrivial-auto-var-init=pattern linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:26.7808507Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:47:26.7809815Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:26.7826532Z checking whether stripping libraries is possible... yes
+2025-07-30T13:47:26.7828764Z checking if libtool supports shared libraries... yes
+2025-07-30T13:47:26.7829432Z checking whether to build shared libraries... no
+2025-07-30T13:47:26.7830063Z checking whether to build static libraries... yes
+2025-07-30T13:47:26.8106018Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Werror... yes
+2025-07-30T13:47:26.8357210Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-30T13:47:26.8605178Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wno-overlength-strings... yes
+2025-07-30T13:47:26.8852251Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wall... yes
+2025-07-30T13:47:26.9097809Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wno-unused-function... yes
+2025-07-30T13:47:26.9345022Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wextra... yes
+2025-07-30T13:47:26.9594352Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wcast-align... yes
+2025-07-30T13:47:26.9863845Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wcast-align=strict... no
+2025-07-30T13:47:27.0115575Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wconditional-uninitialized... yes
+2025-07-30T13:47:27.0369073Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wreserved-identifier... yes
+2025-07-30T13:47:27.0622108Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fvisibility=hidden... yes
+2025-07-30T13:47:27.0917873Z checking for valgrind support... 
+2025-07-30T13:47:27.1527727Z checking for x86_64 assembly availability... yes
+2025-07-30T13:47:27.1749612Z checking that generated files are newer than configure... done
+2025-07-30T13:47:27.1753460Z configure: creating ./config.status
+2025-07-30T13:47:27.5694599Z config.status: creating Makefile
+2025-07-30T13:47:27.5823729Z config.status: creating libsecp256k1.pc
+2025-07-30T13:47:27.5929685Z config.status: executing depfiles commands
+2025-07-30T13:47:27.5944025Z config.status: executing libtool commands
+2025-07-30T13:47:27.6031726Z 
+2025-07-30T13:47:27.6032337Z Build Options:
+2025-07-30T13:47:27.6032734Z   with external callbacks = no
+2025-07-30T13:47:27.6033204Z   with benchmarks         = no
+2025-07-30T13:47:27.6033611Z   with tests              = yes
+2025-07-30T13:47:27.6034016Z   with ctime tests        = no
+2025-07-30T13:47:27.6034423Z   with coverage           = no
+2025-07-30T13:47:27.6034713Z   with examples           = no
+2025-07-30T13:47:27.6034954Z   module ecdh             = no
+2025-07-30T13:47:27.6035298Z   module recovery         = yes
+2025-07-30T13:47:27.6035581Z   module extrakeys        = yes
+2025-07-30T13:47:27.6035829Z   module schnorrsig       = yes
+2025-07-30T13:47:27.6036092Z   module ellswift         = yes
+2025-07-30T13:47:27.6036251Z 
+2025-07-30T13:47:27.6036330Z   asm                     = x86_64
+2025-07-30T13:47:27.6036588Z   ecmult window size      = 15
+2025-07-30T13:47:27.6036838Z   ecmult gen prec. bits   = 4
+2025-07-30T13:47:27.6037050Z 
+2025-07-30T13:47:27.6037178Z   valgrind                = no
+2025-07-30T13:47:27.6037648Z   CC                      = clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:27.6038536Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ -DDEBUG_LOCKORDER -DARENA_DEBUG
+2025-07-30T13:47:27.6040569Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wconditional-uninitialized -Wreserved-identifier -fvisibility=hidden 
+2025-07-30T13:47:27.6042112Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-30T13:47:27.6042519Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:47:27.6340386Z 
+2025-07-30T13:47:27.6341195Z Options used to compile and link:
+2025-07-30T13:47:27.6341831Z   boost process       = yes
+2025-07-30T13:47:27.6342393Z   multiprocess        = no
+2025-07-30T13:47:27.6342898Z   with libs           = no
+2025-07-30T13:47:27.6343327Z   with wallet         = yes
+2025-07-30T13:47:27.6343837Z     with sqlite       = yes
+2025-07-30T13:47:27.6344324Z     with bdb          = yes
+2025-07-30T13:47:27.6344831Z   with gui / qt       = no
+2025-07-30T13:47:27.6345386Z   with zmq            = no
+2025-07-30T13:47:27.6346144Z   with test           = not building test_dash because fuzzing is enabled
+2025-07-30T13:47:27.6346931Z   with fuzz binary    = yes
+2025-07-30T13:47:27.6347415Z   with bench          = no
+2025-07-30T13:47:27.6347813Z   with upnp           = no
+2025-07-30T13:47:27.6348197Z   with natpmp         = no
+2025-07-30T13:47:27.6348893Z   USDT tracing        = yes
+2025-07-30T13:47:27.6349494Z   sanitizers          = fuzzer,address,undefined,integer
+2025-07-30T13:47:27.6349930Z   debug enabled       = no
+2025-07-30T13:47:27.6350227Z   stacktraces enabled = yes
+2025-07-30T13:47:27.6350521Z   crash hooks enabled = no
+2025-07-30T13:47:27.6351002Z   miner enabled       = yes
+2025-07-30T13:47:27.6351299Z   gprof enabled       = no
+2025-07-30T13:47:27.6351494Z   werror              = yes
+2025-07-30T13:47:27.6351630Z 
+2025-07-30T13:47:27.6351711Z   target os           = linux-gnu
+2025-07-30T13:47:27.6351941Z   build os            = linux-gnu
+2025-07-30T13:47:27.6352087Z 
+2025-07-30T13:47:27.6352223Z   CC                  = clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:27.6352633Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-30T13:47:27.6353495Z   CPPFLAGS            =  -DABORT_ON_FAILED_ASSUME  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ -DDEBUG_LOCKORDER -DARENA_DEBUG
+2025-07-30T13:47:27.6354316Z   CXX                 = clang++-18 -ftrivial-auto-var-init=pattern -std=c++20
+2025-07-30T13:47:27.6356578Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wgnu -Wformat -Wformat-security -Wreorder -Wvla -Wshadow-field -Wthread-safety -Wloop-analysis -Wredundant-decls -Wunused-member-function -Wdate-time -Wconditional-uninitialized -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wdocumentation -Wself-assign  -Wno-unused-parameter -Werror   -pipe -std=c++20 -O2 
+2025-07-30T13:47:27.6360151Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:47:27.6361146Z   AR                  = ar
+2025-07-30T13:47:27.6361521Z   ARFLAGS             = cr
+2025-07-30T13:47:27.6361821Z 
+2025-07-30T13:47:27.6861928Z make  distdir-am
+2025-07-30T13:47:27.6915727Z make[1]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-30T13:47:27.6917290Z if test -d "dashcore-linux64_fuzz"; then find "dashcore-linux64_fuzz" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "dashcore-linux64_fuzz" || { sleep 5 && rm -rf "dashcore-linux64_fuzz"; }; else :; fi
+2025-07-30T13:47:27.6929577Z test -d "dashcore-linux64_fuzz" || mkdir "dashcore-linux64_fuzz"
+2025-07-30T13:47:27.9006453Z  (cd src && make  top_distdir=../dashcore-linux64_fuzz distdir=../dashcore-linux64_fuzz/src \
+2025-07-30T13:47:27.9007617Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-30T13:47:27.9235720Z make[2]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:47:27.9236767Z make  distdir-am
+2025-07-30T13:47:28.0663772Z make[3]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:47:28.0767281Z Generated test/data/blockfilters.json.h
+2025-07-30T13:47:28.0849859Z Generated test/data/base58_encode_decode.json.h
+2025-07-30T13:47:28.0947538Z Generated test/data/bip39_vectors.json.h
+2025-07-30T13:47:28.1044347Z Generated test/data/key_io_valid.json.h
+2025-07-30T13:47:28.1129474Z Generated test/data/key_io_invalid.json.h
+2025-07-30T13:47:28.1212585Z Generated test/data/proposals_valid.json.h
+2025-07-30T13:47:28.1301191Z Generated test/data/proposals_invalid.json.h
+2025-07-30T13:47:28.1662543Z Generated test/data/script_tests.json.h
+2025-07-30T13:47:28.1955724Z Generated test/data/sighash.json.h
+2025-07-30T13:47:28.2048750Z Generated test/data/trivially_invalid.json.h
+2025-07-30T13:47:28.2153148Z Generated test/data/trivially_valid.json.h
+2025-07-30T13:47:28.2274238Z Generated test/data/tx_invalid.json.h
+2025-07-30T13:47:28.2401311Z Generated test/data/tx_valid.json.h
+2025-07-30T13:47:28.2482530Z Generated test/data/asmap.raw.h
+2025-07-30T13:47:30.7914256Z  (cd secp256k1 && make  top_distdir=../../dashcore-linux64_fuzz distdir=../../dashcore-linux64_fuzz/src/secp256k1 \
+2025-07-30T13:47:30.7915509Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-30T13:47:30.7952010Z make[4]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:47:30.7952939Z make  distdir-am
+2025-07-30T13:47:30.8069506Z make[5]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:47:30.8070378Z :
+2025-07-30T13:47:30.8071238Z test -d "../../dashcore-linux64_fuzz/src/secp256k1" || mkdir "../../dashcore-linux64_fuzz/src/secp256k1"
+2025-07-30T13:47:31.0291751Z test -n ":" \
+2025-07-30T13:47:31.0292651Z || find "../../dashcore-linux64_fuzz/src/secp256k1" -type d ! -perm -755 \
+2025-07-30T13:47:31.0293885Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-30T13:47:31.0294777Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-30T13:47:31.0295746Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-30T13:47:31.0296632Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/src/secp256k1/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-30T13:47:31.0297565Z || chmod -R a+r "../../dashcore-linux64_fuzz/src/secp256k1"
+2025-07-30T13:47:31.0314138Z make[5]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:47:31.0316943Z make[4]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:47:31.0324003Z make[3]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:47:31.0335274Z make[2]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:47:31.0613567Z  (cd doc/man && make  top_distdir=../../dashcore-linux64_fuzz distdir=../../dashcore-linux64_fuzz/doc/man \
+2025-07-30T13:47:31.0614898Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-30T13:47:31.0635654Z make[2]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:47:31.0636542Z make  distdir-am
+2025-07-30T13:47:31.0671383Z make[3]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:47:31.0797031Z make[3]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:47:31.0799874Z make[2]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:47:31.0805388Z make  \
+2025-07-30T13:47:31.0806352Z   top_distdir="dashcore-linux64_fuzz" distdir="dashcore-linux64_fuzz" \
+2025-07-30T13:47:31.0807474Z   dist-hook
+2025-07-30T13:47:31.0846290Z make[2]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-30T13:47:31.0847444Z /usr/bin/git archive --format=tar HEAD -- src/clientversion.cpp | ${TAR-tar} -C dashcore-linux64_fuzz -xf -
+2025-07-30T13:47:31.0877270Z fatal: pathspec 'src/clientversion.cpp' did not match any files
+2025-07-30T13:47:31.0879852Z tar: This does not look like a tar archive
+2025-07-30T13:47:31.0880583Z tar: Exiting with failure status due to previous errors
+2025-07-30T13:47:31.0884370Z make[2]: [Makefile:1225: dist-hook] Error 2 (ignored)
+2025-07-30T13:47:31.0885118Z make[2]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-30T13:47:31.0886460Z test -n "" \
+2025-07-30T13:47:31.0886881Z || find "dashcore-linux64_fuzz" -type d ! -perm -755 \
+2025-07-30T13:47:31.0887395Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-30T13:47:31.0887758Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-30T13:47:31.0888395Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-30T13:47:31.0888902Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-30T13:47:31.0889392Z || chmod -R a+r "dashcore-linux64_fuzz"
+2025-07-30T13:47:31.1108010Z make[1]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-30T13:47:31.2252477Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:47:31.2332747Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:47:31.2345229Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:47:31.3074487Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:31.3129187Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:31.3213293Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:47:31.3244027Z checking whether build environment is sane... yes
+2025-07-30T13:47:31.3309689Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:47:31.3333050Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:47:31.3338165Z checking for gawk... gawk
+2025-07-30T13:47:31.3403052Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:47:31.3457719Z checking whether make supports nested variables... yes
+2025-07-30T13:47:31.3499950Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:47:31.3501466Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:47:31.5245208Z checking whether the C++ compiler works... yes
+2025-07-30T13:47:31.5245927Z checking for C++ compiler default output file name... a.out
+2025-07-30T13:47:31.6100631Z checking for suffix of executables... 
+2025-07-30T13:47:31.7052086Z checking whether we are cross compiling... no
+2025-07-30T13:47:31.7371361Z checking for suffix of object files... o
+2025-07-30T13:47:31.7681235Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:47:31.7965300Z checking whether clang++-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:32.2471322Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++11 features... unsupported
+2025-07-30T13:47:32.3192580Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++98 features... none needed
+2025-07-30T13:47:32.3271837Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:47:32.3276801Z checking dependency style of clang++-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:32.4470655Z checking whether clang++-18 -ftrivial-auto-var-init=pattern supports C++20 features with -std=c++20... yes
+2025-07-30T13:47:32.4473527Z checking for x86_64-pc-linux-gnu-g++... clang++-18 -ftrivial-auto-var-init=pattern -std=c++20
+2025-07-30T13:47:32.5561487Z checking whether the compiler supports GNU Objective C++... yes
+2025-07-30T13:47:32.5833329Z checking whether clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 accepts -g... yes
+2025-07-30T13:47:32.5836015Z checking dependency style of clang++-18 -ftrivial-auto-var-init=pattern -std=c++20... none
+2025-07-30T13:47:32.5860554Z checking how to print strings... printf
+2025-07-30T13:47:32.5863287Z checking for x86_64-pc-linux-gnu-gcc... clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:32.7158774Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:47:32.7415117Z checking whether clang-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:32.7904643Z checking for clang-18 -ftrivial-auto-var-init=pattern option to enable C11 features... none needed
+2025-07-30T13:47:32.8394033Z checking whether clang-18 -ftrivial-auto-var-init=pattern understands -c and -o together... yes
+2025-07-30T13:47:32.8397511Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:32.8439312Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:47:32.8470996Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:47:32.8487012Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:47:32.8502725Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:47:32.8720560Z checking for ld used by clang-18 -ftrivial-auto-var-init=pattern... /usr/bin/ld
+2025-07-30T13:47:32.8747017Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:47:32.8749820Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:47:32.9172923Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:47:32.9173708Z checking whether ln -s works... yes
+2025-07-30T13:47:32.9217621Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:47:32.9244798Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:47:32.9246426Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:47:32.9247890Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:47:32.9252952Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:47:32.9257401Z checking for file... file
+2025-07-30T13:47:32.9261997Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:32.9266585Z checking for objdump... objdump
+2025-07-30T13:47:32.9270611Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:47:32.9275679Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:47:32.9280351Z checking for dlltool... no
+2025-07-30T13:47:32.9282475Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:47:32.9284383Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:32.9758217Z checking for archiver @FILE support... @
+2025-07-30T13:47:32.9759095Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:47:32.9762151Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:47:33.0884951Z checking command to parse nm output from clang-18 -ftrivial-auto-var-init=pattern object... ok
+2025-07-30T13:47:33.0901736Z checking for sysroot... no
+2025-07-30T13:47:33.0945615Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:47:33.0988377Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:47:33.1265236Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:47:33.1270607Z checking for mt... no
+2025-07-30T13:47:33.1303462Z checking if : is a manifest tool... no
+2025-07-30T13:47:33.1642181Z checking for stdio.h... yes
+2025-07-30T13:47:33.1956465Z checking for stdlib.h... yes
+2025-07-30T13:47:33.2300044Z checking for string.h... yes
+2025-07-30T13:47:33.2637013Z checking for inttypes.h... yes
+2025-07-30T13:47:33.2966476Z checking for stdint.h... yes
+2025-07-30T13:47:33.3308565Z checking for strings.h... yes
+2025-07-30T13:47:33.3646143Z checking for sys/stat.h... yes
+2025-07-30T13:47:33.3972421Z checking for sys/types.h... yes
+2025-07-30T13:47:33.4311802Z checking for unistd.h... yes
+2025-07-30T13:47:33.4660118Z checking for dlfcn.h... yes
+2025-07-30T13:47:33.4700653Z checking for objdir... .libs
+2025-07-30T13:47:33.5902240Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fno-rtti -fno-exceptions... yes
+2025-07-30T13:47:33.5903466Z checking for clang-18 -ftrivial-auto-var-init=pattern option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:33.6195902Z checking if clang-18 -ftrivial-auto-var-init=pattern PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:33.7006521Z checking if clang-18 -ftrivial-auto-var-init=pattern static flag -static works... yes
+2025-07-30T13:47:33.7403198Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... yes
+2025-07-30T13:47:33.7404787Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... (cached) yes
+2025-07-30T13:47:33.7668863Z checking whether the clang-18 -ftrivial-auto-var-init=pattern linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:33.8266018Z checking whether -lc should be explicitly linked in... no
+2025-07-30T13:47:33.9406011Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:47:33.9406991Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:33.9425556Z checking whether stripping libraries is possible... yes
+2025-07-30T13:47:33.9426273Z checking if libtool supports shared libraries... yes
+2025-07-30T13:47:33.9426897Z checking whether to build shared libraries... yes
+2025-07-30T13:47:33.9427508Z checking whether to build static libraries... yes
+2025-07-30T13:47:34.0011389Z checking how to run the C++ preprocessor... clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 -E
+2025-07-30T13:47:34.1999891Z checking for ld used by clang++-18 -ftrivial-auto-var-init=pattern -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:47:34.2024484Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:47:34.2429705Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:34.3572705Z checking for clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:34.3895433Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:34.4748265Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 static flag -static works... yes
+2025-07-30T13:47:34.5140699Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 supports -c -o file.o... yes
+2025-07-30T13:47:34.5142203Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-30T13:47:34.5143541Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:34.5186266Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:47:34.5187317Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:34.5194281Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:47:34.5199442Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-30T13:47:34.5204630Z checking for gcov... /usr/bin/gcov
+2025-07-30T13:47:34.5208655Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-30T13:47:34.5213558Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-30T13:47:34.5217269Z checking for lcov... no
+2025-07-30T13:47:34.5220398Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-30T13:47:34.5225260Z checking for genhtml... no
+2025-07-30T13:47:34.5229210Z checking for git... /usr/bin/git
+2025-07-30T13:47:34.5233227Z checking for ccache... /usr/bin/ccache
+2025-07-30T13:47:34.5237318Z checking for xgettext... /usr/bin/xgettext
+2025-07-30T13:47:34.5241275Z checking for hexdump... /usr/bin/hexdump
+2025-07-30T13:47:34.5245231Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-30T13:47:34.5249651Z checking for objcopy... /usr/bin/objcopy
+2025-07-30T13:47:34.5253979Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:34.5258100Z checking for objdump... /usr/bin/objdump
+2025-07-30T13:47:34.5262345Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-30T13:47:34.5266358Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-30T13:47:34.5270398Z checking for doxygen... no
+2025-07-30T13:47:34.5571316Z checking whether C++ compiler accepts -Werror... yes
+2025-07-30T13:47:34.6433815Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-30T13:47:34.6980516Z checking for execinfo.h... yes
+2025-07-30T13:47:34.7852379Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-30T13:47:34.8128752Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-30T13:47:34.8456910Z checking whether C++ compiler accepts -fsanitize=fuzzer,address,undefined,integer... yes
+2025-07-30T13:47:35.0202575Z checking whether the linker accepts -fsanitize=fuzzer,address,undefined,integer... yes
+2025-07-30T13:47:35.0541560Z checking whether C++ compiler accepts -Warray-bounds... no
+2025-07-30T13:47:35.0865139Z checking whether C++ compiler accepts -Wattributes... no
+2025-07-30T13:47:35.1216293Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-30T13:47:35.1548051Z checking whether C++ compiler accepts -Wstringop-overread... no
+2025-07-30T13:47:35.1864144Z checking whether C++ compiler accepts -Wstringop-overflow... no
+2025-07-30T13:47:35.2173892Z checking whether C++ compiler accepts -Wall... yes
+2025-07-30T13:47:35.2488258Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-30T13:47:35.2806161Z checking whether C++ compiler accepts -Wgnu... yes
+2025-07-30T13:47:35.3124866Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-30T13:47:35.3450333Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-30T13:47:35.3772106Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-30T13:47:35.4097881Z checking whether C++ compiler accepts -Wshadow-field... yes
+2025-07-30T13:47:35.4419634Z checking whether C++ compiler accepts -Wthread-safety... yes
+2025-07-30T13:47:35.4749640Z checking whether C++ compiler accepts -Wloop-analysis... yes
+2025-07-30T13:47:35.5076682Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-30T13:47:35.5400520Z checking whether C++ compiler accepts -Wunused-member-function... yes
+2025-07-30T13:47:35.5728885Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-30T13:47:35.6047233Z checking whether C++ compiler accepts -Wconditional-uninitialized... yes
+2025-07-30T13:47:35.6355726Z checking whether C++ compiler accepts -Wduplicated-branches... no
+2025-07-30T13:47:35.6660572Z checking whether C++ compiler accepts -Wduplicated-cond... no
+2025-07-30T13:47:35.6956111Z checking whether C++ compiler accepts -Wlogical-op... no
+2025-07-30T13:47:35.7266692Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-30T13:47:35.7592494Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-30T13:47:35.7937741Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-30T13:47:35.8274301Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-30T13:47:35.8599542Z checking whether C++ compiler accepts -Wdocumentation... yes
+2025-07-30T13:47:35.8923558Z checking whether C++ compiler accepts -Wself-assign... yes
+2025-07-30T13:47:35.9244284Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-30T13:47:35.9548094Z checking whether C++ compiler accepts -fno-extended-identifiers... no
+2025-07-30T13:47:35.9823996Z checking whether C++ compiler accepts -fstack-reuse=none... no
+2025-07-30T13:47:36.0132648Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-30T13:47:36.0439794Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-30T13:47:36.0747890Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-30T13:47:36.1049784Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-30T13:47:36.5837102Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-30T13:47:36.6645977Z checking for SSE4.2 intrinsics... yes
+2025-07-30T13:47:37.1264971Z checking for SSE4.1 intrinsics... yes
+2025-07-30T13:47:37.5820351Z checking for AVX2 intrinsics... yes
+2025-07-30T13:47:38.0377342Z checking for x86 SHA-NI intrinsics... yes
+2025-07-30T13:47:38.0713759Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-30T13:47:38.1026087Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-30T13:47:38.1759751Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-30T13:47:38.2513529Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-30T13:47:38.3721579Z checking whether byte ordering is bigendian... no
+2025-07-30T13:47:38.4268883Z checking how to run the C preprocessor... clang-18 -ftrivial-auto-var-init=pattern -E
+2025-07-30T13:47:38.5070311Z checking whether clang-18 -ftrivial-auto-var-init=pattern is Clang... yes
+2025-07-30T13:47:38.5830559Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:47:38.7123480Z checking whether Clang needs flag to prevent "argument unused" warning when linking with -pthread... no
+2025-07-30T13:47:38.7795063Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:47:38.7796037Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:47:38.8471837Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:47:40.3190498Z checking whether std::atomic can be used without link library... yes
+2025-07-30T13:47:40.3204314Z checking for special C compiler options needed for large files... no
+2025-07-30T13:47:40.3539696Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-30T13:47:40.4175437Z checking for clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-30T13:47:40.4782054Z checking whether strerror_r is declared... yes
+2025-07-30T13:47:40.5157386Z checking whether strerror_r returns char *... yes
+2025-07-30T13:47:40.5457483Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-30T13:47:40.5768671Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-30T13:47:40.6069035Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-30T13:47:40.6368379Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-30T13:47:40.6690383Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:47:40.6927502Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-30T13:47:40.7163735Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-30T13:47:40.7723517Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:47:40.8295815Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:47:40.8868152Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:47:40.9438017Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:47:41.0342273Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:47:41.1233098Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:47:41.2126730Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:47:41.3027275Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:47:41.3574014Z checking for sys/select.h... yes
+2025-07-30T13:47:41.4116120Z checking for sys/prctl.h... yes
+2025-07-30T13:47:41.4690317Z checking for vm/vm_param.h... no
+2025-07-30T13:47:41.5268623Z checking for sys/vmmeter.h... no
+2025-07-30T13:47:41.5838443Z checking for sys/resources.h... no
+2025-07-30T13:47:41.6247929Z checking whether getifaddrs is declared... yes
+2025-07-30T13:47:41.7163994Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:47:41.7587434Z checking whether freeifaddrs is declared... yes
+2025-07-30T13:47:41.8519610Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:47:41.9136206Z checking whether fork is declared... yes
+2025-07-30T13:47:41.9745751Z checking whether setsid is declared... yes
+2025-07-30T13:47:42.0356805Z checking whether pipe2 is declared... yes
+2025-07-30T13:47:42.0739981Z checking for mallopt M_ARENA_MAX... yes
+2025-07-30T13:47:42.1136685Z checking for getmemoryinfo... yes
+2025-07-30T13:47:42.1499219Z checking for posix_fallocate... yes
+2025-07-30T13:47:42.1809855Z checking for default visibility attribute... yes
+2025-07-30T13:47:42.2135361Z checking for dllexport attribute... no
+2025-07-30T13:47:42.8977466Z checking for thread_local support... yes
+2025-07-30T13:47:42.9350784Z checking for Linux getrandom syscall... yes
+2025-07-30T13:47:42.9711454Z checking for getentropy via random.h... yes
+2025-07-30T13:47:43.0048319Z checking for sysctl... no
+2025-07-30T13:47:43.0401130Z checking for sysctl KERN_ARND... no
+2025-07-30T13:47:43.1289241Z checking for library containing backtrace... none required
+2025-07-30T13:47:43.1629651Z checking for fdatasync... yes
+2025-07-30T13:47:43.1965441Z checking for F_FULLFSYNC... no
+2025-07-30T13:47:43.2298752Z checking for O_CLOEXEC... yes
+2025-07-30T13:47:43.2605957Z checking for __builtin_prefetch... yes
+2025-07-30T13:47:43.3368320Z checking for _mm_prefetch... yes
+2025-07-30T13:47:43.3721677Z checking for strong getauxval support in the system headers... yes
+2025-07-30T13:47:43.4121324Z checking for sockaddr_un... yes
+2025-07-30T13:47:43.5108537Z checking for std::system... yes
+2025-07-30T13:47:43.5718273Z checking for ::_wsystem... no
+2025-07-30T13:47:43.5783316Z configure: WARNING: enable-fuzz will disable all other targets and force --enable-fuzz-binary=yes
+2025-07-30T13:47:43.6039313Z checking whether C++ preprocessor accepts -DABORT_ON_FAILED_ASSUME... yes
+2025-07-30T13:47:43.7802109Z checking whether main function is needed for fuzz binary... checking whether the linker accepts ... yes
+2025-07-30T13:47:43.7803439Z no
+2025-07-30T13:47:45.2106640Z checking for Berkeley DB C++ headers... default
+2025-07-30T13:47:45.2981196Z checking for main in -ldb_cxx-4.8... yes
+2025-07-30T13:47:45.3118656Z checking for sqlite3 >= 3.7.17... yes
+2025-07-30T13:47:45.3119919Z checking whether to build wallet with support for sqlite... yes
+2025-07-30T13:47:45.3493070Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-30T13:47:45.3583966Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-30T13:47:45.3585449Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-30T13:47:45.3586851Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-30T13:47:45.3587927Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-30T13:47:45.3588749Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-30T13:47:45.3867563Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-30T13:47:45.4278795Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-30T13:47:49.6435960Z checking for Boost Process... yes
+2025-07-30T13:47:49.6595454Z checking for libevent >= 2.1.8... yes
+2025-07-30T13:47:49.6713450Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-30T13:47:49.7204094Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-30T13:47:49.7882260Z checking for gmp.h... yes
+2025-07-30T13:47:49.8735885Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:47:49.8851047Z checking for libmultiprocess... no
+2025-07-30T13:47:49.8934881Z checking whether to build dashd... no
+2025-07-30T13:47:49.8935749Z checking whether to build dash-cli... no
+2025-07-30T13:47:49.8936453Z checking whether to build dash-tx... no
+2025-07-30T13:47:49.8937095Z checking whether to build dash-wallet... no
+2025-07-30T13:47:49.8937763Z checking whether to build libraries... no
+2025-07-30T13:47:49.8941521Z checking if wallet should be enabled... yes
+2025-07-30T13:47:49.8943360Z checking whether to build with support for UPnP... no
+2025-07-30T13:47:49.8944877Z checking whether to build with support for NAT-PMP... no
+2025-07-30T13:47:49.8947616Z checking whether to build test_dash... no
+2025-07-30T13:47:49.8948696Z checking whether to reduce exports... no
+2025-07-30T13:47:49.9079251Z checking whether dsymutil needs -flat... yes
+2025-07-30T13:47:49.9079871Z 
+2025-07-30T13:47:49.9439950Z checking that generated files are newer than configure... done
+2025-07-30T13:47:49.9446596Z configure: creating ./config.status
+2025-07-30T13:47:50.5167666Z config.status: creating Makefile
+2025-07-30T13:47:50.5286764Z config.status: creating src/Makefile
+2025-07-30T13:47:50.5849570Z config.status: creating doc/man/Makefile
+2025-07-30T13:47:50.5996119Z config.status: creating share/setup.nsi
+2025-07-30T13:47:50.6147900Z config.status: creating share/qt/Info.plist
+2025-07-30T13:47:50.6298931Z config.status: creating test/config.ini
+2025-07-30T13:47:50.6450488Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-30T13:47:50.6610636Z config.status: creating src/config/bitcoin-config.h
+2025-07-30T13:47:50.7075483Z config.status: executing depfiles commands
+2025-07-30T13:47:50.7089639Z config.status: executing libtool commands
+2025-07-30T13:47:50.7212624Z === configuring in src/dashbls (/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src/dashbls)
+2025-07-30T13:47:50.7259769Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--disable-ccache' '--enable-fuzz' '--with-sanitizers=fuzzer,address,undefined,integer' 'CC=clang-18 -ftrivial-auto-var-init=pattern' 'CXX=clang++-18 -ftrivial-auto-var-init=pattern' '--with-boost-process' 'CPPFLAGS=-DDEBUG_LOCKORDER -DARENA_DEBUG' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-30T13:47:50.8534444Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:47:50.9296616Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:50.9348113Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:50.9427943Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:47:50.9457574Z checking whether build environment is sane... yes
+2025-07-30T13:47:50.9519594Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:47:50.9541397Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:47:50.9544810Z checking for gawk... gawk
+2025-07-30T13:47:50.9608605Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:47:50.9664143Z checking whether make supports nested variables... yes
+2025-07-30T13:47:50.9708898Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:47:50.9711796Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:47:50.9714688Z checking for x86_64-pc-linux-gnu-gcc... clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:51.1372010Z checking whether the C compiler works... yes
+2025-07-30T13:47:51.1372907Z checking for C compiler default output file name... a.out
+2025-07-30T13:47:51.1965096Z checking for suffix of executables... 
+2025-07-30T13:47:51.2625871Z checking whether we are cross compiling... no
+2025-07-30T13:47:51.2940295Z checking for suffix of object files... o
+2025-07-30T13:47:51.3222268Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:47:51.3516452Z checking whether clang-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:51.4018077Z checking for clang-18 -ftrivial-auto-var-init=pattern option to enable C11 features... none needed
+2025-07-30T13:47:51.4532382Z checking whether clang-18 -ftrivial-auto-var-init=pattern understands -c and -o together... yes
+2025-07-30T13:47:51.4610462Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:47:51.4614902Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:51.5707613Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:47:51.5987838Z checking whether clang++-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:52.0405164Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++11 features... unsupported
+2025-07-30T13:47:52.1122176Z checking for clang++-18 -ftrivial-auto-var-init=pattern option to enable C++98 features... none needed
+2025-07-30T13:47:52.1126765Z checking dependency style of clang++-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:52.1705256Z checking whether clang++-18 -ftrivial-auto-var-init=pattern supports C++14 features with -std=c++14... yes
+2025-07-30T13:47:52.1734151Z checking how to print strings... printf
+2025-07-30T13:47:52.1775160Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:47:52.1808234Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:47:52.1825788Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:47:52.1842009Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:47:52.2078568Z checking for ld used by clang-18 -ftrivial-auto-var-init=pattern... /usr/bin/ld
+2025-07-30T13:47:52.2104211Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:47:52.2106668Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:47:52.2546981Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:47:52.2547809Z checking whether ln -s works... yes
+2025-07-30T13:47:52.2591299Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:47:52.2618924Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:47:52.2621537Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:47:52.2622561Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:47:52.2627207Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:47:52.2632006Z checking for file... file
+2025-07-30T13:47:52.2636616Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:52.2641353Z checking for objdump... objdump
+2025-07-30T13:47:52.2645487Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:47:52.2650023Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:47:52.2655846Z checking for dlltool... no
+2025-07-30T13:47:52.2657415Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:47:52.2659416Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:52.3137019Z checking for archiver @FILE support... @
+2025-07-30T13:47:52.3138651Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:47:52.3141867Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:47:52.4270240Z checking command to parse nm output from clang-18 -ftrivial-auto-var-init=pattern object... ok
+2025-07-30T13:47:52.4288157Z checking for sysroot... no
+2025-07-30T13:47:52.4333156Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:47:52.4373566Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:47:52.4646031Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:47:52.4650246Z checking for mt... no
+2025-07-30T13:47:52.4682732Z checking if : is a manifest tool... no
+2025-07-30T13:47:52.5003516Z checking for stdio.h... yes
+2025-07-30T13:47:52.5328713Z checking for stdlib.h... yes
+2025-07-30T13:47:52.5649526Z checking for string.h... yes
+2025-07-30T13:47:52.5977852Z checking for inttypes.h... yes
+2025-07-30T13:47:52.6307588Z checking for stdint.h... yes
+2025-07-30T13:47:52.6645754Z checking for strings.h... yes
+2025-07-30T13:47:52.6972618Z checking for sys/stat.h... yes
+2025-07-30T13:47:52.7308912Z checking for sys/types.h... yes
+2025-07-30T13:47:52.7651584Z checking for unistd.h... yes
+2025-07-30T13:47:52.8000726Z checking for dlfcn.h... yes
+2025-07-30T13:47:52.8036464Z checking for objdir... .libs
+2025-07-30T13:47:52.9245580Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fno-rtti -fno-exceptions... yes
+2025-07-30T13:47:52.9247161Z checking for clang-18 -ftrivial-auto-var-init=pattern option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:52.9571359Z checking if clang-18 -ftrivial-auto-var-init=pattern PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:53.0428834Z checking if clang-18 -ftrivial-auto-var-init=pattern static flag -static works... yes
+2025-07-30T13:47:53.0830267Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... yes
+2025-07-30T13:47:53.0831531Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... (cached) yes
+2025-07-30T13:47:53.1094486Z checking whether the clang-18 -ftrivial-auto-var-init=pattern linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:53.2183880Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:47:53.2184784Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:53.2203174Z checking whether stripping libraries is possible... yes
+2025-07-30T13:47:53.2203949Z checking if libtool supports shared libraries... yes
+2025-07-30T13:47:53.2204769Z checking whether to build shared libraries... no
+2025-07-30T13:47:53.2205899Z checking whether to build static libraries... yes
+2025-07-30T13:47:53.2758954Z checking how to run the C++ preprocessor... clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 -E
+2025-07-30T13:47:53.4645156Z checking for ld used by clang++-18 -ftrivial-auto-var-init=pattern -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:47:53.4669107Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:47:53.5049933Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:53.6210161Z checking for clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:53.6543777Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:53.7412223Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 static flag -static works... yes
+2025-07-30T13:47:53.7829478Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 supports -c -o file.o... yes
+2025-07-30T13:47:53.7832268Z checking if clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-30T13:47:53.7834735Z checking whether the clang++-18 -ftrivial-auto-var-init=pattern -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:53.7879877Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:47:53.7881084Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:53.7887823Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:47:53.7894312Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-30T13:47:53.7896489Z checking for ranlib... (cached) ranlib
+2025-07-30T13:47:53.7900577Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-30T13:47:53.7903338Z checking for strip... (cached) strip
+2025-07-30T13:47:53.7906890Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:53.8197759Z checking whether C compiler accepts -Werror... yes
+2025-07-30T13:47:53.8651051Z checking for gmp.h... yes
+2025-07-30T13:47:53.9272224Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:47:53.9631603Z checking gmp version >= 6.2... yes
+2025-07-30T13:47:53.9664876Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:47:53.9678786Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:47:53.9944090Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -pipe... yes
+2025-07-30T13:47:54.0207092Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fomit-frame-pointer... yes
+2025-07-30T13:47:54.0800006Z checking how to run the C preprocessor... clang-18 -ftrivial-auto-var-init=pattern -E
+2025-07-30T13:47:54.1535027Z checking whether clang-18 -ftrivial-auto-var-init=pattern is Clang... yes
+2025-07-30T13:47:54.2258348Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:47:54.3545749Z checking whether Clang needs flag to prevent "argument unused" warning when linking with -pthread... no
+2025-07-30T13:47:54.4205575Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:47:54.4206814Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:47:54.4871128Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:47:54.5499680Z checking for library containing clock_gettime... none required
+2025-07-30T13:47:54.5821646Z checking whether C compiler accepts -fPIC... yes
+2025-07-30T13:47:54.6128471Z checking whether C compiler accepts -fstack-reuse=none... no
+2025-07-30T13:47:54.6410787Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-30T13:47:54.6715760Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-30T13:47:54.7020610Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-30T13:47:54.7329157Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:47:54.7843998Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:47:54.8361124Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:47:54.8875982Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:47:54.9403518Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:47:54.9999174Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:47:55.0609211Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:47:55.1242187Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:47:55.1856851Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:47:55.2176008Z checking whether C compiler accepts -fno-extended-identifiers... no
+2025-07-30T13:47:55.2178560Z checking whether to build runtest... yes
+2025-07-30T13:47:55.2179197Z checking whether to build runbench... yes
+2025-07-30T13:47:55.2417831Z checking that generated files are newer than configure... done
+2025-07-30T13:47:55.2422561Z configure: creating ./config.status
+2025-07-30T13:47:55.7831161Z config.status: creating Makefile
+2025-07-30T13:47:55.8045573Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-30T13:47:55.8179921Z config.status: executing depfiles commands
+2025-07-30T13:47:55.8194280Z config.status: executing libtool commands
+2025-07-30T13:47:55.8330690Z 
+2025-07-30T13:47:55.8331731Z Options used to compile and link:
+2025-07-30T13:47:55.8332222Z   target os           = linux
+2025-07-30T13:47:55.8332634Z   backend             = gmp
+2025-07-30T13:47:55.8333039Z   build bench         = yes
+2025-07-30T13:47:55.8333472Z   build test          = yes
+2025-07-30T13:47:55.8333848Z   use debug           = no
+2025-07-30T13:47:55.8334184Z   use hardening       = yes
+2025-07-30T13:47:55.8334445Z   use optimizations   = yes
+2025-07-30T13:47:55.8334618Z 
+2025-07-30T13:47:55.8334830Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-30T13:47:55.8335564Z   CFLAGS              =   -fPIC -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE   
+2025-07-30T13:47:55.8336215Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-30T13:47:55.8336843Z   CXXFLAGS            =   -fPIC -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE   
+2025-07-30T13:47:55.8337481Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-30T13:47:55.8337706Z 
+2025-07-30T13:47:55.8699351Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src/secp256k1)
+2025-07-30T13:47:55.8744877Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-zmq' '--disable-ccache' '--enable-fuzz' '--with-sanitizers=fuzzer,address,undefined,integer' 'CC=clang-18 -ftrivial-auto-var-init=pattern' 'CXX=clang++-18 -ftrivial-auto-var-init=pattern' '--with-boost-process' 'CPPFLAGS=-DDEBUG_LOCKORDER -DARENA_DEBUG' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-30T13:47:55.9993177Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:47:56.0725560Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:56.0777189Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:56.0855142Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:47:56.0883988Z checking whether build environment is sane... yes
+2025-07-30T13:47:56.0947152Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:47:56.0969168Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:47:56.0973659Z checking for gawk... gawk
+2025-07-30T13:47:56.1036021Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:47:56.1089753Z checking whether make supports nested variables... yes
+2025-07-30T13:47:56.1133201Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:47:56.1136336Z checking for x86_64-pc-linux-gnu-gcc... clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:56.2837036Z checking whether the C compiler works... yes
+2025-07-30T13:47:56.2837771Z checking for C compiler default output file name... a.out
+2025-07-30T13:47:56.3417289Z checking for suffix of executables... 
+2025-07-30T13:47:56.4062025Z checking whether we are cross compiling... no
+2025-07-30T13:47:56.4372626Z checking for suffix of object files... o
+2025-07-30T13:47:56.4638120Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:47:56.4896636Z checking whether clang-18 -ftrivial-auto-var-init=pattern accepts -g... yes
+2025-07-30T13:47:56.5381280Z checking for clang-18 -ftrivial-auto-var-init=pattern option to enable C11 features... none needed
+2025-07-30T13:47:56.5868650Z checking whether clang-18 -ftrivial-auto-var-init=pattern understands -c and -o together... yes
+2025-07-30T13:47:56.5945811Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:47:56.5949933Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:56.5953999Z checking dependency style of clang-18 -ftrivial-auto-var-init=pattern... none
+2025-07-30T13:47:56.5956178Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:56.6373749Z checking the archiver (ar) interface... ar
+2025-07-30T13:47:56.6397481Z checking how to print strings... printf
+2025-07-30T13:47:56.6437228Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:47:56.6467905Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:47:56.6484560Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:47:56.6499952Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:47:56.6718804Z checking for ld used by clang-18 -ftrivial-auto-var-init=pattern... /usr/bin/ld
+2025-07-30T13:47:56.6744229Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:47:56.6746476Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:47:56.7178325Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:47:56.7179826Z checking whether ln -s works... yes
+2025-07-30T13:47:56.7222362Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:47:56.7247902Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:47:56.7249304Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:47:56.7250246Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:47:56.7256377Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:47:56.7260719Z checking for file... file
+2025-07-30T13:47:56.7265359Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:56.7269783Z checking for objdump... objdump
+2025-07-30T13:47:56.7273533Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:47:56.7278016Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:47:56.7282147Z checking for dlltool... no
+2025-07-30T13:47:56.7284119Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:47:56.7285722Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:56.7747296Z checking for archiver @FILE support... @
+2025-07-30T13:47:56.7748548Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:47:56.7753076Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:47:56.8876134Z checking command to parse nm output from clang-18 -ftrivial-auto-var-init=pattern object... ok
+2025-07-30T13:47:56.8893339Z checking for sysroot... no
+2025-07-30T13:47:56.8935056Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:47:56.8974103Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:47:56.9239470Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:47:56.9244391Z checking for mt... no
+2025-07-30T13:47:56.9275757Z checking if : is a manifest tool... no
+2025-07-30T13:47:56.9577749Z checking for stdio.h... yes
+2025-07-30T13:47:56.9892338Z checking for stdlib.h... yes
+2025-07-30T13:47:57.0203793Z checking for string.h... yes
+2025-07-30T13:47:57.0521129Z checking for inttypes.h... yes
+2025-07-30T13:47:57.0841638Z checking for stdint.h... yes
+2025-07-30T13:47:57.1169772Z checking for strings.h... yes
+2025-07-30T13:47:57.1495020Z checking for sys/stat.h... yes
+2025-07-30T13:47:57.1821267Z checking for sys/types.h... yes
+2025-07-30T13:47:57.2162719Z checking for unistd.h... yes
+2025-07-30T13:47:57.2507623Z checking for dlfcn.h... yes
+2025-07-30T13:47:57.2548559Z checking for objdir... .libs
+2025-07-30T13:47:57.3750138Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fno-rtti -fno-exceptions... yes
+2025-07-30T13:47:57.3751790Z checking for clang-18 -ftrivial-auto-var-init=pattern option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:57.4037733Z checking if clang-18 -ftrivial-auto-var-init=pattern PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:57.4849880Z checking if clang-18 -ftrivial-auto-var-init=pattern static flag -static works... yes
+2025-07-30T13:47:57.5229966Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... yes
+2025-07-30T13:47:57.5232137Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -c -o file.o... (cached) yes
+2025-07-30T13:47:57.5471921Z checking whether the clang-18 -ftrivial-auto-var-init=pattern linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:57.6539868Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:47:57.6540775Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:57.6556847Z checking whether stripping libraries is possible... yes
+2025-07-30T13:47:57.6557518Z checking if libtool supports shared libraries... yes
+2025-07-30T13:47:57.6558923Z checking whether to build shared libraries... no
+2025-07-30T13:47:57.6559507Z checking whether to build static libraries... yes
+2025-07-30T13:47:57.6844493Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Werror... yes
+2025-07-30T13:47:57.7096504Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-30T13:47:57.7347070Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wno-overlength-strings... yes
+2025-07-30T13:47:57.7597686Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wall... yes
+2025-07-30T13:47:57.7846326Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wno-unused-function... yes
+2025-07-30T13:47:57.8090450Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wextra... yes
+2025-07-30T13:47:57.8339888Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wcast-align... yes
+2025-07-30T13:47:57.8612022Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wcast-align=strict... no
+2025-07-30T13:47:57.8859060Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wconditional-uninitialized... yes
+2025-07-30T13:47:57.9107904Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -Wreserved-identifier... yes
+2025-07-30T13:47:57.9352369Z checking if clang-18 -ftrivial-auto-var-init=pattern supports -fvisibility=hidden... yes
+2025-07-30T13:47:57.9642171Z checking for valgrind support... 
+2025-07-30T13:47:58.0258292Z checking for x86_64 assembly availability... yes
+2025-07-30T13:47:58.0475279Z checking that generated files are newer than configure... done
+2025-07-30T13:47:58.0479110Z configure: creating ./config.status
+2025-07-30T13:47:58.4591493Z config.status: creating Makefile
+2025-07-30T13:47:58.4721950Z config.status: creating libsecp256k1.pc
+2025-07-30T13:47:58.4830156Z config.status: executing depfiles commands
+2025-07-30T13:47:58.4843696Z config.status: executing libtool commands
+2025-07-30T13:47:58.4929775Z 
+2025-07-30T13:47:58.4930644Z Build Options:
+2025-07-30T13:47:58.4931171Z   with external callbacks = no
+2025-07-30T13:47:58.4931626Z   with benchmarks         = no
+2025-07-30T13:47:58.4932029Z   with tests              = yes
+2025-07-30T13:47:58.4932433Z   with ctime tests        = no
+2025-07-30T13:47:58.4932831Z   with coverage           = no
+2025-07-30T13:47:58.4933215Z   with examples           = no
+2025-07-30T13:47:58.4933612Z   module ecdh             = no
+2025-07-30T13:47:58.4934012Z   module recovery         = yes
+2025-07-30T13:47:58.4934736Z   module extrakeys        = yes
+2025-07-30T13:47:58.4935180Z   module schnorrsig       = yes
+2025-07-30T13:47:58.4935766Z   module ellswift         = yes
+2025-07-30T13:47:58.4936035Z 
+2025-07-30T13:47:58.4936166Z   asm                     = x86_64
+2025-07-30T13:47:58.4936585Z   ecmult window size      = 15
+2025-07-30T13:47:58.4936932Z   ecmult gen prec. bits   = 4
+2025-07-30T13:47:58.4937209Z 
+2025-07-30T13:47:58.4937347Z   valgrind                = no
+2025-07-30T13:47:58.4937799Z   CC                      = clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:58.4938686Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ -DDEBUG_LOCKORDER -DARENA_DEBUG
+2025-07-30T13:47:58.4940665Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wconditional-uninitialized -Wreserved-identifier -fvisibility=hidden 
+2025-07-30T13:47:58.4942039Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-30T13:47:58.4942423Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:47:58.5247454Z 
+2025-07-30T13:47:58.5248106Z Options used to compile and link:
+2025-07-30T13:47:58.5248808Z   boost process       = yes
+2025-07-30T13:47:58.5249237Z   multiprocess        = no
+2025-07-30T13:47:58.5249641Z   with libs           = no
+2025-07-30T13:47:58.5250042Z   with wallet         = yes
+2025-07-30T13:47:58.5250437Z     with sqlite       = yes
+2025-07-30T13:47:58.5250977Z     with bdb          = yes
+2025-07-30T13:47:58.5251390Z   with gui / qt       = no
+2025-07-30T13:47:58.5251776Z   with zmq            = no
+2025-07-30T13:47:58.5252334Z   with test           = not building test_dash because fuzzing is enabled
+2025-07-30T13:47:58.5252943Z   with fuzz binary    = yes
+2025-07-30T13:47:58.5253207Z   with bench          = no
+2025-07-30T13:47:58.5253446Z   with upnp           = no
+2025-07-30T13:47:58.5253699Z   with natpmp         = no
+2025-07-30T13:47:58.5253945Z   USDT tracing        = yes
+2025-07-30T13:47:58.5254263Z   sanitizers          = fuzzer,address,undefined,integer
+2025-07-30T13:47:58.5254625Z   debug enabled       = no
+2025-07-30T13:47:58.5254888Z   stacktraces enabled = yes
+2025-07-30T13:47:58.5255145Z   crash hooks enabled = no
+2025-07-30T13:47:58.5255396Z   miner enabled       = yes
+2025-07-30T13:47:58.5255648Z   gprof enabled       = no
+2025-07-30T13:47:58.5255884Z   werror              = yes
+2025-07-30T13:47:58.5256038Z 
+2025-07-30T13:47:58.5256130Z   target os           = linux-gnu
+2025-07-30T13:47:58.5256403Z   build os            = linux-gnu
+2025-07-30T13:47:58.5256579Z 
+2025-07-30T13:47:58.5256730Z   CC                  = clang-18 -ftrivial-auto-var-init=pattern
+2025-07-30T13:47:58.5257201Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-30T13:47:58.5258214Z   CPPFLAGS            =  -DABORT_ON_FAILED_ASSUME  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ -DDEBUG_LOCKORDER -DARENA_DEBUG
+2025-07-30T13:47:58.5259415Z   CXX                 = clang++-18 -ftrivial-auto-var-init=pattern -std=c++20
+2025-07-30T13:47:58.5262126Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wgnu -Wformat -Wformat-security -Wreorder -Wvla -Wshadow-field -Wthread-safety -Wloop-analysis -Wredundant-decls -Wunused-member-function -Wdate-time -Wconditional-uninitialized -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wdocumentation -Wself-assign  -Wno-unused-parameter -Werror   -pipe -std=c++20 -O2 
+2025-07-30T13:47:58.5265975Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:47:58.5266805Z   AR                  = ar
+2025-07-30T13:47:58.5267155Z   ARFLAGS             = cr
+2025-07-30T13:47:58.5267602Z 
+2025-07-30T13:47:58.5856552Z Making install in src
+2025-07-30T13:47:58.6077609Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:47:58.6328346Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:47:58.6474828Z   CXX      libbitcoin_node_a-addrdb.o
+2025-07-30T13:47:58.6477868Z   CXX      libbitcoin_node_a-addressindex.o
+2025-07-30T13:47:58.6479571Z   CXX      libbitcoin_node_a-addrman.o
+2025-07-30T13:47:58.6483728Z   CXX      libbitcoin_node_a-banman.o
+2025-07-30T13:48:02.1529772Z   CXX      libbitcoin_node_a-batchedlogger.o
+2025-07-30T13:48:04.2833975Z   CXX      libbitcoin_node_a-bip324.o
+2025-07-30T13:48:05.5023826Z   CXX      libbitcoin_node_a-blockencodings.o
+2025-07-30T13:48:08.6191876Z   CXX      libbitcoin_node_a-blockfilter.o
+2025-07-30T13:48:09.7637672Z   CXX      libbitcoin_node_a-chain.o
+2025-07-30T13:48:13.7911754Z   CXX      libbitcoin_node_a-dbwrapper.o
+2025-07-30T13:48:15.5456288Z   CXX      libbitcoin_node_a-deploymentstatus.o
+2025-07-30T13:48:16.5307029Z   CXX      libbitcoin_node_a-dsnotificationinterface.o
+2025-07-30T13:48:17.9690706Z   CXX      libbitcoin_node_a-flatfile.o
+2025-07-30T13:48:18.2922548Z   CXX      libbitcoin_node_a-httprpc.o
+2025-07-30T13:48:21.5031566Z   CXX      libbitcoin_node_a-httpserver.o
+2025-07-30T13:48:24.0135419Z   CXX      libbitcoin_node_a-i2p.o
+2025-07-30T13:48:28.6115537Z   CXX      libbitcoin_node_a-init.o
+2025-07-30T13:48:30.5882469Z   CXX      libbitcoin_node_a-mapport.o
+2025-07-30T13:48:33.0962854Z   CXX      libbitcoin_node_a-net.o
+2025-07-30T13:48:33.8438659Z   CXX      libbitcoin_node_a-netfulfilledman.o
+2025-07-30T13:48:35.0890099Z   CXX      libbitcoin_node_a-netgroup.o
+2025-07-30T13:48:39.1036045Z   CXX      libbitcoin_node_a-net_processing.o
+2025-07-30T13:48:44.4858886Z   CXX      libbitcoin_node_a-noui.o
+2025-07-30T13:48:50.4095881Z   CXX      libbitcoin_node_a-pow.o
+2025-07-30T13:48:53.8391129Z   CXX      libbitcoin_node_a-rest.o
+2025-07-30T13:49:09.8530710Z   CXX      libbitcoin_node_a-shutdown.o
+2025-07-30T13:49:13.1932378Z   CXX      libbitcoin_node_a-spork.o
+2025-07-30T13:49:14.3171111Z   CXX      libbitcoin_node_a-timedata.o
+2025-07-30T13:49:20.8085150Z   CXX      libbitcoin_node_a-torcontrol.o
+2025-07-30T13:49:22.5611768Z   CXX      libbitcoin_node_a-txdb.o
+2025-07-30T13:49:31.7440780Z   CXX      libbitcoin_node_a-txmempool.o
+2025-07-30T13:49:33.6098519Z   CXX      libbitcoin_node_a-txorphanage.o
+2025-07-30T13:49:34.6139227Z   CXX      libbitcoin_node_a-validation.o
+2025-07-30T13:49:43.0551666Z   CXX      libbitcoin_node_a-validationinterface.o
+2025-07-30T13:49:51.3420025Z   CXX      libbitcoin_node_a-versionbits.o
+2025-07-30T13:49:55.1935972Z   CXX      libbitcoin_common_a-base58.o
+2025-07-30T13:49:55.7131962Z   CXX      libbitcoin_common_a-bech32.o
+2025-07-30T13:49:57.3161362Z   CXX      libbitcoin_common_a-chainparams.o
+2025-07-30T13:49:58.1540623Z   CXX      libbitcoin_common_a-coins.o
+2025-07-30T13:50:05.7809518Z   CXX      libbitcoin_common_a-compressor.o
+2025-07-30T13:50:08.1166203Z   CXX      libbitcoin_common_a-core_read.o
+2025-07-30T13:50:09.3634039Z   CXX      libbitcoin_common_a-core_write.o
+2025-07-30T13:50:10.6270706Z   CXX      libbitcoin_common_a-deploymentinfo.o
+2025-07-30T13:50:11.7308048Z   CXX      evo/libbitcoin_common_a-core_write.o
+2025-07-30T13:50:14.9903641Z   CXX      evo/libbitcoin_common_a-netinfo.o
+2025-07-30T13:50:19.6718093Z   CXX      governance/libbitcoin_common_a-common.o
+2025-07-30T13:50:22.1881230Z   CXX      libbitcoin_common_a-key.o
+2025-07-30T13:50:23.2398664Z   CXX      libbitcoin_common_a-key_io.o
+2025-07-30T13:50:25.1875316Z   CXX      libbitcoin_common_a-merkleblock.o
+2025-07-30T13:50:26.2855522Z   CXX      libbitcoin_common_a-net_types.o
+2025-07-30T13:50:28.2304551Z   CXX      libbitcoin_common_a-netaddress.o
+2025-07-30T13:50:28.6834535Z   CXX      libbitcoin_common_a-netbase.o
+2025-07-30T13:50:32.7936053Z   CXX      libbitcoin_common_a-net_permissions.o
+2025-07-30T13:50:33.4012858Z   CXX      libbitcoin_common_a-outputtype.o
+2025-07-30T13:50:36.0210758Z   CXX      policy/libbitcoin_common_a-feerate.o
+2025-07-30T13:50:36.3815719Z   CXX      policy/libbitcoin_common_a-policy.o
+2025-07-30T13:50:38.2157863Z   CXX      libbitcoin_common_a-protocol.o
+2025-07-30T13:50:38.6843478Z   CXX      libbitcoin_common_a-psbt.o
+2025-07-30T13:50:38.9483944Z   CXX      rpc/libbitcoin_common_a-evo_util.o
+2025-07-30T13:50:39.1859168Z   CXX      rpc/libbitcoin_common_a-rawtransaction_util.o
+2025-07-30T13:50:44.9570476Z   CXX      rpc/libbitcoin_common_a-util.o
+2025-07-30T13:50:45.7966511Z   CXX      libbitcoin_common_a-saltedhasher.o
+2025-07-30T13:50:48.8921928Z   CXX      libbitcoin_common_a-scheduler.o
+2025-07-30T13:50:51.2134331Z   CXX      script/libbitcoin_common_a-descriptor.o
+2025-07-30T13:50:53.2998595Z   CXX      script/libbitcoin_common_a-sign.o
+2025-07-30T13:50:56.3554225Z   CXX      script/libbitcoin_common_a-signingprovider.o
+2025-07-30T13:50:58.4587744Z   CXX      script/libbitcoin_common_a-standard.o
+2025-07-30T13:51:00.6799285Z   CXX      libbitcoin_common_a-warnings.o
+2025-07-30T13:51:02.7002304Z   CXX      coinjoin/libbitcoin_util_a-common.o
+2025-07-30T13:51:05.0044062Z   CXX      coinjoin/libbitcoin_util_a-options.o
+2025-07-30T13:51:05.0160179Z   CXX      libbitcoin_util_a-chainparamsbase.o
+2025-07-30T13:51:06.1159576Z   CXX      libbitcoin_util_a-fs.o
+2025-07-30T13:51:07.7988295Z   CXX      libbitcoin_util_a-logging.o
+2025-07-30T13:51:08.0799510Z   CXX      libbitcoin_util_a-messagesigner.o
+2025-07-30T13:51:08.8419664Z   CXX      libbitcoin_util_a-random.o
+2025-07-30T13:51:10.1612560Z   CXX      libbitcoin_util_a-randomenv.o
+2025-07-30T13:51:11.8565554Z   CXX      rpc/libbitcoin_util_a-request.o
+2025-07-30T13:51:13.1508551Z   CXX      libbitcoin_util_a-stacktraces.o
+2025-07-30T13:51:14.8503867Z   CXX      support/libbitcoin_util_a-cleanse.o
+2025-07-30T13:51:14.9303449Z   CXX      libbitcoin_util_a-sync.o
+2025-07-30T13:51:15.7489764Z   CXX      libbitcoin_consensus_a-arith_uint256.o
+2025-07-30T13:51:17.4168888Z   CXX      bls/libbitcoin_consensus_a-bls.o
+2025-07-30T13:51:18.6755182Z   CXX      consensus/libbitcoin_consensus_a-merkle.o
+2025-07-30T13:51:20.6991163Z   CXX      consensus/libbitcoin_consensus_a-tx_check.o
+2025-07-30T13:51:21.2817013Z   CXX      libbitcoin_consensus_a-hash.o
+2025-07-30T13:51:22.6218618Z   CXX      libbitcoin_consensus_a-pubkey.o
+2025-07-30T13:51:23.1367325Z   CXX      script/libbitcoin_consensus_a-bitcoinconsensus.o
+2025-07-30T13:51:23.5001111Z   CXX      script/libbitcoin_consensus_a-interpreter.o
+2025-07-30T13:51:24.1866625Z   CXX      script/libbitcoin_consensus_a-script.o
+2025-07-30T13:51:24.7477911Z   CXX      script/libbitcoin_consensus_a-script_error.o
+2025-07-30T13:51:25.6316726Z   CXX      libbitcoin_consensus_a-uint256.o
+2025-07-30T13:51:26.9926481Z   CXX      util/libbitcoin_consensus_a-strencodings.o
+2025-07-30T13:51:27.0736844Z   CXX      util/libbitcoin_consensus_a-string.o
+2025-07-30T13:51:27.1025772Z   CXX      coinjoin/libbitcoin_wallet_a-client.o
+2025-07-30T13:51:30.8076652Z   CXX      coinjoin/libbitcoin_wallet_a-interfaces.o
+2025-07-30T13:51:31.3565031Z   CXX      coinjoin/libbitcoin_wallet_a-util.o
+2025-07-30T13:51:40.2037352Z   CXX      wallet/libbitcoin_wallet_a-bip39.o
+2025-07-30T13:51:41.7236224Z   CXX      wallet/libbitcoin_wallet_a-coinjoin.o
+2025-07-30T13:51:44.0512238Z   CXX      wallet/libbitcoin_wallet_a-coincontrol.o
+2025-07-30T13:51:45.1714686Z   CXX      wallet/libbitcoin_wallet_a-context.o
+2025-07-30T13:51:46.8254088Z   CXX      wallet/libbitcoin_wallet_a-crypter.o
+2025-07-30T13:51:48.9108202Z   CXX      wallet/libbitcoin_wallet_a-db.o
+2025-07-30T13:51:53.2855845Z   CXX      wallet/libbitcoin_wallet_a-dump.o
+2025-07-30T13:51:56.2757013Z   CXX      wallet/libbitcoin_wallet_a-fees.o
+2025-07-30T13:52:01.8880318Z   CXX      wallet/libbitcoin_wallet_a-hdchain.o
+2025-07-30T13:52:04.3134918Z   CXX      wallet/libbitcoin_wallet_a-interfaces.o
+2025-07-30T13:52:05.9587805Z   CXX      wallet/libbitcoin_wallet_a-load.o
+2025-07-30T13:52:09.2161251Z   CXX      wallet/libbitcoin_wallet_a-receive.o
+2025-07-30T13:52:11.6061880Z   CXX      wallet/libbitcoin_wallet_a-scriptpubkeyman.o
+2025-07-30T13:52:18.7911541Z   CXX      wallet/libbitcoin_wallet_a-spend.o
+2025-07-30T13:52:22.7626848Z   CXX      wallet/libbitcoin_wallet_a-transaction.o
+2025-07-30T13:52:25.2051415Z   CXX      wallet/libbitcoin_wallet_a-wallet.o
+2025-07-30T13:52:40.7192513Z   CXX      wallet/libbitcoin_wallet_a-walletdb.o
+2025-07-30T13:52:43.3267030Z   CXX      wallet/libbitcoin_wallet_a-walletutil.o
+2025-07-30T13:52:47.7835147Z   CXX      wallet/libbitcoin_wallet_a-coinselection.o
+2025-07-30T13:52:48.3706360Z   CXX      wallet/libbitcoin_wallet_a-sqlite.o
+2025-07-30T13:52:57.2302354Z   CXX      wallet/libbitcoin_wallet_a-bdb.o
+2025-07-30T13:52:58.4456323Z   CXX      wallet/libbitcoin_wallet_a-salvage.o
+2025-07-30T13:53:09.4386457Z   CXX      crypto/libbitcoin_crypto_sse41_la-sha256_sse41.lo
+2025-07-30T13:53:12.1542663Z   CXX      crypto/libbitcoin_crypto_x86_shani_la-sha256_x86_shani.lo
+2025-07-30T13:53:12.3863390Z   CXX      crypto/libbitcoin_crypto_avx2_la-sha256_avx2.lo
+2025-07-30T13:53:13.1833955Z   CXX      rpc/libbitcoin_cli_a-client.o
+2025-07-30T13:53:15.0890012Z make[3]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src/dashbls'
+2025-07-30T13:53:15.0907974Z  /bin/bash ./config.status
+2025-07-30T13:53:15.3110492Z config.status: creating Makefile
+2025-07-30T13:53:15.3148012Z   CXX      crc32c/src/libcrc32c_sse42_la-crc32c_sse42.lo
+2025-07-30T13:53:15.3641842Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-30T13:53:15.3858482Z config.status: executing depfiles commands
+2025-07-30T13:53:15.3879016Z config.status: executing libtool commands
+2025-07-30T13:53:15.5231532Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_add_low.lo
+2025-07-30T13:53:15.7379645Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_inv_low.lo
+2025-07-30T13:53:15.8921408Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_mul_low.lo
+2025-07-30T13:53:15.9075668Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_rdc_low.lo
+2025-07-30T13:53:16.0178706Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_shift_low.lo
+2025-07-30T13:53:16.0958828Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_sqr_low.lo
+2025-07-30T13:53:16.1445330Z make[3]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src/secp256k1'
+2025-07-30T13:53:16.1581057Z   CC       src/libsecp256k1_la-secp256k1.lo
+2025-07-30T13:53:16.2442620Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fb_add_low.lo
+2025-07-30T13:53:16.3751288Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_inv_low.lo
+2025-07-30T13:53:16.5220529Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_itr_low.lo
+2025-07-30T13:53:16.6505421Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_mul_low.lo
+2025-07-30T13:53:16.8505206Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_rdc_low.lo
+2025-07-30T13:53:17.0451977Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fb_shift_low.lo
+2025-07-30T13:53:17.1884504Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_slv_low.lo
+2025-07-30T13:53:17.3441558Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_sqr_low.lo
+2025-07-30T13:53:17.4996133Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_srt_low.lo
+2025-07-30T13:53:17.7924903Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_trc_low.lo
+2025-07-30T13:53:18.0356206Z   CXX      src/runbench-test-bench.o
+2025-07-30T13:53:19.5852625Z   CC       src/libsecp256k1_precomputed_la-precomputed_ecmult.lo
+2025-07-30T13:53:20.5982803Z   CC       src/libsecp256k1_precomputed_la-precomputed_ecmult_gen.lo
+2025-07-30T13:53:20.8873812Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_1byte.o
+2025-07-30T13:53:20.9507567Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_2bytes.o
+2025-07-30T13:53:21.0149689Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_3bytes.o
+2025-07-30T13:53:21.0842573Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_4bytes.o
+2025-07-30T13:53:21.1107783Z   CXX      src/runtest-test.o
+2025-07-30T13:53:22.6658815Z   CCLD     libsecp256k1_precomputed.la
+2025-07-30T13:53:22.8639578Z   CCLD     libsecp256k1.la
+2025-07-30T13:53:23.1343788Z make[3]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src/secp256k1'
+2025-07-30T13:53:23.1375616Z   CXX      src/libdashbls_la-bls.lo
+2025-07-30T13:53:24.7725736Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_5bytes.o
+2025-07-30T13:53:24.8451033Z   CXX      src/libdashbls_la-chaincode.lo
+2025-07-30T13:53:25.3638094Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_6bytes.o
+2025-07-30T13:53:25.4312759Z   CXX      src/libdashbls_la-elements.lo
+2025-07-30T13:53:26.5839194Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_7bytes.o
+2025-07-30T13:53:26.6539953Z   CXX      src/libdashbls_la-extendedprivatekey.lo
+2025-07-30T13:53:27.2426990Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_8bytes.o
+2025-07-30T13:53:27.3104379Z   CXX      src/libdashbls_la-extendedpublickey.lo
+2025-07-30T13:53:28.5078251Z   CXX      wallet/test/fuzz/test_fuzz_fuzz-coinselection.o
+2025-07-30T13:53:28.6305108Z   CXX      src/libdashbls_la-legacy.lo
+2025-07-30T13:53:28.6592501Z   CXX      wallet/test/fuzz/test_fuzz_fuzz-notifications.o
+2025-07-30T13:53:29.8531412Z   CXX      test/fuzz/fuzz-addition_overflow.o
+2025-07-30T13:53:37.9823140Z   CXX      src/libdashbls_la-privatekey.lo
+2025-07-30T13:53:39.6666388Z   CXX      test/fuzz/fuzz-addrman.o
+2025-07-30T13:53:40.6624162Z   CXX      src/libdashbls_la-schemes.lo
+2025-07-30T13:53:42.8027386Z   CXX      test/fuzz/fuzz-asmap.o
+2025-07-30T13:53:43.7984496Z   CXX      test/fuzz/fuzz-asmap_direct.o
+2025-07-30T13:53:46.8396573Z   CXX      src/libdashbls_la-threshold.lo
+2025-07-30T13:53:47.4061612Z   CXX      test/fuzz/fuzz-autofile.o
+2025-07-30T13:53:48.8513206Z   CXX      test/fuzz/fuzz-banman.o
+2025-07-30T13:53:50.5446747Z   CC       depends/mimalloc/src/libmimalloc_secure_la-stats.lo
+2025-07-30T13:53:50.8419006Z   CXX      test/fuzz/fuzz-base_encode_decode.o
+2025-07-30T13:53:54.2292463Z   CC       depends/mimalloc/src/libmimalloc_secure_la-random.lo
+2025-07-30T13:53:54.5158997Z   CC       depends/mimalloc/src/libmimalloc_secure_la-os.lo
+2025-07-30T13:53:54.8886412Z   CC       depends/mimalloc/src/libmimalloc_secure_la-bitmap.lo
+2025-07-30T13:53:55.1571337Z   CC       depends/mimalloc/src/libmimalloc_secure_la-arena.lo
+2025-07-30T13:53:55.2181446Z   CXX      test/fuzz/fuzz-bech32.o
+2025-07-30T13:53:55.4419539Z   CC       depends/mimalloc/src/libmimalloc_secure_la-segment-cache.lo
+2025-07-30T13:53:55.7174927Z   CC       depends/mimalloc/src/libmimalloc_secure_la-segment.lo
+2025-07-30T13:53:56.0566183Z   CC       depends/mimalloc/src/libmimalloc_secure_la-page.lo
+2025-07-30T13:53:56.4126253Z   CXX      test/fuzz/fuzz-bip324.o
+2025-07-30T13:53:56.5315977Z   CC       depends/mimalloc/src/libmimalloc_secure_la-alloc.lo
+2025-07-30T13:53:56.9461223Z   CC       depends/mimalloc/src/libmimalloc_secure_la-alloc-aligned.lo
+2025-07-30T13:53:57.2105335Z   CC       depends/mimalloc/src/libmimalloc_secure_la-alloc-posix.lo
+2025-07-30T13:53:57.2282837Z   CXX      test/fuzz/fuzz-block.o
+2025-07-30T13:53:57.4132963Z   CC       depends/mimalloc/src/libmimalloc_secure_la-heap.lo
+2025-07-30T13:53:57.7280405Z   CC       depends/mimalloc/src/libmimalloc_secure_la-options.lo
+2025-07-30T13:53:57.7523786Z   CC       depends/mimalloc/src/libmimalloc_secure_la-init.lo
+2025-07-30T13:53:58.0122175Z   CXX      test/fuzz/fuzz-block_header.o
+2025-07-30T13:53:58.0411448Z   CC       depends/relic/src/librelic_la-relic_err.lo
+2025-07-30T13:53:58.2130954Z   CC       depends/relic/src/librelic_la-relic_core.lo
+2025-07-30T13:53:58.4649890Z   CC       depends/relic/src/librelic_la-relic_conf.lo
+2025-07-30T13:53:58.6356248Z   CC       depends/relic/src/librelic_la-relic_util.lo
+2025-07-30T13:53:58.8361958Z   CC       depends/relic/src/arch/librelic_la-relic_arch_x64.lo
+2025-07-30T13:53:59.0175321Z   CC       depends/relic/src/rand/librelic_la-relic_rand_call.lo
+2025-07-30T13:53:59.1939773Z   CC       depends/relic/src/rand/librelic_la-relic_rand_core.lo
+2025-07-30T13:53:59.3926055Z   CC       depends/relic/src/rand/librelic_la-relic_rand_hashd.lo
+2025-07-30T13:53:59.6113947Z   CC       depends/relic/src/rand/librelic_la-relic_rand_udev.lo
+2025-07-30T13:53:59.7838411Z   CC       depends/relic/src/dv/librelic_la-relic_dv_mem.lo
+2025-07-30T13:53:59.9490489Z   CC       depends/relic/src/dv/librelic_la-relic_dv_util.lo
+2025-07-30T13:54:00.1958572Z   CC       depends/relic/src/bn/librelic_la-relic_bn_add.lo
+2025-07-30T13:54:00.4043444Z   CC       depends/relic/src/bn/librelic_la-relic_bn_cmp.lo
+2025-07-30T13:54:00.5853911Z   CC       depends/relic/src/bn/librelic_la-relic_bn_div.lo
+2025-07-30T13:54:00.7824779Z   CC       depends/relic/src/bn/librelic_la-relic_bn_factor.lo
+2025-07-30T13:54:00.9583784Z   CC       depends/relic/src/bn/librelic_la-relic_bn_gcd.lo
+2025-07-30T13:54:01.2739725Z   CC       depends/relic/src/bn/librelic_la-relic_bn_inv.lo
+2025-07-30T13:54:01.4370032Z   CC       depends/relic/src/bn/librelic_la-relic_bn_lcm.lo
+2025-07-30T13:54:01.6110556Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mem.lo
+2025-07-30T13:54:01.7951144Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mod.lo
+2025-07-30T13:54:02.0290133Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mul.lo
+2025-07-30T13:54:02.2232482Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mxp.lo
+2025-07-30T13:54:02.4541907Z   CC       depends/relic/src/bn/librelic_la-relic_bn_prime.lo
+2025-07-30T13:54:02.7008897Z   CC       depends/relic/src/bn/librelic_la-relic_bn_rec.lo
+2025-07-30T13:54:03.0893234Z   CC       depends/relic/src/bn/librelic_la-relic_bn_shift.lo
+2025-07-30T13:54:03.2844125Z   CC       depends/relic/src/bn/librelic_la-relic_bn_smb.lo
+2025-07-30T13:54:03.4632941Z   CC       depends/relic/src/bn/librelic_la-relic_bn_sqr.lo
+2025-07-30T13:54:03.6430700Z   CC       depends/relic/src/bn/librelic_la-relic_bn_srt.lo
+2025-07-30T13:54:03.8149547Z   CC       depends/relic/src/bn/librelic_la-relic_bn_util.lo
+2025-07-30T13:54:04.1626817Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_add_low.lo
+2025-07-30T13:54:04.2263084Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_div_low.lo
+2025-07-30T13:54:04.3381495Z   CXX      test/fuzz/fuzz-blockfilter.o
+2025-07-30T13:54:04.3501294Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_mod_low.lo
+2025-07-30T13:54:04.4859715Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_mul_low.lo
+2025-07-30T13:54:04.6122637Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_shift_low.lo
+2025-07-30T13:54:04.7617820Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_sqr_low.lo
+2025-07-30T13:54:04.8942956Z   CC       depends/relic/src/fp/librelic_la-relic_fp_add.lo
+2025-07-30T13:54:05.0882447Z   CC       depends/relic/src/fp/librelic_la-relic_fp_cmp.lo
+2025-07-30T13:54:05.2633194Z   CC       depends/relic/src/fp/librelic_la-relic_fp_exp.lo
+2025-07-30T13:54:05.4454433Z   CC       depends/relic/src/fp/librelic_la-relic_fp_inv.lo
+2025-07-30T13:54:05.6063731Z depends/relic/src/fp/relic_fp_inv.c:463:15: warning: shift count >= width of type [-Wshift-count-overflow]
+2025-07-30T13:54:05.6065217Z   463 |                         d0 = delta >> (RLC_DIG - 1);
+2025-07-30T13:54:05.6065725Z       |                                    ^  ~~~~~~~~~~~~~
+2025-07-30T13:54:05.6834259Z 1 warning generated.
+2025-07-30T13:54:05.6932407Z   CC       depends/relic/src/fp/librelic_la-relic_fp_mul.lo
+2025-07-30T13:54:05.8825894Z   CC       depends/relic/src/fp/librelic_la-relic_fp_param.lo
+2025-07-30T13:54:06.0678220Z   CC       depends/relic/src/fp/librelic_la-relic_fp_prime.lo
+2025-07-30T13:54:06.1563864Z   CC       depends/relic/src/fp/librelic_la-relic_fp_rdc.lo
+2025-07-30T13:54:06.3221893Z   CXX      test/fuzz/fuzz-bloom_filter.o
+2025-07-30T13:54:06.3274884Z   CC       depends/relic/src/fp/librelic_la-relic_fp_shift.lo
+2025-07-30T13:54:06.3797665Z   CC       depends/relic/src/fp/librelic_la-relic_fp_sqr.lo
+2025-07-30T13:54:06.4995702Z   CC       depends/relic/src/fp/librelic_la-relic_fp_srt.lo
+2025-07-30T13:54:06.5646550Z   CXX      test/fuzz/fuzz-buffered_file.o
+2025-07-30T13:54:06.6833090Z   CC       depends/relic/src/fp/librelic_la-relic_fp_util.lo
+2025-07-30T13:54:06.8962110Z   CC       depends/relic/src/fpx/librelic_la-relic_fp2_mul.lo
+2025-07-30T13:54:07.0846855Z   CC       depends/relic/src/fpx/librelic_la-relic_fp2_sqr.lo
+2025-07-30T13:54:07.2677543Z   CC       depends/relic/src/fpx/librelic_la-relic_fp3_mul.lo
+2025-07-30T13:54:07.4629575Z   CC       depends/relic/src/fpx/librelic_la-relic_fp3_sqr.lo
+2025-07-30T13:54:07.6579403Z   CC       depends/relic/src/fpx/librelic_la-relic_fp4_mul.lo
+2025-07-30T13:54:07.8486642Z   CC       depends/relic/src/fpx/librelic_la-relic_fp4_sqr.lo
+2025-07-30T13:54:08.0215405Z   CC       depends/relic/src/fpx/librelic_la-relic_fp6_mul.lo
+2025-07-30T13:54:08.2140135Z   CC       depends/relic/src/fpx/librelic_la-relic_fp6_sqr.lo
+2025-07-30T13:54:08.3994454Z   CC       depends/relic/src/fpx/librelic_la-relic_fp8_mul.lo
+2025-07-30T13:54:08.5988276Z   CC       depends/relic/src/fpx/librelic_la-relic_fp8_sqr.lo
+2025-07-30T13:54:08.7831675Z   CC       depends/relic/src/fpx/librelic_la-relic_fp9_mul.lo
+2025-07-30T13:54:08.9762076Z   CC       depends/relic/src/fpx/librelic_la-relic_fp9_sqr.lo
+2025-07-30T13:54:09.1643722Z   CC       depends/relic/src/fpx/librelic_la-relic_fp12_mul.lo
+2025-07-30T13:54:09.3734031Z   CC       depends/relic/src/fpx/librelic_la-relic_fp12_sqr.lo
+2025-07-30T13:54:09.5965148Z   CC       depends/relic/src/fpx/librelic_la-relic_fp18_mul.lo
+2025-07-30T13:54:09.7915579Z   CC       depends/relic/src/fpx/librelic_la-relic_fp18_sqr.lo
+2025-07-30T13:54:09.9740723Z   CC       depends/relic/src/fpx/librelic_la-relic_fp24_mul.lo
+2025-07-30T13:54:10.1782811Z   CC       depends/relic/src/fpx/librelic_la-relic_fp24_sqr.lo
+2025-07-30T13:54:10.4042453Z   CC       depends/relic/src/fpx/librelic_la-relic_fp48_mul.lo
+2025-07-30T13:54:10.5905686Z   CC       depends/relic/src/fpx/librelic_la-relic_fp48_sqr.lo
+2025-07-30T13:54:10.8124709Z   CC       depends/relic/src/fpx/librelic_la-relic_fp54_mul.lo
+2025-07-30T13:54:10.9909726Z   CC       depends/relic/src/fpx/librelic_la-relic_fp54_sqr.lo
+2025-07-30T13:54:11.1859880Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_add.lo
+2025-07-30T13:54:11.4518097Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_cmp.lo
+2025-07-30T13:54:11.6793676Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_cyc.lo
+2025-07-30T13:54:12.2975125Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_exp.lo
+2025-07-30T13:54:12.5966848Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_field.lo
+2025-07-30T13:54:12.7967862Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_frb.lo
+2025-07-30T13:54:13.0380493Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_inv.lo
+2025-07-30T13:54:13.0662179Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_pck.lo
+2025-07-30T13:54:13.2726413Z   CXX      test/fuzz/fuzz-chain.o
+2025-07-30T13:54:13.3498690Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_rdc.lo
+2025-07-30T13:54:13.5131736Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_srt.lo
+2025-07-30T13:54:13.6996028Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_util.lo
+2025-07-30T13:54:14.1243177Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_add_low.lo
+2025-07-30T13:54:14.3259656Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_mul_low.lo
+2025-07-30T13:54:14.5076485Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_rdc_low.lo
+2025-07-30T13:54:14.6716130Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_sqr_low.lo
+2025-07-30T13:54:14.7015910Z   CC       depends/relic/src/fb/librelic_la-relic_fb_add.lo
+2025-07-30T13:54:14.8496623Z   CXX      test/fuzz/fuzz-checkqueue.o
+2025-07-30T13:54:14.8682091Z   CC       depends/relic/src/fb/librelic_la-relic_fb_cmp.lo
+2025-07-30T13:54:15.0323124Z   CC       depends/relic/src/fb/librelic_la-relic_fb_exp.lo
+2025-07-30T13:54:15.2129559Z   CC       depends/relic/src/fb/librelic_la-relic_fb_inv.lo
+2025-07-30T13:54:15.3933078Z   CC       depends/relic/src/fb/librelic_la-relic_fb_itr.lo
+2025-07-30T13:54:15.4826973Z   CXX      test/fuzz/fuzz-coins_view.o
+2025-07-30T13:54:15.5744965Z   CC       depends/relic/src/fb/librelic_la-relic_fb_mul.lo
+2025-07-30T13:54:15.7694051Z   CC       depends/relic/src/fb/librelic_la-relic_fb_param.lo
+2025-07-30T13:54:15.9495686Z   CC       depends/relic/src/fb/librelic_la-relic_fb_poly.lo
+2025-07-30T13:54:16.1908782Z   CC       depends/relic/src/fb/librelic_la-relic_fb_rdc.lo
+2025-07-30T13:54:16.3744280Z   CC       depends/relic/src/fb/librelic_la-relic_fb_shift.lo
+2025-07-30T13:54:16.5499300Z   CC       depends/relic/src/fb/librelic_la-relic_fb_slv.lo
+2025-07-30T13:54:16.7265559Z   CC       depends/relic/src/fb/librelic_la-relic_fb_sqr.lo
+2025-07-30T13:54:16.9027190Z   CC       depends/relic/src/fb/librelic_la-relic_fb_srt.lo
+2025-07-30T13:54:17.0826909Z   CC       depends/relic/src/fb/librelic_la-relic_fb_trc.lo
+2025-07-30T13:54:17.2553089Z   CC       depends/relic/src/fb/librelic_la-relic_fb_util.lo
+2025-07-30T13:54:17.5003244Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_inv.lo
+2025-07-30T13:54:17.6764081Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_mul.lo
+2025-07-30T13:54:17.8417585Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_slv.lo
+2025-07-30T13:54:17.9973128Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_sqr.lo
+2025-07-30T13:54:18.1563473Z   CC       depends/relic/src/ep/librelic_la-relic_ep_add.lo
+2025-07-30T13:54:18.4098009Z   CC       depends/relic/src/ep/librelic_la-relic_ep_cmp.lo
+2025-07-30T13:54:18.5891073Z   CC       depends/relic/src/ep/librelic_la-relic_ep_curve.lo
+2025-07-30T13:54:18.8248754Z   CC       depends/relic/src/ep/librelic_la-relic_ep_dbl.lo
+2025-07-30T13:54:19.0426389Z   CC       depends/relic/src/ep/librelic_la-relic_ep_map.lo
+2025-07-30T13:54:19.2657953Z   CC       depends/relic/src/ep/librelic_la-relic_ep_mul.lo
+2025-07-30T13:54:19.5412651Z   CC       depends/relic/src/ep/librelic_la-relic_ep_mul_fix.lo
+2025-07-30T13:54:19.8263284Z   CC       depends/relic/src/ep/librelic_la-relic_ep_mul_sim.lo
+2025-07-30T13:54:20.2236646Z   CC       depends/relic/src/ep/librelic_la-relic_ep_neg.lo
+2025-07-30T13:54:20.3764762Z   CC       depends/relic/src/ep/librelic_la-relic_ep_norm.lo
+2025-07-30T13:54:20.5566365Z   CC       depends/relic/src/ep/librelic_la-relic_ep_param.lo
+2025-07-30T13:54:20.7645646Z   CC       depends/relic/src/ep/librelic_la-relic_ep_pck.lo
+2025-07-30T13:54:20.9460764Z   CC       depends/relic/src/ep/librelic_la-relic_ep_psi.lo
+2025-07-30T13:54:21.1099691Z   CC       depends/relic/src/ep/librelic_la-relic_ep_util.lo
+2025-07-30T13:54:21.3190459Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_add.lo
+2025-07-30T13:54:21.5265390Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_cmp.lo
+2025-07-30T13:54:21.6312462Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_curve.lo
+2025-07-30T13:54:21.6769670Z   CXX      test/fuzz/fuzz-coinscache_sim.o
+2025-07-30T13:54:21.8785884Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_dbl.lo
+2025-07-30T13:54:22.0721716Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_frb.lo
+2025-07-30T13:54:22.2479740Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_map.lo
+2025-07-30T13:54:22.4734388Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul.lo
+2025-07-30T13:54:22.7070298Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul_cof.lo
+2025-07-30T13:54:22.8870595Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul_fix.lo
+2025-07-30T13:54:23.0322422Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul_sim.lo
+2025-07-30T13:54:23.1607026Z   CXX      test/fuzz/fuzz-connman.o
+2025-07-30T13:54:23.4136428Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_neg.lo
+2025-07-30T13:54:23.5871576Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_norm.lo
+2025-07-30T13:54:23.7763514Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_pck.lo
+2025-07-30T13:54:23.9560695Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_util.lo
+2025-07-30T13:54:24.1671380Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_add.lo
+2025-07-30T13:54:24.3719623Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_cmp.lo
+2025-07-30T13:54:24.5392054Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_curve.lo
+2025-07-30T13:54:24.7452853Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_dbl.lo
+2025-07-30T13:54:24.9408498Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_frb.lo
+2025-07-30T13:54:25.1035773Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_map.lo
+2025-07-30T13:54:25.2711732Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul.lo
+2025-07-30T13:54:25.5203344Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul_cof.lo
+2025-07-30T13:54:25.6949189Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul_fix.lo
+2025-07-30T13:54:25.9753879Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul_sim.lo
+2025-07-30T13:54:26.3312779Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_neg.lo
+2025-07-30T13:54:26.4867111Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_norm.lo
+2025-07-30T13:54:26.6697874Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_util.lo
+2025-07-30T13:54:26.8796120Z   CC       depends/relic/src/eb/librelic_la-relic_eb_add.lo
+2025-07-30T13:54:27.0823852Z   CC       depends/relic/src/eb/librelic_la-relic_eb_cmp.lo
+2025-07-30T13:54:27.2569275Z   CC       depends/relic/src/eb/librelic_la-relic_eb_curve.lo
+2025-07-30T13:54:27.4550372Z   CC       depends/relic/src/eb/librelic_la-relic_eb_dbl.lo
+2025-07-30T13:54:27.6342961Z   CC       depends/relic/src/eb/librelic_la-relic_eb_frb.lo
+2025-07-30T13:54:27.7945883Z   CC       depends/relic/src/eb/librelic_la-relic_eb_hlv.lo
+2025-07-30T13:54:27.9596369Z   CC       depends/relic/src/eb/librelic_la-relic_eb_map.lo
+2025-07-30T13:54:28.1301823Z   CC       depends/relic/src/eb/librelic_la-relic_eb_mul.lo
+2025-07-30T13:54:28.3365435Z   CC       depends/relic/src/eb/librelic_la-relic_eb_mul_fix.lo
+2025-07-30T13:54:28.4379667Z   CXX      test/fuzz/fuzz-crypto.o
+2025-07-30T13:54:28.6167135Z   CC       depends/relic/src/eb/librelic_la-relic_eb_mul_sim.lo
+2025-07-30T13:54:28.8963785Z   CC       depends/relic/src/eb/librelic_la-relic_eb_neg.lo
+2025-07-30T13:54:29.0744256Z   CC       depends/relic/src/eb/librelic_la-relic_eb_norm.lo
+2025-07-30T13:54:29.2648027Z   CC       depends/relic/src/eb/librelic_la-relic_eb_param.lo
+2025-07-30T13:54:29.4490432Z   CC       depends/relic/src/eb/librelic_la-relic_eb_pck.lo
+2025-07-30T13:54:29.6293493Z   CC       depends/relic/src/eb/librelic_la-relic_eb_util.lo
+2025-07-30T13:54:29.8533894Z   CC       depends/relic/src/ed/librelic_la-relic_ed_add.lo
+2025-07-30T13:54:30.0574099Z   CC       depends/relic/src/ed/librelic_la-relic_ed_cmp.lo
+2025-07-30T13:54:30.2309850Z   CC       depends/relic/src/ed/librelic_la-relic_ed_curve.lo
+2025-07-30T13:54:30.3998401Z   CC       depends/relic/src/ed/librelic_la-relic_ed_dbl.lo
+2025-07-30T13:54:30.5637874Z   CC       depends/relic/src/ed/librelic_la-relic_ed_map.lo
+2025-07-30T13:54:30.7414131Z   CC       depends/relic/src/ed/librelic_la-relic_ed_mul.lo
+2025-07-30T13:54:30.9689324Z   CC       depends/relic/src/ed/librelic_la-relic_ed_mul_fix.lo
+2025-07-30T13:54:31.2389305Z   CC       depends/relic/src/ed/librelic_la-relic_ed_mul_sim.lo
+2025-07-30T13:54:31.4970055Z   CC       depends/relic/src/ed/librelic_la-relic_ed_neg.lo
+2025-07-30T13:54:31.5523126Z   CC       depends/relic/src/ed/librelic_la-relic_ed_norm.lo
+2025-07-30T13:54:31.6501084Z   CXX      test/fuzz/fuzz-crypto_aes256.o
+2025-07-30T13:54:31.7383323Z   CC       depends/relic/src/ed/librelic_la-relic_ed_param.lo
+2025-07-30T13:54:31.9262412Z   CC       depends/relic/src/ed/librelic_la-relic_ed_pck.lo
+2025-07-30T13:54:32.1036862Z   CC       depends/relic/src/ed/librelic_la-relic_ed_util.lo
+2025-07-30T13:54:32.3243340Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k2.lo
+2025-07-30T13:54:32.4969032Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k8.lo
+2025-07-30T13:54:32.6837225Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k12.lo
+2025-07-30T13:54:32.8839492Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k24.lo
+2025-07-30T13:54:33.0618436Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k48.lo
+2025-07-30T13:54:33.2553775Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k54.lo
+2025-07-30T13:54:33.4494795Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k2.lo
+2025-07-30T13:54:33.6434155Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k8.lo
+2025-07-30T13:54:33.8589187Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k12.lo
+2025-07-30T13:54:34.0698803Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k24.lo
+2025-07-30T13:54:34.1846070Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k48.lo
+2025-07-30T13:54:34.2472197Z   CXX      test/fuzz/fuzz-crypto_aes256cbc.o
+2025-07-30T13:54:34.3702221Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k54.lo
+2025-07-30T13:54:34.5596492Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k2.lo
+2025-07-30T13:54:34.7313979Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k8.lo
+2025-07-30T13:54:34.9120239Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k12.lo
+2025-07-30T13:54:35.0975783Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k24.lo
+2025-07-30T13:54:35.2776841Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k48.lo
+2025-07-30T13:54:35.4634758Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k54.lo
+2025-07-30T13:54:35.6623592Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map.lo
+2025-07-30T13:54:35.8349564Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k2.lo
+2025-07-30T13:54:36.0629727Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k8.lo
+2025-07-30T13:54:36.2422451Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k12.lo
+2025-07-30T13:54:36.4865672Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k24.lo
+2025-07-30T13:54:36.5631179Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k48.lo
+2025-07-30T13:54:36.6887763Z   CXX      test/fuzz/fuzz-crypto_chacha20.o
+2025-07-30T13:54:36.7393257Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k54.lo
+2025-07-30T13:54:36.9448487Z   CC       depends/relic/src/pp/librelic_la-relic_pp_norm.lo
+2025-07-30T13:54:37.1279397Z   CC       depends/relic/src/pc/librelic_la-relic_pc_core.lo
+2025-07-30T13:54:37.3068317Z   CC       depends/relic/src/pc/librelic_la-relic_pc_exp.lo
+2025-07-30T13:54:37.5092931Z   CC       depends/relic/src/pc/librelic_la-relic_pc_util.lo
+2025-07-30T13:54:37.7182580Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bbs.lo
+2025-07-30T13:54:37.9601142Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bdpe.lo
+2025-07-30T13:54:38.2172583Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bgn.lo
+2025-07-30T13:54:38.4996061Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bls.lo
+2025-07-30T13:54:38.7361034Z   CC       depends/relic/src/cp/librelic_la-relic_cp_cls.lo
+2025-07-30T13:54:39.0463837Z   CC       depends/relic/src/cp/librelic_la-relic_cp_cmlhs.lo
+2025-07-30T13:54:39.1453222Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecdh.lo
+2025-07-30T13:54:39.3543362Z   CXX      test/fuzz/fuzz-crypto_common.o
+2025-07-30T13:54:39.3874072Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecdsa.lo
+2025-07-30T13:54:39.6439117Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecies.lo
+2025-07-30T13:54:39.8988665Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecmqv.lo
+2025-07-30T13:54:40.1442055Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecss.lo
+2025-07-30T13:54:40.4112731Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ers.lo
+2025-07-30T13:54:40.6746755Z   CC       depends/relic/src/cp/librelic_la-relic_cp_etrs.lo
+2025-07-30T13:54:41.0060325Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ghpe.lo
+2025-07-30T13:54:41.2540382Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ibe.lo
+2025-07-30T13:54:41.5273679Z   CC       depends/relic/src/cp/librelic_la-relic_cp_mklhs.lo
+2025-07-30T13:54:41.8483275Z   CC       depends/relic/src/cp/librelic_la-relic_cp_mpss.lo
+2025-07-30T13:54:42.0340685Z   CC       depends/relic/src/cp/librelic_la-relic_cp_pcdel.lo
+2025-07-30T13:54:42.1511738Z   CXX      test/fuzz/fuzz-crypto_diff_fuzz_chacha20.o
+2025-07-30T13:54:42.3199551Z   CC       depends/relic/src/cp/librelic_la-relic_cp_phpe.lo
+2025-07-30T13:54:42.5781526Z   CC       depends/relic/src/cp/librelic_la-relic_cp_pok.lo
+2025-07-30T13:54:42.8465086Z   CC       depends/relic/src/cp/librelic_la-relic_cp_pss.lo
+2025-07-30T13:54:43.1057823Z   CC       depends/relic/src/cp/librelic_la-relic_cp_rabin.lo
+2025-07-30T13:54:43.3709744Z   CC       depends/relic/src/cp/librelic_la-relic_cp_rsa.lo
+2025-07-30T13:54:43.7071015Z   CC       depends/relic/src/cp/librelic_la-relic_cp_sok.lo
+2025-07-30T13:54:43.9563028Z   CC       depends/relic/src/cp/librelic_la-relic_cp_sokaka.lo
+2025-07-30T13:54:44.1940655Z   CC       depends/relic/src/cp/librelic_la-relic_cp_vbnn.lo
+2025-07-30T13:54:44.4386611Z   CC       depends/relic/src/cp/librelic_la-relic_cp_zss.lo
+2025-07-30T13:54:44.6844139Z   CC       depends/relic/src/bc/librelic_la-relic_bc_aes.lo
+2025-07-30T13:54:44.8024841Z   CC       depends/relic/src/bc/librelic_la-rijndael-alg-fst.lo
+2025-07-30T13:54:44.8663751Z   CXX      test/fuzz/fuzz-crypto_hkdf_hmac_sha256_l32.o
+2025-07-30T13:54:45.0527875Z   CC       depends/relic/src/bc/librelic_la-rijndael-api-fst.lo
+2025-07-30T13:54:45.3378922Z   CC       depends/relic/src/md/librelic_la-blake2s-ref.lo
+2025-07-30T13:54:45.7841588Z   CC       depends/relic/src/md/librelic_la-relic_md_blake2s.lo
+2025-07-30T13:54:45.9582975Z   CC       depends/relic/src/md/librelic_la-relic_md_hmac.lo
+2025-07-30T13:54:46.1391638Z   CC       depends/relic/src/md/librelic_la-relic_md_kdf.lo
+2025-07-30T13:54:46.3145047Z   CC       depends/relic/src/md/librelic_la-relic_md_mgf.lo
+2025-07-30T13:54:46.4827094Z   CC       depends/relic/src/md/librelic_la-relic_md_sha224.lo
+2025-07-30T13:54:46.6545001Z   CC       depends/relic/src/md/librelic_la-relic_md_sha256.lo
+2025-07-30T13:54:46.8253537Z   CC       depends/relic/src/md/librelic_la-relic_md_sha384.lo
+2025-07-30T13:54:46.8653911Z   CXX      test/fuzz/fuzz-crypto_poly1305.o
+2025-07-30T13:54:46.9826197Z   CC       depends/relic/src/md/librelic_la-relic_md_sha512.lo
+2025-07-30T13:54:47.1579732Z   CC       depends/relic/src/md/librelic_la-relic_md_xmd.lo
+2025-07-30T13:54:47.4306892Z   CC       depends/relic/src/md/librelic_la-sha224-256.lo
+2025-07-30T13:54:47.6229858Z   CC       depends/relic/src/md/librelic_la-sha384-512.lo
+2025-07-30T13:54:47.8613563Z   CC       depends/relic/src/mpc/librelic_la-relic_mt_mpc.lo
+2025-07-30T13:54:48.0454872Z   CC       depends/relic/src/mpc/librelic_la-relic_pc_mpc.lo
+2025-07-30T13:54:48.2580199Z   CCLD     libmimalloc-secure.la
+2025-07-30T13:54:48.5585317Z   CCLD     librelic.la
+2025-07-30T13:54:51.1304605Z   CXXLD    libdashbls.la
+2025-07-30T13:54:51.1377279Z   CXX      test/fuzz/fuzz-cuckoocache.o
+2025-07-30T13:54:52.3562505Z   CXX      test/fuzz/fuzz-decode_tx.o
+2025-07-30T13:54:52.8266100Z   CXXLD    runtest
+2025-07-30T13:54:53.3106784Z   CXXLD    runbench
+2025-07-30T13:54:53.7339542Z make[3]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src/dashbls'
+2025-07-30T13:54:53.7366510Z   CXX      test/fuzz/fuzz-descriptor_parse.o
+2025-07-30T13:54:54.7000448Z   CXX      test/fuzz/fuzz-deserialize.o
+2025-07-30T13:54:54.8037004Z   CXX      test/fuzz/fuzz-eval_script.o
+2025-07-30T13:54:57.2612665Z   CXX      test/fuzz/fuzz-fee_rate.o
+2025-07-30T13:54:58.4531034Z   CXX      test/fuzz/fuzz-fees.o
+2025-07-30T13:54:59.5286837Z   CXX      test/fuzz/fuzz-flatfile.o
+2025-07-30T13:55:04.5591619Z   CXX      test/fuzz/fuzz-float.o
+2025-07-30T13:55:05.7095311Z   CXX      test/fuzz/fuzz-golomb_rice.o
+2025-07-30T13:55:07.2932521Z   CXX      test/fuzz/fuzz-hex.o
+2025-07-30T13:55:11.8467574Z   CXX      test/fuzz/fuzz-http_request.o
+2025-07-30T13:55:12.0407279Z   CXX      test/fuzz/fuzz-integer.o
+2025-07-30T13:55:15.2642332Z   CXX      test/fuzz/fuzz-key.o
+2025-07-30T13:55:19.1248457Z   CXX      test/fuzz/fuzz-key_io.o
+2025-07-30T13:55:23.2606234Z   CXX      test/fuzz/fuzz-kitchen_sink.o
+2025-07-30T13:55:23.4293706Z   CXX      test/fuzz/fuzz-load_external_block_file.o
+2025-07-30T13:55:23.6784173Z   CXX      test/fuzz/fuzz-locale.o
+2025-07-30T13:55:25.6290269Z   CXX      test/fuzz/fuzz-merkleblock.o
+2025-07-30T13:55:29.7532354Z   CXX      test/fuzz/fuzz-message.o
+2025-07-30T13:55:31.0906696Z   CXX      test/fuzz/fuzz-minisketch.o
+2025-07-30T13:55:31.3611288Z   CXX      test/fuzz/fuzz-muhash.o
+2025-07-30T13:55:36.7919402Z   CXX      test/fuzz/fuzz-multiplication_overflow.o
+2025-07-30T13:55:37.2832033Z   CXX      test/fuzz/fuzz-net.o
+2025-07-30T13:55:39.0012840Z   CXX      test/fuzz/fuzz-net_permissions.o
+2025-07-30T13:55:39.4466800Z   CXX      test/fuzz/fuzz-netaddress.o
+2025-07-30T13:55:43.0385003Z   CXX      test/fuzz/fuzz-netbase_dns_lookup.o
+2025-07-30T13:55:44.3796136Z   CXX      test/fuzz/fuzz-node_eviction.o
+2025-07-30T13:55:46.7036182Z   CXX      test/fuzz/fuzz-p2p_transport_serialization.o
+2025-07-30T13:55:47.2862062Z   CXX      test/fuzz/fuzz-parse_hd_keypath.o
+2025-07-30T13:55:48.1147987Z   CXX      test/fuzz/fuzz-parse_iso8601.o
+2025-07-30T13:55:51.0445073Z   CXX      test/fuzz/fuzz-parse_numbers.o
+2025-07-30T13:55:52.0943631Z   CXX      test/fuzz/fuzz-parse_script.o
+2025-07-30T13:55:53.1704298Z   CXX      test/fuzz/fuzz-parse_univalue.o
+2025-07-30T13:55:54.1210290Z   CXX      test/fuzz/fuzz-policy_estimator.o
+2025-07-30T13:55:54.8615377Z   CXX      test/fuzz/fuzz-policy_estimator_io.o
+2025-07-30T13:55:58.2809047Z   CXX      test/fuzz/fuzz-poolresource.o
+2025-07-30T13:55:59.6288369Z   CXX      test/fuzz/fuzz-pow.o
+2025-07-30T13:56:02.5604414Z   CXX      test/fuzz/fuzz-prevector.o
+2025-07-30T13:56:04.6376699Z   CXX      test/fuzz/fuzz-primitives_transaction.o
+2025-07-30T13:56:07.5427338Z   CXX      test/fuzz/fuzz-process_message.o
+2025-07-30T13:56:08.4409744Z   CXX      test/fuzz/fuzz-process_messages.o
+2025-07-30T13:56:12.8616011Z   CXX      test/fuzz/fuzz-protocol.o
+2025-07-30T13:56:13.9803597Z   CXX      test/fuzz/fuzz-psbt.o
+2025-07-30T13:56:18.2515476Z   CXX      test/fuzz/fuzz-random.o
+2025-07-30T13:56:18.4799549Z   CXX      test/fuzz/fuzz-rolling_bloom_filter.o
+2025-07-30T13:56:20.6759637Z   CXX      test/fuzz/fuzz-rpc.o
+2025-07-30T13:56:23.6464906Z   CXX      test/fuzz/fuzz-script.o
+2025-07-30T13:56:25.9725870Z   CXX      test/fuzz/fuzz-script_bitcoin_consensus.o
+2025-07-30T13:56:26.2795008Z   CXX      test/fuzz/fuzz-script_descriptor_cache.o
+2025-07-30T13:56:33.6112942Z   CXX      test/fuzz/fuzz-script_flags.o
+2025-07-30T13:56:33.8712683Z   CXX      test/fuzz/fuzz-script_format.o
+2025-07-30T13:56:33.9046805Z   CXX      test/fuzz/fuzz-script_interpreter.o
+2025-07-30T13:56:37.6664620Z   CXX      test/fuzz/fuzz-script_ops.o
+2025-07-30T13:56:41.3252122Z   CXX      test/fuzz/fuzz-script_sigcache.o
+2025-07-30T13:56:42.4902214Z   CXX      test/fuzz/fuzz-script_sign.o
+2025-07-30T13:56:45.4922354Z   CXX      test/fuzz/fuzz-scriptnum_ops.o
+2025-07-30T13:56:46.0334246Z   CXX      test/fuzz/fuzz-secp256k1_ec_seckey_import_export_der.o
+2025-07-30T13:56:50.9504318Z   CXX      test/fuzz/fuzz-secp256k1_ecdsa_signature_parse_der_lax.o
+2025-07-30T13:56:53.0578931Z   CXX      test/fuzz/fuzz-signature_checker.o
+2025-07-30T13:56:53.5642732Z   CXX      test/fuzz/fuzz-socks5.o
+2025-07-30T13:56:56.9649974Z   CXX      test/fuzz/fuzz-span.o
+2025-07-30T13:56:58.6101805Z   CXX      test/fuzz/fuzz-spanparsing.o
+2025-07-30T13:57:00.1826862Z   CXX      test/fuzz/fuzz-string.o
+2025-07-30T13:57:00.8872949Z   CXX      test/fuzz/fuzz-strprintf.o
+2025-07-30T13:57:01.3102420Z   CXX      test/fuzz/fuzz-system.o
+2025-07-30T13:57:04.4403864Z   CXX      test/fuzz/fuzz-timedata.o
+2025-07-30T13:57:10.2272761Z   CXX      test/fuzz/fuzz-torcontrol.o
+2025-07-30T13:57:10.4328806Z   CXX      test/fuzz/fuzz-transaction.o
+2025-07-30T13:57:11.3798955Z   CXX      test/fuzz/fuzz-tx_in.o
+2025-07-30T13:57:12.4267824Z   CXX      test/fuzz/fuzz-tx_out.o
+2025-07-30T13:57:14.1180730Z   CXX      test/fuzz/fuzz-tx_pool.o
+2025-07-30T13:57:15.1904506Z   CXX      test/fuzz/fuzz-utxo_snapshot.o
+2025-07-30T13:57:18.3340292Z   CXX      test/fuzz/fuzz-validation_load_mempool.o
+2025-07-30T13:57:18.7611442Z   CXX      test/fuzz/fuzz-versionbits.o
+2025-07-30T13:57:24.4839175Z   CXX      test/fuzz/libtest_fuzz_a-fuzz.o
+2025-07-30T13:57:27.3840041Z   CXX      test/util/libtest_fuzz_a-mining.o
+2025-07-30T13:57:27.5732597Z   CXX      test/fuzz/libtest_fuzz_a-util.o
+2025-07-30T13:57:28.9889132Z   CXX      test/fuzz/util/libtest_fuzz_a-net.o
+2025-07-30T13:57:31.9386586Z test/fuzz/util/net.cpp:55:32: error: use of undeclared identifier 'PROTOCOL_VERSION'
+2025-07-30T13:57:31.9417799Z    55 |     CDataStream s(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
+2025-07-30T13:57:31.9418485Z       |                                ^
+2025-07-30T13:57:32.0655523Z   CXX      test/util/libtest_util_a-blockfilter.o
+2025-07-30T13:57:32.4947177Z 1 error generated.
+2025-07-30T13:57:32.5125645Z make[2]: *** [Makefile:13257: test/fuzz/util/libtest_fuzz_a-net.o] Error 1
+2025-07-30T13:57:32.5126696Z make[2]: *** Waiting for unfinished jobs....
+2025-07-30T13:57:37.5531994Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:57:37.5540690Z make[1]: *** [Makefile:20633: install-recursive] Error 1
+2025-07-30T13:57:37.5542010Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:57:37.5549965Z make: *** [Makefile:788: install-recursive] Error 1
+2025-07-30T13:57:37.5555293Z Build failure. Verbose build follows.
+2025-07-30T13:57:37.5619494Z Making install in src
+2025-07-30T13:57:37.5839787Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:57:37.6118641Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:57:37.6127809Z clang++-18 -ftrivial-auto-var-init=pattern -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -DABORT_ON_FAILED_ASSUME -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ -DDEBUG_LOCKORDER -DARENA_DEBUG -g1 -fno-omit-frame-pointer -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wgnu -Wformat -Wformat-security -Wreorder -Wvla -Wshadow-field -Wthread-safety -Wloop-analysis -Wredundant-decls -Wunused-member-function -Wdate-time -Wconditional-uninitialized -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wdocumentation -Wself-assign -Wno-unused-parameter -Werror  -fsanitize=fuzzer,address,undefined,integer  -fPIE -pipe -std=c++20 -O2  -c -o test/fuzz/util/libtest_fuzz_a-net.o `test -f 'test/fuzz/util/net.cpp' || echo './'`test/fuzz/util/net.cpp
+2025-07-30T13:57:39.2318673Z test/fuzz/util/net.cpp:55:32: error: use of undeclared identifier 'PROTOCOL_VERSION'
+2025-07-30T13:57:39.2320190Z    55 |     CDataStream s(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
+2025-07-30T13:57:39.2324271Z       |                                ^
+2025-07-30T13:57:39.5570706Z 1 error generated.
+2025-07-30T13:57:39.5700022Z make[2]: *** [Makefile:13257: test/fuzz/util/libtest_fuzz_a-net.o] Error 1
+2025-07-30T13:57:39.5701251Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:57:39.5710438Z make[1]: *** [Makefile:20633: install-recursive] Error 1
+2025-07-30T13:57:39.5711974Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_fuzz/src'
+2025-07-30T13:57:39.5723741Z make: *** [Makefile:788: install-recursive] Error 1
+2025-07-30T13:57:39.5785726Z ##[error]Process completed with exit code 2.
+2025-07-30T13:57:39.5875429Z Post job cleanup.
+2025-07-30T13:57:39.5879537Z ##[command]/usr/bin/docker exec  2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T13:57:39.7919292Z [command]/usr/bin/git version
+2025-07-30T13:57:39.7958753Z git version 2.43.0
+2025-07-30T13:57:39.7999368Z Copying '/github/home/.gitconfig' to '/__w/_temp/5fb6b5fa-aea9-4a6b-9e92-246d512b6d41/.gitconfig'
+2025-07-30T13:57:39.8011325Z Temporarily overriding HOME='/__w/_temp/5fb6b5fa-aea9-4a6b-9e92-246d512b6d41' before making global git config changes
+2025-07-30T13:57:39.8013803Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-30T13:57:39.8018047Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-30T13:57:39.8053030Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-30T13:57:39.8090149Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-30T13:57:39.8317972Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-30T13:57:39.8338432Z http.https://github.com/.extraheader
+2025-07-30T13:57:39.8352081Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-07-30T13:57:39.8387694Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-30T13:57:39.8724252Z Stop and remove container: e629db8815984cbf9985d15319787204_ghcriodashcoreautoguixdashdashcorecirunnerbackport027batch556pr26859_57af2c
+2025-07-30T13:57:39.8728780Z ##[command]/usr/bin/docker rm --force 2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926
+2025-07-30T13:57:39.9769534Z 2bdf0fcdc98021233f9179f904e922480ebb98b85c53473614d7f79d177b3926
+2025-07-30T13:57:39.9809256Z Remove container network: github_network_f14c4402ce2947a5be80f529f4c1bca9
+2025-07-30T13:57:39.9815658Z ##[command]/usr/bin/docker network rm github_network_f14c4402ce2947a5be80f529f4c1bca9
+2025-07-30T13:57:40.0861496Z github_network_f14c4402ce2947a5be80f529f4c1bca9
+2025-07-30T13:57:40.0925606Z Evaluate and set job outputs
+2025-07-30T13:57:40.0930786Z Cleaning up orphan processes

--- a/linux64_nowallet_logs.txt
+++ b/linux64_nowallet_logs.txt
@@ -1,0 +1,3496 @@
+﻿2025-07-30T13:46:38.0423944Z Current runner version: '2.327.1'
+2025-07-30T13:46:38.0457349Z ##[group]Runner Image Provisioner
+2025-07-30T13:46:38.0458926Z Hosted Compute Agent
+2025-07-30T13:46:38.0459815Z Version: 20250711.363
+2025-07-30T13:46:38.0460678Z Commit: 6785254374ce925a23743850c1cb91912ce5c14c
+2025-07-30T13:46:38.0461951Z Build Date: 2025-07-11T20:04:25Z
+2025-07-30T13:46:38.0462887Z ##[endgroup]
+2025-07-30T13:46:38.0463672Z ##[group]Operating System
+2025-07-30T13:46:38.0464501Z Ubuntu
+2025-07-30T13:46:38.0465366Z 24.04.2
+2025-07-30T13:46:38.0466058Z LTS
+2025-07-30T13:46:38.0466870Z ##[endgroup]
+2025-07-30T13:46:38.0467915Z ##[group]Runner Image
+2025-07-30T13:46:38.0468803Z Image: ubuntu-24.04
+2025-07-30T13:46:38.0469680Z Version: 20250728.1.0
+2025-07-30T13:46:38.0471344Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250728.1/images/ubuntu/Ubuntu2404-Readme.md
+2025-07-30T13:46:38.0473908Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250728.1
+2025-07-30T13:46:38.0475704Z ##[endgroup]
+2025-07-30T13:46:38.0478178Z ##[group]GITHUB_TOKEN Permissions
+2025-07-30T13:46:38.0480987Z Contents: read
+2025-07-30T13:46:38.0481799Z Metadata: read
+2025-07-30T13:46:38.0482674Z Packages: write
+2025-07-30T13:46:38.0483413Z ##[endgroup]
+2025-07-30T13:46:38.0486634Z Secret source: Actions
+2025-07-30T13:46:38.0488522Z Prepare workflow directory
+2025-07-30T13:46:38.1207028Z Prepare all required actions
+2025-07-30T13:46:38.1246662Z Getting action download info
+2025-07-30T13:46:38.3657914Z ##[group]Download immutable action package 'actions/checkout@v4'
+2025-07-30T13:46:38.3658959Z Version: 4.2.2
+2025-07-30T13:46:38.3659938Z Digest: sha256:ccb2698953eaebd21c7bf6268a94f9c26518a7e38e27e0b83c1fe1ad049819b1
+2025-07-30T13:46:38.3661124Z Source commit SHA: 11bd71901bbe5b1630ceea73d27597364c9af683
+2025-07-30T13:46:38.3661867Z ##[endgroup]
+2025-07-30T13:46:38.4592128Z ##[group]Download immutable action package 'actions/cache@v4'
+2025-07-30T13:46:38.4592978Z Version: 4.2.3
+2025-07-30T13:46:38.4593785Z Digest: sha256:c8a3bb963e1f1826d8fcc8d1354f0dd29d8ac1db1d4f6f20247055ae11b81ed9
+2025-07-30T13:46:38.4594707Z Source commit SHA: 5a3ec84eff668545956fd18022155c47e93e2684
+2025-07-30T13:46:38.4595438Z ##[endgroup]
+2025-07-30T13:46:38.6317457Z ##[group]Download immutable action package 'actions/upload-artifact@v4'
+2025-07-30T13:46:38.6318590Z Version: 4.6.2
+2025-07-30T13:46:38.6319315Z Digest: sha256:290722aa3281d5caf23d0acdc3dbeb3424786a1a01a9cc97e72f147225e37c38
+2025-07-30T13:46:38.6320245Z Source commit SHA: ea165f8d65b6e75b540449e92b4886f43607fa02
+2025-07-30T13:46:38.6320978Z ##[endgroup]
+2025-07-30T13:46:38.8421492Z Uses: DashCoreAutoGuix/dash/.github/workflows/build-src.yml@refs/heads/backport-0.27-batch-556-pr-26859 (3edf8361bf6a05778eab7a21802074376a229653)
+2025-07-30T13:46:38.8426293Z ##[group] Inputs
+2025-07-30T13:46:38.8426813Z   build-target: linux64_nowallet
+2025-07-30T13:46:38.8427970Z   container-path: ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:46:38.8430235Z   depends-key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64_nowallet-6406e557d92eb8207c3eec3f6232e2e934591164c8dd13cf2cf4f108b4c6f462-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:46:38.8432083Z ##[endgroup]
+2025-07-30T13:46:38.8432570Z Complete job name: linux64_nowallet-build / Build source
+2025-07-30T13:46:38.8934769Z ##[group]Checking docker version
+2025-07-30T13:46:38.8948583Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2025-07-30T13:46:38.9693252Z '1.48'
+2025-07-30T13:46:38.9704608Z Docker daemon API version: '1.48'
+2025-07-30T13:46:38.9705430Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2025-07-30T13:46:38.9871654Z '1.48'
+2025-07-30T13:46:38.9884706Z Docker client API version: '1.48'
+2025-07-30T13:46:38.9890869Z ##[endgroup]
+2025-07-30T13:46:38.9894598Z ##[group]Clean up resources from previous jobs
+2025-07-30T13:46:38.9900661Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=643634"
+2025-07-30T13:46:39.0060410Z ##[command]/usr/bin/docker network prune --force --filter "label=643634"
+2025-07-30T13:46:39.0209031Z ##[endgroup]
+2025-07-30T13:46:39.0209550Z ##[group]Create local container network
+2025-07-30T13:46:39.0220094Z ##[command]/usr/bin/docker network create --label 643634 github_network_9ade282e830c415fb855ca0a07641eca
+2025-07-30T13:46:39.0822320Z 5e531eb5521410d672ffb0519eac2a48dfa1bbc85d69dc6c374e16df04c31936
+2025-07-30T13:46:39.0845564Z ##[endgroup]
+2025-07-30T13:46:39.0881550Z ##[group]Starting job container
+2025-07-30T13:46:39.0914068Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_41266219-9b55-40a4-be9a-6f1370cc1025 login ghcr.io -u DashCoreAutoGuix --password-stdin
+2025-07-30T13:46:39.7432990Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_41266219-9b55-40a4-be9a-6f1370cc1025 pull ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:46:40.5841356Z backport-0.27-batch-556-pr-26859: Pulling from dashcoreautoguix/dash/dashcore-ci-runner
+2025-07-30T13:46:40.7094578Z 32f112e3802c: Pulling fs layer
+2025-07-30T13:46:40.7095466Z 3c418bbf5534: Pulling fs layer
+2025-07-30T13:46:40.7096053Z 824b5144f7af: Pulling fs layer
+2025-07-30T13:46:40.7096662Z bb9f5c709011: Pulling fs layer
+2025-07-30T13:46:40.7097284Z c31b5eed60b6: Pulling fs layer
+2025-07-30T13:46:40.7098121Z da96180e845f: Pulling fs layer
+2025-07-30T13:46:40.7098722Z f28d6a4cf5de: Pulling fs layer
+2025-07-30T13:46:40.7099376Z 49cbdb9e902d: Pulling fs layer
+2025-07-30T13:46:40.7099947Z 247fd41058fa: Pulling fs layer
+2025-07-30T13:46:40.7100499Z d6a01b6e446c: Pulling fs layer
+2025-07-30T13:46:40.7101134Z 4f4fb700ef54: Pulling fs layer
+2025-07-30T13:46:40.7101684Z 1382f2390a1c: Pulling fs layer
+2025-07-30T13:46:40.7102239Z be38403a389e: Pulling fs layer
+2025-07-30T13:46:40.7102822Z 409781d99354: Pulling fs layer
+2025-07-30T13:46:40.7103369Z c418b82685d0: Pulling fs layer
+2025-07-30T13:46:40.7103912Z 247fd41058fa: Waiting
+2025-07-30T13:46:40.7104442Z d6a01b6e446c: Waiting
+2025-07-30T13:46:40.7104966Z 4f4fb700ef54: Waiting
+2025-07-30T13:46:40.7105512Z be38403a389e: Waiting
+2025-07-30T13:46:40.7106330Z c418b82685d0: Waiting
+2025-07-30T13:46:40.7107147Z bb9f5c709011: Waiting
+2025-07-30T13:46:40.7108032Z 409781d99354: Waiting
+2025-07-30T13:46:40.7108550Z c31b5eed60b6: Waiting
+2025-07-30T13:46:40.7109075Z 49cbdb9e902d: Waiting
+2025-07-30T13:46:40.7109573Z f28d6a4cf5de: Waiting
+2025-07-30T13:46:40.7110085Z 1382f2390a1c: Waiting
+2025-07-30T13:46:40.8307543Z 3c418bbf5534: Verifying Checksum
+2025-07-30T13:46:40.8309904Z 3c418bbf5534: Download complete
+2025-07-30T13:46:40.8426087Z 824b5144f7af: Verifying Checksum
+2025-07-30T13:46:40.8426581Z 824b5144f7af: Download complete
+2025-07-30T13:46:40.9265879Z 32f112e3802c: Verifying Checksum
+2025-07-30T13:46:40.9266419Z 32f112e3802c: Download complete
+2025-07-30T13:46:41.1583463Z c31b5eed60b6: Verifying Checksum
+2025-07-30T13:46:41.1584004Z c31b5eed60b6: Download complete
+2025-07-30T13:46:41.2630699Z f28d6a4cf5de: Verifying Checksum
+2025-07-30T13:46:41.2636927Z f28d6a4cf5de: Download complete
+2025-07-30T13:46:41.3532172Z da96180e845f: Verifying Checksum
+2025-07-30T13:46:41.3533738Z da96180e845f: Download complete
+2025-07-30T13:46:41.4337229Z bb9f5c709011: Verifying Checksum
+2025-07-30T13:46:41.4338131Z bb9f5c709011: Download complete
+2025-07-30T13:46:41.5186704Z 49cbdb9e902d: Verifying Checksum
+2025-07-30T13:46:41.5187333Z 49cbdb9e902d: Download complete
+2025-07-30T13:46:41.5303354Z d6a01b6e446c: Verifying Checksum
+2025-07-30T13:46:41.5303878Z d6a01b6e446c: Download complete
+2025-07-30T13:46:41.8316906Z 4f4fb700ef54: Verifying Checksum
+2025-07-30T13:46:41.8321152Z 4f4fb700ef54: Download complete
+2025-07-30T13:46:42.2948377Z 32f112e3802c: Pull complete
+2025-07-30T13:46:42.4085631Z 247fd41058fa: Verifying Checksum
+2025-07-30T13:46:42.4086804Z 247fd41058fa: Download complete
+2025-07-30T13:46:42.6489119Z 409781d99354: Verifying Checksum
+2025-07-30T13:46:42.6489854Z 409781d99354: Download complete
+2025-07-30T13:46:42.8434141Z c418b82685d0: Verifying Checksum
+2025-07-30T13:46:42.8434772Z c418b82685d0: Download complete
+2025-07-30T13:46:43.0143569Z be38403a389e: Verifying Checksum
+2025-07-30T13:46:43.0144104Z be38403a389e: Download complete
+2025-07-30T13:46:43.9117374Z 1382f2390a1c: Verifying Checksum
+2025-07-30T13:46:43.9118159Z 1382f2390a1c: Download complete
+2025-07-30T13:46:44.7365259Z 3c418bbf5534: Pull complete
+2025-07-30T13:46:45.5364946Z 824b5144f7af: Pull complete
+2025-07-30T13:46:49.7303263Z bb9f5c709011: Pull complete
+2025-07-30T13:46:53.3523897Z c31b5eed60b6: Pull complete
+2025-07-30T13:46:54.3949443Z da96180e845f: Pull complete
+2025-07-30T13:46:54.4488796Z f28d6a4cf5de: Pull complete
+2025-07-30T13:46:54.4915231Z 49cbdb9e902d: Pull complete
+2025-07-30T13:47:00.5472027Z 247fd41058fa: Pull complete
+2025-07-30T13:47:00.5676395Z d6a01b6e446c: Pull complete
+2025-07-30T13:47:00.5790438Z 4f4fb700ef54: Pull complete
+2025-07-30T13:47:16.2442943Z 1382f2390a1c: Pull complete
+2025-07-30T13:47:20.1411190Z be38403a389e: Pull complete
+2025-07-30T13:47:20.2380905Z 409781d99354: Pull complete
+2025-07-30T13:47:20.2485552Z c418b82685d0: Pull complete
+2025-07-30T13:47:20.2528107Z Digest: sha256:cb77d7b2020ec7db2823fc4528c92549266d05db97a83ceb6c2a222660fd2915
+2025-07-30T13:47:20.2542354Z Status: Downloaded newer image for ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:47:20.2555631Z ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859
+2025-07-30T13:47:20.2644516Z ##[command]/usr/bin/docker create --name 4666d9babae14c91ae729dba7059fae0_ghcriodashcoreautoguixdashdashcorecirunnerbackport027batch556pr26859_20564f --label 643634 --workdir /__w/dash/dash --network github_network_9ade282e830c415fb855ca0a07641eca --user root -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" -v "/home/runner/actions-runner/cached/externals":"/__e":ro -v "/home/runner/work/_temp":"/__w/_temp" -v "/home/runner/work/_actions":"/__w/_actions" -v "/opt/hostedtoolcache":"/__t" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" ghcr.io/dashcoreautoguix/dash/dashcore-ci-runner:backport-0.27-batch-556-pr-26859 "-f" "/dev/null"
+2025-07-30T13:47:20.2902617Z a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5
+2025-07-30T13:47:20.2928262Z ##[command]/usr/bin/docker start a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5
+2025-07-30T13:47:20.4891550Z a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5
+2025-07-30T13:47:20.4910883Z ##[command]/usr/bin/docker ps --all --filter id=a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5 --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2025-07-30T13:47:20.5040127Z a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5 Up Less than a second
+2025-07-30T13:47:20.5060611Z ##[command]/usr/bin/docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5
+2025-07-30T13:47:20.5194840Z HOME=/github/home
+2025-07-30T13:47:20.5195290Z GITHUB_ACTIONS=true
+2025-07-30T13:47:20.5195572Z CI=true
+2025-07-30T13:47:20.5196975Z PATH=/opt/shellcheck:/usr/local/pyenv/shims:/usr/local/pyenv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+2025-07-30T13:47:20.5198354Z DEBIAN_FRONTEND=noninteractive
+2025-07-30T13:47:20.5198738Z TZ=Europe/London
+2025-07-30T13:47:20.5199137Z APT_ARGS=-y --no-install-recommends --no-upgrade
+2025-07-30T13:47:20.5199659Z PYENV_ROOT=/usr/local/pyenv
+2025-07-30T13:47:20.5200042Z LD_LIBRARY_PATH=/usr/lib/llvm-18/lib
+2025-07-30T13:47:20.5220721Z ##[endgroup]
+2025-07-30T13:47:20.5230238Z ##[group]Waiting for all services to be ready
+2025-07-30T13:47:20.5231792Z ##[endgroup]
+2025-07-30T13:47:20.5470139Z ##[group]Run actions/checkout@v4
+2025-07-30T13:47:20.5470733Z with:
+2025-07-30T13:47:20.5471151Z   fetch-depth: 50
+2025-07-30T13:47:20.5471355Z   repository: DashCoreAutoGuix/dash
+2025-07-30T13:47:20.5471818Z   token: ***
+2025-07-30T13:47:20.5472001Z   ssh-strict: true
+2025-07-30T13:47:20.5472174Z   ssh-user: git
+2025-07-30T13:47:20.5546692Z   persist-credentials: true
+2025-07-30T13:47:20.5546992Z   clean: true
+2025-07-30T13:47:20.5547196Z   sparse-checkout-cone-mode: true
+2025-07-30T13:47:20.5547434Z   fetch-tags: false
+2025-07-30T13:47:20.5547908Z   show-progress: true
+2025-07-30T13:47:20.5548191Z   lfs: false
+2025-07-30T13:47:20.5548368Z   submodules: false
+2025-07-30T13:47:20.5548548Z   set-safe-directory: true
+2025-07-30T13:47:20.5549740Z ##[endgroup]
+2025-07-30T13:47:20.5613058Z ##[command]/usr/bin/docker exec  a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T13:47:20.7798015Z Syncing repository: DashCoreAutoGuix/dash
+2025-07-30T13:47:20.7799490Z ##[group]Getting Git version info
+2025-07-30T13:47:20.7799888Z Working directory is '/__w/dash/dash'
+2025-07-30T13:47:20.7800502Z [command]/usr/bin/git version
+2025-07-30T13:47:20.7800910Z git version 2.43.0
+2025-07-30T13:47:20.7825728Z ##[endgroup]
+2025-07-30T13:47:20.7842552Z Temporarily overriding HOME='/__w/_temp/94bfc343-32d0-4bab-9ef0-fe24bc78baec' before making global git config changes
+2025-07-30T13:47:20.7843292Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-30T13:47:20.7849488Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-30T13:47:20.7893445Z Deleting the contents of '/__w/dash/dash'
+2025-07-30T13:47:20.7897833Z ##[group]Initializing the repository
+2025-07-30T13:47:20.7901980Z [command]/usr/bin/git init /__w/dash/dash
+2025-07-30T13:47:20.7934707Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-07-30T13:47:20.7935602Z hint: is subject to change. To configure the initial branch name to use in all
+2025-07-30T13:47:20.7936229Z hint: of your new repositories, which will suppress this warning, call:
+2025-07-30T13:47:20.7936741Z hint: 
+2025-07-30T13:47:20.7937163Z hint: 	git config --global init.defaultBranch <name>
+2025-07-30T13:47:20.7937865Z hint: 
+2025-07-30T13:47:20.7938350Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-07-30T13:47:20.7939174Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-07-30T13:47:20.7939805Z hint: 
+2025-07-30T13:47:20.7940129Z hint: 	git branch -m <name>
+2025-07-30T13:47:20.7943917Z Initialized empty Git repository in /__w/dash/dash/.git/
+2025-07-30T13:47:20.7956296Z [command]/usr/bin/git remote add origin https://github.com/DashCoreAutoGuix/dash
+2025-07-30T13:47:20.7986326Z ##[endgroup]
+2025-07-30T13:47:20.7986934Z ##[group]Disabling automatic garbage collection
+2025-07-30T13:47:20.7990775Z [command]/usr/bin/git config --local gc.auto 0
+2025-07-30T13:47:20.8018912Z ##[endgroup]
+2025-07-30T13:47:20.8019242Z ##[group]Setting up auth
+2025-07-30T13:47:20.8026030Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-30T13:47:20.8054220Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-30T13:47:20.8272732Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-30T13:47:20.8302540Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-30T13:47:20.8521189Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-07-30T13:47:20.8561548Z ##[endgroup]
+2025-07-30T13:47:20.8562239Z ##[group]Fetching the repository
+2025-07-30T13:47:20.8572148Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=50 origin +3edf8361bf6a05778eab7a21802074376a229653:refs/remotes/origin/backport-0.27-batch-556-pr-26859
+2025-07-30T13:47:22.7963479Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-30T13:47:22.7964399Z  * [new ref]         3edf8361bf6a05778eab7a21802074376a229653 -> origin/backport-0.27-batch-556-pr-26859
+2025-07-30T13:47:22.7992999Z ##[endgroup]
+2025-07-30T13:47:22.7993586Z ##[group]Determining the checkout info
+2025-07-30T13:47:22.7994189Z ##[endgroup]
+2025-07-30T13:47:22.7998873Z [command]/usr/bin/git sparse-checkout disable
+2025-07-30T13:47:22.8037506Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-07-30T13:47:22.8066732Z ##[group]Checking out the ref
+2025-07-30T13:47:22.8071643Z [command]/usr/bin/git checkout --progress --force -B backport-0.27-batch-556-pr-26859 refs/remotes/origin/backport-0.27-batch-556-pr-26859
+2025-07-30T13:47:23.2038523Z Switched to a new branch 'backport-0.27-batch-556-pr-26859'
+2025-07-30T13:47:23.2039436Z branch 'backport-0.27-batch-556-pr-26859' set up to track 'origin/backport-0.27-batch-556-pr-26859'.
+2025-07-30T13:47:23.2064220Z ##[endgroup]
+2025-07-30T13:47:23.2106002Z [command]/usr/bin/git log -1 --format=%H
+2025-07-30T13:47:23.2132301Z 3edf8361bf6a05778eab7a21802074376a229653
+2025-07-30T13:47:23.2360096Z ##[group]Run git config --global --add safe.directory "$PWD"
+2025-07-30T13:47:23.2360635Z [36;1mgit config --global --add safe.directory "$PWD"[0m
+2025-07-30T13:47:23.2360972Z [36;1mgit fetch -fu origin develop:develop[0m
+2025-07-30T13:47:23.2361250Z [36;1mBUILD_TARGET="linux64_nowallet"[0m
+2025-07-30T13:47:23.2361499Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-30T13:47:23.2361756Z [36;1mecho "HOST=${HOST}" >> $GITHUB_OUTPUT[0m
+2025-07-30T13:47:23.2362023Z [36;1mecho "PR_BASE_SHA=" >> $GITHUB_OUTPUT[0m
+2025-07-30T13:47:23.2365657Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-30T13:47:23.2365958Z ##[endgroup]
+2025-07-30T13:47:23.4655116Z From https://github.com/DashCoreAutoGuix/dash
+2025-07-30T13:47:23.4655844Z  * [new branch]      develop    -> develop
+2025-07-30T13:47:23.4656382Z  * [new branch]      develop    -> origin/develop
+2025-07-30T13:47:23.4735606Z Setting specific values in env
+2025-07-30T13:47:23.4736211Z Fallback to default values in env (if not yet set)
+2025-07-30T13:47:23.5255368Z ##[group]Run actions/cache/restore@v4
+2025-07-30T13:47:23.5255641Z with:
+2025-07-30T13:47:23.5255863Z   path: depends/built
+depends/x86_64-pc-linux-gnu
+
+2025-07-30T13:47:23.5256839Z   key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64_nowallet-6406e557d92eb8207c3eec3f6232e2e934591164c8dd13cf2cf4f108b4c6f462-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:47:23.5258203Z   fail-on-cache-miss: true
+2025-07-30T13:47:23.5258593Z   enableCrossOsArchive: false
+2025-07-30T13:47:23.5258947Z   lookup-only: false
+2025-07-30T13:47:23.5259236Z ##[endgroup]
+2025-07-30T13:47:23.5262577Z ##[command]/usr/bin/docker exec  a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T13:47:23.9197306Z Cache hit for: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64_nowallet-6406e557d92eb8207c3eec3f6232e2e934591164c8dd13cf2cf4f108b4c6f462-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:47:24.4133740Z Received 82870187 of 82870187 (100.0%), 171.8 MBs/sec
+2025-07-30T13:47:24.4135618Z Cache Size: ~79 MB (82870187 B)
+2025-07-30T13:47:24.4165761Z [command]/usr/bin/tar -xf /__w/_temp/4a9c9ee9-8a83-4eb5-97c9-cb5139a4b21e/cache.tzst -P -C /__w/dash/dash --use-compress-program unzstd
+2025-07-30T13:47:25.7135131Z Cache restored successfully
+2025-07-30T13:47:25.7382607Z Cache restored from key: depends-8d8b447eb52b5ae2b1502c1f17063f3469c895de5cb00e206594681be493940c-linux64_nowallet-6406e557d92eb8207c3eec3f6232e2e934591164c8dd13cf2cf4f108b4c6f462-f5e950451cdefd07f6af0c6b4cfb0ab0a542623860d6dbc24a1bb43afc0d21ed
+2025-07-30T13:47:25.9095341Z ##[group]Run actions/cache@v4
+2025-07-30T13:47:25.9095791Z with:
+2025-07-30T13:47:25.9095962Z   path: /cache
+
+2025-07-30T13:47:25.9096506Z   key: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_nowallet-3edf8361bf6a05778eab7a21802074376a229653
+2025-07-30T13:47:25.9097320Z   restore-keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_nowallet-
+
+2025-07-30T13:47:25.9098109Z   enableCrossOsArchive: false
+2025-07-30T13:47:25.9098338Z   fail-on-cache-miss: false
+2025-07-30T13:47:25.9098542Z   lookup-only: false
+2025-07-30T13:47:25.9098723Z   save-always: false
+2025-07-30T13:47:25.9098905Z ##[endgroup]
+2025-07-30T13:47:25.9102210Z ##[command]/usr/bin/docker exec  a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T13:47:26.2684097Z Cache not found for input keys: ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_nowallet-3edf8361bf6a05778eab7a21802074376a229653, ccache-78b03b3a2bf75dd03fa501c273c1ac88e498f7a528d630906ef3500f89a28c15-linux64_nowallet-
+2025-07-30T13:47:26.2800385Z ##[group]Run CCACHE_SIZE="400M"
+2025-07-30T13:47:26.2800708Z [36;1mCCACHE_SIZE="400M"[0m
+2025-07-30T13:47:26.2800923Z [36;1mCACHE_DIR="/cache"[0m
+2025-07-30T13:47:26.2801143Z [36;1mmkdir /output[0m
+2025-07-30T13:47:26.2801356Z [36;1mBASE_OUTDIR="/output"[0m
+2025-07-30T13:47:26.2801590Z [36;1mBUILD_TARGET="linux64_nowallet"[0m
+2025-07-30T13:47:26.2801854Z [36;1msource ./ci/dash/matrix.sh[0m
+2025-07-30T13:47:26.2802095Z [36;1m./ci/dash/build_src.sh[0m
+2025-07-30T13:47:26.2802320Z [36;1mccache -X 9[0m
+2025-07-30T13:47:26.2802512Z [36;1mccache -c[0m
+2025-07-30T13:47:26.2802888Z shell: bash --noprofile --norc -e -o pipefail {0}
+2025-07-30T13:47:26.2803163Z ##[endgroup]
+2025-07-30T13:47:26.3436551Z Setting specific values in env
+2025-07-30T13:47:26.3437105Z Fallback to default values in env (if not yet set)
+2025-07-30T13:47:26.3818213Z Setting specific values in env
+2025-07-30T13:47:26.3818565Z Fallback to default values in env (if not yet set)
+2025-07-30T13:47:26.4593739Z Statistics zeroed
+2025-07-30T13:47:26.4594571Z Set cache size limit to 400.0 MB
+2025-07-30T13:47:31.5110817Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-30T13:47:31.5111452Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-30T13:47:31.5354550Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-30T13:47:31.5355186Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-30T13:47:31.5628678Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-30T13:47:31.5915751Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-30T13:47:31.6196367Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-30T13:47:31.6490653Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-30T13:47:33.7205949Z configure.ac:38: installing 'build-aux/compile'
+2025-07-30T13:47:33.7224074Z configure.ac:12: installing 'build-aux/config.guess'
+2025-07-30T13:47:33.7241830Z configure.ac:12: installing 'build-aux/config.sub'
+2025-07-30T13:47:33.7259833Z configure.ac:17: installing 'build-aux/install-sh'
+2025-07-30T13:47:33.7278279Z configure.ac:17: installing 'build-aux/missing'
+2025-07-30T13:47:33.7932888Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-30T13:47:36.1708255Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-30T13:47:36.1708976Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-30T13:47:36.1953732Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-30T13:47:36.1954454Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-30T13:47:36.2160532Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-30T13:47:36.2370544Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-30T13:47:36.2593035Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-30T13:47:36.2815663Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-30T13:47:37.7686709Z configure.ac:39: installing 'build-aux/ar-lib'
+2025-07-30T13:47:37.7704402Z configure.ac:37: installing 'build-aux/compile'
+2025-07-30T13:47:37.7724004Z configure.ac:24: installing 'build-aux/config.guess'
+2025-07-30T13:47:37.7742524Z configure.ac:24: installing 'build-aux/config.sub'
+2025-07-30T13:47:37.7760276Z configure.ac:27: installing 'build-aux/install-sh'
+2025-07-30T13:47:37.7778898Z configure.ac:27: installing 'build-aux/missing'
+2025-07-30T13:47:37.8149479Z Makefile.am: installing 'build-aux/depcomp'
+2025-07-30T13:47:37.8568585Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-30T13:47:37.9544159Z libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
+2025-07-30T13:47:37.9544875Z libtoolize: copying file 'build-aux/ltmain.sh'
+2025-07-30T13:47:37.9809953Z libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
+2025-07-30T13:47:37.9810654Z libtoolize: copying file 'build-aux/m4/libtool.m4'
+2025-07-30T13:47:38.0246844Z libtoolize: copying file 'build-aux/m4/ltoptions.m4'
+2025-07-30T13:47:38.0701406Z libtoolize: copying file 'build-aux/m4/ltsugar.m4'
+2025-07-30T13:47:38.1156389Z libtoolize: copying file 'build-aux/m4/ltversion.m4'
+2025-07-30T13:47:38.1604442Z libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
+2025-07-30T13:47:40.8053781Z configure.ac:105: installing 'build-aux/compile'
+2025-07-30T13:47:40.8075129Z configure.ac:48: installing 'build-aux/config.guess'
+2025-07-30T13:47:40.8096596Z configure.ac:48: installing 'build-aux/config.sub'
+2025-07-30T13:47:40.8116217Z configure.ac:55: installing 'build-aux/install-sh'
+2025-07-30T13:47:40.8136200Z configure.ac:55: installing 'build-aux/missing'
+2025-07-30T13:47:41.0779697Z src/Makefile.am: installing 'build-aux/depcomp'
+2025-07-30T13:47:43.6557460Z parallel-tests: installing 'build-aux/test-driver'
+2025-07-30T13:47:43.8470446Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:47:43.8547018Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:47:43.8558580Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:47:43.8964340Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:43.9015709Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:47:43.9096131Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:47:43.9125105Z checking whether build environment is sane... yes
+2025-07-30T13:47:43.9188659Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:47:43.9214689Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:47:43.9219431Z checking for gawk... gawk
+2025-07-30T13:47:43.9283684Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:47:43.9336330Z checking whether make supports nested variables... yes
+2025-07-30T13:47:43.9378038Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:47:43.9379728Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:47:44.0012702Z checking whether the C++ compiler works... yes
+2025-07-30T13:47:44.0014403Z checking for C++ compiler default output file name... a.out
+2025-07-30T13:47:44.0425262Z checking for suffix of executables... 
+2025-07-30T13:47:44.0962418Z checking whether we are cross compiling... no
+2025-07-30T13:47:44.1147159Z checking for suffix of object files... o
+2025-07-30T13:47:44.1301386Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:47:44.1463816Z checking whether g++-14 accepts -g... yes
+2025-07-30T13:47:44.4676888Z checking for g++-14 option to enable C++11 features... unsupported
+2025-07-30T13:47:44.5232101Z checking for g++-14 option to enable C++98 features... none needed
+2025-07-30T13:47:44.5311096Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:47:44.5313671Z checking dependency style of g++-14... none
+2025-07-30T13:47:44.6230021Z checking whether g++-14 supports C++20 features with -std=c++20... yes
+2025-07-30T13:47:44.6232893Z checking for x86_64-pc-linux-gnu-g++... g++-14 -std=c++20
+2025-07-30T13:47:44.6527108Z checking whether the compiler supports GNU Objective C++... no
+2025-07-30T13:47:44.6806030Z checking whether g++-14 -std=c++20 accepts -g... no
+2025-07-30T13:47:44.6808580Z checking dependency style of g++-14 -std=c++20... none
+2025-07-30T13:47:44.6833385Z checking how to print strings... printf
+2025-07-30T13:47:44.6835612Z checking for x86_64-pc-linux-gnu-gcc... gcc-14
+2025-07-30T13:47:44.7232088Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:47:44.7425001Z checking whether gcc-14 accepts -g... yes
+2025-07-30T13:47:44.7815996Z checking for gcc-14 option to enable C11 features... none needed
+2025-07-30T13:47:44.8105730Z checking whether gcc-14 understands -c and -o together... yes
+2025-07-30T13:47:44.8108012Z checking dependency style of gcc-14... none
+2025-07-30T13:47:44.8146536Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:47:44.8177856Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:47:44.8192914Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:47:44.8208498Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:47:44.8256765Z checking for ld used by gcc-14... /usr/bin/ld
+2025-07-30T13:47:44.8282963Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:47:44.8285599Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:47:44.8598118Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:47:44.8598505Z checking whether ln -s works... yes
+2025-07-30T13:47:44.8642439Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:47:44.8671172Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:47:44.8674480Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:47:44.8675444Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:47:44.8681011Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:47:44.8686523Z checking for file... file
+2025-07-30T13:47:44.8692108Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:44.8697530Z checking for objdump... objdump
+2025-07-30T13:47:44.8702078Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:47:44.8707334Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:47:44.8713395Z checking for dlltool... no
+2025-07-30T13:47:44.8714527Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:47:44.8717382Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:47:44.9106314Z checking for archiver @FILE support... @
+2025-07-30T13:47:44.9106963Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:47:44.9109719Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:47:44.9827883Z checking command to parse nm output from gcc-14 object... ok
+2025-07-30T13:47:44.9847240Z checking for sysroot... no
+2025-07-30T13:47:44.9896454Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:47:44.9935537Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:47:45.0039475Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:47:45.0044812Z checking for mt... no
+2025-07-30T13:47:45.0075647Z checking if : is a manifest tool... no
+2025-07-30T13:47:45.0224103Z checking for stdio.h... yes
+2025-07-30T13:47:45.0399478Z checking for stdlib.h... yes
+2025-07-30T13:47:45.0570289Z checking for string.h... yes
+2025-07-30T13:47:45.0746328Z checking for inttypes.h... yes
+2025-07-30T13:47:45.0921554Z checking for stdint.h... yes
+2025-07-30T13:47:45.1116280Z checking for strings.h... yes
+2025-07-30T13:47:45.1324793Z checking for sys/stat.h... yes
+2025-07-30T13:47:45.1550103Z checking for sys/types.h... yes
+2025-07-30T13:47:45.1781172Z checking for unistd.h... yes
+2025-07-30T13:47:45.2012966Z checking for dlfcn.h... yes
+2025-07-30T13:47:45.2055290Z checking for objdir... .libs
+2025-07-30T13:47:45.2698674Z checking if gcc-14 supports -fno-rtti -fno-exceptions... no
+2025-07-30T13:47:45.2699534Z checking for gcc-14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:45.2844673Z checking if gcc-14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:45.3476788Z checking if gcc-14 static flag -static works... yes
+2025-07-30T13:47:45.3697238Z checking if gcc-14 supports -c -o file.o... yes
+2025-07-30T13:47:45.3698043Z checking if gcc-14 supports -c -o file.o... (cached) yes
+2025-07-30T13:47:45.3791644Z checking whether the gcc-14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:45.4010781Z checking whether -lc should be explicitly linked in... no
+2025-07-30T13:47:45.4531268Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:47:45.4532097Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:45.4550703Z checking whether stripping libraries is possible... yes
+2025-07-30T13:47:45.4551360Z checking if libtool supports shared libraries... yes
+2025-07-30T13:47:45.4551942Z checking whether to build shared libraries... yes
+2025-07-30T13:47:45.4552983Z checking whether to build static libraries... yes
+2025-07-30T13:47:45.4850593Z checking how to run the C++ preprocessor... g++-14 -std=c++20 -E
+2025-07-30T13:47:45.5724290Z checking for ld used by g++-14 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:47:45.5752214Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:47:45.5824596Z checking whether the g++-14 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:45.6418840Z checking for g++-14 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:47:45.6587735Z checking if g++-14 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:47:45.7224448Z checking if g++-14 -std=c++20 static flag -static works... yes
+2025-07-30T13:47:45.7450883Z checking if g++-14 -std=c++20 supports -c -o file.o... yes
+2025-07-30T13:47:45.7451612Z checking if g++-14 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-30T13:47:45.7452466Z checking whether the g++-14 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:47:45.7499552Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:47:45.7501286Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:47:45.7507810Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:47:45.7514364Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-30T13:47:45.7520297Z checking for gcov... /usr/bin/gcov
+2025-07-30T13:47:45.7525571Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-30T13:47:45.7531100Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-30T13:47:45.7536253Z checking for lcov... no
+2025-07-30T13:47:45.7540490Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-30T13:47:45.7545305Z checking for genhtml... no
+2025-07-30T13:47:45.7548775Z checking for git... /usr/bin/git
+2025-07-30T13:47:45.7552758Z checking for ccache... /usr/bin/ccache
+2025-07-30T13:47:45.7556855Z checking for xgettext... /usr/bin/xgettext
+2025-07-30T13:47:45.7561295Z checking for hexdump... /usr/bin/hexdump
+2025-07-30T13:47:45.7566463Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-30T13:47:45.7572963Z checking for objcopy... /usr/bin/objcopy
+2025-07-30T13:47:45.7577155Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:47:45.7581794Z checking for objdump... /usr/bin/objdump
+2025-07-30T13:47:45.7586736Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-30T13:47:45.7592185Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-30T13:47:45.7597315Z checking for doxygen... no
+2025-07-30T13:47:45.7772578Z checking whether C++ compiler accepts -Werror... yes
+2025-07-30T13:47:45.8198354Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-30T13:47:45.8673839Z checking for execinfo.h... yes
+2025-07-30T13:47:45.9121000Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-30T13:47:45.9332656Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-30T13:47:45.9520625Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-30T13:47:45.9702827Z checking whether C++ compiler accepts -Wattributes... no
+2025-07-30T13:47:45.9895319Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-30T13:47:46.0087462Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-30T13:47:46.0270905Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-30T13:47:46.0450788Z checking whether C++ compiler accepts -Wall... yes
+2025-07-30T13:47:46.0628344Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-30T13:47:46.0766330Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-30T13:47:46.0947152Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-30T13:47:46.1147343Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-30T13:47:46.1336510Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-30T13:47:46.1517145Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-30T13:47:46.1732161Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-30T13:47:46.1932350Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-30T13:47:46.2148186Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-30T13:47:46.2404124Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-30T13:47:46.2640863Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-30T13:47:46.2931570Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-30T13:47:46.3125443Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-30T13:47:46.3322455Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-30T13:47:46.3519330Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-30T13:47:46.3710772Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-30T13:47:46.3903866Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-30T13:47:46.4102440Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-30T13:47:46.4297020Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-30T13:47:46.4499450Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-30T13:47:46.4678687Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-30T13:47:46.4871702Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-30T13:47:46.5072948Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-30T13:47:46.5239064Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-30T13:47:46.5439790Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-30T13:47:46.5631129Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-30T13:47:46.5833148Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-30T13:47:46.6035895Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-30T13:47:47.1288528Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-30T13:47:47.1746343Z checking for SSE4.2 intrinsics... yes
+2025-07-30T13:47:47.6807467Z checking for SSE4.1 intrinsics... yes
+2025-07-30T13:47:48.1647490Z checking for AVX2 intrinsics... yes
+2025-07-30T13:47:48.6559796Z checking for x86 SHA-NI intrinsics... yes
+2025-07-30T13:47:48.6739224Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-30T13:47:48.6909685Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-30T13:47:48.7065501Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-30T13:47:48.7223238Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-30T13:47:48.8075649Z checking whether byte ordering is bigendian... no
+2025-07-30T13:47:48.8304683Z checking how to run the C preprocessor... gcc-14 -E
+2025-07-30T13:47:48.8615863Z checking whether gcc-14 is Clang... no
+2025-07-30T13:47:48.9079572Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:47:48.9446956Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:47:48.9448474Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:47:48.9826244Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:47:50.0381896Z checking whether std::atomic can be used without link library... yes
+2025-07-30T13:47:50.0390424Z checking for special C compiler options needed for large files... no
+2025-07-30T13:47:50.0605160Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-30T13:47:50.0950998Z checking for g++-14 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-30T13:47:50.1500442Z checking whether strerror_r is declared... yes
+2025-07-30T13:47:50.1746931Z checking whether strerror_r returns char *... yes
+2025-07-30T13:47:50.1908129Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-30T13:47:50.2084673Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-30T13:47:50.2260460Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-30T13:47:50.2426148Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-30T13:47:50.2613934Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:47:50.2701887Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-30T13:47:50.2795174Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-30T13:47:50.3125926Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:47:50.3399032Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:47:50.3674026Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:47:50.3945763Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:47:50.4426132Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:47:50.4882706Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:47:50.5361168Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:47:50.5821505Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:47:50.6280188Z checking for sys/select.h... yes
+2025-07-30T13:47:50.6724997Z checking for sys/prctl.h... yes
+2025-07-30T13:47:50.7065341Z checking for vm/vm_param.h... no
+2025-07-30T13:47:50.7397493Z checking for sys/vmmeter.h... no
+2025-07-30T13:47:50.7724375Z checking for sys/resources.h... no
+2025-07-30T13:47:50.8022097Z checking whether getifaddrs is declared... yes
+2025-07-30T13:47:50.8565853Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:47:50.8866099Z checking whether freeifaddrs is declared... yes
+2025-07-30T13:47:50.9391064Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:47:50.9925079Z checking whether fork is declared... yes
+2025-07-30T13:47:51.0449218Z checking whether setsid is declared... yes
+2025-07-30T13:47:51.0989064Z checking whether pipe2 is declared... yes
+2025-07-30T13:47:51.1262586Z checking for mallopt M_ARENA_MAX... yes
+2025-07-30T13:47:51.1523118Z checking for getmemoryinfo... yes
+2025-07-30T13:47:51.1738901Z checking for posix_fallocate... yes
+2025-07-30T13:47:51.1901063Z checking for default visibility attribute... yes
+2025-07-30T13:47:51.2057199Z checking for dllexport attribute... no
+2025-07-30T13:47:51.7216721Z checking for thread_local support... yes
+2025-07-30T13:47:51.7515822Z checking for Linux getrandom syscall... yes
+2025-07-30T13:47:51.7857955Z checking for getentropy via random.h... yes
+2025-07-30T13:47:51.8065871Z checking for sysctl... no
+2025-07-30T13:47:51.8273673Z checking for sysctl KERN_ARND... no
+2025-07-30T13:47:51.8734504Z checking for library containing backtrace... none required
+2025-07-30T13:47:51.9003041Z checking for fdatasync... yes
+2025-07-30T13:47:51.9219315Z checking for F_FULLFSYNC... no
+2025-07-30T13:47:51.9446452Z checking for O_CLOEXEC... yes
+2025-07-30T13:47:51.9623133Z checking for __builtin_prefetch... yes
+2025-07-30T13:47:52.0055994Z checking for _mm_prefetch... yes
+2025-07-30T13:47:52.0276007Z checking for strong getauxval support in the system headers... yes
+2025-07-30T13:47:52.0597173Z checking for sockaddr_un... yes
+2025-07-30T13:47:52.1162474Z checking for std::system... yes
+2025-07-30T13:47:52.1495655Z checking for ::_wsystem... no
+2025-07-30T13:47:52.1669030Z checking for Qt5Core >= 5.11.3... yes
+2025-07-30T13:47:52.1778564Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-30T13:47:52.1887561Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-30T13:47:52.2007116Z checking for Qt5Network >= 5.11.3... yes
+2025-07-30T13:47:52.2138702Z checking for Qt5Test >= 5.11.3... yes
+2025-07-30T13:47:52.2251117Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-30T13:47:52.4740218Z checking for static Qt... yes
+2025-07-30T13:47:52.4856821Z checking for Qt5AccessibilitySupport... yes
+2025-07-30T13:47:52.4965950Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-30T13:47:52.5076751Z checking for Qt5EdidSupport... yes
+2025-07-30T13:47:52.5195079Z checking for Qt5EventDispatcherSupport... yes
+2025-07-30T13:47:52.5317504Z checking for Qt5FbSupport... yes
+2025-07-30T13:47:52.5430507Z checking for Qt5FontDatabaseSupport... yes
+2025-07-30T13:47:52.5543884Z checking for Qt5ThemeSupport... yes
+2025-07-30T13:47:52.5659919Z checking for Qt5InputSupport... yes
+2025-07-30T13:47:52.5787477Z checking for Qt5ServiceSupport... yes
+2025-07-30T13:47:52.5926583Z checking for Qt5XcbQpa... yes
+2025-07-30T13:47:52.6040113Z checking for Qt5XkbCommonSupport... yes
+2025-07-30T13:47:54.8961907Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-30T13:47:57.3135708Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-30T13:47:57.5549241Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-30T13:47:57.5565521Z checking for moc-qt5... no
+2025-07-30T13:47:57.5569230Z checking for moc5... no
+2025-07-30T13:47:57.5569950Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-30T13:47:57.5571920Z checking for uic-qt5... no
+2025-07-30T13:47:57.5572361Z checking for uic5... no
+2025-07-30T13:47:57.5573277Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-30T13:47:57.5575710Z checking for rcc-qt5... no
+2025-07-30T13:47:57.5576455Z checking for rcc5... no
+2025-07-30T13:47:57.5578851Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-30T13:47:57.5580710Z checking for lrelease-qt5... no
+2025-07-30T13:47:57.5582812Z checking for lrelease5... no
+2025-07-30T13:47:57.5584273Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-30T13:47:57.5585640Z checking for lupdate-qt5... no
+2025-07-30T13:47:57.5586532Z checking for lupdate5... no
+2025-07-30T13:47:57.5588766Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-30T13:47:57.5590174Z checking for lconvert-qt5... no
+2025-07-30T13:47:57.5591479Z checking for lconvert5... no
+2025-07-30T13:47:57.5593100Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-30T13:47:57.5640052Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-30T13:47:57.5641027Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-30T13:47:57.6306290Z checking whether main function is needed for fuzz binary... checking whether the linker accepts ... no
+2025-07-30T13:47:57.6307358Z yes
+2025-07-30T13:47:57.6526993Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-30T13:47:57.7065190Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-30T13:47:57.7582920Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-30T13:47:57.8061836Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-30T13:47:57.8101879Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-30T13:47:57.8583799Z checking for miniupnpc/upnperrors.h... yes
+2025-07-30T13:47:57.8625866Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-30T13:47:57.8716327Z checking whether miniUPnPc API version is supported... yes
+2025-07-30T13:47:57.9230736Z checking for natpmp.h... yes
+2025-07-30T13:47:57.9689438Z checking for initnatpmp in -lnatpmp... yes
+2025-07-30T13:47:57.9763508Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-30T13:47:57.9766697Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-30T13:47:57.9768424Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-30T13:47:57.9769756Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-30T13:47:57.9770797Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-30T13:47:57.9923644Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-30T13:47:58.0235109Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-30T13:48:01.4477168Z checking for Boost Process... yes
+2025-07-30T13:48:01.4723334Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-30T13:48:01.5216937Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-30T13:48:01.5516433Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-30T13:48:01.5642363Z checking for libevent >= 2.1.8... yes
+2025-07-30T13:48:01.5765646Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-30T13:48:01.6122837Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-30T13:48:01.6253225Z checking for libqrencode... yes
+2025-07-30T13:48:01.6372866Z checking for libzmq >= 4... yes
+2025-07-30T13:48:01.6999803Z checking for gmp.h... yes
+2025-07-30T13:48:01.7440152Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:48:01.7562599Z checking for libmultiprocess... no
+2025-07-30T13:48:01.7646696Z checking whether to build dashd... yes
+2025-07-30T13:48:01.7647304Z checking whether to build dash-cli... yes
+2025-07-30T13:48:01.7648105Z checking whether to build dash-tx... yes
+2025-07-30T13:48:01.7648722Z checking whether to build dash-wallet... yes
+2025-07-30T13:48:01.7649787Z checking whether to build libraries... yes
+2025-07-30T13:48:01.7652870Z checking if ccache should be used... yes
+2025-07-30T13:48:01.7945921Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-30T13:48:01.8061002Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-30T13:48:01.8062296Z checking if wallet should be enabled... no
+2025-07-30T13:48:01.8063836Z checking whether to build with support for UPnP... yes
+2025-07-30T13:48:01.8066267Z checking whether to build with support for NAT-PMP... yes
+2025-07-30T13:48:01.8068862Z checking whether to build GUI with support for D-Bus... yes
+2025-07-30T13:48:01.8070306Z checking whether to build GUI with support for QR codes... yes
+2025-07-30T13:48:01.8070984Z checking whether to build test_dash-qt... yes
+2025-07-30T13:48:01.8072843Z checking whether to build test_dash... yes
+2025-07-30T13:48:01.8073334Z checking whether to reduce exports... yes
+2025-07-30T13:48:01.8216338Z checking whether dsymutil needs -flat... yes
+2025-07-30T13:48:01.8216684Z 
+2025-07-30T13:48:01.8659872Z checking that generated files are newer than configure... done
+2025-07-30T13:48:01.8665758Z configure: creating ./config.status
+2025-07-30T13:48:02.5280047Z config.status: creating libdashconsensus.pc
+2025-07-30T13:48:02.5401336Z config.status: creating Makefile
+2025-07-30T13:48:02.5532571Z config.status: creating src/Makefile
+2025-07-30T13:48:02.6112597Z config.status: creating doc/man/Makefile
+2025-07-30T13:48:02.6276017Z config.status: creating share/setup.nsi
+2025-07-30T13:48:02.6439285Z config.status: creating share/qt/Info.plist
+2025-07-30T13:48:02.6602430Z config.status: creating test/config.ini
+2025-07-30T13:48:02.6771071Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-30T13:48:02.6950512Z config.status: creating src/config/bitcoin-config.h
+2025-07-30T13:48:02.7139618Z config.status: linking ../contrib/filter-lcov.py to contrib/filter-lcov.py
+2025-07-30T13:48:02.7205196Z config.status: linking ../src/.bear-tidy-config to src/.bear-tidy-config
+2025-07-30T13:48:02.7270192Z config.status: linking ../src/.clang-tidy to src/.clang-tidy
+2025-07-30T13:48:02.7344869Z config.status: linking ../test/functional/test_runner.py to test/functional/test_runner.py
+2025-07-30T13:48:02.7420059Z config.status: linking ../test/fuzz/test_runner.py to test/fuzz/test_runner.py
+2025-07-30T13:48:02.7501018Z config.status: linking ../test/util/test_runner.py to test/util/test_runner.py
+2025-07-30T13:48:02.7571831Z config.status: linking ../test/util/rpcauth-test.py to test/util/rpcauth-test.py
+2025-07-30T13:48:02.7603046Z config.status: executing depfiles commands
+2025-07-30T13:48:02.7616903Z config.status: executing libtool commands
+2025-07-30T13:48:02.7738030Z === configuring in src/dashbls (/__w/dash/dash/build-ci/src/dashbls)
+2025-07-30T13:48:02.7797329Z configure: running /bin/bash ../../../src/dashbls/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-reduce-exports' '--with-boost-process' 'CC=gcc-14' 'CXX=g++-14' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/dashbls
+2025-07-30T13:48:02.8910547Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:48:02.9350035Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:02.9403548Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:02.9487517Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:48:02.9518120Z checking whether build environment is sane... yes
+2025-07-30T13:48:02.9583237Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:48:02.9608025Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:48:02.9611935Z checking for gawk... gawk
+2025-07-30T13:48:02.9679934Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:48:02.9734404Z checking whether make supports nested variables... yes
+2025-07-30T13:48:02.9779792Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:48:02.9781374Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:48:02.9783680Z checking for x86_64-pc-linux-gnu-gcc... gcc-14
+2025-07-30T13:48:03.0375252Z checking whether the C compiler works... yes
+2025-07-30T13:48:03.0376003Z checking for C compiler default output file name... a.out
+2025-07-30T13:48:03.0696370Z checking for suffix of executables... 
+2025-07-30T13:48:03.1094879Z checking whether we are cross compiling... no
+2025-07-30T13:48:03.1263078Z checking for suffix of object files... o
+2025-07-30T13:48:03.1408887Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:48:03.1581786Z checking whether gcc-14 accepts -g... yes
+2025-07-30T13:48:03.1955513Z checking for gcc-14 option to enable C11 features... none needed
+2025-07-30T13:48:03.2252233Z checking whether gcc-14 understands -c and -o together... yes
+2025-07-30T13:48:03.2330503Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:48:03.2331727Z checking dependency style of gcc-14... none
+2025-07-30T13:48:03.2694118Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:48:03.2872270Z checking whether g++-14 accepts -g... yes
+2025-07-30T13:48:03.6082547Z checking for g++-14 option to enable C++11 features... unsupported
+2025-07-30T13:48:03.6614317Z checking for g++-14 option to enable C++98 features... none needed
+2025-07-30T13:48:03.6616658Z checking dependency style of g++-14... none
+2025-07-30T13:48:03.7031048Z checking whether g++-14 supports C++14 features with -std=c++14... yes
+2025-07-30T13:48:03.7056532Z checking how to print strings... printf
+2025-07-30T13:48:03.7096654Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:48:03.7128238Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:48:03.7143335Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:48:03.7158849Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:48:03.7206283Z checking for ld used by gcc-14... /usr/bin/ld
+2025-07-30T13:48:03.7230043Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:48:03.7232256Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:48:03.7534326Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:48:03.7534912Z checking whether ln -s works... yes
+2025-07-30T13:48:03.7575941Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:48:03.7601772Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:48:03.7603946Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:48:03.7605174Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:48:03.7609357Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:48:03.7613380Z checking for file... file
+2025-07-30T13:48:03.7617406Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:48:03.7621820Z checking for objdump... objdump
+2025-07-30T13:48:03.7625822Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:48:03.7630655Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:48:03.7635251Z checking for dlltool... no
+2025-07-30T13:48:03.7637143Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:48:03.7638275Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:48:03.8000218Z checking for archiver @FILE support... @
+2025-07-30T13:48:03.8001921Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:48:03.8004580Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:48:03.8705684Z checking command to parse nm output from gcc-14 object... ok
+2025-07-30T13:48:03.8726443Z checking for sysroot... no
+2025-07-30T13:48:03.8769518Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:48:03.8809354Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:48:03.8917026Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:48:03.8920727Z checking for mt... no
+2025-07-30T13:48:03.8953093Z checking if : is a manifest tool... no
+2025-07-30T13:48:03.9114211Z checking for stdio.h... yes
+2025-07-30T13:48:03.9292350Z checking for stdlib.h... yes
+2025-07-30T13:48:03.9473930Z checking for string.h... yes
+2025-07-30T13:48:03.9651927Z checking for inttypes.h... yes
+2025-07-30T13:48:03.9830145Z checking for stdint.h... yes
+2025-07-30T13:48:04.0021168Z checking for strings.h... yes
+2025-07-30T13:48:04.0210074Z checking for sys/stat.h... yes
+2025-07-30T13:48:04.0407451Z checking for sys/types.h... yes
+2025-07-30T13:48:04.0627939Z checking for unistd.h... yes
+2025-07-30T13:48:04.0855697Z checking for dlfcn.h... yes
+2025-07-30T13:48:04.0890269Z checking for objdir... .libs
+2025-07-30T13:48:04.1528046Z checking if gcc-14 supports -fno-rtti -fno-exceptions... no
+2025-07-30T13:48:04.1528855Z checking for gcc-14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:04.1676508Z checking if gcc-14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:04.2327764Z checking if gcc-14 static flag -static works... yes
+2025-07-30T13:48:04.2539577Z checking if gcc-14 supports -c -o file.o... yes
+2025-07-30T13:48:04.2540105Z checking if gcc-14 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:04.2640567Z checking whether the gcc-14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:04.3153258Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:48:04.3154043Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:04.3172131Z checking whether stripping libraries is possible... yes
+2025-07-30T13:48:04.3172801Z checking if libtool supports shared libraries... yes
+2025-07-30T13:48:04.3173346Z checking whether to build shared libraries... no
+2025-07-30T13:48:04.3173740Z checking whether to build static libraries... yes
+2025-07-30T13:48:04.3451313Z checking how to run the C++ preprocessor... g++-14 -std=c++14 -E
+2025-07-30T13:48:04.4322479Z checking for ld used by g++-14 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:48:04.4349880Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:48:04.4424950Z checking whether the g++-14 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:04.5011348Z checking for g++-14 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:04.5181560Z checking if g++-14 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:04.5835015Z checking if g++-14 -std=c++14 static flag -static works... yes
+2025-07-30T13:48:04.6083546Z checking if g++-14 -std=c++14 supports -c -o file.o... yes
+2025-07-30T13:48:04.6084362Z checking if g++-14 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:04.6085288Z checking whether the g++-14 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:04.6137482Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:48:04.6138507Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:04.6146514Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:48:04.6153638Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-30T13:48:04.6155178Z checking for ranlib... (cached) ranlib
+2025-07-30T13:48:04.6161461Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-30T13:48:04.6163479Z checking for strip... (cached) strip
+2025-07-30T13:48:04.6167098Z checking dependency style of gcc-14... none
+2025-07-30T13:48:04.6332302Z checking whether C compiler accepts -Werror... yes
+2025-07-30T13:48:04.6595288Z checking for gmp.h... yes
+2025-07-30T13:48:04.6941836Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:48:04.7134124Z checking gmp version >= 6.2... yes
+2025-07-30T13:48:04.7165466Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:48:04.7178637Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:48:04.7274216Z checking if gcc-14 supports -pipe... yes
+2025-07-30T13:48:04.7380804Z checking if gcc-14 supports -fomit-frame-pointer... yes
+2025-07-30T13:48:04.7679923Z checking how to run the C preprocessor... gcc-14 -E
+2025-07-30T13:48:04.8005933Z checking whether gcc-14 is Clang... no
+2025-07-30T13:48:04.8496536Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:48:04.8870193Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:48:04.8871132Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:48:04.9258351Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:48:04.9605265Z checking for library containing clock_gettime... none required
+2025-07-30T13:48:04.9792340Z checking whether C compiler accepts -fPIC... yes
+2025-07-30T13:48:04.9968624Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-30T13:48:05.0131172Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-30T13:48:05.0311230Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-30T13:48:05.0479776Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-30T13:48:05.0648978Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:48:05.0876061Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:48:05.1102881Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:48:05.1326737Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:48:05.1570190Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:48:05.1896862Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:48:05.2245548Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:48:05.2580499Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:48:05.2915436Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:48:05.3098005Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-30T13:48:05.3099310Z checking whether to build runtest... yes
+2025-07-30T13:48:05.3100444Z checking whether to build runbench... yes
+2025-07-30T13:48:05.3339954Z checking that generated files are newer than configure... done
+2025-07-30T13:48:05.3343556Z configure: creating ./config.status
+2025-07-30T13:48:05.8851090Z config.status: creating Makefile
+2025-07-30T13:48:05.9066541Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-30T13:48:05.9208568Z config.status: executing depfiles commands
+2025-07-30T13:48:05.9222032Z config.status: executing libtool commands
+2025-07-30T13:48:05.9346516Z 
+2025-07-30T13:48:05.9347317Z Options used to compile and link:
+2025-07-30T13:48:05.9347946Z   target os           = linux
+2025-07-30T13:48:05.9348323Z   backend             = gmp
+2025-07-30T13:48:05.9348660Z   build bench         = yes
+2025-07-30T13:48:05.9348989Z   build test          = yes
+2025-07-30T13:48:05.9349299Z   use debug           = no
+2025-07-30T13:48:05.9349624Z   use hardening       = yes
+2025-07-30T13:48:05.9349941Z   use optimizations   = yes
+2025-07-30T13:48:05.9350076Z 
+2025-07-30T13:48:05.9350252Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-30T13:48:05.9351079Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-30T13:48:05.9352214Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-30T13:48:05.9353338Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-30T13:48:05.9354343Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-30T13:48:05.9354535Z 
+2025-07-30T13:48:05.9724980Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/src/secp256k1)
+2025-07-30T13:48:05.9782258Z configure: running /bin/bash ../../../src/secp256k1/configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-reduce-exports' '--with-boost-process' 'CC=gcc-14' 'CXX=g++-14' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=../../../src/secp256k1
+2025-07-30T13:48:06.0881149Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:48:06.1315899Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:06.1365265Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:06.1445793Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:48:06.1474527Z checking whether build environment is sane... yes
+2025-07-30T13:48:06.1538510Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:48:06.1559743Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:48:06.1563651Z checking for gawk... gawk
+2025-07-30T13:48:06.1637933Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:48:06.1696916Z checking whether make supports nested variables... yes
+2025-07-30T13:48:06.1741810Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:48:06.1743803Z checking for x86_64-pc-linux-gnu-gcc... gcc-14
+2025-07-30T13:48:06.2345026Z checking whether the C compiler works... yes
+2025-07-30T13:48:06.2345683Z checking for C compiler default output file name... a.out
+2025-07-30T13:48:06.2653554Z checking for suffix of executables... 
+2025-07-30T13:48:06.3046853Z checking whether we are cross compiling... no
+2025-07-30T13:48:06.3238580Z checking for suffix of object files... o
+2025-07-30T13:48:06.3401017Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:48:06.3576902Z checking whether gcc-14 accepts -g... yes
+2025-07-30T13:48:06.3965460Z checking for gcc-14 option to enable C11 features... none needed
+2025-07-30T13:48:06.4262095Z checking whether gcc-14 understands -c and -o together... yes
+2025-07-30T13:48:06.4334052Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:48:06.4336628Z checking dependency style of gcc-14... none
+2025-07-30T13:48:06.4340335Z checking dependency style of gcc-14... none
+2025-07-30T13:48:06.4342850Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:48:06.4618604Z checking the archiver (ar) interface... ar
+2025-07-30T13:48:06.4642094Z checking how to print strings... printf
+2025-07-30T13:48:06.4686027Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:48:06.4720583Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:48:06.4736579Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:48:06.4753061Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:48:06.4804999Z checking for ld used by gcc-14... /usr/bin/ld
+2025-07-30T13:48:06.4828566Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:48:06.4830819Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:48:06.5136533Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:48:06.5137208Z checking whether ln -s works... yes
+2025-07-30T13:48:06.5186776Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:48:06.5217240Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:48:06.5218572Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:48:06.5219437Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:48:06.5225251Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:48:06.5230286Z checking for file... file
+2025-07-30T13:48:06.5234755Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:48:06.5239890Z checking for objdump... objdump
+2025-07-30T13:48:06.5243115Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:48:06.5248110Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:48:06.5253184Z checking for dlltool... no
+2025-07-30T13:48:06.5255519Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:48:06.5257397Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:48:06.5622578Z checking for archiver @FILE support... @
+2025-07-30T13:48:06.5623886Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:48:06.5625315Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:48:06.6352227Z checking command to parse nm output from gcc-14 object... ok
+2025-07-30T13:48:06.6371306Z checking for sysroot... no
+2025-07-30T13:48:06.6416550Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:48:06.6456997Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:48:06.6569399Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:48:06.6573929Z checking for mt... no
+2025-07-30T13:48:06.6607310Z checking if : is a manifest tool... no
+2025-07-30T13:48:06.6771057Z checking for stdio.h... yes
+2025-07-30T13:48:06.6933938Z checking for stdlib.h... yes
+2025-07-30T13:48:06.7121123Z checking for string.h... yes
+2025-07-30T13:48:06.7309299Z checking for inttypes.h... yes
+2025-07-30T13:48:06.7503308Z checking for stdint.h... yes
+2025-07-30T13:48:06.7683507Z checking for strings.h... yes
+2025-07-30T13:48:06.7864114Z checking for sys/stat.h... yes
+2025-07-30T13:48:06.8052673Z checking for sys/types.h... yes
+2025-07-30T13:48:06.8287535Z checking for unistd.h... yes
+2025-07-30T13:48:06.8511043Z checking for dlfcn.h... yes
+2025-07-30T13:48:06.8555013Z checking for objdir... .libs
+2025-07-30T13:48:06.9190562Z checking if gcc-14 supports -fno-rtti -fno-exceptions... no
+2025-07-30T13:48:06.9191305Z checking for gcc-14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:06.9349158Z checking if gcc-14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:06.9951045Z checking if gcc-14 static flag -static works... yes
+2025-07-30T13:48:07.0184176Z checking if gcc-14 supports -c -o file.o... yes
+2025-07-30T13:48:07.0184794Z checking if gcc-14 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:07.0284412Z checking whether the gcc-14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:07.0788646Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:48:07.0789407Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:07.0808391Z checking whether stripping libraries is possible... yes
+2025-07-30T13:48:07.0809193Z checking if libtool supports shared libraries... yes
+2025-07-30T13:48:07.0810083Z checking whether to build shared libraries... no
+2025-07-30T13:48:07.0810607Z checking whether to build static libraries... yes
+2025-07-30T13:48:07.0928055Z checking if gcc-14 supports -Werror... yes
+2025-07-30T13:48:07.1027162Z checking if gcc-14 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-30T13:48:07.1124607Z checking if gcc-14 supports -Wno-overlength-strings... yes
+2025-07-30T13:48:07.1231287Z checking if gcc-14 supports -Wall... yes
+2025-07-30T13:48:07.1340836Z checking if gcc-14 supports -Wno-unused-function... yes
+2025-07-30T13:48:07.1443374Z checking if gcc-14 supports -Wextra... yes
+2025-07-30T13:48:07.1553196Z checking if gcc-14 supports -Wcast-align... yes
+2025-07-30T13:48:07.1659062Z checking if gcc-14 supports -Wcast-align=strict... yes
+2025-07-30T13:48:07.1905980Z checking if gcc-14 supports -Wconditional-uninitialized... no
+2025-07-30T13:48:07.2111387Z checking if gcc-14 supports -Wreserved-identifier... no
+2025-07-30T13:48:07.2211956Z checking if gcc-14 supports -fvisibility=hidden... yes
+2025-07-30T13:48:07.2373071Z checking for valgrind support... 
+2025-07-30T13:48:07.2734556Z checking for x86_64 assembly availability... yes
+2025-07-30T13:48:07.2954782Z checking that generated files are newer than configure... done
+2025-07-30T13:48:07.2958120Z configure: creating ./config.status
+2025-07-30T13:48:07.6981496Z config.status: creating Makefile
+2025-07-30T13:48:07.7111928Z config.status: creating libsecp256k1.pc
+2025-07-30T13:48:07.7219445Z config.status: executing depfiles commands
+2025-07-30T13:48:07.7233321Z config.status: executing libtool commands
+2025-07-30T13:48:07.7320005Z 
+2025-07-30T13:48:07.7320340Z Build Options:
+2025-07-30T13:48:07.7320885Z   with external callbacks = no
+2025-07-30T13:48:07.7321307Z   with benchmarks         = no
+2025-07-30T13:48:07.7321686Z   with tests              = yes
+2025-07-30T13:48:07.7322064Z   with ctime tests        = no
+2025-07-30T13:48:07.7322377Z   with coverage           = no
+2025-07-30T13:48:07.7322659Z   with examples           = no
+2025-07-30T13:48:07.7323001Z   module ecdh             = no
+2025-07-30T13:48:07.7323393Z   module recovery         = yes
+2025-07-30T13:48:07.7323782Z   module extrakeys        = yes
+2025-07-30T13:48:07.7324184Z   module schnorrsig       = yes
+2025-07-30T13:48:07.7324566Z   module ellswift         = yes
+2025-07-30T13:48:07.7324828Z 
+2025-07-30T13:48:07.7324961Z   asm                     = x86_64
+2025-07-30T13:48:07.7325364Z   ecmult window size      = 15
+2025-07-30T13:48:07.7325751Z   ecmult gen prec. bits   = 4
+2025-07-30T13:48:07.7326016Z 
+2025-07-30T13:48:07.7326143Z   valgrind                = no
+2025-07-30T13:48:07.7326499Z   CC                      = gcc-14
+2025-07-30T13:48:07.7327037Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-30T13:48:07.7328814Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-30T13:48:07.7330193Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-30T13:48:07.7330563Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:48:07.7648978Z 
+2025-07-30T13:48:07.7649442Z Options used to compile and link:
+2025-07-30T13:48:07.7649931Z   boost process       = yes
+2025-07-30T13:48:07.7650812Z   multiprocess        = no
+2025-07-30T13:48:07.7651208Z   with libs           = yes
+2025-07-30T13:48:07.7651647Z   with wallet         = no
+2025-07-30T13:48:07.7651867Z   with gui / qt       = yes
+2025-07-30T13:48:07.7652077Z     with qr           = yes
+2025-07-30T13:48:07.7652279Z   with zmq            = yes
+2025-07-30T13:48:07.7652487Z   with test           = yes
+2025-07-30T13:48:07.7652698Z   with fuzz binary    = yes
+2025-07-30T13:48:07.7652927Z   with bench          = yes
+2025-07-30T13:48:07.7653133Z   with upnp           = yes
+2025-07-30T13:48:07.7653350Z   with natpmp         = yes
+2025-07-30T13:48:07.7653892Z   USDT tracing        = yes
+2025-07-30T13:48:07.7654122Z   sanitizers          = 
+2025-07-30T13:48:07.7654346Z   debug enabled       = no
+2025-07-30T13:48:07.7654566Z   stacktraces enabled = yes
+2025-07-30T13:48:07.7654783Z   crash hooks enabled = no
+2025-07-30T13:48:07.7654997Z   miner enabled       = yes
+2025-07-30T13:48:07.7655211Z   gprof enabled       = no
+2025-07-30T13:48:07.7655416Z   werror              = yes
+2025-07-30T13:48:07.7655554Z 
+2025-07-30T13:48:07.7655639Z   target os           = linux-gnu
+2025-07-30T13:48:07.7655896Z   build os            = linux-gnu
+2025-07-30T13:48:07.7656065Z 
+2025-07-30T13:48:07.7656171Z   CC                  = /usr/bin/ccache gcc-14
+2025-07-30T13:48:07.7656576Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-30T13:48:07.7657534Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-30T13:48:07.7658672Z   CXX                 = /usr/bin/ccache g++-14 -std=c++20
+2025-07-30T13:48:07.7660993Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-30T13:48:07.7664787Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:48:07.7665630Z   AR                  = ar
+2025-07-30T13:48:07.7666014Z   ARFLAGS             = cr
+2025-07-30T13:48:07.7666266Z 
+2025-07-30T13:48:07.8268927Z make  distdir-am
+2025-07-30T13:48:07.8324441Z make[1]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-30T13:48:07.8326257Z if test -d "dashcore-linux64_nowallet"; then find "dashcore-linux64_nowallet" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "dashcore-linux64_nowallet" || { sleep 5 && rm -rf "dashcore-linux64_nowallet"; }; else :; fi
+2025-07-30T13:48:07.8342234Z test -d "dashcore-linux64_nowallet" || mkdir "dashcore-linux64_nowallet"
+2025-07-30T13:48:08.0515787Z  (cd src && make  top_distdir=../dashcore-linux64_nowallet distdir=../dashcore-linux64_nowallet/src \
+2025-07-30T13:48:08.0516538Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-30T13:48:08.0766175Z make[2]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:48:08.0766745Z make  distdir-am
+2025-07-30T13:48:08.2224815Z make[3]: Entering directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:48:08.3083225Z Generated bench/data/block813851.raw.h
+2025-07-30T13:48:08.3336353Z Generated test/data/blockfilters.json.h
+2025-07-30T13:48:08.3426031Z Generated test/data/base58_encode_decode.json.h
+2025-07-30T13:48:08.3529092Z Generated test/data/bip39_vectors.json.h
+2025-07-30T13:48:08.3620863Z Generated test/data/key_io_valid.json.h
+2025-07-30T13:48:08.3704546Z Generated test/data/key_io_invalid.json.h
+2025-07-30T13:48:08.3788063Z Generated test/data/proposals_valid.json.h
+2025-07-30T13:48:08.3873817Z Generated test/data/proposals_invalid.json.h
+2025-07-30T13:48:08.4235431Z Generated test/data/script_tests.json.h
+2025-07-30T13:48:08.4527826Z Generated test/data/sighash.json.h
+2025-07-30T13:48:08.4624901Z Generated test/data/trivially_invalid.json.h
+2025-07-30T13:48:08.4728079Z Generated test/data/trivially_valid.json.h
+2025-07-30T13:48:08.4853786Z Generated test/data/tx_invalid.json.h
+2025-07-30T13:48:08.4977093Z Generated test/data/tx_valid.json.h
+2025-07-30T13:48:08.5060209Z Generated test/data/asmap.raw.h
+2025-07-30T13:48:11.0826054Z  (cd secp256k1 && make  top_distdir=../../dashcore-linux64_nowallet distdir=../../dashcore-linux64_nowallet/src/secp256k1 \
+2025-07-30T13:48:11.0863874Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-30T13:48:11.0864508Z make[4]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:48:11.0864879Z make  distdir-am
+2025-07-30T13:48:11.0981545Z make[5]: Entering directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:48:11.0982253Z :
+2025-07-30T13:48:11.0983059Z test -d "../../dashcore-linux64_nowallet/src/secp256k1" || mkdir "../../dashcore-linux64_nowallet/src/secp256k1"
+2025-07-30T13:48:11.3273227Z test -n ":" \
+2025-07-30T13:48:11.3273841Z || find "../../dashcore-linux64_nowallet/src/secp256k1" -type d ! -perm -755 \
+2025-07-30T13:48:11.3274356Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-30T13:48:11.3274685Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-30T13:48:11.3275041Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-30T13:48:11.3275598Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/src/secp256k1/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-30T13:48:11.3276136Z || chmod -R a+r "../../dashcore-linux64_nowallet/src/secp256k1"
+2025-07-30T13:48:11.3288122Z make[5]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:48:11.3290176Z make[4]: Leaving directory '/__w/dash/dash/build-ci/src/secp256k1'
+2025-07-30T13:48:11.3296601Z make[3]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:48:11.3305651Z make[2]: Leaving directory '/__w/dash/dash/build-ci/src'
+2025-07-30T13:48:11.3585779Z  (cd doc/man && make  top_distdir=../../dashcore-linux64_nowallet distdir=../../dashcore-linux64_nowallet/doc/man \
+2025-07-30T13:48:11.3586738Z      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
+2025-07-30T13:48:11.3608187Z make[2]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:48:11.3608827Z make  distdir-am
+2025-07-30T13:48:11.3642017Z make[3]: Entering directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:48:11.3806780Z make[3]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:48:11.3807767Z make[2]: Leaving directory '/__w/dash/dash/build-ci/doc/man'
+2025-07-30T13:48:11.3812954Z make  \
+2025-07-30T13:48:11.3813490Z   top_distdir="dashcore-linux64_nowallet" distdir="dashcore-linux64_nowallet" \
+2025-07-30T13:48:11.3814143Z   dist-hook
+2025-07-30T13:48:11.3848247Z make[2]: Entering directory '/__w/dash/dash/build-ci'
+2025-07-30T13:48:11.3849145Z /usr/bin/git archive --format=tar HEAD -- src/clientversion.cpp | ${TAR-tar} -C dashcore-linux64_nowallet -xf -
+2025-07-30T13:48:11.3878281Z fatal: pathspec 'src/clientversion.cpp' did not match any files
+2025-07-30T13:48:11.3880380Z tar: This does not look like a tar archive
+2025-07-30T13:48:11.3880914Z tar: Exiting with failure status due to previous errors
+2025-07-30T13:48:11.3885952Z make[2]: [Makefile:1225: dist-hook] Error 2 (ignored)
+2025-07-30T13:48:11.3886977Z make[2]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-30T13:48:11.3888477Z test -n "" \
+2025-07-30T13:48:11.3888979Z || find "dashcore-linux64_nowallet" -type d ! -perm -755 \
+2025-07-30T13:48:11.3889569Z 	-exec chmod u+rwx,go+rx {} \; -o \
+2025-07-30T13:48:11.3889913Z   ! -type d ! -perm -444 -links 1 -exec chmod a+r {} \; -o \
+2025-07-30T13:48:11.3890241Z   ! -type d ! -perm -400 -exec chmod a+r {} \; -o \
+2025-07-30T13:48:11.3890651Z   ! -type d ! -perm -444 -exec /bin/bash /__w/dash/dash/build-aux/install-sh -c -m a+r {} {} \; \
+2025-07-30T13:48:11.3891052Z || chmod -R a+r "dashcore-linux64_nowallet"
+2025-07-30T13:48:11.4117316Z make[1]: Leaving directory '/__w/dash/dash/build-ci'
+2025-07-30T13:48:11.5115475Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:48:11.5193851Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:48:11.5205482Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:48:11.5588476Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:11.5637793Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:11.5717721Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:48:11.5746324Z checking whether build environment is sane... yes
+2025-07-30T13:48:11.5806980Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:48:11.5826944Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:48:11.5831869Z checking for gawk... gawk
+2025-07-30T13:48:11.5905810Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:48:11.5950719Z checking whether make supports nested variables... yes
+2025-07-30T13:48:11.5993655Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:48:11.5995356Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:48:11.6656836Z checking whether the C++ compiler works... yes
+2025-07-30T13:48:11.6657804Z checking for C++ compiler default output file name... a.out
+2025-07-30T13:48:11.7062696Z checking for suffix of executables... 
+2025-07-30T13:48:11.7611313Z checking whether we are cross compiling... no
+2025-07-30T13:48:11.7799046Z checking for suffix of object files... o
+2025-07-30T13:48:11.7959170Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:48:11.8145796Z checking whether g++-14 accepts -g... yes
+2025-07-30T13:48:12.1374727Z checking for g++-14 option to enable C++11 features... unsupported
+2025-07-30T13:48:12.1902604Z checking for g++-14 option to enable C++98 features... none needed
+2025-07-30T13:48:12.1984622Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:48:12.1987045Z checking dependency style of g++-14... none
+2025-07-30T13:48:12.2886037Z checking whether g++-14 supports C++20 features with -std=c++20... yes
+2025-07-30T13:48:12.2889170Z checking for x86_64-pc-linux-gnu-g++... g++-14 -std=c++20
+2025-07-30T13:48:12.3198403Z checking whether the compiler supports GNU Objective C++... no
+2025-07-30T13:48:12.3482173Z checking whether g++-14 -std=c++20 accepts -g... no
+2025-07-30T13:48:12.3484159Z checking dependency style of g++-14 -std=c++20... none
+2025-07-30T13:48:12.3509363Z checking how to print strings... printf
+2025-07-30T13:48:12.3511513Z checking for x86_64-pc-linux-gnu-gcc... gcc-14
+2025-07-30T13:48:12.3917103Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:48:12.4072983Z checking whether gcc-14 accepts -g... yes
+2025-07-30T13:48:12.4437335Z checking for gcc-14 option to enable C11 features... none needed
+2025-07-30T13:48:12.4735316Z checking whether gcc-14 understands -c and -o together... yes
+2025-07-30T13:48:12.4736470Z checking dependency style of gcc-14... none
+2025-07-30T13:48:12.4776838Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:48:12.4808662Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:48:12.4824625Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:48:12.4842459Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:48:12.4894123Z checking for ld used by gcc-14... /usr/bin/ld
+2025-07-30T13:48:12.4919952Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:48:12.4922247Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:48:12.5229922Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:48:12.5230505Z checking whether ln -s works... yes
+2025-07-30T13:48:12.5273912Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:48:12.5301387Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:48:12.5302497Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:48:12.5304323Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:48:12.5309641Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:48:12.5313884Z checking for file... file
+2025-07-30T13:48:12.5319110Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:48:12.5323320Z checking for objdump... objdump
+2025-07-30T13:48:12.5327215Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:48:12.5332152Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:48:12.5336342Z checking for dlltool... no
+2025-07-30T13:48:12.5337863Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:48:12.5340517Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:48:12.5694104Z checking for archiver @FILE support... @
+2025-07-30T13:48:12.5694573Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:48:12.5696710Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:48:12.6425217Z checking command to parse nm output from gcc-14 object... ok
+2025-07-30T13:48:12.6441882Z checking for sysroot... no
+2025-07-30T13:48:12.6484810Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:48:12.6523759Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:48:12.6625754Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:48:12.6630204Z checking for mt... no
+2025-07-30T13:48:12.6661885Z checking if : is a manifest tool... no
+2025-07-30T13:48:12.6817486Z checking for stdio.h... yes
+2025-07-30T13:48:12.6996249Z checking for stdlib.h... yes
+2025-07-30T13:48:12.7174616Z checking for string.h... yes
+2025-07-30T13:48:12.7361888Z checking for inttypes.h... yes
+2025-07-30T13:48:12.7542690Z checking for stdint.h... yes
+2025-07-30T13:48:12.7722904Z checking for strings.h... yes
+2025-07-30T13:48:12.7924089Z checking for sys/stat.h... yes
+2025-07-30T13:48:12.8126818Z checking for sys/types.h... yes
+2025-07-30T13:48:12.8362143Z checking for unistd.h... yes
+2025-07-30T13:48:12.8585660Z checking for dlfcn.h... yes
+2025-07-30T13:48:12.8624783Z checking for objdir... .libs
+2025-07-30T13:48:12.9270352Z checking if gcc-14 supports -fno-rtti -fno-exceptions... no
+2025-07-30T13:48:12.9271222Z checking for gcc-14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:12.9423584Z checking if gcc-14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:13.0030470Z checking if gcc-14 static flag -static works... yes
+2025-07-30T13:48:13.0284588Z checking if gcc-14 supports -c -o file.o... yes
+2025-07-30T13:48:13.0285160Z checking if gcc-14 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:13.0385756Z checking whether the gcc-14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:13.0603990Z checking whether -lc should be explicitly linked in... no
+2025-07-30T13:48:13.1140085Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:48:13.1140817Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:13.1156640Z checking whether stripping libraries is possible... yes
+2025-07-30T13:48:13.1157259Z checking if libtool supports shared libraries... yes
+2025-07-30T13:48:13.1158003Z checking whether to build shared libraries... yes
+2025-07-30T13:48:13.1158505Z checking whether to build static libraries... yes
+2025-07-30T13:48:13.1446629Z checking how to run the C++ preprocessor... g++-14 -std=c++20 -E
+2025-07-30T13:48:13.2281900Z checking for ld used by g++-14 -std=c++20... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:48:13.2305855Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:48:13.2375482Z checking whether the g++-14 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:13.2962200Z checking for g++-14 -std=c++20 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:13.3118336Z checking if g++-14 -std=c++20 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:13.3743080Z checking if g++-14 -std=c++20 static flag -static works... yes
+2025-07-30T13:48:13.3962818Z checking if g++-14 -std=c++20 supports -c -o file.o... yes
+2025-07-30T13:48:13.3964299Z checking if g++-14 -std=c++20 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:13.3965423Z checking whether the g++-14 -std=c++20 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:13.4012550Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:48:13.4013298Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:13.4020639Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:48:13.4026294Z checking for x86_64-pc-linux-gnu-gcov... no
+2025-07-30T13:48:13.4031585Z checking for gcov... /usr/bin/gcov
+2025-07-30T13:48:13.4035668Z checking for x86_64-pc-linux-gnu-llvm-cov... no
+2025-07-30T13:48:13.4040201Z checking for llvm-cov... /usr/bin/llvm-cov
+2025-07-30T13:48:13.4044133Z checking for lcov... no
+2025-07-30T13:48:13.4048457Z checking for python3.9... /usr/local/pyenv/shims/python3.9
+2025-07-30T13:48:13.4052623Z checking for genhtml... no
+2025-07-30T13:48:13.4056532Z checking for git... /usr/bin/git
+2025-07-30T13:48:13.4060790Z checking for ccache... /usr/bin/ccache
+2025-07-30T13:48:13.4064093Z checking for xgettext... /usr/bin/xgettext
+2025-07-30T13:48:13.4067752Z checking for hexdump... /usr/bin/hexdump
+2025-07-30T13:48:13.4071836Z checking for x86_64-pc-linux-gnu-objcopy... no
+2025-07-30T13:48:13.4075938Z checking for objcopy... /usr/bin/objcopy
+2025-07-30T13:48:13.4080347Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:48:13.4084487Z checking for objdump... /usr/bin/objdump
+2025-07-30T13:48:13.4089575Z checking for x86_64-pc-linux-gnu-dsymutil... no
+2025-07-30T13:48:13.4094535Z checking for dsymutil... /usr/bin/dsymutil
+2025-07-30T13:48:13.4098502Z checking for doxygen... no
+2025-07-30T13:48:13.4282285Z checking whether C++ compiler accepts -Werror... yes
+2025-07-30T13:48:13.4742307Z checking whether the linker accepts -Wl,--fatal-warnings... yes
+2025-07-30T13:48:13.5195058Z checking for execinfo.h... yes
+2025-07-30T13:48:13.5645077Z checking whether the linker accepts -Wl,-wrap=__cxa_allocate_exception... yes
+2025-07-30T13:48:13.5858151Z checking whether C++ compiler accepts -Wa,-mbig-obj... no
+2025-07-30T13:48:13.6056340Z checking whether C++ compiler accepts -Warray-bounds... yes
+2025-07-30T13:48:13.6233040Z checking whether C++ compiler accepts -Wattributes... no
+2025-07-30T13:48:13.6415298Z checking whether C++ compiler accepts -Wcpp... no
+2025-07-30T13:48:13.6603491Z checking whether C++ compiler accepts -Wstringop-overread... yes
+2025-07-30T13:48:13.6797545Z checking whether C++ compiler accepts -Wstringop-overflow... yes
+2025-07-30T13:48:13.7019667Z checking whether C++ compiler accepts -Wall... yes
+2025-07-30T13:48:13.7207286Z checking whether C++ compiler accepts -Wextra... yes
+2025-07-30T13:48:13.7346472Z checking whether C++ compiler accepts -Wgnu... no
+2025-07-30T13:48:13.7535175Z checking whether C++ compiler accepts -Wformat -Wformat-security... yes
+2025-07-30T13:48:13.7728227Z checking whether C++ compiler accepts -Wreorder... yes
+2025-07-30T13:48:13.7917486Z checking whether C++ compiler accepts -Wvla... yes
+2025-07-30T13:48:13.8093417Z checking whether C++ compiler accepts -Wshadow-field... no
+2025-07-30T13:48:13.8301180Z checking whether C++ compiler accepts -Wthread-safety... no
+2025-07-30T13:48:13.8495215Z checking whether C++ compiler accepts -Wloop-analysis... no
+2025-07-30T13:48:13.8689466Z checking whether C++ compiler accepts -Wredundant-decls... yes
+2025-07-30T13:48:13.8950378Z checking whether C++ compiler accepts -Wunused-member-function... no
+2025-07-30T13:48:13.9134640Z checking whether C++ compiler accepts -Wdate-time... yes
+2025-07-30T13:48:13.9414027Z checking whether C++ compiler accepts -Wconditional-uninitialized... no
+2025-07-30T13:48:13.9605783Z checking whether C++ compiler accepts -Wduplicated-branches... yes
+2025-07-30T13:48:13.9801898Z checking whether C++ compiler accepts -Wduplicated-cond... yes
+2025-07-30T13:48:13.9991989Z checking whether C++ compiler accepts -Wlogical-op... yes
+2025-07-30T13:48:14.0193536Z checking whether C++ compiler accepts -Woverloaded-virtual... yes
+2025-07-30T13:48:14.0392784Z checking whether C++ compiler accepts -Wsuggest-override... yes
+2025-07-30T13:48:14.0587173Z checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
+2025-07-30T13:48:14.0782459Z checking whether C++ compiler accepts -Wunreachable-code... yes
+2025-07-30T13:48:14.0983939Z checking whether C++ compiler accepts -Wdocumentation... no
+2025-07-30T13:48:14.1164650Z checking whether C++ compiler accepts -Wself-assign... no
+2025-07-30T13:48:14.1365640Z checking whether C++ compiler accepts -Wunused-parameter... yes
+2025-07-30T13:48:14.1573843Z checking whether C++ compiler accepts -fno-extended-identifiers... yes
+2025-07-30T13:48:14.1742527Z checking whether C++ compiler accepts -fstack-reuse=none... yes
+2025-07-30T13:48:14.1933077Z checking whether C++ compiler accepts -msse4.2... yes
+2025-07-30T13:48:14.2138771Z checking whether C++ compiler accepts -msse4.1... yes
+2025-07-30T13:48:14.2352711Z checking whether C++ compiler accepts -mavx -mavx2... yes
+2025-07-30T13:48:14.2549407Z checking whether C++ compiler accepts -msse4 -msha... yes
+2025-07-30T13:48:14.7770738Z checking whether C++ compiler accepts -mpclmul... yes
+2025-07-30T13:48:14.8252115Z checking for SSE4.2 intrinsics... yes
+2025-07-30T13:48:15.3290482Z checking for SSE4.1 intrinsics... yes
+2025-07-30T13:48:15.8119575Z checking for AVX2 intrinsics... yes
+2025-07-30T13:48:16.3071196Z checking for x86 SHA-NI intrinsics... yes
+2025-07-30T13:48:16.3250931Z checking whether C++ compiler accepts -march=armv8-a+crc+crypto... no
+2025-07-30T13:48:16.3414223Z checking whether C++ compiler accepts -march=armv8-a+crypto... no
+2025-07-30T13:48:16.3575110Z checking for ARMv8 CRC32 intrinsics... no
+2025-07-30T13:48:16.3737832Z checking for ARMv8 SHA-NI intrinsics... no
+2025-07-30T13:48:16.4589460Z checking whether byte ordering is bigendian... no
+2025-07-30T13:48:16.4845587Z checking how to run the C preprocessor... gcc-14 -E
+2025-07-30T13:48:16.5177293Z checking whether gcc-14 is Clang... no
+2025-07-30T13:48:16.5664533Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:48:16.6038731Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:48:16.6039879Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:48:16.6418763Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:48:17.6773752Z checking whether std::atomic can be used without link library... yes
+2025-07-30T13:48:17.6786471Z checking for special C compiler options needed for large files... no
+2025-07-30T13:48:17.7003571Z checking for _FILE_OFFSET_BITS value needed for large files... no
+2025-07-30T13:48:17.7376459Z checking for g++-14 -std=c++20 options needed to detect all undeclared functions... none needed
+2025-07-30T13:48:17.7917089Z checking whether strerror_r is declared... yes
+2025-07-30T13:48:17.8167787Z checking whether strerror_r returns char *... yes
+2025-07-30T13:48:17.8341637Z checking whether C++ compiler accepts -fPIC... yes
+2025-07-30T13:48:17.8504437Z checking whether C++ compiler accepts -Wstack-protector... yes
+2025-07-30T13:48:17.8671708Z checking whether C++ compiler accepts -fstack-protector-all... yes
+2025-07-30T13:48:17.8843952Z checking whether C++ compiler accepts -fcf-protection=full... yes
+2025-07-30T13:48:17.9022906Z checking whether C++ compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:48:17.9107843Z checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
+2025-07-30T13:48:17.9193368Z checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
+2025-07-30T13:48:17.9451746Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:48:17.9713165Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:48:17.9988963Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:48:18.0275292Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:48:18.0764596Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:48:18.1229181Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:48:18.1689243Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:48:18.2173409Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:48:18.2627123Z checking for sys/select.h... yes
+2025-07-30T13:48:18.3084814Z checking for sys/prctl.h... yes
+2025-07-30T13:48:18.3424915Z checking for vm/vm_param.h... no
+2025-07-30T13:48:18.3764923Z checking for sys/vmmeter.h... no
+2025-07-30T13:48:18.4099213Z checking for sys/resources.h... no
+2025-07-30T13:48:18.4394269Z checking whether getifaddrs is declared... yes
+2025-07-30T13:48:18.4933431Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:48:18.5242242Z checking whether freeifaddrs is declared... yes
+2025-07-30T13:48:18.5765787Z checking whether ifaddrs funcs can be used without link library... yes
+2025-07-30T13:48:18.6316632Z checking whether fork is declared... yes
+2025-07-30T13:48:18.6859694Z checking whether setsid is declared... yes
+2025-07-30T13:48:18.7379759Z checking whether pipe2 is declared... yes
+2025-07-30T13:48:18.7627566Z checking for mallopt M_ARENA_MAX... yes
+2025-07-30T13:48:18.7890629Z checking for getmemoryinfo... yes
+2025-07-30T13:48:18.8104952Z checking for posix_fallocate... yes
+2025-07-30T13:48:18.8269407Z checking for default visibility attribute... yes
+2025-07-30T13:48:18.8424630Z checking for dllexport attribute... no
+2025-07-30T13:48:19.3566342Z checking for thread_local support... yes
+2025-07-30T13:48:19.3870966Z checking for Linux getrandom syscall... yes
+2025-07-30T13:48:19.4221870Z checking for getentropy via random.h... yes
+2025-07-30T13:48:19.4423640Z checking for sysctl... no
+2025-07-30T13:48:19.4624051Z checking for sysctl KERN_ARND... no
+2025-07-30T13:48:19.5078607Z checking for library containing backtrace... none required
+2025-07-30T13:48:19.5339574Z checking for fdatasync... yes
+2025-07-30T13:48:19.5559196Z checking for F_FULLFSYNC... no
+2025-07-30T13:48:19.5790622Z checking for O_CLOEXEC... yes
+2025-07-30T13:48:19.5967776Z checking for __builtin_prefetch... yes
+2025-07-30T13:48:19.6396320Z checking for _mm_prefetch... yes
+2025-07-30T13:48:19.6602234Z checking for strong getauxval support in the system headers... yes
+2025-07-30T13:48:19.6889188Z checking for sockaddr_un... yes
+2025-07-30T13:48:19.7456387Z checking for std::system... yes
+2025-07-30T13:48:19.7758559Z checking for ::_wsystem... no
+2025-07-30T13:48:19.7934383Z checking for Qt5Core >= 5.11.3... yes
+2025-07-30T13:48:19.8042140Z checking for Qt5Gui >= 5.11.3... yes
+2025-07-30T13:48:19.8156281Z checking for Qt5Widgets >= 5.11.3... yes
+2025-07-30T13:48:19.8270834Z checking for Qt5Network >= 5.11.3... yes
+2025-07-30T13:48:19.8391284Z checking for Qt5Test >= 5.11.3... yes
+2025-07-30T13:48:19.8503916Z checking for Qt5DBus >= 5.11.3... yes
+2025-07-30T13:48:20.1028761Z checking for static Qt... yes
+2025-07-30T13:48:20.1146695Z checking for Qt5AccessibilitySupport... yes
+2025-07-30T13:48:20.1256100Z checking for Qt5DeviceDiscoverySupport... yes
+2025-07-30T13:48:20.1364531Z checking for Qt5EdidSupport... yes
+2025-07-30T13:48:20.1475417Z checking for Qt5EventDispatcherSupport... yes
+2025-07-30T13:48:20.1585360Z checking for Qt5FbSupport... yes
+2025-07-30T13:48:20.1701950Z checking for Qt5FontDatabaseSupport... yes
+2025-07-30T13:48:20.1823656Z checking for Qt5ThemeSupport... yes
+2025-07-30T13:48:20.1940289Z checking for Qt5InputSupport... yes
+2025-07-30T13:48:20.2060235Z checking for Qt5ServiceSupport... yes
+2025-07-30T13:48:20.2201239Z checking for Qt5XcbQpa... yes
+2025-07-30T13:48:20.2326524Z checking for Qt5XkbCommonSupport... yes
+2025-07-30T13:48:22.5496092Z checking for QMinimalIntegrationPlugin (-lqminimal)... yes
+2025-07-30T13:48:24.9945047Z checking for QXcbIntegrationPlugin (-lqxcb)... yes
+2025-07-30T13:48:25.2479575Z checking whether -fPIE can be used with this Qt config... yes
+2025-07-30T13:48:25.2493019Z checking for moc-qt5... no
+2025-07-30T13:48:25.2493832Z checking for moc5... no
+2025-07-30T13:48:25.2495428Z checking for moc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/moc
+2025-07-30T13:48:25.2498217Z checking for uic-qt5... no
+2025-07-30T13:48:25.2499680Z checking for uic5... no
+2025-07-30T13:48:25.2501672Z checking for uic... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/uic
+2025-07-30T13:48:25.2503204Z checking for rcc-qt5... no
+2025-07-30T13:48:25.2504089Z checking for rcc5... no
+2025-07-30T13:48:25.2506675Z checking for rcc... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc
+2025-07-30T13:48:25.2509213Z checking for lrelease-qt5... no
+2025-07-30T13:48:25.2509886Z checking for lrelease5... no
+2025-07-30T13:48:25.2512378Z checking for lrelease... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lrelease
+2025-07-30T13:48:25.2513837Z checking for lupdate-qt5... no
+2025-07-30T13:48:25.2515295Z checking for lupdate5... no
+2025-07-30T13:48:25.2517459Z checking for lupdate... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lupdate
+2025-07-30T13:48:25.2519858Z checking for lconvert-qt5... no
+2025-07-30T13:48:25.2520409Z checking for lconvert5... no
+2025-07-30T13:48:25.2523047Z checking for lconvert... /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/lconvert
+2025-07-30T13:48:25.2555529Z checking whether /__w/dash/dash/depends/x86_64-pc-linux-gnu/native/bin/rcc accepts --format-version option... yes
+2025-07-30T13:48:25.2556741Z checking whether to build Dash Core GUI... yes (Qt5)
+2025-07-30T13:48:25.3228362Z checking whether main function is needed for fuzz binary... checking whether the linker accepts ... no
+2025-07-30T13:48:25.3229446Z yes
+2025-07-30T13:48:25.3451725Z checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
+2025-07-30T13:48:25.3948988Z checking for miniupnpc/miniupnpc.h... yes
+2025-07-30T13:48:25.4433995Z checking for upnpDiscover in -lminiupnpc... yes
+2025-07-30T13:48:25.4920422Z checking for miniupnpc/upnpcommands.h... yes
+2025-07-30T13:48:25.4960276Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-30T13:48:25.5433351Z checking for miniupnpc/upnperrors.h... yes
+2025-07-30T13:48:25.5471913Z checking for upnpDiscover in -lminiupnpc... (cached) yes
+2025-07-30T13:48:25.5554272Z checking whether miniUPnPc API version is supported... yes
+2025-07-30T13:48:25.6076190Z checking for natpmp.h... yes
+2025-07-30T13:48:25.6527086Z checking for initnatpmp in -lnatpmp... yes
+2025-07-30T13:48:25.6602610Z checking for boostlib >= 1.73.0 (107300) includes in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include"... yes
+2025-07-30T13:48:25.6603980Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/x86_64-linux-gnu"... no
+2025-07-30T13:48:25.6605127Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib64"... no
+2025-07-30T13:48:25.6606159Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/libx32"... no
+2025-07-30T13:48:25.6606934Z checking for boostlib >= 1.73.0 (107300) lib path in "/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib"... yes
+2025-07-30T13:48:25.6759749Z checking for Boost headers >= 1.73.0 (107300)... yes
+2025-07-30T13:48:25.7073363Z checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... no
+2025-07-30T13:48:29.1313134Z checking for Boost Process... yes
+2025-07-30T13:48:29.1552499Z checking whether C++ compiler accepts -fvisibility=hidden... yes
+2025-07-30T13:48:29.2033422Z checking whether the linker accepts -Wl,--exclude-libs,ALL... yes
+2025-07-30T13:48:29.2329520Z checking whether the linker accepts -Wl,-no_exported_symbols... no
+2025-07-30T13:48:29.2449586Z checking for libevent >= 2.1.8... yes
+2025-07-30T13:48:29.2570364Z checking for libevent_pthreads >= 2.1.8... yes
+2025-07-30T13:48:29.2928535Z checking if evhttp_connection_get_peer expects const char**... no
+2025-07-30T13:48:29.3060820Z checking for libqrencode... yes
+2025-07-30T13:48:29.3178085Z checking for libzmq >= 4... yes
+2025-07-30T13:48:29.3784058Z checking for gmp.h... yes
+2025-07-30T13:48:29.4229213Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:48:29.4343424Z checking for libmultiprocess... no
+2025-07-30T13:48:29.4423145Z checking whether to build dashd... yes
+2025-07-30T13:48:29.4424733Z checking whether to build dash-cli... yes
+2025-07-30T13:48:29.4425261Z checking whether to build dash-tx... yes
+2025-07-30T13:48:29.4426242Z checking whether to build dash-wallet... yes
+2025-07-30T13:48:29.4426747Z checking whether to build libraries... yes
+2025-07-30T13:48:29.4430604Z checking if ccache should be used... yes
+2025-07-30T13:48:29.4528010Z checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
+2025-07-30T13:48:29.4650151Z checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
+2025-07-30T13:48:29.4652127Z checking if wallet should be enabled... no
+2025-07-30T13:48:29.4652919Z checking whether to build with support for UPnP... yes
+2025-07-30T13:48:29.4654492Z checking whether to build with support for NAT-PMP... yes
+2025-07-30T13:48:29.4657383Z checking whether to build GUI with support for D-Bus... yes
+2025-07-30T13:48:29.4658835Z checking whether to build GUI with support for QR codes... yes
+2025-07-30T13:48:29.4659491Z checking whether to build test_dash-qt... yes
+2025-07-30T13:48:29.4661268Z checking whether to build test_dash... yes
+2025-07-30T13:48:29.4662175Z checking whether to reduce exports... yes
+2025-07-30T13:48:29.4799905Z checking whether dsymutil needs -flat... yes
+2025-07-30T13:48:29.4800302Z 
+2025-07-30T13:48:29.5230999Z checking that generated files are newer than configure... done
+2025-07-30T13:48:29.5237922Z configure: creating ./config.status
+2025-07-30T13:48:30.1896563Z config.status: creating libdashconsensus.pc
+2025-07-30T13:48:30.2022347Z config.status: creating Makefile
+2025-07-30T13:48:30.2151197Z config.status: creating src/Makefile
+2025-07-30T13:48:30.2727075Z config.status: creating doc/man/Makefile
+2025-07-30T13:48:30.2882037Z config.status: creating share/setup.nsi
+2025-07-30T13:48:30.3045174Z config.status: creating share/qt/Info.plist
+2025-07-30T13:48:30.3207989Z config.status: creating test/config.ini
+2025-07-30T13:48:30.3365317Z config.status: creating contrib/devtools/split-debug.sh
+2025-07-30T13:48:30.3526971Z config.status: creating src/config/bitcoin-config.h
+2025-07-30T13:48:30.3995638Z config.status: executing depfiles commands
+2025-07-30T13:48:30.4009253Z config.status: executing libtool commands
+2025-07-30T13:48:30.4129148Z === configuring in src/dashbls (/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src/dashbls)
+2025-07-30T13:48:30.4172306Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-reduce-exports' '--with-boost-process' 'CC=gcc-14' 'CXX=g++-14' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-30T13:48:30.5257142Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:48:30.5676454Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:30.5725210Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:30.5807376Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:48:30.5838401Z checking whether build environment is sane... yes
+2025-07-30T13:48:30.5908369Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:48:30.5929830Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:48:30.5933709Z checking for gawk... gawk
+2025-07-30T13:48:30.6003240Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:48:30.6059925Z checking whether make supports nested variables... yes
+2025-07-30T13:48:30.6104150Z checking whether to enable maintainer-specific portions of Makefiles... yes
+2025-07-30T13:48:30.6105819Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:48:30.6108635Z checking for x86_64-pc-linux-gnu-gcc... gcc-14
+2025-07-30T13:48:30.6686324Z checking whether the C compiler works... yes
+2025-07-30T13:48:30.6687048Z checking for C compiler default output file name... a.out
+2025-07-30T13:48:30.6993448Z checking for suffix of executables... 
+2025-07-30T13:48:30.7392088Z checking whether we are cross compiling... no
+2025-07-30T13:48:30.7560776Z checking for suffix of object files... o
+2025-07-30T13:48:30.7715941Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:48:30.7885610Z checking whether gcc-14 accepts -g... yes
+2025-07-30T13:48:30.8263117Z checking for gcc-14 option to enable C11 features... none needed
+2025-07-30T13:48:30.8555877Z checking whether gcc-14 understands -c and -o together... yes
+2025-07-30T13:48:30.8630252Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:48:30.8633509Z checking dependency style of gcc-14... none
+2025-07-30T13:48:30.9024107Z checking whether the compiler supports GNU C++... yes
+2025-07-30T13:48:30.9202258Z checking whether g++-14 accepts -g... yes
+2025-07-30T13:48:31.2429506Z checking for g++-14 option to enable C++11 features... unsupported
+2025-07-30T13:48:31.2996238Z checking for g++-14 option to enable C++98 features... none needed
+2025-07-30T13:48:31.2998086Z checking dependency style of g++-14... none
+2025-07-30T13:48:31.3423410Z checking whether g++-14 supports C++14 features with -std=c++14... yes
+2025-07-30T13:48:31.3448413Z checking how to print strings... printf
+2025-07-30T13:48:31.3488283Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:48:31.3519822Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:48:31.3537976Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:48:31.3554180Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:48:31.3606287Z checking for ld used by gcc-14... /usr/bin/ld
+2025-07-30T13:48:31.3630358Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:48:31.3632191Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:48:31.3923920Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:48:31.3924306Z checking whether ln -s works... yes
+2025-07-30T13:48:31.3965510Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:48:31.3992679Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:48:31.3994238Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:48:31.3996990Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:48:31.4000504Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:48:31.4004602Z checking for file... file
+2025-07-30T13:48:31.4008898Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:48:31.4012964Z checking for objdump... objdump
+2025-07-30T13:48:31.4017386Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:48:31.4022932Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:48:31.4026825Z checking for dlltool... no
+2025-07-30T13:48:31.4029253Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:48:31.4030628Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:48:31.4387964Z checking for archiver @FILE support... @
+2025-07-30T13:48:31.4388597Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:48:31.4391480Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:48:31.5108555Z checking command to parse nm output from gcc-14 object... ok
+2025-07-30T13:48:31.5126162Z checking for sysroot... no
+2025-07-30T13:48:31.5168169Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:48:31.5208675Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:48:31.5320616Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:48:31.5325060Z checking for mt... no
+2025-07-30T13:48:31.5357024Z checking if : is a manifest tool... no
+2025-07-30T13:48:31.5538450Z checking for stdio.h... yes
+2025-07-30T13:48:31.5721741Z checking for stdlib.h... yes
+2025-07-30T13:48:31.5900699Z checking for string.h... yes
+2025-07-30T13:48:31.6072107Z checking for inttypes.h... yes
+2025-07-30T13:48:31.6254427Z checking for stdint.h... yes
+2025-07-30T13:48:31.6449356Z checking for strings.h... yes
+2025-07-30T13:48:31.6636561Z checking for sys/stat.h... yes
+2025-07-30T13:48:31.6839755Z checking for sys/types.h... yes
+2025-07-30T13:48:31.7075347Z checking for unistd.h... yes
+2025-07-30T13:48:31.7300268Z checking for dlfcn.h... yes
+2025-07-30T13:48:31.7336196Z checking for objdir... .libs
+2025-07-30T13:48:31.7966145Z checking if gcc-14 supports -fno-rtti -fno-exceptions... no
+2025-07-30T13:48:31.7966914Z checking for gcc-14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:31.8125246Z checking if gcc-14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:31.8741067Z checking if gcc-14 static flag -static works... yes
+2025-07-30T13:48:31.8964194Z checking if gcc-14 supports -c -o file.o... yes
+2025-07-30T13:48:31.8964652Z checking if gcc-14 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:31.9063541Z checking whether the gcc-14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:31.9564261Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:48:31.9565006Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:31.9581091Z checking whether stripping libraries is possible... yes
+2025-07-30T13:48:31.9581773Z checking if libtool supports shared libraries... yes
+2025-07-30T13:48:31.9582355Z checking whether to build shared libraries... no
+2025-07-30T13:48:31.9583052Z checking whether to build static libraries... yes
+2025-07-30T13:48:31.9874205Z checking how to run the C++ preprocessor... g++-14 -std=c++14 -E
+2025-07-30T13:48:32.0755172Z checking for ld used by g++-14 -std=c++14... /usr/bin/ld -m elf_x86_64
+2025-07-30T13:48:32.0780661Z checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
+2025-07-30T13:48:32.0856355Z checking whether the g++-14 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:32.1458669Z checking for g++-14 -std=c++14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:32.1604257Z checking if g++-14 -std=c++14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:32.2231918Z checking if g++-14 -std=c++14 static flag -static works... yes
+2025-07-30T13:48:32.2474712Z checking if g++-14 -std=c++14 supports -c -o file.o... yes
+2025-07-30T13:48:32.2475472Z checking if g++-14 -std=c++14 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:32.2476380Z checking whether the g++-14 -std=c++14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:32.2521666Z checking dynamic linker characteristics... (cached) GNU/Linux ld.so
+2025-07-30T13:48:32.2522924Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:32.2529772Z checking for x86_64-pc-linux-gnu-ar... (cached) ar
+2025-07-30T13:48:32.2534953Z checking for x86_64-pc-linux-gnu-ranlib... no
+2025-07-30T13:48:32.2537216Z checking for ranlib... (cached) ranlib
+2025-07-30T13:48:32.2541457Z checking for x86_64-pc-linux-gnu-strip... no
+2025-07-30T13:48:32.2544321Z checking for strip... (cached) strip
+2025-07-30T13:48:32.2546948Z checking dependency style of gcc-14... none
+2025-07-30T13:48:32.2703557Z checking whether C compiler accepts -Werror... yes
+2025-07-30T13:48:32.2966602Z checking for gmp.h... yes
+2025-07-30T13:48:32.3310445Z checking for __gmpz_init in -lgmp... yes
+2025-07-30T13:48:32.3501170Z checking gmp version >= 6.2... yes
+2025-07-30T13:48:32.3533463Z checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/pkg-config --static
+2025-07-30T13:48:32.3546730Z checking pkg-config is at least version 0.9.0... yes
+2025-07-30T13:48:32.3660009Z checking if gcc-14 supports -pipe... yes
+2025-07-30T13:48:32.3774809Z checking if gcc-14 supports -fomit-frame-pointer... yes
+2025-07-30T13:48:32.4041948Z checking how to run the C preprocessor... gcc-14 -E
+2025-07-30T13:48:32.4378035Z checking whether gcc-14 is Clang... no
+2025-07-30T13:48:32.4872237Z checking whether pthreads work with "-pthread" and "-lpthread"... yes
+2025-07-30T13:48:32.5242165Z checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+2025-07-30T13:48:32.5242680Z checking whether more special flags are required for pthreads... no
+2025-07-30T13:48:32.5603957Z checking for PTHREAD_PRIO_INHERIT... yes
+2025-07-30T13:48:32.5966344Z checking for library containing clock_gettime... none required
+2025-07-30T13:48:32.6158233Z checking whether C compiler accepts -fPIC... yes
+2025-07-30T13:48:32.6341428Z checking whether C compiler accepts -fstack-reuse=none... yes
+2025-07-30T13:48:32.6505220Z checking whether C compiler accepts -Wstack-protector... yes
+2025-07-30T13:48:32.6686171Z checking whether C compiler accepts -fstack-protector-all... yes
+2025-07-30T13:48:32.6859262Z checking whether C compiler accepts -fcf-protection=full... yes
+2025-07-30T13:48:32.7044138Z checking whether C compiler accepts -fstack-clash-protection... yes
+2025-07-30T13:48:32.7295452Z checking whether the linker accepts -Wl,--enable-reloc-section... no
+2025-07-30T13:48:32.7531432Z checking whether the linker accepts -Wl,--dynamicbase... no
+2025-07-30T13:48:32.7756505Z checking whether the linker accepts -Wl,--nxcompat... no
+2025-07-30T13:48:32.7996159Z checking whether the linker accepts -Wl,--high-entropy-va... no
+2025-07-30T13:48:32.8330126Z checking whether the linker accepts -Wl,-z,relro... yes
+2025-07-30T13:48:32.8649003Z checking whether the linker accepts -Wl,-z,now... yes
+2025-07-30T13:48:32.8969225Z checking whether the linker accepts -Wl,-z,separate-code... yes
+2025-07-30T13:48:32.9303198Z checking whether the linker accepts -fPIE -pie... yes
+2025-07-30T13:48:32.9500850Z checking whether C compiler accepts -fno-extended-identifiers... yes
+2025-07-30T13:48:32.9501826Z checking whether to build runtest... yes
+2025-07-30T13:48:32.9502497Z checking whether to build runbench... yes
+2025-07-30T13:48:32.9738965Z checking that generated files are newer than configure... done
+2025-07-30T13:48:32.9743059Z configure: creating ./config.status
+2025-07-30T13:48:33.5212549Z config.status: creating Makefile
+2025-07-30T13:48:33.5435953Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-30T13:48:33.5573212Z config.status: executing depfiles commands
+2025-07-30T13:48:33.5587122Z config.status: executing libtool commands
+2025-07-30T13:48:33.5728319Z 
+2025-07-30T13:48:33.5728780Z Options used to compile and link:
+2025-07-30T13:48:33.5729235Z   target os           = linux
+2025-07-30T13:48:33.5729500Z   backend             = gmp
+2025-07-30T13:48:33.5729709Z   build bench         = yes
+2025-07-30T13:48:33.5729917Z   build test          = yes
+2025-07-30T13:48:33.5730116Z   use debug           = no
+2025-07-30T13:48:33.5730321Z   use hardening       = yes
+2025-07-30T13:48:33.5730524Z   use optimizations   = yes
+2025-07-30T13:48:33.5730647Z 
+2025-07-30T13:48:33.5730824Z   LDFLAGS             =  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie  
+2025-07-30T13:48:33.5731558Z   CFLAGS              =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-30T13:48:33.5732544Z   CPPFLAGS            =  -DHAVE_BUILD_INFO 
+2025-07-30T13:48:33.5733193Z   CXXFLAGS            =   -fPIC -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -fPIE  -fno-extended-identifiers  
+2025-07-30T13:48:33.5733824Z   PTHREAD_FLAGS       = -pthread -lpthread
+2025-07-30T13:48:33.5734009Z 
+2025-07-30T13:48:33.6096914Z === configuring in src/secp256k1 (/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src/secp256k1)
+2025-07-30T13:48:33.6140532Z configure: running /bin/bash ./configure --disable-option-checking '--prefix=/__w/dash/dash/depends/x86_64-pc-linux-gnu'  '--disable-dependency-tracking' '--bindir=/output/bin' '--libdir=/output/lib' '--enable-werror' '--enable-reduce-exports' '--with-boost-process' 'CC=gcc-14' 'CXX=g++-14' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' '--disable-openssl-tests' --cache-file=/dev/null --srcdir=.
+2025-07-30T13:48:33.7241947Z configure: loading site script /__w/dash/dash/depends/x86_64-pc-linux-gnu/share/config.site
+2025-07-30T13:48:33.7686856Z checking build system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:33.7739919Z checking host system type... x86_64-pc-linux-gnu
+2025-07-30T13:48:33.7827499Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-07-30T13:48:33.7855695Z checking whether build environment is sane... yes
+2025-07-30T13:48:33.7919480Z checking for x86_64-pc-linux-gnu-strip... strip
+2025-07-30T13:48:33.7940619Z checking for a race-free mkdir -p... /usr/bin/mkdir -p
+2025-07-30T13:48:33.7944413Z checking for gawk... gawk
+2025-07-30T13:48:33.8008400Z checking whether make sets $(MAKE)... yes
+2025-07-30T13:48:33.8062772Z checking whether make supports nested variables... yes
+2025-07-30T13:48:33.8105224Z checking whether make supports nested variables... (cached) yes
+2025-07-30T13:48:33.8107991Z checking for x86_64-pc-linux-gnu-gcc... gcc-14
+2025-07-30T13:48:33.8694848Z checking whether the C compiler works... yes
+2025-07-30T13:48:33.8695772Z checking for C compiler default output file name... a.out
+2025-07-30T13:48:33.9020454Z checking for suffix of executables... 
+2025-07-30T13:48:33.9423458Z checking whether we are cross compiling... no
+2025-07-30T13:48:33.9593229Z checking for suffix of object files... o
+2025-07-30T13:48:33.9737435Z checking whether the compiler supports GNU C... yes
+2025-07-30T13:48:33.9913533Z checking whether gcc-14 accepts -g... yes
+2025-07-30T13:48:34.0300129Z checking for gcc-14 option to enable C11 features... none needed
+2025-07-30T13:48:34.0580859Z checking whether gcc-14 understands -c and -o together... yes
+2025-07-30T13:48:34.0652114Z checking whether make supports the include directive... yes (GNU style)
+2025-07-30T13:48:34.0655788Z checking dependency style of gcc-14... none
+2025-07-30T13:48:34.0659653Z checking dependency style of gcc-14... none
+2025-07-30T13:48:34.0662107Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:48:34.0939538Z checking the archiver (ar) interface... ar
+2025-07-30T13:48:34.0961497Z checking how to print strings... printf
+2025-07-30T13:48:34.0999191Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-07-30T13:48:34.1029062Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-07-30T13:48:34.1044451Z checking for egrep... /usr/bin/grep -E
+2025-07-30T13:48:34.1059634Z checking for fgrep... /usr/bin/grep -F
+2025-07-30T13:48:34.1106240Z checking for ld used by gcc-14... /usr/bin/ld
+2025-07-30T13:48:34.1130243Z checking if the linker (/usr/bin/ld) is GNU ld... yes
+2025-07-30T13:48:34.1131961Z checking for BSD- or MS-compatible name lister (nm)... nm
+2025-07-30T13:48:34.1426945Z checking the name lister (nm) interface... BSD nm
+2025-07-30T13:48:34.1427499Z checking whether ln -s works... yes
+2025-07-30T13:48:34.1469189Z checking the maximum length of command line arguments... 3145728
+2025-07-30T13:48:34.1498092Z checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+2025-07-30T13:48:34.1499591Z checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+2025-07-30T13:48:34.1500631Z checking for /usr/bin/ld option to reload object files... -r
+2025-07-30T13:48:34.1505367Z checking for x86_64-pc-linux-gnu-file... no
+2025-07-30T13:48:34.1509983Z checking for file... file
+2025-07-30T13:48:34.1514074Z checking for x86_64-pc-linux-gnu-objdump... no
+2025-07-30T13:48:34.1519094Z checking for objdump... objdump
+2025-07-30T13:48:34.1523408Z checking how to recognize dependent libraries... pass_all
+2025-07-30T13:48:34.1528704Z checking for x86_64-pc-linux-gnu-dlltool... no
+2025-07-30T13:48:34.1532746Z checking for dlltool... no
+2025-07-30T13:48:34.1535000Z checking how to associate runtime and link libraries... printf %s\n
+2025-07-30T13:48:34.1536563Z checking for x86_64-pc-linux-gnu-ar... ar
+2025-07-30T13:48:34.1926573Z checking for archiver @FILE support... @
+2025-07-30T13:48:34.1928110Z checking for x86_64-pc-linux-gnu-strip... (cached) strip
+2025-07-30T13:48:34.1929671Z checking for x86_64-pc-linux-gnu-ranlib... ranlib
+2025-07-30T13:48:34.2629889Z checking command to parse nm output from gcc-14 object... ok
+2025-07-30T13:48:34.2648177Z checking for sysroot... no
+2025-07-30T13:48:34.2693916Z checking for a working dd... /usr/bin/dd
+2025-07-30T13:48:34.2732032Z checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
+2025-07-30T13:48:34.2842893Z checking for x86_64-pc-linux-gnu-mt... no
+2025-07-30T13:48:34.2847367Z checking for mt... no
+2025-07-30T13:48:34.2878953Z checking if : is a manifest tool... no
+2025-07-30T13:48:34.3039460Z checking for stdio.h... yes
+2025-07-30T13:48:34.3215049Z checking for stdlib.h... yes
+2025-07-30T13:48:34.3385912Z checking for string.h... yes
+2025-07-30T13:48:34.3566681Z checking for inttypes.h... yes
+2025-07-30T13:48:34.3758187Z checking for stdint.h... yes
+2025-07-30T13:48:34.3942892Z checking for strings.h... yes
+2025-07-30T13:48:34.4141603Z checking for sys/stat.h... yes
+2025-07-30T13:48:34.4345494Z checking for sys/types.h... yes
+2025-07-30T13:48:34.4559631Z checking for unistd.h... yes
+2025-07-30T13:48:34.4796069Z checking for dlfcn.h... yes
+2025-07-30T13:48:34.4840469Z checking for objdir... .libs
+2025-07-30T13:48:34.5479508Z checking if gcc-14 supports -fno-rtti -fno-exceptions... no
+2025-07-30T13:48:34.5480224Z checking for gcc-14 option to produce PIC... -fPIC -DPIC
+2025-07-30T13:48:34.5620662Z checking if gcc-14 PIC flag -fPIC -DPIC works... yes
+2025-07-30T13:48:34.6229499Z checking if gcc-14 static flag -static works... yes
+2025-07-30T13:48:34.6457525Z checking if gcc-14 supports -c -o file.o... yes
+2025-07-30T13:48:34.6458327Z checking if gcc-14 supports -c -o file.o... (cached) yes
+2025-07-30T13:48:34.6555369Z checking whether the gcc-14 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+2025-07-30T13:48:34.7071509Z checking dynamic linker characteristics... GNU/Linux ld.so
+2025-07-30T13:48:34.7072348Z checking how to hardcode library paths into programs... immediate
+2025-07-30T13:48:34.7090128Z checking whether stripping libraries is possible... yes
+2025-07-30T13:48:34.7092338Z checking if libtool supports shared libraries... yes
+2025-07-30T13:48:34.7092872Z checking whether to build shared libraries... no
+2025-07-30T13:48:34.7093376Z checking whether to build static libraries... yes
+2025-07-30T13:48:34.7208646Z checking if gcc-14 supports -Werror... yes
+2025-07-30T13:48:34.7308799Z checking if gcc-14 supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
+2025-07-30T13:48:34.7413164Z checking if gcc-14 supports -Wno-overlength-strings... yes
+2025-07-30T13:48:34.7516874Z checking if gcc-14 supports -Wall... yes
+2025-07-30T13:48:34.7624212Z checking if gcc-14 supports -Wno-unused-function... yes
+2025-07-30T13:48:34.7743998Z checking if gcc-14 supports -Wextra... yes
+2025-07-30T13:48:34.7865066Z checking if gcc-14 supports -Wcast-align... yes
+2025-07-30T13:48:34.7970214Z checking if gcc-14 supports -Wcast-align=strict... yes
+2025-07-30T13:48:34.8227556Z checking if gcc-14 supports -Wconditional-uninitialized... no
+2025-07-30T13:48:34.8446482Z checking if gcc-14 supports -Wreserved-identifier... no
+2025-07-30T13:48:34.8553891Z checking if gcc-14 supports -fvisibility=hidden... yes
+2025-07-30T13:48:34.8719257Z checking for valgrind support... 
+2025-07-30T13:48:34.9076792Z checking for x86_64 assembly availability... yes
+2025-07-30T13:48:34.9293002Z checking that generated files are newer than configure... done
+2025-07-30T13:48:34.9296256Z configure: creating ./config.status
+2025-07-30T13:48:35.3364950Z config.status: creating Makefile
+2025-07-30T13:48:35.3497429Z config.status: creating libsecp256k1.pc
+2025-07-30T13:48:35.3610029Z config.status: executing depfiles commands
+2025-07-30T13:48:35.3622379Z config.status: executing libtool commands
+2025-07-30T13:48:35.3716729Z 
+2025-07-30T13:48:35.3717306Z Build Options:
+2025-07-30T13:48:35.3718069Z   with external callbacks = no
+2025-07-30T13:48:35.3718613Z   with benchmarks         = no
+2025-07-30T13:48:35.3719520Z   with tests              = yes
+2025-07-30T13:48:35.3720025Z   with ctime tests        = no
+2025-07-30T13:48:35.3720519Z   with coverage           = no
+2025-07-30T13:48:35.3720995Z   with examples           = no
+2025-07-30T13:48:35.3721473Z   module ecdh             = no
+2025-07-30T13:48:35.3721953Z   module recovery         = yes
+2025-07-30T13:48:35.3722442Z   module extrakeys        = yes
+2025-07-30T13:48:35.3722826Z   module schnorrsig       = yes
+2025-07-30T13:48:35.3723125Z   module ellswift         = yes
+2025-07-30T13:48:35.3723317Z 
+2025-07-30T13:48:35.3723425Z   asm                     = x86_64
+2025-07-30T13:48:35.3723730Z   ecmult window size      = 15
+2025-07-30T13:48:35.3724013Z   ecmult gen prec. bits   = 4
+2025-07-30T13:48:35.3724196Z 
+2025-07-30T13:48:35.3724297Z   valgrind                = no
+2025-07-30T13:48:35.3724556Z   CC                      = gcc-14
+2025-07-30T13:48:35.3724959Z   CPPFLAGS                = -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-30T13:48:35.3726173Z   SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
+2025-07-30T13:48:35.3727333Z   CFLAGS                  = -pipe -std=c11 -O2 
+2025-07-30T13:48:35.3728226Z   LDFLAGS                 = -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:48:35.4049520Z 
+2025-07-30T13:48:35.4050110Z Options used to compile and link:
+2025-07-30T13:48:35.4050739Z   boost process       = yes
+2025-07-30T13:48:35.4051223Z   multiprocess        = no
+2025-07-30T13:48:35.4051699Z   with libs           = yes
+2025-07-30T13:48:35.4052176Z   with wallet         = no
+2025-07-30T13:48:35.4052651Z   with gui / qt       = yes
+2025-07-30T13:48:35.4053105Z     with qr           = yes
+2025-07-30T13:48:35.4053563Z   with zmq            = yes
+2025-07-30T13:48:35.4054067Z   with test           = yes
+2025-07-30T13:48:35.4054573Z   with fuzz binary    = yes
+2025-07-30T13:48:35.4055039Z   with bench          = yes
+2025-07-30T13:48:35.4055498Z   with upnp           = yes
+2025-07-30T13:48:35.4055959Z   with natpmp         = yes
+2025-07-30T13:48:35.4056417Z   USDT tracing        = yes
+2025-07-30T13:48:35.4056880Z   sanitizers          = 
+2025-07-30T13:48:35.4057311Z   debug enabled       = no
+2025-07-30T13:48:35.4058029Z   stacktraces enabled = yes
+2025-07-30T13:48:35.4058487Z   crash hooks enabled = no
+2025-07-30T13:48:35.4058777Z   miner enabled       = yes
+2025-07-30T13:48:35.4059056Z   gprof enabled       = no
+2025-07-30T13:48:35.4059335Z   werror              = yes
+2025-07-30T13:48:35.4059511Z 
+2025-07-30T13:48:35.4059628Z   target os           = linux-gnu
+2025-07-30T13:48:35.4059956Z   build os            = linux-gnu
+2025-07-30T13:48:35.4060163Z 
+2025-07-30T13:48:35.4060288Z   CC                  = /usr/bin/ccache gcc-14
+2025-07-30T13:48:35.4060786Z   CFLAGS              =  -g1 -fno-omit-frame-pointer -pthread -pipe -std=c11 -O2 
+2025-07-30T13:48:35.4062261Z   CPPFLAGS            =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/ 
+2025-07-30T13:48:35.4063527Z   CXX                 = /usr/bin/ccache g++-14 -std=c++20
+2025-07-30T13:48:35.4067307Z   CXXFLAGS            =  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=$(abs_top_srcdir)=.  -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code  -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2 
+2025-07-30T13:48:35.4071869Z   LDFLAGS             = -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib 
+2025-07-30T13:48:35.4072717Z   AR                  = ar
+2025-07-30T13:48:35.4073079Z   ARFLAGS             = cr
+2025-07-30T13:48:35.4073302Z 
+2025-07-30T13:48:35.4719220Z Making install in src
+2025-07-30T13:48:35.4961058Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T13:48:35.5241890Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T13:48:35.5277249Z   CXX      dashd-bitcoind.o
+2025-07-30T13:48:35.5277867Z   CXX      libbitcoin_node_a-addrdb.o
+2025-07-30T13:48:35.5316066Z   CXX      libbitcoin_node_a-addressindex.o
+2025-07-30T13:48:35.5330853Z   CXX      libbitcoin_node_a-addrman.o
+2025-07-30T13:48:38.1035691Z   CXX      libbitcoin_node_a-banman.o
+2025-07-30T13:48:39.6613238Z   CXX      libbitcoin_node_a-batchedlogger.o
+2025-07-30T13:48:41.3773597Z   CXX      libbitcoin_node_a-bip324.o
+2025-07-30T13:48:42.5520846Z   CXX      libbitcoin_node_a-blockencodings.o
+2025-07-30T13:48:42.5725429Z   CXX      libbitcoin_node_a-blockfilter.o
+2025-07-30T13:48:44.4733793Z   CXX      libbitcoin_node_a-chain.o
+2025-07-30T13:48:44.7432938Z   CXX      libbitcoin_node_a-dbwrapper.o
+2025-07-30T13:48:45.5573803Z   CXX      libbitcoin_node_a-deploymentstatus.o
+2025-07-30T13:48:47.5413518Z   CXX      libbitcoin_node_a-dsnotificationinterface.o
+2025-07-30T13:48:48.2034671Z   CXX      libbitcoin_node_a-flatfile.o
+2025-07-30T13:48:49.8713913Z   CXX      libbitcoin_node_a-httprpc.o
+2025-07-30T13:48:49.9905878Z   CXX      libbitcoin_node_a-httpserver.o
+2025-07-30T13:48:52.3314715Z   CXX      libbitcoin_node_a-i2p.o
+2025-07-30T13:48:56.1955792Z   CXX      libbitcoin_node_a-init.o
+2025-07-30T13:48:56.6215739Z   CXX      libbitcoin_node_a-mapport.o
+2025-07-30T13:48:56.7446657Z   CXX      libbitcoin_node_a-net.o
+2025-07-30T13:48:58.5692403Z   CXX      libbitcoin_node_a-netfulfilledman.o
+2025-07-30T13:49:01.8427980Z   CXX      libbitcoin_node_a-netgroup.o
+2025-07-30T13:49:04.6829572Z   CXX      libbitcoin_node_a-net_processing.o
+2025-07-30T13:49:04.7239263Z   CXX      libbitcoin_node_a-noui.o
+2025-07-30T13:49:09.2670969Z   CXX      libbitcoin_node_a-pow.o
+2025-07-30T13:49:11.4910665Z   CXX      libbitcoin_node_a-rest.o
+2025-07-30T13:49:17.7748339Z   CXX      libbitcoin_node_a-shutdown.o
+2025-07-30T13:49:20.1293642Z   CXX      libbitcoin_node_a-spork.o
+2025-07-30T13:49:20.5831874Z   CXX      libbitcoin_node_a-timedata.o
+2025-07-30T13:49:22.2718434Z   CXX      libbitcoin_node_a-torcontrol.o
+2025-07-30T13:49:24.9607736Z   CXX      libbitcoin_node_a-txdb.o
+2025-07-30T13:49:29.8096791Z   CXX      libbitcoin_node_a-txmempool.o
+2025-07-30T13:49:31.0803093Z   CXX      libbitcoin_node_a-txorphanage.o
+2025-07-30T13:49:31.9794949Z   CXX      libbitcoin_node_a-validation.o
+2025-07-30T13:49:36.5930633Z   CXX      libbitcoin_node_a-validationinterface.o
+2025-07-30T13:49:36.7275034Z   CXX      libbitcoin_node_a-versionbits.o
+2025-07-30T13:49:39.2631063Z   CXX      libbitcoin_node_a-dummywallet.o
+2025-07-30T13:49:42.5563138Z   CXX      libbitcoin_common_a-base58.o
+2025-07-30T13:49:43.2416319Z   CXX      libbitcoin_common_a-bech32.o
+2025-07-30T13:49:44.3320660Z   CXX      libbitcoin_common_a-chainparams.o
+2025-07-30T13:49:44.5627842Z   CXX      libbitcoin_common_a-coins.o
+2025-07-30T13:49:46.3819859Z   CXX      libbitcoin_common_a-compressor.o
+2025-07-30T13:49:48.1280150Z   CXX      libbitcoin_common_a-core_read.o
+2025-07-30T13:49:48.7889627Z   CXX      libbitcoin_common_a-core_write.o
+2025-07-30T13:49:51.7400216Z   CXX      libbitcoin_common_a-deploymentinfo.o
+2025-07-30T13:49:52.2978320Z   CXX      evo/libbitcoin_common_a-core_write.o
+2025-07-30T13:49:52.5190688Z   CXX      evo/libbitcoin_common_a-netinfo.o
+2025-07-30T13:49:57.4467220Z   CXX      governance/libbitcoin_common_a-common.o
+2025-07-30T13:49:58.0470744Z   CXX      init/libbitcoin_common_a-common.o
+2025-07-30T13:49:58.6927134Z   CXX      libbitcoin_common_a-key.o
+2025-07-30T13:49:58.7057371Z   CXX      libbitcoin_common_a-key_io.o
+2025-07-30T13:49:59.4413939Z   CXX      libbitcoin_common_a-merkleblock.o
+2025-07-30T13:50:01.5203500Z   CXX      libbitcoin_common_a-net_types.o
+2025-07-30T13:50:01.6609063Z   CXX      libbitcoin_common_a-netaddress.o
+2025-07-30T13:50:02.0595533Z   CXX      libbitcoin_common_a-netbase.o
+2025-07-30T13:50:03.3814184Z   CXX      libbitcoin_common_a-net_permissions.o
+2025-07-30T13:50:05.6494508Z   CXX      libbitcoin_common_a-outputtype.o
+2025-07-30T13:50:06.6412054Z   CXX      policy/libbitcoin_common_a-feerate.o
+2025-07-30T13:50:07.3202816Z   CXX      policy/libbitcoin_common_a-policy.o
+2025-07-30T13:50:07.8044559Z   CXX      libbitcoin_common_a-protocol.o
+2025-07-30T13:50:07.9360209Z   CXX      libbitcoin_common_a-psbt.o
+2025-07-30T13:50:08.6549226Z   CXX      rpc/libbitcoin_common_a-evo_util.o
+2025-07-30T13:50:09.3030814Z   CXX      rpc/libbitcoin_common_a-rawtransaction_util.o
+2025-07-30T13:50:11.9745667Z   CXX      rpc/libbitcoin_common_a-util.o
+2025-07-30T13:50:13.6673422Z   CXX      libbitcoin_common_a-saltedhasher.o
+2025-07-30T13:50:15.5746460Z   CXX      libbitcoin_common_a-scheduler.o
+2025-07-30T13:50:16.1189839Z   CXX      script/libbitcoin_common_a-descriptor.o
+2025-07-30T13:50:17.7143098Z   CXX      script/libbitcoin_common_a-sign.o
+2025-07-30T13:50:18.3102474Z   CXX      script/libbitcoin_common_a-signingprovider.o
+2025-07-30T13:50:19.6662342Z   CXX      script/libbitcoin_common_a-standard.o
+2025-07-30T13:50:21.7846165Z   CXX      libbitcoin_common_a-warnings.o
+2025-07-30T13:50:22.2477309Z   CXX      coinjoin/libbitcoin_util_a-common.o
+2025-07-30T13:50:23.5609487Z   CXX      coinjoin/libbitcoin_util_a-options.o
+2025-07-30T13:50:24.0506380Z   CXX      libbitcoin_util_a-chainparamsbase.o
+2025-07-30T13:50:24.9399255Z   CXX      libbitcoin_util_a-fs.o
+2025-07-30T13:50:25.3456438Z   CXX      libbitcoin_util_a-logging.o
+2025-07-30T13:50:26.2905274Z   CXX      libbitcoin_util_a-messagesigner.o
+2025-07-30T13:50:26.5850424Z   CXX      libbitcoin_util_a-random.o
+2025-07-30T13:50:27.4531429Z   CXX      libbitcoin_util_a-randomenv.o
+2025-07-30T13:50:28.7670171Z   CXX      rpc/libbitcoin_util_a-request.o
+2025-07-30T13:50:29.7102258Z   CXX      libbitcoin_util_a-stacktraces.o
+2025-07-30T13:50:30.4084749Z   CXX      support/libbitcoin_util_a-cleanse.o
+2025-07-30T13:50:30.5156889Z   CXX      libbitcoin_util_a-sync.o
+2025-07-30T13:50:30.6086876Z   CXX      libbitcoin_consensus_a-arith_uint256.o
+2025-07-30T13:50:31.6872227Z   CXX      bls/libbitcoin_consensus_a-bls.o
+2025-07-30T13:50:32.4146237Z   CXX      consensus/libbitcoin_consensus_a-merkle.o
+2025-07-30T13:50:33.7453820Z   CXX      consensus/libbitcoin_consensus_a-tx_check.o
+2025-07-30T13:50:34.0431611Z   CXX      libbitcoin_consensus_a-hash.o
+2025-07-30T13:50:34.8575810Z   CXX      libbitcoin_consensus_a-pubkey.o
+2025-07-30T13:50:35.5403395Z   CXX      script/libbitcoin_consensus_a-bitcoinconsensus.o
+2025-07-30T13:50:35.5852058Z   CXX      script/libbitcoin_consensus_a-interpreter.o
+2025-07-30T13:50:36.1693060Z   CXX      script/libbitcoin_consensus_a-script.o
+2025-07-30T13:50:36.5186883Z   CXX      script/libbitcoin_consensus_a-script_error.o
+2025-07-30T13:50:37.1835238Z   CXX      libbitcoin_consensus_a-uint256.o
+2025-07-30T13:50:37.6173580Z   CXX      util/libbitcoin_consensus_a-strencodings.o
+2025-07-30T13:50:38.1632590Z   CXX      util/libbitcoin_consensus_a-string.o
+2025-07-30T13:50:38.4821599Z   CXX      crypto/libbitcoin_crypto_sse41_la-sha256_sse41.lo
+2025-07-30T13:50:39.9696607Z   CXX      crypto/libbitcoin_crypto_x86_shani_la-sha256_x86_shani.lo
+2025-07-30T13:50:39.9933941Z   CXX      crypto/libbitcoin_crypto_avx2_la-sha256_avx2.lo
+2025-07-30T13:50:41.3440832Z make[3]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src/dashbls'
+2025-07-30T13:50:41.3491398Z  /bin/bash ./config.status
+2025-07-30T13:50:41.5861491Z config.status: creating Makefile
+2025-07-30T13:50:41.6316051Z config.status: creating depends/relic/include/relic_conf.h
+2025-07-30T13:50:41.6521493Z config.status: executing depfiles commands
+2025-07-30T13:50:41.6542928Z config.status: executing libtool commands
+2025-07-30T13:50:41.7783058Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_add_low.lo
+2025-07-30T13:50:41.8705666Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_inv_low.lo
+2025-07-30T13:50:41.9901472Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_mul_low.lo
+2025-07-30T13:50:42.0075756Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_rdc_low.lo
+2025-07-30T13:50:42.0690681Z In file included from depends/relic/src/low/gmp/relic_fp_mul_low.c:34:
+2025-07-30T13:50:42.0692997Z depends/relic/src/low/gmp/relic_fp_mul_low.c: In function ‘fp_mulm_low’:
+2025-07-30T13:50:42.0697408Z ./depends/relic/include/relic_fp.h:344:33: warning: ‘fp_rdc_monty_comba’ accessing 272 bytes in a region of size 96 [-Wstringop-overflow=]
+2025-07-30T13:50:42.0698778Z   344 | #define fp_rdc_monty(C, A)      fp_rdc_monty_comba(C, A)
+2025-07-30T13:50:42.0699361Z       |                                 ^~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.0700350Z ./depends/relic/include/relic_fp.h:329:33: note: in expansion of macro ‘fp_rdc_monty’
+2025-07-30T13:50:42.0701129Z   329 | #define fp_rdc(C, A)            fp_rdc_monty(C, A)
+2025-07-30T13:50:42.0701607Z       |                                 ^~~~~~~~~~~~
+2025-07-30T13:50:42.0702456Z depends/relic/src/low/gmp/relic_fp_mul_low.c:57:9: note: in expansion of macro ‘fp_rdc’
+2025-07-30T13:50:42.0703098Z    57 |         fp_rdc(c, t);
+2025-07-30T13:50:42.0703450Z       |         ^~~~~~
+2025-07-30T13:50:42.0704393Z ./depends/relic/include/relic_fp.h:344:33: note: referencing argument 2 of type ‘dig_t[34]’ {aka ‘long unsigned int[34]’}
+2025-07-30T13:50:42.0705308Z   344 | #define fp_rdc_monty(C, A)      fp_rdc_monty_comba(C, A)
+2025-07-30T13:50:42.0705832Z       |                                 ^~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.0706630Z ./depends/relic/include/relic_fp.h:329:33: note: in expansion of macro ‘fp_rdc_monty’
+2025-07-30T13:50:42.0707358Z   329 | #define fp_rdc(C, A)            fp_rdc_monty(C, A)
+2025-07-30T13:50:42.0708127Z       |                                 ^~~~~~~~~~~~
+2025-07-30T13:50:42.0708935Z depends/relic/src/low/gmp/relic_fp_mul_low.c:57:9: note: in expansion of macro ‘fp_rdc’
+2025-07-30T13:50:42.0709620Z    57 |         fp_rdc(c, t);
+2025-07-30T13:50:42.0709965Z       |         ^~~~~~
+2025-07-30T13:50:42.0710684Z ./depends/relic/include/relic_fp.h:975:6: note: in a call to function ‘fp_rdc_monty_comba’
+2025-07-30T13:50:42.0711400Z   975 | void fp_rdc_monty_comba(fp_t c, dv_t a);
+2025-07-30T13:50:42.0711819Z       |      ^~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.1009321Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_shift_low.lo
+2025-07-30T13:50:42.1845340Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fp_sqr_low.lo
+2025-07-30T13:50:42.2670786Z In file included from depends/relic/src/low/gmp/relic_fp_sqr_low.c:34:
+2025-07-30T13:50:42.2672292Z depends/relic/src/low/gmp/relic_fp_sqr_low.c: In function ‘fp_sqrm_low’:
+2025-07-30T13:50:42.2674121Z ./depends/relic/include/relic_fp.h:344:33: warning: ‘fp_rdc_monty_comba’ accessing 272 bytes in a region of size 96 [-Wstringop-overflow=]
+2025-07-30T13:50:42.2676031Z   344 | #define fp_rdc_monty(C, A)      fp_rdc_monty_comba(C, A)
+2025-07-30T13:50:42.2676739Z       |                                 ^~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.2677921Z ./depends/relic/include/relic_fp.h:329:33: note: in expansion of macro ‘fp_rdc_monty’
+2025-07-30T13:50:42.2678845Z   329 | #define fp_rdc(C, A)            fp_rdc_monty(C, A)
+2025-07-30T13:50:42.2679465Z       |                                 ^~~~~~~~~~~~
+2025-07-30T13:50:42.2680425Z depends/relic/src/low/gmp/relic_fp_sqr_low.c:49:9: note: in expansion of macro ‘fp_rdc’
+2025-07-30T13:50:42.2681202Z    49 |         fp_rdc(c, t);
+2025-07-30T13:50:42.2681663Z       |         ^~~~~~
+2025-07-30T13:50:42.2689448Z ./depends/relic/include/relic_fp.h:344:33: note: referencing argument 2 of type ‘dig_t[34]’ {aka ‘long unsigned int[34]’}
+2025-07-30T13:50:42.2690787Z   344 | #define fp_rdc_monty(C, A)      fp_rdc_monty_comba(C, A)
+2025-07-30T13:50:42.2691346Z       |                                 ^~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.2692142Z ./depends/relic/include/relic_fp.h:329:33: note: in expansion of macro ‘fp_rdc_monty’
+2025-07-30T13:50:42.2692920Z   329 | #define fp_rdc(C, A)            fp_rdc_monty(C, A)
+2025-07-30T13:50:42.2693396Z       |                                 ^~~~~~~~~~~~
+2025-07-30T13:50:42.2694193Z depends/relic/src/low/gmp/relic_fp_sqr_low.c:49:9: note: in expansion of macro ‘fp_rdc’
+2025-07-30T13:50:42.2694860Z    49 |         fp_rdc(c, t);
+2025-07-30T13:50:42.2695279Z       |         ^~~~~~
+2025-07-30T13:50:42.2695956Z ./depends/relic/include/relic_fp.h:975:6: note: in a call to function ‘fp_rdc_monty_comba’
+2025-07-30T13:50:42.2696680Z   975 | void fp_rdc_monty_comba(fp_t c, dv_t a);
+2025-07-30T13:50:42.2697119Z       |      ^~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.2716708Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fb_add_low.lo
+2025-07-30T13:50:42.2940880Z   CXX      crc32c/src/libcrc32c_sse42_la-crc32c_sse42.lo
+2025-07-30T13:50:42.3837993Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_inv_low.lo
+2025-07-30T13:50:42.5236823Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_itr_low.lo
+2025-07-30T13:50:42.6139522Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_mul_low.lo
+2025-07-30T13:50:42.6372434Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_rdc_low.lo
+2025-07-30T13:50:42.7083170Z In file included from depends/relic/src/low/easy/relic_fb_mul_low.c:34:
+2025-07-30T13:50:42.7084393Z depends/relic/src/low/easy/relic_fb_mul_low.c: In function ‘fb_mulm_low’:
+2025-07-30T13:50:42.7085881Z ./depends/relic/include/relic_fb.h:263:33: warning: ‘fb_rdc_quick’ accessing 272 bytes in a region of size 80 [-Wstringop-overflow=]
+2025-07-30T13:50:42.7086840Z   263 | #define fb_rdc(C, A)            fb_rdc_quick(C, A)
+2025-07-30T13:50:42.7087343Z       |                                 ^~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.7088628Z depends/relic/src/low/easy/relic_fb_mul_low.c:230:9: note: in expansion of macro ‘fb_rdc’
+2025-07-30T13:50:42.7089339Z   230 |         fb_rdc(c, t);
+2025-07-30T13:50:42.7089703Z       |         ^~~~~~
+2025-07-30T13:50:42.7090677Z ./depends/relic/include/relic_fb.h:263:33: note: referencing argument 2 of type ‘dig_t[34]’ {aka ‘long unsigned int[34]’}
+2025-07-30T13:50:42.7091625Z   263 | #define fb_rdc(C, A)            fb_rdc_quick(C, A)
+2025-07-30T13:50:42.7092111Z       |                                 ^~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:42.7093012Z depends/relic/src/low/easy/relic_fb_mul_low.c:230:9: note: in expansion of macro ‘fb_rdc’
+2025-07-30T13:50:42.7093724Z   230 |         fb_rdc(c, t);
+2025-07-30T13:50:42.7094082Z       |         ^~~~~~
+2025-07-30T13:50:42.7094845Z ./depends/relic/include/relic_fb.h:782:6: note: in a call to function ‘fb_rdc_quick’
+2025-07-30T13:50:42.7095557Z   782 | void fb_rdc_quick(fb_t c, dv_t a);
+2025-07-30T13:50:42.7095989Z       |      ^~~~~~~~~~~~
+2025-07-30T13:50:42.7864068Z depends/relic/src/low/easy/relic_fb_mul_low.c: In function ‘fb_muld_low’:
+2025-07-30T13:50:42.7865665Z depends/relic/src/low/easy/relic_fb_mul_low.c:152:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:50:42.7867076Z   152 | void fb_muld_low(dig_t *c, const dig_t *a, const dig_t *b, int size) {
+2025-07-30T13:50:42.7867960Z       |      ^~~~~~~~~~~
+2025-07-30T13:50:42.8299006Z   CC       depends/relic/src/low/gmp/librelic_la-relic_fb_shift_low.lo
+2025-07-30T13:50:42.8340993Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_slv_low.lo
+2025-07-30T13:50:42.9579169Z make[3]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src/secp256k1'
+2025-07-30T13:50:42.9654558Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_sqr_low.lo
+2025-07-30T13:50:42.9704684Z   CC       src/libsecp256k1_la-secp256k1.lo
+2025-07-30T13:50:43.0423654Z In file included from depends/relic/src/low/easy/relic_fb_sqr_low.c:32:
+2025-07-30T13:50:43.0425317Z depends/relic/src/low/easy/relic_fb_sqr_low.c: In function ‘fb_sqrm_low’:
+2025-07-30T13:50:43.0434478Z ./depends/relic/include/relic_fb.h:263:33: warning: ‘fb_rdc_quick’ accessing 272 bytes in a region of size 80 [-Wstringop-overflow=]
+2025-07-30T13:50:43.0435541Z   263 | #define fb_rdc(C, A)            fb_rdc_quick(C, A)
+2025-07-30T13:50:43.0436045Z       |                                 ^~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:43.0436901Z depends/relic/src/low/easy/relic_fb_sqr_low.c:163:9: note: in expansion of macro ‘fb_rdc’
+2025-07-30T13:50:43.0437841Z   163 |         fb_rdc(c, t);
+2025-07-30T13:50:43.0438187Z       |         ^~~~~~
+2025-07-30T13:50:43.0449076Z ./depends/relic/include/relic_fb.h:263:33: note: referencing argument 2 of type ‘dig_t[34]’ {aka ‘long unsigned int[34]’}
+2025-07-30T13:50:43.0450121Z   263 | #define fb_rdc(C, A)            fb_rdc_quick(C, A)
+2025-07-30T13:50:43.0450798Z       |                                 ^~~~~~~~~~~~~~~~~~
+2025-07-30T13:50:43.0451689Z depends/relic/src/low/easy/relic_fb_sqr_low.c:163:9: note: in expansion of macro ‘fb_rdc’
+2025-07-30T13:50:43.0452362Z   163 |         fb_rdc(c, t);
+2025-07-30T13:50:43.0452712Z       |         ^~~~~~
+2025-07-30T13:50:43.0455798Z ./depends/relic/include/relic_fb.h:782:6: note: in a call to function ‘fb_rdc_quick’
+2025-07-30T13:50:43.0456480Z   782 | void fb_rdc_quick(fb_t c, dv_t a);
+2025-07-30T13:50:43.0456888Z       |      ^~~~~~~~~~~~
+2025-07-30T13:50:43.0618888Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_srt_low.lo
+2025-07-30T13:50:43.0951286Z   CC       src/libsecp256k1_precomputed_la-precomputed_ecmult.lo
+2025-07-30T13:50:43.2754418Z   CC       depends/relic/src/low/easy/librelic_la-relic_fb_trc_low.lo
+2025-07-30T13:50:43.5049919Z   CXX      src/runbench-test-bench.o
+2025-07-30T13:50:44.3914542Z   CC       src/libsecp256k1_precomputed_la-precomputed_ecmult_gen.lo
+2025-07-30T13:50:44.6451815Z   CXX      dash_cli-bitcoin-cli.o
+2025-07-30T13:50:45.3228696Z   CCLD     libsecp256k1_precomputed.la
+2025-07-30T13:50:45.5325381Z   CXX      rpc/libbitcoin_cli_a-client.o
+2025-07-30T13:50:45.6065607Z   CCLD     libsecp256k1.la
+2025-07-30T13:50:45.8004822Z   CXX      src/runtest-test.o
+2025-07-30T13:50:45.8639969Z make[3]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src/secp256k1'
+2025-07-30T13:50:45.8668292Z   CXX      src/libdashbls_la-bls.lo
+2025-07-30T13:50:46.9468244Z   CXX      dash_tx-bitcoin-tx.o
+2025-07-30T13:50:50.0996263Z   CXX      src/libdashbls_la-chaincode.lo
+2025-07-30T13:50:51.2764358Z   CXX      src/libdashbls_la-elements.lo
+2025-07-30T13:50:52.7744593Z   CXX      src/libdashbls_la-extendedprivatekey.lo
+2025-07-30T13:50:53.4593372Z   CXX      src/libdashbls_la-extendedpublickey.lo
+2025-07-30T13:50:54.0624776Z   CXX      src/libdashbls_la-legacy.lo
+2025-07-30T13:50:54.5593355Z   CXX      src/libdashbls_la-privatekey.lo
+2025-07-30T13:50:54.6740241Z Generated test/data/blockfilters.json.h
+2025-07-30T13:50:54.6766147Z   CXX      src/libdashbls_la-schemes.lo
+2025-07-30T13:50:54.8386737Z Generated test/data/base58_encode_decode.json.h
+2025-07-30T13:50:54.8410138Z   CXX      src/libdashbls_la-threshold.lo
+2025-07-30T13:50:55.7876949Z Generated test/data/bip39_vectors.json.h
+2025-07-30T13:50:55.7899644Z   CC       depends/mimalloc/src/libmimalloc_secure_la-stats.lo
+2025-07-30T13:50:56.1077262Z Generated test/data/key_io_valid.json.h
+2025-07-30T13:50:56.1108716Z   CC       depends/mimalloc/src/libmimalloc_secure_la-random.lo
+2025-07-30T13:50:56.3720199Z Generated test/data/key_io_invalid.json.h
+2025-07-30T13:50:56.3742687Z   CC       depends/mimalloc/src/libmimalloc_secure_la-os.lo
+2025-07-30T13:50:56.4098136Z Generated test/data/proposals_valid.json.h
+2025-07-30T13:50:56.4121470Z   CC       depends/mimalloc/src/libmimalloc_secure_la-bitmap.lo
+2025-07-30T13:50:56.7412345Z Generated test/data/proposals_invalid.json.h
+2025-07-30T13:50:56.7433383Z   CC       depends/mimalloc/src/libmimalloc_secure_la-arena.lo
+2025-07-30T13:50:56.8188317Z Generated test/data/script_tests.json.h
+2025-07-30T13:50:56.8213532Z   CC       depends/mimalloc/src/libmimalloc_secure_la-segment-cache.lo
+2025-07-30T13:50:57.0681259Z Generated test/data/trivially_invalid.json.h
+2025-07-30T13:50:57.0702269Z   CC       depends/mimalloc/src/libmimalloc_secure_la-segment.lo
+2025-07-30T13:50:57.0862126Z Generated test/data/sighash.json.h
+2025-07-30T13:50:57.0910173Z   CC       depends/mimalloc/src/libmimalloc_secure_la-page.lo
+2025-07-30T13:50:57.6072263Z Generated test/data/trivially_valid.json.h
+2025-07-30T13:50:57.6095372Z   CC       depends/mimalloc/src/libmimalloc_secure_la-alloc.lo
+2025-07-30T13:50:57.6521866Z Generated test/data/tx_invalid.json.h
+2025-07-30T13:50:57.6542229Z   CC       depends/mimalloc/src/libmimalloc_secure_la-alloc-aligned.lo
+2025-07-30T13:50:57.7678628Z Generated test/data/tx_valid.json.h
+2025-07-30T13:50:57.7702304Z   CC       depends/mimalloc/src/libmimalloc_secure_la-alloc-posix.lo
+2025-07-30T13:50:57.9151174Z Generated test/data/asmap.raw.h
+2025-07-30T13:50:57.9151874Z   CC       depends/mimalloc/src/libmimalloc_secure_la-heap.lo
+2025-07-30T13:50:57.9564210Z   CC       depends/mimalloc/src/libmimalloc_secure_la-options.lo
+2025-07-30T13:50:58.2216557Z   CC       depends/mimalloc/src/libmimalloc_secure_la-init.lo
+2025-07-30T13:50:58.2479091Z   CC       depends/relic/src/librelic_la-relic_err.lo
+2025-07-30T13:50:58.2709882Z   CC       depends/relic/src/librelic_la-relic_core.lo
+2025-07-30T13:50:58.3943722Z   CC       depends/relic/src/librelic_la-relic_conf.lo
+2025-07-30T13:50:58.4339145Z   CC       depends/relic/src/librelic_la-relic_util.lo
+2025-07-30T13:50:58.4714631Z   CC       depends/relic/src/arch/librelic_la-relic_arch_x64.lo
+2025-07-30T13:50:58.5369021Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_1byte.o
+2025-07-30T13:50:58.5867101Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_2bytes.o
+2025-07-30T13:50:58.6184559Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_3bytes.o
+2025-07-30T13:50:58.6228280Z   CC       depends/relic/src/rand/librelic_la-relic_rand_call.lo
+2025-07-30T13:50:58.6735981Z   CC       depends/relic/src/rand/librelic_la-relic_rand_core.lo
+2025-07-30T13:50:58.7012286Z   CC       depends/relic/src/rand/librelic_la-relic_rand_hashd.lo
+2025-07-30T13:50:58.7616020Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_4bytes.o
+2025-07-30T13:50:58.8359988Z depends/relic/src/rand/relic_rand_hashd.c: In function ‘rand_hash.constprop’:
+2025-07-30T13:50:58.8361640Z depends/relic/src/rand/relic_rand_hashd.c:56:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:50:58.8362892Z    56 | static void rand_hash(uint8_t *out, int out_len, uint8_t *in, int in_len) {
+2025-07-30T13:50:58.8363446Z       |             ^~~~~~~~~
+2025-07-30T13:50:58.8443768Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_5bytes.o
+2025-07-30T13:50:58.8764957Z depends/relic/src/rand/relic_rand_hashd.c: In function ‘rand_seed’:
+2025-07-30T13:50:58.8767462Z depends/relic/src/rand/relic_rand_hashd.c:176:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:50:58.8769092Z   176 | void rand_seed(uint8_t *buf, int size) {
+2025-07-30T13:50:58.8769528Z       |      ^~~~~~~~~
+2025-07-30T13:50:58.8908660Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_6bytes.o
+2025-07-30T13:50:58.9325554Z   CC       depends/relic/src/rand/librelic_la-relic_rand_udev.lo
+2025-07-30T13:50:58.9755190Z   CC       depends/relic/src/dv/librelic_la-relic_dv_mem.lo
+2025-07-30T13:50:59.0602400Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_7bytes.o
+2025-07-30T13:50:59.0953819Z   CXX      minisketch/src/fields/libminisketch_clmul_a-clmul_8bytes.o
+2025-07-30T13:50:59.1463342Z   CC       depends/relic/src/dv/librelic_la-relic_dv_util.lo
+2025-07-30T13:50:59.1780965Z   CC       depends/relic/src/bn/librelic_la-relic_bn_add.lo
+2025-07-30T13:50:59.3512624Z   CC       depends/relic/src/bn/librelic_la-relic_bn_cmp.lo
+2025-07-30T13:50:59.4857534Z   CXX      bench/bench_dash-duplicate_inputs.o
+2025-07-30T13:50:59.5524858Z Generated bench/data/block813851.raw.h
+2025-07-30T13:50:59.5548527Z   CC       depends/relic/src/bn/librelic_la-relic_bn_div.lo
+2025-07-30T13:50:59.7183485Z   CXX      bench/bench_dash-ecdsa.o
+2025-07-30T13:51:01.8122408Z   CC       depends/relic/src/bn/librelic_la-relic_bn_factor.lo
+2025-07-30T13:51:01.9609774Z   CXX      bench/bench_dash-ellswift.o
+2025-07-30T13:51:02.8951528Z   CC       depends/relic/src/bn/librelic_la-relic_bn_gcd.lo
+2025-07-30T13:51:03.2692075Z   CXX      bench/bench_dash-examples.o
+2025-07-30T13:51:04.7828876Z   CC       depends/relic/src/bn/librelic_la-relic_bn_inv.lo
+2025-07-30T13:51:04.9221533Z   CXX      bench/bench_dash-rollingbloom.o
+2025-07-30T13:51:05.8230594Z   CC       depends/relic/src/bn/librelic_la-relic_bn_lcm.lo
+2025-07-30T13:51:05.9631801Z   CXX      bench/bench_dash-chacha20.o
+2025-07-30T13:51:06.3765466Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mem.lo
+2025-07-30T13:51:06.5265328Z   CXX      bench/bench_dash-crypto_hash.o
+2025-07-30T13:51:07.7019326Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mod.lo
+2025-07-30T13:51:07.9260598Z   CXX      bench/bench_dash-ccoins_caching.o
+2025-07-30T13:51:08.4099571Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mul.lo
+2025-07-30T13:51:08.5760473Z   CXX      bench/bench_dash-gcs_filter.o
+2025-07-30T13:51:10.9312303Z   CC       depends/relic/src/bn/librelic_la-relic_bn_mxp.lo
+2025-07-30T13:51:11.0850785Z depends/relic/src/bn/relic_bn_mxp.c: In function ‘bn_mxp_slide’:
+2025-07-30T13:51:11.0853068Z depends/relic/src/bn/relic_bn_mxp.c:117:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:11.0855330Z   117 | void bn_mxp_slide(bn_t c, const bn_t a, const bn_t b, const bn_t m) {
+2025-07-30T13:51:11.0855881Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:11.1476211Z   CXX      bench/bench_dash-hashpadding.o
+2025-07-30T13:51:11.5079760Z   CC       depends/relic/src/bn/librelic_la-relic_bn_prime.lo
+2025-07-30T13:51:11.7079153Z   CXX      bench/bench_dash-load_external.o
+2025-07-30T13:51:11.8082140Z   CC       depends/relic/src/bn/librelic_la-relic_bn_rec.lo
+2025-07-30T13:51:12.2479725Z   CXX      bench/bench_dash-merkle_root.o
+2025-07-30T13:51:13.8818626Z   CC       depends/relic/src/bn/librelic_la-relic_bn_shift.lo
+2025-07-30T13:51:14.0441856Z   CXX      bench/bench_dash-mempool_eviction.o
+2025-07-30T13:51:15.0156826Z   CC       depends/relic/src/bn/librelic_la-relic_bn_smb.lo
+2025-07-30T13:51:15.1809527Z   CXX      bench/bench_dash-mempool_stress.o
+2025-07-30T13:51:18.1268896Z   CC       depends/relic/src/bn/librelic_la-relic_bn_sqr.lo
+2025-07-30T13:51:18.2890261Z   CXX      bench/bench_dash-nanobench.o
+2025-07-30T13:51:20.2803169Z   CC       depends/relic/src/bn/librelic_la-relic_bn_srt.lo
+2025-07-30T13:51:20.4260875Z   CXX      bench/bench_dash-peer_eviction.o
+2025-07-30T13:51:20.5932078Z   CC       depends/relic/src/bn/librelic_la-relic_bn_util.lo
+2025-07-30T13:51:20.9158606Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_add_low.lo
+2025-07-30T13:51:21.0415237Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_div_low.lo
+2025-07-30T13:51:21.1368459Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_mod_low.lo
+2025-07-30T13:51:21.2374914Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_mul_low.lo
+2025-07-30T13:51:21.3409631Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_shift_low.lo
+2025-07-30T13:51:21.4665116Z   CC       depends/relic/src/low/gmp/librelic_la-relic_bn_sqr_low.lo
+2025-07-30T13:51:21.5840477Z   CC       depends/relic/src/fp/librelic_la-relic_fp_add.lo
+2025-07-30T13:51:21.7576797Z   CC       depends/relic/src/fp/librelic_la-relic_fp_cmp.lo
+2025-07-30T13:51:21.9036611Z   CC       depends/relic/src/fp/librelic_la-relic_fp_exp.lo
+2025-07-30T13:51:22.0651153Z   CC       depends/relic/src/fp/librelic_la-relic_fp_inv.lo
+2025-07-30T13:51:22.1827259Z depends/relic/src/fp/relic_fp_inv.c: In function ‘fp_inv_divst’:
+2025-07-30T13:51:22.1831606Z depends/relic/src/fp/relic_fp_inv.c:463:36: warning: right shift count >= width of type [-Wshift-count-overflow]
+2025-07-30T13:51:22.1834844Z   463 |                         d0 = delta >> (RLC_DIG - 1);
+2025-07-30T13:51:22.1835367Z       |                                    ^~
+2025-07-30T13:51:22.2254029Z   CC       depends/relic/src/fp/librelic_la-relic_fp_mul.lo
+2025-07-30T13:51:22.2880684Z depends/relic/src/fp/relic_fp_inv.c: In function ‘fp_inv_sim’:
+2025-07-30T13:51:22.2911214Z depends/relic/src/fp/relic_fp_inv.c:523:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:22.2912986Z   523 | void fp_inv_sim(fp_t *c, const fp_t *a, int n) {
+2025-07-30T13:51:22.2914080Z       |      ^~~~~~~~~~
+2025-07-30T13:51:22.3082557Z   CXX      bench/bench_dash-pool.o
+2025-07-30T13:51:22.3929108Z   CC       depends/relic/src/fp/librelic_la-relic_fp_param.lo
+2025-07-30T13:51:22.5396429Z   CC       depends/relic/src/fp/librelic_la-relic_fp_prime.lo
+2025-07-30T13:51:22.7881639Z   CC       depends/relic/src/fp/librelic_la-relic_fp_rdc.lo
+2025-07-30T13:51:22.9341504Z   CC       depends/relic/src/fp/librelic_la-relic_fp_shift.lo
+2025-07-30T13:51:23.0853551Z   CC       depends/relic/src/fp/librelic_la-relic_fp_sqr.lo
+2025-07-30T13:51:23.2663749Z   CC       depends/relic/src/fp/librelic_la-relic_fp_srt.lo
+2025-07-30T13:51:23.4269680Z   CC       depends/relic/src/fp/librelic_la-relic_fp_util.lo
+2025-07-30T13:51:23.6332830Z   CC       depends/relic/src/fpx/librelic_la-relic_fp2_mul.lo
+2025-07-30T13:51:23.7990864Z   CC       depends/relic/src/fpx/librelic_la-relic_fp2_sqr.lo
+2025-07-30T13:51:23.9446064Z   CC       depends/relic/src/fpx/librelic_la-relic_fp3_mul.lo
+2025-07-30T13:51:24.1258493Z   CC       depends/relic/src/fpx/librelic_la-relic_fp3_sqr.lo
+2025-07-30T13:51:24.2823479Z   CC       depends/relic/src/fpx/librelic_la-relic_fp4_mul.lo
+2025-07-30T13:51:24.4575646Z   CC       depends/relic/src/fpx/librelic_la-relic_fp4_sqr.lo
+2025-07-30T13:51:24.5873830Z   CC       depends/relic/src/fpx/librelic_la-relic_fp6_mul.lo
+2025-07-30T13:51:24.7397185Z   CC       depends/relic/src/fpx/librelic_la-relic_fp6_sqr.lo
+2025-07-30T13:51:24.8953296Z   CC       depends/relic/src/fpx/librelic_la-relic_fp8_mul.lo
+2025-07-30T13:51:25.0699200Z   CC       depends/relic/src/fpx/librelic_la-relic_fp8_sqr.lo
+2025-07-30T13:51:25.1128298Z   CC       depends/relic/src/fpx/librelic_la-relic_fp9_mul.lo
+2025-07-30T13:51:25.2236911Z   CXX      bench/bench_dash-rpc_blockchain.o
+2025-07-30T13:51:25.2846126Z   CC       depends/relic/src/fpx/librelic_la-relic_fp9_sqr.lo
+2025-07-30T13:51:25.3604582Z   CC       depends/relic/src/fpx/librelic_la-relic_fp12_mul.lo
+2025-07-30T13:51:25.4305502Z   CXX      bench/bench_dash-rpc_mempool.o
+2025-07-30T13:51:25.4966913Z depends/relic/src/fpx/relic_fp12_mul.c: In function ‘fp12_mul_dxs_basic’:
+2025-07-30T13:51:25.4969103Z depends/relic/src/fpx/relic_fp12_mul.c:196:25: warning: ‘fp6_mul_dxs’ accessing 288 bytes in a region of size 96 [-Wstringop-overflow=]
+2025-07-30T13:51:25.4975516Z   196 |                         fp6_mul_dxs(t1, a[1], b[1]);
+2025-07-30T13:51:25.4975957Z       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:25.4977007Z depends/relic/src/fpx/relic_fp12_mul.c:196:25: note: referencing argument 3 of type ‘dig_t[3][2][6]’ {aka ‘long unsigned int[3][2][6]’}
+2025-07-30T13:51:25.4980284Z In file included from ./depends/relic/include/relic_epx.h:44,
+2025-07-30T13:51:25.4980889Z                  from ./depends/relic/include/relic_core.h:47,
+2025-07-30T13:51:25.4981445Z                  from depends/relic/src/fpx/relic_fp12_mul.c:32:
+2025-07-30T13:51:25.4982361Z ./depends/relic/include/relic_fpx.h:2348:6: note: in a call to function ‘fp6_mul_dxs’
+2025-07-30T13:51:25.4983080Z  2348 | void fp6_mul_dxs(fp6_t c, fp6_t a, fp6_t b);
+2025-07-30T13:51:25.4983525Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:25.5598109Z   CC       depends/relic/src/fpx/librelic_la-relic_fp12_sqr.lo
+2025-07-30T13:51:25.7656696Z   CC       depends/relic/src/fpx/librelic_la-relic_fp18_mul.lo
+2025-07-30T13:51:25.9382777Z   CC       depends/relic/src/fpx/librelic_la-relic_fp18_sqr.lo
+2025-07-30T13:51:26.1011420Z   CC       depends/relic/src/fpx/librelic_la-relic_fp24_mul.lo
+2025-07-30T13:51:26.2894267Z   CC       depends/relic/src/fpx/librelic_la-relic_fp24_sqr.lo
+2025-07-30T13:51:26.4961553Z   CC       depends/relic/src/fpx/librelic_la-relic_fp48_mul.lo
+2025-07-30T13:51:26.6233542Z depends/relic/src/fpx/relic_fp48_mul.c: In function ‘fp48_mul_dxs’:
+2025-07-30T13:51:26.6235282Z depends/relic/src/fpx/relic_fp48_mul.c:138:17: warning: ‘fp24_add’ accessing 1152 bytes in a region of size 384 [-Wstringop-overflow=]
+2025-07-30T13:51:26.6238767Z   138 |                 fp24_add(c[1], a[0], a[1]);
+2025-07-30T13:51:26.6239227Z       |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:26.6243566Z depends/relic/src/fpx/relic_fp48_mul.c:138:17: note: referencing argument 3 of type ‘dig_t[3][2][2][2][6]’ {aka ‘long unsigned int[3][2][2][2][6]’}
+2025-07-30T13:51:26.6244805Z In file included from ./depends/relic/include/relic_epx.h:44,
+2025-07-30T13:51:26.6245311Z                  from ./depends/relic/include/relic_core.h:47,
+2025-07-30T13:51:26.6245797Z                  from depends/relic/src/fpx/relic_fp48_mul.c:32:
+2025-07-30T13:51:26.6246621Z ./depends/relic/include/relic_fpx.h:3709:6: note: in a call to function ‘fp24_add’
+2025-07-30T13:51:26.6247242Z  3709 | void fp24_add(fp24_t c, fp24_t a, fp24_t b);
+2025-07-30T13:51:26.6247839Z       |      ^~~~~~~~
+2025-07-30T13:51:26.6429258Z   CC       depends/relic/src/fpx/librelic_la-relic_fp48_sqr.lo
+2025-07-30T13:51:26.7928202Z   CC       depends/relic/src/fpx/librelic_la-relic_fp54_mul.lo
+2025-07-30T13:51:26.8330026Z   CXX      bench/bench_dash-strencodings.o
+2025-07-30T13:51:26.9266682Z depends/relic/src/fpx/relic_fp54_mul.c: In function ‘fp54_mul_dxs’:
+2025-07-30T13:51:26.9277464Z depends/relic/src/fpx/relic_fp54_mul.c:144:17: warning: ‘fp18_add’ accessing 864 bytes in a region of size 432 [-Wstringop-overflow=]
+2025-07-30T13:51:26.9278672Z   144 |                 fp18_add(t3, a[1], a[2]);
+2025-07-30T13:51:26.9279127Z       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:26.9280261Z depends/relic/src/fpx/relic_fp54_mul.c:144:17: note: referencing argument 3 of type ‘dig_t[2][3][3][6]’ {aka ‘long unsigned int[2][3][3][6]’}
+2025-07-30T13:51:26.9281293Z In file included from ./depends/relic/include/relic_epx.h:44,
+2025-07-30T13:51:26.9281891Z                  from ./depends/relic/include/relic_core.h:47,
+2025-07-30T13:51:26.9282435Z                  from depends/relic/src/fpx/relic_fp54_mul.c:32:
+2025-07-30T13:51:26.9283285Z ./depends/relic/include/relic_fpx.h:3446:6: note: in a call to function ‘fp18_add’
+2025-07-30T13:51:26.9283996Z  3446 | void fp18_add(fp18_t c, fp18_t a, fp18_t b);
+2025-07-30T13:51:26.9284445Z       |      ^~~~~~~~
+2025-07-30T13:51:26.9288032Z depends/relic/src/fpx/relic_fp54_mul.c:161:17: warning: ‘fp18_add’ accessing 864 bytes in a region of size 432 [-Wstringop-overflow=]
+2025-07-30T13:51:26.9290481Z   161 |                 fp18_add(t4, a[0], a[2]);
+2025-07-30T13:51:26.9291722Z       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:26.9292882Z depends/relic/src/fpx/relic_fp54_mul.c:161:17: note: referencing argument 3 of type ‘dig_t[2][3][3][6]’ {aka ‘long unsigned int[2][3][3][6]’}
+2025-07-30T13:51:26.9308597Z ./depends/relic/include/relic_fpx.h:3446:6: note: in a call to function ‘fp18_add’
+2025-07-30T13:51:26.9310149Z  3446 | void fp18_add(fp18_t c, fp18_t a, fp18_t b);
+2025-07-30T13:51:26.9310624Z       |      ^~~~~~~~
+2025-07-30T13:51:26.9498856Z   CC       depends/relic/src/fpx/librelic_la-relic_fp54_sqr.lo
+2025-07-30T13:51:27.1420222Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_add.lo
+2025-07-30T13:51:27.3977295Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_cmp.lo
+2025-07-30T13:51:27.6160100Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_cyc.lo
+2025-07-30T13:51:27.9272432Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp12_back_cyc_sim’:
+2025-07-30T13:51:27.9277543Z depends/relic/src/fpx/relic_fpx_cyc.c:377:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:27.9279485Z   377 | void fp12_back_cyc_sim(fp12_t c[], fp12_t a[], int n) {
+2025-07-30T13:51:27.9281723Z       |      ^~~~~~~~~~~~~~~~~
+2025-07-30T13:51:27.9583712Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp12_exp_cyc’:
+2025-07-30T13:51:27.9585853Z depends/relic/src/fpx/relic_fpx_cyc.c:456:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:27.9587190Z   456 | void fp12_exp_cyc(fp12_t c, fp12_t a, bn_t b) {
+2025-07-30T13:51:27.9588108Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:28.0699589Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp12_exp_cyc_sps’:
+2025-07-30T13:51:28.0701266Z depends/relic/src/fpx/relic_fpx_cyc.c:808:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.0702827Z   808 | void fp12_exp_cyc_sps(fp12_t c, fp12_t a, const int *b, int len, int sign) {
+2025-07-30T13:51:28.0709893Z       |      ^~~~~~~~~~~~~~~~
+2025-07-30T13:51:28.1110945Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp24_back_cyc_sim’:
+2025-07-30T13:51:28.1117532Z depends/relic/src/fpx/relic_fpx_cyc.c:1005:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.1119705Z  1005 | void fp24_back_cyc_sim(fp24_t c[], fp24_t a[], int n) {
+2025-07-30T13:51:28.1120935Z       |      ^~~~~~~~~~~~~~~~~
+2025-07-30T13:51:28.1465821Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp24_exp_cyc’:
+2025-07-30T13:51:28.1467771Z depends/relic/src/fpx/relic_fpx_cyc.c:1084:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.1469181Z  1084 | void fp24_exp_cyc(fp24_t c, fp24_t a, bn_t b) {
+2025-07-30T13:51:28.1470026Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:28.2182836Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp24_exp_cyc_sps’:
+2025-07-30T13:51:28.2184591Z depends/relic/src/fpx/relic_fpx_cyc.c:1336:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.2186088Z  1336 | void fp24_exp_cyc_sps(fp24_t c, fp24_t a, const int *b, int len, int sign) {
+2025-07-30T13:51:28.2187079Z       |      ^~~~~~~~~~~~~~~~
+2025-07-30T13:51:28.2586427Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp48_back_cyc_sim’:
+2025-07-30T13:51:28.2623196Z depends/relic/src/fpx/relic_fpx_cyc.c:1533:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.2625345Z  1533 | void fp48_back_cyc_sim(fp48_t c[], fp48_t a[], int n) {
+2025-07-30T13:51:28.2626381Z       |      ^~~~~~~~~~~~~~~~~
+2025-07-30T13:51:28.2812242Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp48_exp_cyc’:
+2025-07-30T13:51:28.2814007Z depends/relic/src/fpx/relic_fpx_cyc.c:1612:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.2815895Z  1612 | void fp48_exp_cyc(fp48_t c, fp48_t a, bn_t b) {
+2025-07-30T13:51:28.2816808Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:28.3118207Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp48_exp_cyc_sps’:
+2025-07-30T13:51:28.3120012Z depends/relic/src/fpx/relic_fpx_cyc.c:1707:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.3121667Z  1707 | void fp48_exp_cyc_sps(fp48_t c, fp48_t a, const int *b, int len, int sign) {
+2025-07-30T13:51:28.3122770Z       |      ^~~~~~~~~~~~~~~~
+2025-07-30T13:51:28.3523188Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp54_back_cyc_sim’:
+2025-07-30T13:51:28.3525132Z depends/relic/src/fpx/relic_fpx_cyc.c:1903:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.3527175Z  1903 | void fp54_back_cyc_sim(fp54_t c[], fp54_t a[], int n) {
+2025-07-30T13:51:28.3528375Z       |      ^~~~~~~~~~~~~~~~~
+2025-07-30T13:51:28.3789549Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp54_exp_cyc’:
+2025-07-30T13:51:28.3791390Z depends/relic/src/fpx/relic_fpx_cyc.c:1982:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.3792983Z  1982 | void fp54_exp_cyc(fp54_t c, fp54_t a, bn_t b) {
+2025-07-30T13:51:28.3793915Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:28.4133078Z depends/relic/src/fpx/relic_fpx_cyc.c: In function ‘fp54_exp_cyc_sps’:
+2025-07-30T13:51:28.4135965Z depends/relic/src/fpx/relic_fpx_cyc.c:2078:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:28.4138177Z  2078 | void fp54_exp_cyc_sps(fp54_t c, fp54_t a, const int *b, int len, int sign) {
+2025-07-30T13:51:28.4139403Z       |      ^~~~~~~~~~~~~~~~
+2025-07-30T13:51:28.4455469Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_exp.lo
+2025-07-30T13:51:28.7586196Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_field.lo
+2025-07-30T13:51:28.9466089Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_frb.lo
+2025-07-30T13:51:29.1734110Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_inv.lo
+2025-07-30T13:51:29.2191661Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_pck.lo
+2025-07-30T13:51:29.3180235Z depends/relic/src/fpx/relic_fpx_inv.c: In function ‘fp2_inv_sim’:
+2025-07-30T13:51:29.3181307Z depends/relic/src/fpx/relic_fpx_inv.c:97:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:29.3182189Z    97 | void fp2_inv_sim(fp2_t *c, fp2_t *a, int n) {
+2025-07-30T13:51:29.3182567Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:29.3429526Z depends/relic/src/fpx/relic_fpx_inv.c: In function ‘fp3_inv_sim’:
+2025-07-30T13:51:29.3432158Z depends/relic/src/fpx/relic_fpx_inv.c:223:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:29.3433323Z   223 | void fp3_inv_sim(fp3_t * c, fp3_t * a, int n) {
+2025-07-30T13:51:29.3433806Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:29.3603258Z depends/relic/src/fpx/relic_fpx_inv.c: In function ‘fp4_inv_sim’:
+2025-07-30T13:51:29.3605953Z depends/relic/src/fpx/relic_fpx_inv.c:299:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:29.3607077Z   299 | void fp4_inv_sim(fp4_t * c, fp4_t * a, int n) {
+2025-07-30T13:51:29.3607565Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:29.3786959Z   CXX      bench/bench_dash-util_time.o
+2025-07-30T13:51:29.3839137Z depends/relic/src/fpx/relic_fpx_inv.c: In function ‘fp8_inv_sim’:
+2025-07-30T13:51:29.3841985Z depends/relic/src/fpx/relic_fpx_inv.c:434:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:29.3843093Z   434 | void fp8_inv_sim(fp8_t *c, fp8_t *a, int n) {
+2025-07-30T13:51:29.3844030Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:29.4029244Z depends/relic/src/fpx/relic_fpx_inv.c: In function ‘fp9_inv_sim’:
+2025-07-30T13:51:29.4031875Z depends/relic/src/fpx/relic_fpx_inv.c:536:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:29.4032970Z   536 | void fp9_inv_sim(fp9_t * c, fp9_t * a, int n) {
+2025-07-30T13:51:29.4033466Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:29.4612286Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_rdc.lo
+2025-07-30T13:51:29.5952976Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_srt.lo
+2025-07-30T13:51:29.7554162Z   CC       depends/relic/src/fpx/librelic_la-relic_fpx_util.lo
+2025-07-30T13:51:30.1977459Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_add_low.lo
+2025-07-30T13:51:30.4107345Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_mul_low.lo
+2025-07-30T13:51:30.5822313Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_rdc_low.lo
+2025-07-30T13:51:30.7231230Z   CC       depends/relic/src/low/easy/librelic_la-relic_fpx_sqr_low.lo
+2025-07-30T13:51:30.8816732Z   CC       depends/relic/src/fb/librelic_la-relic_fb_add.lo
+2025-07-30T13:51:31.0249248Z   CC       depends/relic/src/fb/librelic_la-relic_fb_cmp.lo
+2025-07-30T13:51:31.1671900Z   CC       depends/relic/src/fb/librelic_la-relic_fb_exp.lo
+2025-07-30T13:51:31.3472394Z   CC       depends/relic/src/fb/librelic_la-relic_fb_inv.lo
+2025-07-30T13:51:31.5787233Z   CC       depends/relic/src/fb/librelic_la-relic_fb_itr.lo
+2025-07-30T13:51:31.5840556Z depends/relic/src/fb/relic_fb_inv.c: In function ‘fb_inv_itoht’:
+2025-07-30T13:51:31.5860535Z depends/relic/src/fb/relic_fb_inv.c:439:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:31.5861607Z   439 | void fb_inv_itoht(fb_t c, const fb_t a) {
+2025-07-30T13:51:31.5862049Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:31.6366208Z depends/relic/src/fb/relic_fb_inv.c: In function ‘fb_inv_sim’:
+2025-07-30T13:51:31.6367495Z depends/relic/src/fb/relic_fb_inv.c:659:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:31.6368753Z   659 | void fb_inv_sim(fb_t *c, const fb_t *a, int n) {
+2025-07-30T13:51:31.6369237Z       |      ^~~~~~~~~~
+2025-07-30T13:51:31.6556121Z   CC       depends/relic/src/fb/librelic_la-relic_fb_mul.lo
+2025-07-30T13:51:31.7475457Z   CC       depends/relic/src/fb/librelic_la-relic_fb_param.lo
+2025-07-30T13:51:31.8243297Z   CXX      bench/bench_dash-base58.o
+2025-07-30T13:51:31.8652871Z   CC       depends/relic/src/fb/librelic_la-relic_fb_poly.lo
+2025-07-30T13:51:31.9010649Z   CXX      bench/bench_dash-bech32.o
+2025-07-30T13:51:32.0964642Z   CC       depends/relic/src/fb/librelic_la-relic_fb_rdc.lo
+2025-07-30T13:51:32.2409340Z   CC       depends/relic/src/fb/librelic_la-relic_fb_shift.lo
+2025-07-30T13:51:32.3794188Z   CC       depends/relic/src/fb/librelic_la-relic_fb_slv.lo
+2025-07-30T13:51:32.5236740Z   CC       depends/relic/src/fb/librelic_la-relic_fb_sqr.lo
+2025-07-30T13:51:32.6676866Z   CC       depends/relic/src/fb/librelic_la-relic_fb_srt.lo
+2025-07-30T13:51:32.8090802Z   CC       depends/relic/src/fb/librelic_la-relic_fb_trc.lo
+2025-07-30T13:51:32.9524191Z   CC       depends/relic/src/fb/librelic_la-relic_fb_util.lo
+2025-07-30T13:51:33.1748575Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_inv.lo
+2025-07-30T13:51:33.3128418Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_mul.lo
+2025-07-30T13:51:33.4500511Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_slv.lo
+2025-07-30T13:51:33.5892545Z   CC       depends/relic/src/fbx/librelic_la-relic_fb2_sqr.lo
+2025-07-30T13:51:33.7284426Z   CC       depends/relic/src/ep/librelic_la-relic_ep_add.lo
+2025-07-30T13:51:33.9734646Z   CC       depends/relic/src/ep/librelic_la-relic_ep_cmp.lo
+2025-07-30T13:51:33.9756077Z   CXX      bench/bench_dash-lockedpool.o
+2025-07-30T13:51:34.1107078Z   CC       depends/relic/src/ep/librelic_la-relic_ep_curve.lo
+2025-07-30T13:51:34.1691436Z   CC       depends/relic/src/ep/librelic_la-relic_ep_dbl.lo
+2025-07-30T13:51:34.3439960Z   CXX      bench/bench_dash-poly1305.o
+2025-07-30T13:51:34.3880937Z   CC       depends/relic/src/ep/librelic_la-relic_ep_map.lo
+2025-07-30T13:51:34.4287026Z   CC       depends/relic/src/ep/librelic_la-relic_ep_mul.lo
+2025-07-30T13:51:34.5829375Z depends/relic/src/ep/relic_ep_map.c: In function ‘ep_map_dst’:
+2025-07-30T13:51:34.5831239Z depends/relic/src/ep/relic_ep_map.c:185:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:34.5833596Z   185 | void ep_map_dst(ep_t p, const uint8_t *msg, int len, const uint8_t *dst,
+2025-07-30T13:51:34.5834175Z       |      ^~~~~~~~~~
+2025-07-30T13:51:34.6030038Z   CXX      bench/bench_dash-prevector.o
+2025-07-30T13:51:34.6989176Z   CC       depends/relic/src/ep/librelic_la-relic_ep_mul_fix.lo
+2025-07-30T13:51:34.9844353Z   CC       depends/relic/src/ep/librelic_la-relic_ep_mul_sim.lo
+2025-07-30T13:51:35.3404841Z depends/relic/src/ep/relic_ep_mul_sim.c: In function ‘ep_mul_sim_lot’:
+2025-07-30T13:51:35.3406079Z depends/relic/src/ep/relic_ep_mul_sim.c:769:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:35.3407098Z   769 | void ep_mul_sim_lot(ep_t r, ep_t p[], const bn_t k[], int n) {
+2025-07-30T13:51:35.3407773Z       |      ^~~~~~~~~~~~~~
+2025-07-30T13:51:35.4059030Z   CC       depends/relic/src/ep/librelic_la-relic_ep_neg.lo
+2025-07-30T13:51:35.5446779Z   CC       depends/relic/src/ep/librelic_la-relic_ep_norm.lo
+2025-07-30T13:51:35.6918454Z depends/relic/src/ep/relic_ep_norm.c: In function ‘ep_norm_sim’:
+2025-07-30T13:51:35.6920305Z depends/relic/src/ep/relic_ep_norm.c:112:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:35.6923096Z   112 | void ep_norm_sim(ep_t *r, const ep_t *t, int n) {
+2025-07-30T13:51:35.6923622Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:35.7119819Z   CC       depends/relic/src/ep/librelic_la-relic_ep_param.lo
+2025-07-30T13:51:35.8985787Z   CC       depends/relic/src/ep/librelic_la-relic_ep_pck.lo
+2025-07-30T13:51:36.0481508Z   CC       depends/relic/src/ep/librelic_la-relic_ep_psi.lo
+2025-07-30T13:51:36.1914439Z   CC       depends/relic/src/ep/librelic_la-relic_ep_util.lo
+2025-07-30T13:51:36.3893449Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_add.lo
+2025-07-30T13:51:36.5464489Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_cmp.lo
+2025-07-30T13:51:36.5674525Z   CXX      bench/bench_dash-string_cast.o
+2025-07-30T13:51:36.6851376Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_curve.lo
+2025-07-30T13:51:36.7412151Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_dbl.lo
+2025-07-30T13:51:36.8681081Z depends/relic/src/epx/relic_ep2_curve.c: In function ‘ep2_curve_set_twist’:
+2025-07-30T13:51:36.8684901Z depends/relic/src/epx/relic_ep2_curve.c:860:25: warning: ‘fp2_inv’ accessing 96 bytes in a region of size 48 [-Wstringop-overflow=]
+2025-07-30T13:51:36.8685898Z   860 |                         fp2_inv(ctx->ep2_frb[0], ctx->ep2_frb[0]);
+2025-07-30T13:51:36.8686377Z       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:36.8687425Z depends/relic/src/epx/relic_ep2_curve.c:860:25: note: referencing argument 1 of type ‘dig_t[2][6]’ {aka ‘long unsigned int[2][6]’}
+2025-07-30T13:51:36.8689105Z depends/relic/src/epx/relic_ep2_curve.c:860:25: warning: ‘fp2_inv’ accessing 96 bytes in a region of size 48 [-Wstringop-overflow=]
+2025-07-30T13:51:36.8690669Z depends/relic/src/epx/relic_ep2_curve.c:860:25: note: referencing argument 2 of type ‘dig_t[2][6]’ {aka ‘long unsigned int[2][6]’}
+2025-07-30T13:51:36.8691718Z In file included from ./depends/relic/include/relic_epx.h:44,
+2025-07-30T13:51:36.8692335Z                  from ./depends/relic/include/relic_core.h:47,
+2025-07-30T13:51:36.8692924Z                  from depends/relic/src/epx/relic_ep2_curve.c:33:
+2025-07-30T13:51:36.8694336Z ./depends/relic/include/relic_fpx.h:1532:6: note: in a call to function ‘fp2_inv’
+2025-07-30T13:51:36.8695035Z  1532 | void fp2_inv(fp2_t c, fp2_t a);
+2025-07-30T13:51:36.8695449Z       |      ^~~~~~~
+2025-07-30T13:51:36.8696545Z depends/relic/src/epx/relic_ep2_curve.c:861:25: warning: ‘fp2_inv’ accessing 96 bytes in a region of size 48 [-Wstringop-overflow=]
+2025-07-30T13:51:36.8697552Z   861 |                         fp2_inv(ctx->ep2_frb[1], ctx->ep2_frb[1]);
+2025-07-30T13:51:36.8698281Z       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:36.8699461Z depends/relic/src/epx/relic_ep2_curve.c:861:25: note: referencing argument 1 of type ‘dig_t[2][6]’ {aka ‘long unsigned int[2][6]’}
+2025-07-30T13:51:36.8701098Z depends/relic/src/epx/relic_ep2_curve.c:861:25: warning: ‘fp2_inv’ accessing 96 bytes in a region of size 48 [-Wstringop-overflow=]
+2025-07-30T13:51:36.8703081Z depends/relic/src/epx/relic_ep2_curve.c:861:25: note: referencing argument 2 of type ‘dig_t[2][6]’ {aka ‘long unsigned int[2][6]’}
+2025-07-30T13:51:36.8704480Z ./depends/relic/include/relic_fpx.h:1532:6: note: in a call to function ‘fp2_inv’
+2025-07-30T13:51:36.8705169Z  1532 | void fp2_inv(fp2_t c, fp2_t a);
+2025-07-30T13:51:36.8705585Z       |      ^~~~~~~
+2025-07-30T13:51:36.9184258Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_map.lo
+2025-07-30T13:51:36.9188080Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_frb.lo
+2025-07-30T13:51:37.0588864Z   CXX      bench/bench_dash-verify_script.o
+2025-07-30T13:51:37.1147565Z depends/relic/src/epx/relic_ep2_map.c: In function ‘ep2_map_dst’:
+2025-07-30T13:51:37.1149094Z depends/relic/src/epx/relic_ep2_map.c:170:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:37.1150356Z   170 | void ep2_map_dst(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
+2025-07-30T13:51:37.1151035Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:37.1337198Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul.lo
+2025-07-30T13:51:37.3706348Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul_cof.lo
+2025-07-30T13:51:37.5147538Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul_fix.lo
+2025-07-30T13:51:37.7903015Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_mul_sim.lo
+2025-07-30T13:51:38.1297228Z depends/relic/src/epx/relic_ep2_mul_sim.c: In function ‘ep2_mul_sim_lot’:
+2025-07-30T13:51:38.1299217Z depends/relic/src/epx/relic_ep2_mul_sim.c:544:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:38.1300678Z   544 | void ep2_mul_sim_lot(ep2_t r, ep2_t p[], const bn_t k[], int n) {
+2025-07-30T13:51:38.1301432Z       |      ^~~~~~~~~~~~~~~
+2025-07-30T13:51:38.1876780Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_neg.lo
+2025-07-30T13:51:38.3287183Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_norm.lo
+2025-07-30T13:51:38.4720070Z depends/relic/src/epx/relic_ep2_norm.c: In function ‘ep2_norm_sim’:
+2025-07-30T13:51:38.4723655Z depends/relic/src/epx/relic_ep2_norm.c:103:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:38.4724742Z   103 | void ep2_norm_sim(ep2_t *r, ep2_t *t, int n) {
+2025-07-30T13:51:38.4725238Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:38.4904487Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_pck.lo
+2025-07-30T13:51:38.6383454Z   CC       depends/relic/src/epx/librelic_la-relic_ep2_util.lo
+2025-07-30T13:51:38.6556358Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_add.lo
+2025-07-30T13:51:38.8280510Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_cmp.lo
+2025-07-30T13:51:38.8412931Z   GEN      qt/forms/ui_addressbookpage.h
+2025-07-30T13:51:38.8493606Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_curve.lo
+2025-07-30T13:51:38.9799002Z   GEN      qt/forms/ui_appearancewidget.h
+2025-07-30T13:51:38.9914748Z   GEN      qt/forms/ui_askpassphrasedialog.h
+2025-07-30T13:51:38.9990214Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_dbl.lo
+2025-07-30T13:51:39.0405443Z   GEN      qt/forms/ui_coincontroldialog.h
+2025-07-30T13:51:39.0488319Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_frb.lo
+2025-07-30T13:51:39.1726394Z   GEN      qt/forms/ui_createwalletdialog.h
+2025-07-30T13:51:39.1796158Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_map.lo
+2025-07-30T13:51:39.1886116Z   GEN      qt/forms/ui_editaddressdialog.h
+2025-07-30T13:51:39.1960015Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul.lo
+2025-07-30T13:51:39.3203789Z   GEN      qt/forms/ui_governancelist.h
+2025-07-30T13:51:39.3277008Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul_cof.lo
+2025-07-30T13:51:39.4339802Z   GEN      qt/forms/ui_helpmessagedialog.h
+2025-07-30T13:51:39.4419857Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul_fix.lo
+2025-07-30T13:51:39.4748570Z   GEN      qt/forms/ui_intro.h
+2025-07-30T13:51:39.4829077Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_mul_sim.lo
+2025-07-30T13:51:39.7122033Z   GEN      qt/forms/ui_modaloverlay.h
+2025-07-30T13:51:39.7193542Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_neg.lo
+2025-07-30T13:51:39.7800956Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_norm.lo
+2025-07-30T13:51:39.7834491Z depends/relic/src/epx/relic_ep4_mul_sim.c: In function ‘ep4_mul_sim_lot’:
+2025-07-30T13:51:39.7840036Z depends/relic/src/epx/relic_ep4_mul_sim.c:429:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:39.7841353Z   429 | void ep4_mul_sim_lot(ep4_t r, ep4_t p[], const bn_t k[], int n) {
+2025-07-30T13:51:39.7842037Z       |      ^~~~~~~~~~~~~~~
+2025-07-30T13:51:39.8538580Z   CC       depends/relic/src/epx/librelic_la-relic_ep4_util.lo
+2025-07-30T13:51:39.8556501Z   GEN      qt/forms/ui_masternodelist.h
+2025-07-30T13:51:39.8636044Z   CC       depends/relic/src/eb/librelic_la-relic_eb_add.lo
+2025-07-30T13:51:39.9196674Z depends/relic/src/epx/relic_ep4_norm.c: In function ‘ep4_norm_sim’:
+2025-07-30T13:51:39.9198175Z depends/relic/src/epx/relic_ep4_norm.c:103:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:39.9199257Z   103 | void ep4_norm_sim(ep4_t *r, ep4_t *t, int n) {
+2025-07-30T13:51:39.9199718Z       |      ^~~~~~~~~~~~
+2025-07-30T13:51:39.9400856Z   CC       depends/relic/src/eb/librelic_la-relic_eb_cmp.lo
+2025-07-30T13:51:40.0361133Z   GEN      qt/forms/ui_qrdialog.h
+2025-07-30T13:51:40.0426748Z   CC       depends/relic/src/eb/librelic_la-relic_eb_curve.lo
+2025-07-30T13:51:40.0508983Z   CC       depends/relic/src/eb/librelic_la-relic_eb_dbl.lo
+2025-07-30T13:51:40.0596166Z   GEN      qt/forms/ui_openuridialog.h
+2025-07-30T13:51:40.0672966Z   CC       depends/relic/src/eb/librelic_la-relic_eb_frb.lo
+2025-07-30T13:51:40.0875273Z   GEN      qt/forms/ui_optionsdialog.h
+2025-07-30T13:51:40.0966195Z   CC       depends/relic/src/eb/librelic_la-relic_eb_hlv.lo
+2025-07-30T13:51:40.1996285Z   CC       depends/relic/src/eb/librelic_la-relic_eb_map.lo
+2025-07-30T13:51:40.2042918Z   GEN      qt/forms/ui_overviewpage.h
+2025-07-30T13:51:40.2159664Z   GEN      qt/forms/ui_psbtoperationsdialog.h
+2025-07-30T13:51:40.2184887Z   GEN      qt/forms/ui_receivecoinsdialog.h
+2025-07-30T13:51:40.2225070Z   CC       depends/relic/src/eb/librelic_la-relic_eb_mul.lo
+2025-07-30T13:51:40.2262111Z   CC       depends/relic/src/eb/librelic_la-relic_eb_mul_fix.lo
+2025-07-30T13:51:40.2443778Z   GEN      qt/forms/ui_receiverequestdialog.h
+2025-07-30T13:51:40.2563940Z   GEN      qt/forms/ui_debugwindow.h
+2025-07-30T13:51:40.2680302Z   CC       depends/relic/src/eb/librelic_la-relic_eb_mul_sim.lo
+2025-07-30T13:51:40.3473374Z   GEN      qt/forms/ui_sendcoinsdialog.h
+2025-07-30T13:51:40.3581079Z   CC       depends/relic/src/eb/librelic_la-relic_eb_neg.lo
+2025-07-30T13:51:40.4919537Z   GEN      qt/forms/ui_sendcoinsentry.h
+2025-07-30T13:51:40.5019950Z   CC       depends/relic/src/eb/librelic_la-relic_eb_norm.lo
+2025-07-30T13:51:40.5098783Z   GEN      qt/forms/ui_signverifymessagedialog.h
+2025-07-30T13:51:40.5242799Z   GEN      qt/forms/ui_transactiondescdialog.h
+2025-07-30T13:51:40.5320597Z   CC       depends/relic/src/eb/librelic_la-relic_eb_param.lo
+2025-07-30T13:51:40.5381221Z   GEN      qt/moc_addressbookpage.cpp
+2025-07-30T13:51:40.5432056Z   CC       depends/relic/src/eb/librelic_la-relic_eb_pck.lo
+2025-07-30T13:51:40.5448274Z   GEN      qt/moc_addresstablemodel.cpp
+2025-07-30T13:51:40.5563448Z   CC       depends/relic/src/eb/librelic_la-relic_eb_util.lo
+2025-07-30T13:51:40.6418300Z depends/relic/src/eb/relic_eb_norm.c: In function ‘eb_norm_sim’:
+2025-07-30T13:51:40.6419543Z depends/relic/src/eb/relic_eb_norm.c:107:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:40.6420652Z   107 | void eb_norm_sim(eb_t *r, const eb_t *t, int n) {
+2025-07-30T13:51:40.6421130Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:40.6612986Z   GEN      qt/moc_appearancewidget.cpp
+2025-07-30T13:51:40.6805535Z   GEN      qt/moc_askpassphrasedialog.cpp
+2025-07-30T13:51:40.6852792Z   CC       depends/relic/src/ed/librelic_la-relic_ed_add.lo
+2025-07-30T13:51:40.6875941Z   GEN      qt/moc_createwalletdialog.cpp
+2025-07-30T13:51:40.6920964Z   CC       depends/relic/src/ed/librelic_la-relic_ed_cmp.lo
+2025-07-30T13:51:40.6936110Z   CC       depends/relic/src/ed/librelic_la-relic_ed_curve.lo
+2025-07-30T13:51:40.7597352Z   GEN      qt/moc_bantablemodel.cpp
+2025-07-30T13:51:40.7906276Z   CC       depends/relic/src/ed/librelic_la-relic_ed_dbl.lo
+2025-07-30T13:51:40.8318037Z   CC       depends/relic/src/ed/librelic_la-relic_ed_map.lo
+2025-07-30T13:51:40.8352992Z   GEN      qt/moc_bitcoin.cpp
+2025-07-30T13:51:40.8582081Z   GEN      qt/moc_bitcoinaddressvalidator.cpp
+2025-07-30T13:51:40.8632017Z   CC       depends/relic/src/ed/librelic_la-relic_ed_mul.lo
+2025-07-30T13:51:40.8669661Z   CC       depends/relic/src/ed/librelic_la-relic_ed_mul_fix.lo
+2025-07-30T13:51:40.9455365Z   GEN      qt/moc_bitcoinamountfield.cpp
+2025-07-30T13:51:40.9508637Z   CC       depends/relic/src/ed/librelic_la-relic_ed_mul_sim.lo
+2025-07-30T13:51:40.9756568Z depends/relic/src/ed/relic_ed_map.c: In function ‘ed_map_dst’:
+2025-07-30T13:51:40.9757985Z depends/relic/src/ed/relic_ed_map.c:190:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:40.9759231Z   190 | void ed_map_dst(ed_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
+2025-07-30T13:51:40.9759851Z       |      ^~~~~~~~~~
+2025-07-30T13:51:40.9968536Z   GEN      qt/moc_bitcoingui.cpp
+2025-07-30T13:51:41.0042144Z   CC       depends/relic/src/ed/librelic_la-relic_ed_neg.lo
+2025-07-30T13:51:41.0913893Z   GEN      qt/moc_bitcoinunits.cpp
+2025-07-30T13:51:41.0972575Z   CC       depends/relic/src/ed/librelic_la-relic_ed_norm.lo
+2025-07-30T13:51:41.1174205Z   GEN      qt/moc_clientmodel.cpp
+2025-07-30T13:51:41.1449660Z   GEN      qt/moc_coincontroldialog.cpp
+2025-07-30T13:51:41.1472917Z   CC       depends/relic/src/ed/librelic_la-relic_ed_param.lo
+2025-07-30T13:51:41.1508055Z   CC       depends/relic/src/ed/librelic_la-relic_ed_pck.lo
+2025-07-30T13:51:41.1753727Z   GEN      qt/moc_coincontroltreewidget.cpp
+2025-07-30T13:51:41.1801423Z   CC       depends/relic/src/ed/librelic_la-relic_ed_util.lo
+2025-07-30T13:51:41.2311466Z depends/relic/src/ed/relic_ed_norm.c: In function ‘ed_norm_sim’:
+2025-07-30T13:51:41.2330604Z depends/relic/src/ed/relic_ed_norm.c:88:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:41.2331703Z    88 | void ed_norm_sim(ed_t *r, const ed_t *t, int n) {
+2025-07-30T13:51:41.2332192Z       |      ^~~~~~~~~~~
+2025-07-30T13:51:41.2503377Z   GEN      qt/moc_csvmodelwriter.cpp
+2025-07-30T13:51:41.2552797Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k2.lo
+2025-07-30T13:51:41.2875009Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k8.lo
+2025-07-30T13:51:41.2978361Z   GEN      qt/moc_editaddressdialog.cpp
+2025-07-30T13:51:41.3033854Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k12.lo
+2025-07-30T13:51:41.3750089Z   GEN      qt/moc_governancelist.cpp
+2025-07-30T13:51:41.3934860Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k24.lo
+2025-07-30T13:51:41.4145032Z   GEN      qt/moc_guiutil.cpp
+2025-07-30T13:51:41.4447169Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k48.lo
+2025-07-30T13:51:41.4453285Z   CC       depends/relic/src/pp/librelic_la-relic_pp_add_k54.lo
+2025-07-30T13:51:41.4803071Z   GEN      qt/moc_initexecutor.cpp
+2025-07-30T13:51:41.5116218Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k2.lo
+2025-07-30T13:51:41.5397305Z   GEN      qt/moc_intro.cpp
+2025-07-30T13:51:41.5448361Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k8.lo
+2025-07-30T13:51:41.6011133Z   GEN      qt/moc_macdockiconhandler.cpp
+2025-07-30T13:51:41.6016345Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k12.lo
+2025-07-30T13:51:41.6070292Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k24.lo
+2025-07-30T13:51:41.6646241Z   GEN      qt/moc_macnotificationhandler.cpp
+2025-07-30T13:51:41.6720752Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k48.lo
+2025-07-30T13:51:41.7526856Z   GEN      qt/moc_modaloverlay.cpp
+2025-07-30T13:51:41.7547487Z   GEN      qt/moc_masternodelist.cpp
+2025-07-30T13:51:41.7573721Z   GEN      qt/moc_notificator.cpp
+2025-07-30T13:51:41.7625241Z   CC       depends/relic/src/pp/librelic_la-relic_pp_dbl_k54.lo
+2025-07-30T13:51:41.7713556Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k2.lo
+2025-07-30T13:51:41.8190656Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k8.lo
+2025-07-30T13:51:41.8305202Z   GEN      qt/moc_openuridialog.cpp
+2025-07-30T13:51:41.8355679Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k12.lo
+2025-07-30T13:51:41.9051093Z   GEN      qt/moc_optionsdialog.cpp
+2025-07-30T13:51:41.9101857Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k24.lo
+2025-07-30T13:51:41.9239699Z   GEN      qt/moc_optionsmodel.cpp
+2025-07-30T13:51:41.9298583Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k48.lo
+2025-07-30T13:51:41.9594273Z   GEN      qt/moc_overviewpage.cpp
+2025-07-30T13:51:41.9834319Z   CC       depends/relic/src/pp/librelic_la-relic_pp_exp_k54.lo
+2025-07-30T13:51:41.9944588Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map.lo
+2025-07-30T13:51:42.0555377Z   GEN      qt/moc_peertablemodel.cpp
+2025-07-30T13:51:42.0827506Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k2.lo
+2025-07-30T13:51:42.0860793Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k8.lo
+2025-07-30T13:51:42.1250605Z   GEN      qt/moc_peertablesortproxy.cpp
+2025-07-30T13:51:42.1301558Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k12.lo
+2025-07-30T13:51:42.1612910Z   GEN      qt/moc_paymentserver.cpp
+2025-07-30T13:51:42.1699089Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k24.lo
+2025-07-30T13:51:42.2055717Z depends/relic/src/pp/relic_pp_map_k8.c: In function ‘pp_mil_k8.constprop’:
+2025-07-30T13:51:42.2059034Z depends/relic/src/pp/relic_pp_map_k8.c:52:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.2060256Z    52 | static void pp_mil_k8(fp8_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, bn_t a) {
+2025-07-30T13:51:42.2060851Z       |             ^~~~~~~~~
+2025-07-30T13:51:42.2173065Z depends/relic/src/pp/relic_pp_map_k2.c: In function ‘pp_mil_k2’:
+2025-07-30T13:51:42.2185141Z depends/relic/src/pp/relic_pp_map_k2.c:51:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.2186387Z    51 | static void pp_mil_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
+2025-07-30T13:51:42.2186991Z       |             ^~~~~~~~~
+2025-07-30T13:51:42.2293827Z   GEN      qt/moc_psbtoperationsdialog.cpp
+2025-07-30T13:51:42.2306958Z depends/relic/src/pp/relic_pp_map_k2.c: In function ‘pp_mil_lit_k2’:
+2025-07-30T13:51:42.2311237Z depends/relic/src/pp/relic_pp_map_k2.c:105:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.2313975Z   105 | static void pp_mil_lit_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
+2025-07-30T13:51:42.2314568Z       |             ^~~~~~~~~~~~~
+2025-07-30T13:51:42.2504793Z depends/relic/src/pp/relic_pp_map_k2.c: In function ‘pp_map_sim_tatep_k2’:
+2025-07-30T13:51:42.2507313Z depends/relic/src/pp/relic_pp_map_k2.c:197:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.2508586Z   197 | void pp_map_sim_tatep_k2(fp2_t r, ep_t *p, ep_t *q, int m) {
+2025-07-30T13:51:42.2509096Z       |      ^~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:42.2707536Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k48.lo
+2025-07-30T13:51:42.2734966Z depends/relic/src/pp/relic_pp_map_k2.c: In function ‘pp_map_sim_weilp_k2’:
+2025-07-30T13:51:42.2740522Z depends/relic/src/pp/relic_pp_map_k2.c:309:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.2742932Z   309 | void pp_map_sim_weilp_k2(fp2_t r, ep_t *p, ep_t *q, int m) {
+2025-07-30T13:51:42.2743459Z       |      ^~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:42.2785330Z depends/relic/src/pp/relic_pp_map_k12.c: In function ‘pp_mil_lit_k12’:
+2025-07-30T13:51:42.2786647Z depends/relic/src/pp/relic_pp_map_k12.c:146:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.2788052Z   146 | static void pp_mil_lit_k12(fp12_t r, ep_t *t, ep_t *p, ep2_t *q, int m, bn_t a) {
+2025-07-30T13:51:42.2788676Z       |             ^~~~~~~~~~~~~~
+2025-07-30T13:51:42.3000530Z   GEN      qt/moc_qrdialog.cpp
+2025-07-30T13:51:42.3054499Z depends/relic/src/pp/relic_pp_map_k12.c: In function ‘pp_mil_k12’:
+2025-07-30T13:51:42.3055782Z depends/relic/src/pp/relic_pp_map_k12.c:51:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.3057014Z    51 | static void pp_mil_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, bn_t a) {
+2025-07-30T13:51:42.3058159Z       |             ^~~~~~~~~~
+2025-07-30T13:51:42.3158460Z depends/relic/src/pp/relic_pp_map_k24.c: In function ‘pp_mil_k24’:
+2025-07-30T13:51:42.3159710Z depends/relic/src/pp/relic_pp_map_k24.c:51:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.3160916Z    51 | static void pp_mil_k24(fp24_t r, ep4_t *t, ep4_t *q, ep_t *p, int m, bn_t a) {
+2025-07-30T13:51:42.3161526Z       |             ^~~~~~~~~~
+2025-07-30T13:51:42.3240006Z   GEN      qt/moc_qrimagewidget.cpp
+2025-07-30T13:51:42.3295104Z   CC       depends/relic/src/pp/librelic_la-relic_pp_map_k54.lo
+2025-07-30T13:51:42.3425569Z depends/relic/src/pp/relic_pp_map_k12.c: In function ‘pp_map_sim_tatep_k12’:
+2025-07-30T13:51:42.3431865Z depends/relic/src/pp/relic_pp_map_k12.c:276:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.3433576Z   276 | void pp_map_sim_tatep_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
+2025-07-30T13:51:42.3434567Z       |      ^~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:42.3492711Z depends/relic/src/pp/relic_pp_map_k24.c: In function ‘pp_map_sim_k24’:
+2025-07-30T13:51:42.3494411Z depends/relic/src/pp/relic_pp_map_k24.c:188:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.3495904Z   188 | void pp_map_sim_k24(fp24_t r, ep_t *p, ep4_t *q, int m) {
+2025-07-30T13:51:42.3498864Z       |      ^~~~~~~~~~~~~~
+2025-07-30T13:51:42.3682376Z depends/relic/src/pp/relic_pp_map_k12.c: In function ‘pp_map_sim_weilp_k12’:
+2025-07-30T13:51:42.3684813Z depends/relic/src/pp/relic_pp_map_k12.c:387:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.3686642Z   387 | void pp_map_sim_weilp_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
+2025-07-30T13:51:42.3688638Z       |      ^~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:42.3729528Z   GEN      qt/moc_qvalidatedlineedit.cpp
+2025-07-30T13:51:42.3788669Z   CC       depends/relic/src/pp/librelic_la-relic_pp_norm.lo
+2025-07-30T13:51:42.3982240Z depends/relic/src/pp/relic_pp_map_k12.c: In function ‘pp_map_sim_oatep_k12’:
+2025-07-30T13:51:42.3984414Z depends/relic/src/pp/relic_pp_map_k12.c:523:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:42.3986866Z   523 | void pp_map_sim_oatep_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
+2025-07-30T13:51:42.3987400Z       |      ^~~~~~~~~~~~~~~~~~~~
+2025-07-30T13:51:42.4238842Z   GEN      qt/moc_qvaluecombobox.cpp
+2025-07-30T13:51:42.4295297Z   CC       depends/relic/src/pc/librelic_la-relic_pc_core.lo
+2025-07-30T13:51:42.4353967Z   GEN      qt/moc_receivecoinsdialog.cpp
+2025-07-30T13:51:42.4693589Z   CC       depends/relic/src/pc/librelic_la-relic_pc_exp.lo
+2025-07-30T13:51:42.5116603Z   GEN      qt/moc_receiverequestdialog.cpp
+2025-07-30T13:51:42.5214269Z   CC       depends/relic/src/pc/librelic_la-relic_pc_util.lo
+2025-07-30T13:51:42.5335524Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bbs.lo
+2025-07-30T13:51:42.5713060Z   GEN      qt/moc_recentrequeststablemodel.cpp
+2025-07-30T13:51:42.5814222Z   GEN      qt/moc_rpcconsole.cpp
+2025-07-30T13:51:42.6165042Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bdpe.lo
+2025-07-30T13:51:42.6431541Z   GEN      qt/moc_sendcoinsdialog.cpp
+2025-07-30T13:51:42.6671742Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bgn.lo
+2025-07-30T13:51:42.7029987Z   GEN      qt/moc_sendcoinsentry.cpp
+2025-07-30T13:51:42.7136944Z   CC       depends/relic/src/cp/librelic_la-relic_cp_bls.lo
+2025-07-30T13:51:42.7269579Z   CC       depends/relic/src/cp/librelic_la-relic_cp_cls.lo
+2025-07-30T13:51:42.8305843Z   GEN      qt/moc_signverifymessagedialog.cpp
+2025-07-30T13:51:42.8382532Z   CC       depends/relic/src/cp/librelic_la-relic_cp_cmlhs.lo
+2025-07-30T13:51:42.8914313Z   GEN      qt/moc_splashscreen.cpp
+2025-07-30T13:51:42.8968945Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecdh.lo
+2025-07-30T13:51:42.9040581Z   GEN      qt/moc_trafficgraphwidget.cpp
+2025-07-30T13:51:42.9113211Z   GEN      qt/moc_transactiondesc.cpp
+2025-07-30T13:51:42.9173982Z   GEN      qt/moc_transactiondescdialog.cpp
+2025-07-30T13:51:42.9226528Z   GEN      qt/moc_transactionfilterproxy.cpp
+2025-07-30T13:51:42.9278372Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecdsa.lo
+2025-07-30T13:51:43.0190744Z   GEN      qt/moc_transactionoverviewwidget.cpp
+2025-07-30T13:51:43.0242773Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecies.lo
+2025-07-30T13:51:43.0339419Z depends/relic/src/cp/relic_cp_cmlhs.c: In function ‘cp_cmlhs_sig’:
+2025-07-30T13:51:43.0345980Z depends/relic/src/cp/relic_cp_cmlhs.c:92:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.0347879Z    92 | int cp_cmlhs_sig(g1_t sig, g2_t z, g1_t a, g1_t c, g1_t r, g2_t s, bn_t msg,
+2025-07-30T13:51:43.0348480Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:43.0678517Z depends/relic/src/cp/relic_cp_cmlhs.c: In function ‘cp_cmlhs_ver’:
+2025-07-30T13:51:43.0683955Z depends/relic/src/cp/relic_cp_cmlhs.c:190:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.0685164Z   190 | int cp_cmlhs_ver(g1_t r, g2_t s, g1_t sig[], g2_t z[], g1_t a[], g1_t c[],
+2025-07-30T13:51:43.0685756Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:43.0794727Z   GEN      qt/moc_transactiontablemodel.cpp
+2025-07-30T13:51:43.0851673Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecmqv.lo
+2025-07-30T13:51:43.1065959Z depends/relic/src/cp/relic_cp_cmlhs.c: In function ‘cp_cmlhs_onv’:
+2025-07-30T13:51:43.1069056Z depends/relic/src/cp/relic_cp_cmlhs.c:302:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.1070291Z   302 | int cp_cmlhs_onv(g1_t r, g2_t s, g1_t sig[], g2_t z[], g1_t a[], g1_t c[],
+2025-07-30T13:51:43.1071318Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:43.1324722Z   GEN      qt/moc_transactionview.cpp
+2025-07-30T13:51:43.1380850Z   GEN      qt/moc_utilitydialog.cpp
+2025-07-30T13:51:43.1426710Z   GEN      qt/moc_walletcontroller.cpp
+2025-07-30T13:51:43.1550590Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ecss.lo
+2025-07-30T13:51:43.1616461Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ers.lo
+2025-07-30T13:51:43.2228553Z   GEN      qt/moc_walletframe.cpp
+2025-07-30T13:51:43.2284215Z   CC       depends/relic/src/cp/librelic_la-relic_cp_etrs.lo
+2025-07-30T13:51:43.2734237Z   GEN      qt/moc_walletmodel.cpp
+2025-07-30T13:51:43.3008292Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ghpe.lo
+2025-07-30T13:51:43.3210124Z depends/relic/src/cp/relic_cp_ecss.c: In function ‘cp_ecss_sig’:
+2025-07-30T13:51:43.3219794Z depends/relic/src/cp/relic_cp_ecss.c:60:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.3222183Z    60 | int cp_ecss_sig(bn_t e, bn_t s, uint8_t *msg, int len, bn_t d) {
+2025-07-30T13:51:43.3222746Z       |     ^~~~~~~~~~~
+2025-07-30T13:51:43.3356447Z depends/relic/src/cp/relic_cp_ecss.c: In function ‘cp_ecss_ver’:
+2025-07-30T13:51:43.3358295Z depends/relic/src/cp/relic_cp_ecss.c:125:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.3360893Z   125 | int cp_ecss_ver(bn_t e, bn_t s, uint8_t *msg, int len, ec_t q) {
+2025-07-30T13:51:43.3361451Z       |     ^~~~~~~~~~~
+2025-07-30T13:51:43.3581813Z   GEN      qt/moc_walletview.cpp
+2025-07-30T13:51:43.3666242Z   CC       depends/relic/src/cp/librelic_la-relic_cp_ibe.lo
+2025-07-30T13:51:43.4122729Z   CC       depends/relic/src/cp/librelic_la-relic_cp_mklhs.lo
+2025-07-30T13:51:43.4534909Z depends/relic/src/cp/relic_cp_etrs.c: In function ‘cp_etrs_ver’:
+2025-07-30T13:51:43.4537119Z depends/relic/src/cp/relic_cp_etrs.c:151:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.4539856Z   151 | int cp_etrs_ver(int thres, bn_t *td, bn_t *y, int max, etrs_t *s, int size,
+2025-07-30T13:51:43.4540473Z       |     ^~~~~~~~~~~
+2025-07-30T13:51:43.5090858Z depends/relic/src/cp/relic_cp_etrs.c: In function ‘cp_etrs_uni’:
+2025-07-30T13:51:43.5095796Z depends/relic/src/cp/relic_cp_etrs.c:302:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.5097072Z   302 | int cp_etrs_uni(int thres, bn_t *td, bn_t *y, int max, etrs_t *p, int *size,
+2025-07-30T13:51:43.5097877Z       |     ^~~~~~~~~~~
+2025-07-30T13:51:43.5171402Z   CC       depends/relic/src/cp/librelic_la-relic_cp_mpss.lo
+2025-07-30T13:51:43.5437938Z depends/relic/src/cp/relic_cp_ibe.c: In function ‘cp_ibe_enc’:
+2025-07-30T13:51:43.5439516Z depends/relic/src/cp/relic_cp_ibe.c:68:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.5441935Z    68 | int cp_ibe_enc(uint8_t *out, int *out_len, uint8_t *in, int in_len, char *id,
+2025-07-30T13:51:43.5442533Z       |     ^~~~~~~~~~
+2025-07-30T13:51:43.5488961Z   GEN      qt/qrc_bitcoin.cpp
+2025-07-30T13:51:43.5575360Z depends/relic/src/cp/relic_cp_ibe.c: In function ‘cp_ibe_dec’:
+2025-07-30T13:51:43.5577018Z depends/relic/src/cp/relic_cp_ibe.c:143:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.5579841Z   143 | int cp_ibe_dec(uint8_t *out, int *out_len, uint8_t *in, int in_len, g2_t prv) {
+2025-07-30T13:51:43.5580458Z       |     ^~~~~~~~~~
+2025-07-30T13:51:43.5801206Z   GEN      qt/locale/dash_ar.qm
+2025-07-30T13:51:43.5956003Z   CC       depends/relic/src/cp/librelic_la-relic_cp_pcdel.lo
+2025-07-30T13:51:43.6048542Z depends/relic/src/cp/relic_cp_mklhs.c: In function ‘cp_mklhs_sig’:
+2025-07-30T13:51:43.6056411Z depends/relic/src/cp/relic_cp_mklhs.c:60:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.6059348Z    60 | int cp_mklhs_sig(g1_t s, bn_t m, char *data, char *id, char *tag, bn_t sk) {
+2025-07-30T13:51:43.6059939Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:43.6359595Z depends/relic/src/cp/relic_cp_mklhs.c: In function ‘cp_mklhs_ver’:
+2025-07-30T13:51:43.6361247Z depends/relic/src/cp/relic_cp_mklhs.c:137:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.6363998Z   137 | int cp_mklhs_ver(g1_t sig, bn_t m, bn_t mu[], char *data, char *id[],
+2025-07-30T13:51:43.6364573Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:43.6780937Z depends/relic/src/cp/relic_cp_mklhs.c: In function ‘cp_mklhs_off’:
+2025-07-30T13:51:43.6782517Z depends/relic/src/cp/relic_cp_mklhs.c:238:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.6785505Z   238 | int cp_mklhs_off(g1_t h[], dig_t ft[], char *id[], char *tag[], dig_t *f[],
+2025-07-30T13:51:43.6786118Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:43.7042201Z depends/relic/src/cp/relic_cp_mklhs.c: In function ‘cp_mklhs_onv’:
+2025-07-30T13:51:43.7044341Z depends/relic/src/cp/relic_cp_mklhs.c:286:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.7046705Z   286 | int cp_mklhs_onv(g1_t sig, bn_t m, bn_t mu[], char *data, char *id[], g1_t h[],
+2025-07-30T13:51:43.7047323Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:43.7395492Z   GEN      qt/locale/dash_bg.qm
+2025-07-30T13:51:43.7553437Z   CC       depends/relic/src/cp/librelic_la-relic_cp_phpe.lo
+2025-07-30T13:51:43.7622390Z depends/relic/src/cp/relic_cp_mpss.c: In function ‘cp_mpsb_ver’:
+2025-07-30T13:51:43.7624202Z depends/relic/src/cp/relic_cp_mpss.c:311:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:43.7627233Z   311 | int cp_mpsb_ver(gt_t e, g1_t a, g1_t b[2], bn_t m[][2], g2_t h, g2_t x,
+2025-07-30T13:51:43.7628023Z       |     ^~~~~~~~~~~
+2025-07-30T13:51:43.8081820Z   GEN      qt/locale/dash_de.qm
+2025-07-30T13:51:43.8320967Z   CC       depends/relic/src/cp/librelic_la-relic_cp_pok.lo
+2025-07-30T13:51:43.8361814Z   GEN      qt/locale/dash_en.qm
+2025-07-30T13:51:43.8601373Z   CC       depends/relic/src/cp/librelic_la-relic_cp_pss.lo
+2025-07-30T13:51:43.9483789Z   GEN      qt/locale/dash_es.qm
+2025-07-30T13:51:43.9614236Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:43.9617161Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:43.9643126Z   CC       depends/relic/src/cp/librelic_la-relic_cp_rabin.lo
+2025-07-30T13:51:43.9784608Z   CC       depends/relic/src/cp/librelic_la-relic_cp_rsa.lo
+2025-07-30T13:51:44.0429597Z   GEN      qt/locale/dash_fi.qm
+2025-07-30T13:51:44.0578980Z   CC       depends/relic/src/cp/librelic_la-relic_cp_sok.lo
+2025-07-30T13:51:44.0681877Z   GEN      qt/locale/dash_fr.qm
+2025-07-30T13:51:44.0851600Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:44.0852740Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:44.0939296Z   GEN      qt/locale/dash_it.qm
+2025-07-30T13:51:44.1100456Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:44.1101736Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:44.1190682Z   GEN      qt/locale/dash_ja.qm
+2025-07-30T13:51:44.1360554Z   CC       depends/relic/src/cp/librelic_la-relic_cp_sokaka.lo
+2025-07-30T13:51:44.1762103Z depends/relic/src/cp/relic_cp_rsa.c: In function ‘pad_pkcs2’:
+2025-07-30T13:51:44.1763859Z depends/relic/src/cp/relic_cp_rsa.c:418:12: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.1765706Z   418 | static int pad_pkcs2(bn_t m, int *p_len, int m_len, int k_len, int operation) {
+2025-07-30T13:51:44.1766831Z       |            ^~~~~~~~~
+2025-07-30T13:51:44.1767209Z   GEN      qt/locale/dash_ko.qm
+2025-07-30T13:51:44.1922027Z   CC       depends/relic/src/cp/librelic_la-relic_cp_vbnn.lo
+2025-07-30T13:51:44.2233754Z depends/relic/src/cp/relic_cp_sok.c: In function ‘cp_sokdl_sig’:
+2025-07-30T13:51:44.2236810Z depends/relic/src/cp/relic_cp_sok.c:43:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.2238136Z    43 | int cp_sokdl_sig(bn_t c, bn_t s, uint8_t *msg, int len, ec_t y, bn_t x) {
+2025-07-30T13:51:44.2238670Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:44.2356588Z depends/relic/src/cp/relic_cp_sok.c: In function ‘cp_sokdl_ver’:
+2025-07-30T13:51:44.2361261Z depends/relic/src/cp/relic_cp_sok.c:100:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.2362452Z   100 | int cp_sokdl_ver(bn_t c, bn_t s, uint8_t *msg, int len, ec_t y) {
+2025-07-30T13:51:44.2363063Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:44.2488238Z depends/relic/src/cp/relic_cp_sok.c: In function ‘cp_sokor_sig’:
+2025-07-30T13:51:44.2489766Z depends/relic/src/cp/relic_cp_sok.c:156:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.2491946Z   156 | int cp_sokor_sig(bn_t c[2], bn_t s[2], uint8_t *msg, int len, ec_t y[2],
+2025-07-30T13:51:44.2492513Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:44.2677127Z depends/relic/src/cp/relic_cp_sok.c: In function ‘cp_sokor_ver’:
+2025-07-30T13:51:44.2678913Z depends/relic/src/cp/relic_cp_sok.c:244:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.2681388Z   244 | int cp_sokor_ver(bn_t c[2], bn_t s[2], uint8_t *msg, int len, ec_t y[2]) {
+2025-07-30T13:51:44.2681996Z       |     ^~~~~~~~~~~~
+2025-07-30T13:51:44.2787958Z depends/relic/src/cp/relic_cp_rsa.c: In function ‘cp_rsa_ver’:
+2025-07-30T13:51:44.2789751Z depends/relic/src/cp/relic_cp_rsa.c:943:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.2792347Z   943 | int cp_rsa_ver(uint8_t *sig, int sig_len, uint8_t *msg, int msg_len, int hash, rsa_t pub) {
+2025-07-30T13:51:44.2793021Z       |     ^~~~~~~~~~
+2025-07-30T13:51:44.2966828Z   GEN      qt/locale/dash_nl.qm
+2025-07-30T13:51:44.3110910Z   GEN      qt/locale/dash_pl.qm
+2025-07-30T13:51:44.3119377Z   CC       depends/relic/src/cp/librelic_la-relic_cp_zss.lo
+2025-07-30T13:51:44.3147785Z depends/relic/src/cp/relic_cp_sokaka.c: In function ‘cp_sokaka_key’:
+2025-07-30T13:51:44.3149462Z depends/relic/src/cp/relic_cp_sokaka.c:73:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.3152061Z    73 | int cp_sokaka_key(uint8_t *key, unsigned int key_len, char *id1,
+2025-07-30T13:51:44.3152603Z       |     ^~~~~~~~~~~~~
+2025-07-30T13:51:44.3263419Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:44.3264527Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:44.3290118Z   CC       depends/relic/src/bc/librelic_la-relic_bc_aes.lo
+2025-07-30T13:51:44.3396499Z   GEN      qt/locale/dash_pt.qm
+2025-07-30T13:51:44.3532435Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:44.3533780Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:44.3560935Z depends/relic/src/cp/relic_cp_vbnn.c: In function ‘cp_vbnn_gen_prv’:
+2025-07-30T13:51:44.3562592Z depends/relic/src/cp/relic_cp_vbnn.c:73:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.3564827Z    73 | int cp_vbnn_gen_prv(bn_t sk, ec_t pk, bn_t msk, uint8_t *id, int id_len) {
+2025-07-30T13:51:44.3565407Z       |     ^~~~~~~~~~~~~~~
+2025-07-30T13:51:44.3575244Z   CC       depends/relic/src/bc/librelic_la-rijndael-alg-fst.lo
+2025-07-30T13:51:44.3661169Z depends/relic/src/cp/relic_cp_vbnn.c: In function ‘cp_vbnn_sig’:
+2025-07-30T13:51:44.3662899Z depends/relic/src/cp/relic_cp_vbnn.c:125:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.3665321Z   125 | int cp_vbnn_sig(ec_t r, bn_t z, bn_t h, uint8_t *id, int id_len,
+2025-07-30T13:51:44.3665874Z       |     ^~~~~~~~~~~
+2025-07-30T13:51:44.3803150Z depends/relic/src/cp/relic_cp_vbnn.c: In function ‘cp_vbnn_ver’:
+2025-07-30T13:51:44.3811079Z depends/relic/src/cp/relic_cp_vbnn.c:189:5: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.3812216Z   189 | int cp_vbnn_ver(ec_t r, bn_t z, bn_t h, uint8_t *id, int id_len,
+2025-07-30T13:51:44.3812782Z       |     ^~~~~~~~~~~
+2025-07-30T13:51:44.4116281Z   GEN      qt/locale/dash_ro.qm
+2025-07-30T13:51:44.4278684Z   CC       depends/relic/src/bc/librelic_la-rijndael-api-fst.lo
+2025-07-30T13:51:44.4724787Z   GEN      qt/locale/dash_ru.qm
+2025-07-30T13:51:44.4882653Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:44.4883845Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:44.4910901Z   CC       depends/relic/src/md/librelic_la-blake2s-ref.lo
+2025-07-30T13:51:44.5004373Z   GEN      qt/locale/dash_sk.qm
+2025-07-30T13:51:44.5141794Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:44.5142716Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:44.5167037Z   CC       depends/relic/src/md/librelic_la-relic_md_blake2s.lo
+2025-07-30T13:51:44.6363768Z   GEN      qt/locale/dash_th.qm
+2025-07-30T13:51:44.6520384Z   CC       depends/relic/src/md/librelic_la-relic_md_hmac.lo
+2025-07-30T13:51:44.6594805Z   GEN      qt/locale/dash_tr.qm
+2025-07-30T13:51:44.6716255Z Removed plural forms as the target language has less forms.
+2025-07-30T13:51:44.6717391Z If this sounds wrong, possibly the target language is not set or recognized.
+2025-07-30T13:51:44.6742021Z   CC       depends/relic/src/md/librelic_la-relic_md_kdf.lo
+2025-07-30T13:51:44.7313866Z   GEN      qt/locale/dash_vi.qm
+2025-07-30T13:51:44.7438949Z   CC       depends/relic/src/md/librelic_la-relic_md_mgf.lo
+2025-07-30T13:51:44.7793806Z depends/relic/src/md/relic_md_hmac.c: In function ‘md_hmac’:
+2025-07-30T13:51:44.7795082Z depends/relic/src/md/relic_md_hmac.c:43:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.7796338Z    43 | void md_hmac(uint8_t *mac, const uint8_t *in, int in_len, const uint8_t *key,
+2025-07-30T13:51:44.7796995Z       |      ^~~~~~~
+2025-07-30T13:51:44.7993422Z depends/relic/src/md/relic_md_kdf.c: In function ‘md_kdf’:
+2025-07-30T13:51:44.7994531Z depends/relic/src/md/relic_md_kdf.c:43:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.7995584Z    43 | void md_kdf(uint8_t *key, int key_len, const uint8_t *in,
+2025-07-30T13:51:44.7996111Z       |      ^~~~~~
+2025-07-30T13:51:44.8048465Z   GEN      qt/locale/dash_zh_CN.qm
+2025-07-30T13:51:44.8228174Z   CXX      init/qt_test_test_dash_qt-bitcoind.o
+2025-07-30T13:51:44.8279553Z   GEN      qt/locale/dash_zh_TW.qm
+2025-07-30T13:51:44.8470717Z   CC       depends/relic/src/md/librelic_la-relic_md_sha224.lo
+2025-07-30T13:51:44.8704875Z depends/relic/src/md/relic_md_mgf.c: In function ‘md_mgf’:
+2025-07-30T13:51:44.8706261Z depends/relic/src/md/relic_md_mgf.c:43:6: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
+2025-07-30T13:51:44.8707520Z    43 | void md_mgf(uint8_t *key, int key_len, const uint8_t *in,
+2025-07-30T13:51:44.8708298Z       |      ^~~~~~
+2025-07-30T13:51:44.8772177Z   CC       depends/relic/src/md/librelic_la-relic_md_sha256.lo
+2025-07-30T13:51:44.8939345Z   CC       depends/relic/src/md/librelic_la-relic_md_sha384.lo
+2025-07-30T13:51:44.9885141Z   GEN      qt/test/moc_apptests.cpp
+2025-07-30T13:51:44.9936167Z   CC       depends/relic/src/md/librelic_la-relic_md_sha512.lo
+2025-07-30T13:51:45.0092903Z   GEN      qt/test/moc_optiontests.cpp
+2025-07-30T13:51:45.0150638Z   CC       depends/relic/src/md/librelic_la-relic_md_xmd.lo
+2025-07-30T13:51:45.0265968Z   GEN      qt/test/moc_rpcnestedtests.cpp
+2025-07-30T13:51:45.0312428Z   CC       depends/relic/src/md/librelic_la-sha224-256.lo
+2025-07-30T13:51:45.1271006Z   GEN      qt/test/moc_trafficgraphdatatests.cpp
+2025-07-30T13:51:45.1326170Z   CC       depends/relic/src/md/librelic_la-sha384-512.lo
+2025-07-30T13:51:45.2159532Z   GEN      qt/test/moc_uritests.cpp
+2025-07-30T13:51:45.2213121Z   CC       depends/relic/src/mpc/librelic_la-relic_mt_mpc.lo
+2025-07-30T13:51:45.2705521Z   CC       depends/relic/src/mpc/librelic_la-relic_pc_mpc.lo
+2025-07-30T13:51:45.3811564Z   CCLD     libmimalloc-secure.la
+2025-07-30T13:51:45.4173194Z   CXX      test/util/libtest_fuzz_a-mining.o
+2025-07-30T13:51:45.4679875Z   CXX      test/fuzz/libtest_fuzz_a-util.o
+2025-07-30T13:51:45.6714595Z   CCLD     librelic.la
+2025-07-30T13:51:48.2294766Z   CXXLD    libdashbls.la
+2025-07-30T13:51:49.3392069Z   CXX      support/libdashconsensus_la-cleanse.lo
+2025-07-30T13:51:49.5247922Z   CXX      crypto/libdashconsensus_la-aes.lo
+2025-07-30T13:51:49.8676449Z   CXXLD    runtest
+2025-07-30T13:51:50.0210944Z   CXXLD    runbench
+2025-07-30T13:51:50.2302698Z   CXX      crypto/libdashconsensus_la-chacha20.lo
+2025-07-30T13:51:50.3326097Z make[3]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src/dashbls'
+2025-07-30T13:51:50.3356736Z   CXX      crypto/libdashconsensus_la-chacha20poly1305.lo
+2025-07-30T13:51:50.9227184Z   CXX      crypto/libdashconsensus_la-hkdf_sha256_32.lo
+2025-07-30T13:51:51.2278498Z   CXX      crypto/libdashconsensus_la-hmac_sha256.lo
+2025-07-30T13:51:51.5814340Z   CXX      crypto/libdashconsensus_la-hmac_sha512.lo
+2025-07-30T13:51:51.7960867Z   CXX      crypto/libdashconsensus_la-muhash.lo
+2025-07-30T13:51:51.8939332Z   CXX      crypto/libdashconsensus_la-poly1305.lo
+2025-07-30T13:51:52.4355274Z   CXX      crypto/libdashconsensus_la-pkcs5_pbkdf2_hmac_sha512.lo
+2025-07-30T13:51:52.6484496Z   CXX      crypto/libdashconsensus_la-ripemd160.lo
+2025-07-30T13:51:52.8234600Z   CXX      crypto/libdashconsensus_la-sha1.lo
+2025-07-30T13:51:53.1495305Z   CXX      crypto/libdashconsensus_la-sha256.lo
+2025-07-30T13:51:53.2115941Z   CXX      crypto/libdashconsensus_la-sha256_sse4.lo
+2025-07-30T13:51:53.2975465Z   CXX      crypto/libdashconsensus_la-sha3.lo
+2025-07-30T13:51:53.3959315Z   CXX      crypto/libdashconsensus_la-sha512.lo
+2025-07-30T13:51:53.5852549Z   CXX      crypto/libdashconsensus_la-siphash.lo
+2025-07-30T13:51:53.8844240Z   CC       crypto/x11/libdashconsensus_la-aes_helper.lo
+2025-07-30T13:51:54.0143371Z   CC       crypto/x11/libdashconsensus_la-blake.lo
+2025-07-30T13:51:54.3499744Z   CC       crypto/x11/libdashconsensus_la-bmw.lo
+2025-07-30T13:51:54.4798242Z   CC       crypto/x11/libdashconsensus_la-cubehash.lo
+2025-07-30T13:51:54.7392581Z   CC       crypto/x11/libdashconsensus_la-echo.lo
+2025-07-30T13:51:54.7605857Z   CC       crypto/x11/libdashconsensus_la-groestl.lo
+2025-07-30T13:51:55.4623761Z   CC       crypto/x11/libdashconsensus_la-jh.lo
+2025-07-30T13:51:55.5303119Z   CC       crypto/x11/libdashconsensus_la-keccak.lo
+2025-07-30T13:51:55.6041588Z   CC       crypto/x11/libdashconsensus_la-luffa.lo
+2025-07-30T13:51:55.9640998Z   CC       crypto/x11/libdashconsensus_la-shavite.lo
+2025-07-30T13:51:56.0789256Z   CC       crypto/x11/libdashconsensus_la-simd.lo
+2025-07-30T13:51:56.1807236Z   CC       crypto/x11/libdashconsensus_la-skein.lo
+2025-07-30T13:51:56.7658072Z   CXX      libdashconsensus_la-arith_uint256.lo
+2025-07-30T13:51:57.1777858Z   CXX      bls/libdashconsensus_la-bls.lo
+2025-07-30T13:51:57.2200481Z   CXX      consensus/libdashconsensus_la-merkle.lo
+2025-07-30T13:51:57.7077986Z   CXX      consensus/libdashconsensus_la-tx_check.lo
+2025-07-30T13:51:57.8637957Z   CXX      libdashconsensus_la-hash.lo
+2025-07-30T13:51:58.9063127Z   CXX      primitives/libdashconsensus_la-block.lo
+2025-07-30T13:51:59.4062505Z   CXX      primitives/libdashconsensus_la-transaction.lo
+2025-07-30T13:51:59.5924486Z   CXX      libdashconsensus_la-pubkey.lo
+2025-07-30T13:52:01.1011258Z   CXX      script/libdashconsensus_la-bitcoinconsensus.lo
+2025-07-30T13:52:01.3574570Z   CXX      script/libdashconsensus_la-interpreter.lo
+2025-07-30T13:52:01.5341461Z   CXX      script/libdashconsensus_la-script.lo
+2025-07-30T13:52:03.1250050Z   CXX      script/libdashconsensus_la-script_error.lo
+2025-07-30T13:52:03.2941048Z   CXX      libdashconsensus_la-uint256.lo
+2025-07-30T13:52:03.6135830Z   CXX      util/libdashconsensus_la-strencodings.lo
+2025-07-30T13:52:03.8591458Z   CXX      util/libdashconsensus_la-string.lo
+2025-07-30T13:52:04.5989960Z   CXX      init/dashd-bitcoind.o
+2025-07-30T13:52:05.0592178Z   CXX      coinjoin/libbitcoin_node_a-coinjoin.o
+2025-07-30T13:52:05.9557545Z   CXX      coinjoin/libbitcoin_node_a-context.o
+2025-07-30T13:52:06.0323875Z   CXX      coinjoin/libbitcoin_node_a-server.o
+2025-07-30T13:52:09.3295878Z   CXX      consensus/libbitcoin_node_a-tx_verify.o
+2025-07-30T13:52:10.1813960Z   CXX      evo/libbitcoin_node_a-assetlocktx.o
+2025-07-30T13:52:12.9135737Z   CXX      evo/libbitcoin_node_a-cbtx.o
+2025-07-30T13:52:15.1030232Z   CXX      evo/libbitcoin_node_a-creditpool.o
+2025-07-30T13:52:17.2905361Z   CXX      evo/libbitcoin_node_a-chainhelper.o
+2025-07-30T13:52:19.5139934Z   CXX      evo/libbitcoin_node_a-deterministicmns.o
+2025-07-30T13:52:21.2254904Z   CXX      evo/libbitcoin_node_a-dmnstate.o
+2025-07-30T13:52:22.1782415Z   CXX      evo/libbitcoin_node_a-evodb.o
+2025-07-30T13:52:25.8440492Z   CXX      evo/libbitcoin_node_a-mnauth.o
+2025-07-30T13:52:26.1203721Z   CXX      evo/libbitcoin_node_a-mnhftx.o
+2025-07-30T13:52:26.8019722Z   CXX      evo/libbitcoin_node_a-providertx.o
+2025-07-30T13:52:32.5192079Z   CXX      evo/libbitcoin_node_a-simplifiedmns.o
+2025-07-30T13:52:33.1080152Z   CXX      evo/libbitcoin_node_a-smldiff.o
+2025-07-30T13:52:36.5741502Z   CXX      evo/libbitcoin_node_a-specialtx.o
+2025-07-30T13:52:37.0861901Z   CXX      evo/libbitcoin_node_a-specialtxman.o
+2025-07-30T13:52:38.1437426Z   CXX      governance/libbitcoin_node_a-classes.o
+2025-07-30T13:52:38.3356410Z   CXX      governance/libbitcoin_node_a-exceptions.o
+2025-07-30T13:52:39.6770644Z   CXX      governance/libbitcoin_node_a-governance.o
+2025-07-30T13:52:43.7734048Z   CXX      governance/libbitcoin_node_a-object.o
+2025-07-30T13:52:46.4284748Z   CXX      governance/libbitcoin_node_a-validators.o
+2025-07-30T13:52:50.6486141Z   CXX      governance/libbitcoin_node_a-vote.o
+2025-07-30T13:52:50.8463547Z   CXX      governance/libbitcoin_node_a-votedb.o
+2025-07-30T13:52:53.2582648Z   CXX      gsl/libbitcoin_node_a-assert.o
+2025-07-30T13:52:54.9654602Z   CXX      index/libbitcoin_node_a-base.o
+2025-07-30T13:52:55.4890352Z   CXX      index/libbitcoin_node_a-blockfilterindex.o
+2025-07-30T13:52:58.5246137Z   CXX      index/libbitcoin_node_a-coinstatsindex.o
+2025-07-30T13:52:59.8341823Z   CXX      index/libbitcoin_node_a-txindex.o
+2025-07-30T13:53:02.5820601Z   CXX      instantsend/libbitcoin_node_a-db.o
+2025-07-30T13:53:03.2143381Z   CXX      instantsend/libbitcoin_node_a-instantsend.o
+2025-07-30T13:53:06.8367005Z   CXX      instantsend/libbitcoin_node_a-lock.o
+2025-07-30T13:53:07.2964915Z   CXX      instantsend/libbitcoin_node_a-signing.o
+2025-07-30T13:53:09.2254639Z   CXX      llmq/libbitcoin_node_a-blockprocessor.o
+2025-07-30T13:53:10.4837286Z   CXX      llmq/libbitcoin_node_a-chainlocks.o
+2025-07-30T13:53:16.9235360Z   CXX      llmq/libbitcoin_node_a-clsig.o
+2025-07-30T13:53:18.1661259Z   CXX      llmq/libbitcoin_node_a-commitment.o
+2025-07-30T13:53:19.6211190Z   CXX      llmq/libbitcoin_node_a-context.o
+2025-07-30T13:53:21.4294209Z   CXX      llmq/libbitcoin_node_a-debug.o
+2025-07-30T13:53:23.1513055Z   CXX      llmq/libbitcoin_node_a-dkgsession.o
+2025-07-30T13:53:27.8868269Z   CXX      llmq/libbitcoin_node_a-dkgsessionhandler.o
+2025-07-30T13:53:28.4645738Z   CXX      llmq/libbitcoin_node_a-dkgsessionmgr.o
+2025-07-30T13:53:29.0394290Z   CXX      llmq/libbitcoin_node_a-ehf_signals.o
+2025-07-30T13:53:36.8448364Z   CXX      llmq/libbitcoin_node_a-options.o
+2025-07-30T13:53:37.2341630Z   CXX      llmq/libbitcoin_node_a-quorums.o
+2025-07-30T13:53:40.2216407Z   CXX      llmq/libbitcoin_node_a-signing.o
+2025-07-30T13:53:41.9841355Z   CXX      llmq/libbitcoin_node_a-signing_shares.o
+2025-07-30T13:53:42.3799412Z   CXX      llmq/libbitcoin_node_a-snapshot.o
+2025-07-30T13:53:53.1687249Z   CXX      llmq/libbitcoin_node_a-utils.o
+2025-07-30T13:53:54.5387414Z   CXX      masternode/libbitcoin_node_a-node.o
+2025-07-30T13:53:55.8437052Z   CXX      masternode/libbitcoin_node_a-meta.o
+2025-07-30T13:54:01.2675524Z   CXX      masternode/libbitcoin_node_a-payments.o
+2025-07-30T13:54:01.3290130Z   CXX      masternode/libbitcoin_node_a-sync.o
+2025-07-30T13:54:02.3128157Z   CXX      masternode/libbitcoin_node_a-utils.o
+2025-07-30T13:54:05.1738847Z   CXX      node/libbitcoin_node_a-blockstorage.o
+2025-07-30T13:54:08.4322459Z   CXX      node/libbitcoin_node_a-caches.o
+2025-07-30T13:54:10.1345352Z   CXX      node/libbitcoin_node_a-chainstate.o
+2025-07-30T13:54:10.5051916Z   CXX      node/libbitcoin_node_a-coin.o
+2025-07-30T13:54:14.0367004Z   CXX      node/libbitcoin_node_a-coinstats.o
+2025-07-30T13:54:16.2745117Z   CXX      node/libbitcoin_node_a-connection_types.o
+2025-07-30T13:54:16.6063470Z   CXX      node/libbitcoin_node_a-context.o
+2025-07-30T13:54:16.8659509Z   CXX      node/libbitcoin_node_a-eviction.o
+2025-07-30T13:54:17.7230736Z   CXX      node/libbitcoin_node_a-interfaces.o
+2025-07-30T13:54:20.4259484Z   CXX      node/libbitcoin_node_a-miner.o
+2025-07-30T13:54:20.8255986Z   CXX      node/libbitcoin_node_a-minisketchwrapper.o
+2025-07-30T13:54:24.1623029Z   CXX      node/libbitcoin_node_a-psbt.o
+2025-07-30T13:54:25.7743833Z   CXX      node/libbitcoin_node_a-transaction.o
+2025-07-30T13:54:27.3468091Z   CXX      node/libbitcoin_node_a-txreconciliation.o
+2025-07-30T13:54:30.7863304Z   CXX      node/libbitcoin_node_a-interface_ui.o
+2025-07-30T13:54:32.4253342Z   CXX      policy/libbitcoin_node_a-fees.o
+2025-07-30T13:54:32.9045510Z   CXX      policy/libbitcoin_node_a-packages.o
+2025-07-30T13:54:32.9396982Z   CXX      policy/libbitcoin_node_a-policy.o
+2025-07-30T13:54:33.2410878Z   CXX      policy/libbitcoin_node_a-settings.o
+2025-07-30T13:54:34.7241927Z   CXX      rpc/libbitcoin_node_a-blockchain.o
+2025-07-30T13:54:35.1139916Z   CXX      rpc/libbitcoin_node_a-coinjoin.o
+2025-07-30T13:54:41.0137370Z   CXX      rpc/libbitcoin_node_a-evo.o
+2025-07-30T13:54:44.9633554Z   CXX      rpc/libbitcoin_node_a-fees.o
+2025-07-30T13:54:45.1500149Z   CXX      rpc/libbitcoin_node_a-index_util.o
+2025-07-30T13:54:51.0582625Z   CXX      rpc/libbitcoin_node_a-masternode.o
+2025-07-30T13:54:52.4357427Z   CXX      rpc/libbitcoin_node_a-mempool.o
+2025-07-30T13:54:53.2864505Z   CXX      rpc/libbitcoin_node_a-governance.o
+2025-07-30T13:54:56.3800379Z   CXX      rpc/libbitcoin_node_a-mining.o
+2025-07-30T13:55:01.8514373Z   CXX      rpc/libbitcoin_node_a-node.o
+2025-07-30T13:55:03.5330128Z   CXX      rpc/libbitcoin_node_a-net.o
+2025-07-30T13:55:05.0566236Z   CXX      rpc/libbitcoin_node_a-output_script.o
+2025-07-30T13:55:11.2195448Z   CXX      rpc/libbitcoin_node_a-quorums.o
+2025-07-30T13:55:11.7142334Z   CXX      rpc/libbitcoin_node_a-rawtransaction.o
+2025-07-30T13:55:15.4982279Z   CXX      rpc/libbitcoin_node_a-server.o
+2025-07-30T13:55:16.9268308Z   CXX      rpc/libbitcoin_node_a-server_util.o
+2025-07-30T13:55:23.3762974Z   CXX      rpc/libbitcoin_node_a-signmessage.o
+2025-07-30T13:55:26.6388835Z   CXX      rpc/libbitcoin_node_a-txoutproof.o
+2025-07-30T13:55:26.6843935Z   CXX      script/libbitcoin_node_a-sigcache.o
+2025-07-30T13:55:29.1390750Z   CXX      stats/libbitcoin_node_a-client.o
+2025-07-30T13:55:30.7539777Z   CXX      stats/libbitcoin_node_a-rawsender.o
+2025-07-30T13:55:32.9626214Z   CXX      common/libbitcoin_common_a-bloom.o
+2025-07-30T13:55:34.2648400Z   CXX      bls/libbitcoin_util_a-bls_ies.o
+2025-07-30T13:55:35.1653093Z   CXX      bls/libbitcoin_util_a-bls_worker.o
+2025-07-30T13:55:35.3507902Z   CXX      support/libbitcoin_util_a-lockedpool.o
+2025-07-30T13:55:37.2555524Z   CXX      libbitcoin_util_a-clientversion.o
+2025-07-30T13:55:37.6568551Z   CXX      interfaces/libbitcoin_util_a-echo.o
+2025-07-30T13:55:38.5882188Z   CXX      interfaces/libbitcoin_util_a-handler.o
+2025-07-30T13:55:38.6780050Z   CXX      interfaces/libbitcoin_util_a-init.o
+2025-07-30T13:55:39.2144499Z   CXX      util/libbitcoin_util_a-asmap.o
+2025-07-30T13:55:42.4898005Z   CXX      util/libbitcoin_util_a-bip32.o
+2025-07-30T13:55:42.9423700Z   CXX      util/libbitcoin_util_a-bytevectorhash.o
+2025-07-30T13:55:43.6431836Z   CXX      util/libbitcoin_util_a-check.o
+2025-07-30T13:55:44.2779684Z   CXX      util/libbitcoin_util_a-edge.o
+2025-07-30T13:55:44.9398389Z   CXX      util/libbitcoin_util_a-error.o
+2025-07-30T13:55:45.0001409Z   CXX      util/libbitcoin_util_a-fees.o
+2025-07-30T13:55:46.5379301Z   CXX      util/libbitcoin_util_a-hasher.o
+2025-07-30T13:55:48.0231839Z   CXX      util/libbitcoin_util_a-getuniquepath.o
+2025-07-30T13:55:48.0260584Z   CXX      util/libbitcoin_util_a-sock.o
+2025-07-30T13:55:48.8375478Z   CXX      util/libbitcoin_util_a-syserror.o
+2025-07-30T13:55:48.9744816Z   CXX      util/libbitcoin_util_a-system.o
+2025-07-30T13:55:50.0610376Z   CXX      util/libbitcoin_util_a-message.o
+2025-07-30T13:55:50.2700625Z   CXX      util/libbitcoin_util_a-moneystr.o
+2025-07-30T13:55:51.8647981Z   CXX      util/libbitcoin_util_a-readwritefile.o
+2025-07-30T13:55:52.0463261Z   CXX      util/libbitcoin_util_a-settings.o
+2025-07-30T13:55:52.4076430Z   CXX      util/libbitcoin_util_a-ranges_set.o
+2025-07-30T13:55:53.1349789Z   CXX      util/libbitcoin_util_a-spanparsing.o
+2025-07-30T13:55:53.8895499Z   CXX      util/libbitcoin_util_a-strencodings.o
+2025-07-30T13:55:53.9046612Z   CXX      util/libbitcoin_util_a-time.o
+2025-07-30T13:55:54.0204959Z   CXX      util/libbitcoin_util_a-serfloat.o
+2025-07-30T13:55:54.4594560Z   CXX      util/libbitcoin_util_a-string.o
+2025-07-30T13:55:54.4811839Z   CXX      util/libbitcoin_util_a-thread.o
+2025-07-30T13:55:55.4324461Z   CXX      util/libbitcoin_util_a-threadinterrupt.o
+2025-07-30T13:55:57.5434924Z   CXX      util/libbitcoin_util_a-threadnames.o
+2025-07-30T13:55:57.7379133Z   CXX      util/libbitcoin_util_a-tokenpipe.o
+2025-07-30T13:55:57.9890179Z   CXX      util/libbitcoin_util_a-wpipe.o
+2025-07-30T13:55:58.6037440Z   CXX      util/libbitcoin_util_a-url.o
+2025-07-30T13:55:59.2539799Z   CXX      univalue/lib/libunivalue_la-univalue.lo
+2025-07-30T13:56:01.7776321Z   CXX      univalue/lib/libunivalue_la-univalue_get.lo
+2025-07-30T13:56:01.7802063Z   CXX      univalue/lib/libunivalue_la-univalue_read.lo
+2025-07-30T13:56:01.8433924Z   CXX      univalue/lib/libunivalue_la-univalue_write.lo
+2025-07-30T13:56:02.9355133Z   CXX      zmq/libbitcoin_zmq_a-zmqabstractnotifier.o
+2025-07-30T13:56:03.3340248Z   CXX      zmq/libbitcoin_zmq_a-zmqnotificationinterface.o
+2025-07-30T13:56:03.4755864Z   CXX      zmq/libbitcoin_zmq_a-zmqpublishnotifier.o
+2025-07-30T13:56:03.8228661Z   CXX      zmq/libbitcoin_zmq_a-zmqrpc.o
+2025-07-30T13:56:05.7844100Z   CXX      zmq/libbitcoin_zmq_a-zmqutil.o
+2025-07-30T13:56:08.0634300Z   CXX      primitives/libbitcoin_consensus_a-block.o
+2025-07-30T13:56:08.2150314Z   CXX      primitives/libbitcoin_consensus_a-transaction.o
+2025-07-30T13:56:08.7883460Z   CXX      crypto/libbitcoin_crypto_base_la-aes.lo
+2025-07-30T13:56:09.2797166Z   CXX      crypto/libbitcoin_crypto_base_la-chacha20.lo
+2025-07-30T13:56:10.2773391Z   CXX      crypto/libbitcoin_crypto_base_la-chacha20poly1305.lo
+2025-07-30T13:56:10.6216091Z   CXX      crypto/libbitcoin_crypto_base_la-hkdf_sha256_32.lo
+2025-07-30T13:56:10.8485803Z   CXX      crypto/libbitcoin_crypto_base_la-hmac_sha256.lo
+2025-07-30T13:56:11.0273232Z   CXX      crypto/libbitcoin_crypto_base_la-hmac_sha512.lo
+2025-07-30T13:56:11.2235400Z   CXX      crypto/libbitcoin_crypto_base_la-muhash.lo
+2025-07-30T13:56:11.2418741Z   CXX      crypto/libbitcoin_crypto_base_la-poly1305.lo
+2025-07-30T13:56:11.4964305Z   CXX      crypto/libbitcoin_crypto_base_la-pkcs5_pbkdf2_hmac_sha512.lo
+2025-07-30T13:56:11.6897482Z   CXX      crypto/libbitcoin_crypto_base_la-ripemd160.lo
+2025-07-30T13:56:11.7728206Z   CXX      crypto/libbitcoin_crypto_base_la-sha1.lo
+2025-07-30T13:56:11.8129795Z   CXX      crypto/libbitcoin_crypto_base_la-sha256.lo
+2025-07-30T13:56:12.1997290Z   CXX      crypto/libbitcoin_crypto_base_la-sha256_sse4.lo
+2025-07-30T13:56:12.2056792Z   CXX      crypto/libbitcoin_crypto_base_la-sha3.lo
+2025-07-30T13:56:12.3710063Z   CXX      crypto/libbitcoin_crypto_base_la-sha512.lo
+2025-07-30T13:56:12.7818959Z   CXX      crypto/libbitcoin_crypto_base_la-siphash.lo
+2025-07-30T13:56:12.9148195Z   CC       crypto/x11/libbitcoin_crypto_base_la-aes_helper.lo
+2025-07-30T13:56:13.0317127Z   CC       crypto/x11/libbitcoin_crypto_base_la-blake.lo
+2025-07-30T13:56:13.2870733Z   CC       crypto/x11/libbitcoin_crypto_base_la-bmw.lo
+2025-07-30T13:56:13.6264765Z   CC       crypto/x11/libbitcoin_crypto_base_la-cubehash.lo
+2025-07-30T13:56:13.6897306Z   CC       crypto/x11/libbitcoin_crypto_base_la-echo.lo
+2025-07-30T13:56:13.7454022Z   CC       crypto/x11/libbitcoin_crypto_base_la-groestl.lo
+2025-07-30T13:56:14.1519908Z   CC       crypto/x11/libbitcoin_crypto_base_la-jh.lo
+2025-07-30T13:56:14.5014432Z   CC       crypto/x11/libbitcoin_crypto_base_la-keccak.lo
+2025-07-30T13:56:14.7568536Z   CC       crypto/x11/libbitcoin_crypto_base_la-luffa.lo
+2025-07-30T13:56:14.9358211Z   CC       crypto/x11/libbitcoin_crypto_base_la-shavite.lo
+2025-07-30T13:56:15.0458186Z   CC       crypto/x11/libbitcoin_crypto_base_la-simd.lo
+2025-07-30T13:56:15.3350650Z   CC       crypto/x11/libbitcoin_crypto_base_la-skein.lo
+2025-07-30T13:56:15.9205748Z   CXXLD    crypto/libbitcoin_crypto_sse41.la
+2025-07-30T13:56:15.9674221Z   CXXLD    crypto/libbitcoin_crypto_x86_shani.la
+2025-07-30T13:56:16.1251747Z   CXXLD    crypto/libbitcoin_crypto_avx2.la
+2025-07-30T13:56:16.1680254Z   CXX      leveldb/db/libleveldb_la-builder.lo
+2025-07-30T13:56:16.2080017Z   CXX      leveldb/db/libleveldb_la-c.lo
+2025-07-30T13:56:16.3512359Z   CXX      leveldb/db/libleveldb_la-dbformat.lo
+2025-07-30T13:56:16.6494027Z   CXX      leveldb/db/libleveldb_la-db_impl.lo
+2025-07-30T13:56:17.4811207Z   CXX      leveldb/db/libleveldb_la-db_iter.lo
+2025-07-30T13:56:17.6867307Z   CXX      leveldb/db/libleveldb_la-dumpfile.lo
+2025-07-30T13:56:17.9384401Z   CXX      leveldb/db/libleveldb_la-filename.lo
+2025-07-30T13:56:19.3959142Z   CXX      leveldb/db/libleveldb_la-log_reader.lo
+2025-07-30T13:56:19.5696836Z   CXX      leveldb/db/libleveldb_la-log_writer.lo
+2025-07-30T13:56:19.8127066Z   CXX      leveldb/db/libleveldb_la-memtable.lo
+2025-07-30T13:56:20.7519916Z   CXX      leveldb/db/libleveldb_la-repair.lo
+2025-07-30T13:56:20.8236006Z   CXX      leveldb/db/libleveldb_la-table_cache.lo
+2025-07-30T13:56:20.8905355Z   CXX      leveldb/db/libleveldb_la-version_edit.lo
+2025-07-30T13:56:21.4219468Z   CXX      leveldb/db/libleveldb_la-version_set.lo
+2025-07-30T13:56:22.1864970Z   CXX      leveldb/db/libleveldb_la-write_batch.lo
+2025-07-30T13:56:22.8395013Z   CXX      leveldb/table/libleveldb_la-block_builder.lo
+2025-07-30T13:56:23.5231905Z   CXX      leveldb/table/libleveldb_la-block.lo
+2025-07-30T13:56:23.6603880Z   CXX      leveldb/table/libleveldb_la-filter_block.lo
+2025-07-30T13:56:24.3313078Z   CXX      leveldb/table/libleveldb_la-format.lo
+2025-07-30T13:56:25.0144889Z   CXX      leveldb/table/libleveldb_la-iterator.lo
+2025-07-30T13:56:25.0804393Z   CXX      leveldb/table/libleveldb_la-merger.lo
+2025-07-30T13:56:25.6319532Z   CXX      leveldb/table/libleveldb_la-table_builder.lo
+2025-07-30T13:56:25.7737484Z   CXX      leveldb/table/libleveldb_la-table.lo
+2025-07-30T13:56:25.8201179Z   CXX      leveldb/table/libleveldb_la-two_level_iterator.lo
+2025-07-30T13:56:26.2746897Z   CXX      leveldb/util/libleveldb_la-arena.lo
+2025-07-30T13:56:26.9288891Z   CXX      leveldb/util/libleveldb_la-bloom.lo
+2025-07-30T13:56:26.9514905Z   CXX      leveldb/util/libleveldb_la-cache.lo
+2025-07-30T13:56:27.1983170Z   CXX      leveldb/util/libleveldb_la-coding.lo
+2025-07-30T13:56:27.2795644Z   CXX      leveldb/util/libleveldb_la-comparator.lo
+2025-07-30T13:56:27.6561416Z   CXX      leveldb/util/libleveldb_la-crc32c.lo
+2025-07-30T13:56:28.2539215Z   CXX      leveldb/util/libleveldb_la-env.lo
+2025-07-30T13:56:28.5298033Z   CXX      leveldb/util/libleveldb_la-filter_policy.lo
+2025-07-30T13:56:28.6118924Z   CXX      leveldb/util/libleveldb_la-hash.lo
+2025-07-30T13:56:28.8430080Z   CXX      leveldb/util/libleveldb_la-histogram.lo
+2025-07-30T13:56:29.1671336Z   CXX      leveldb/util/libleveldb_la-logging.lo
+2025-07-30T13:56:29.3762314Z   CXX      leveldb/util/libleveldb_la-options.lo
+2025-07-30T13:56:29.6962991Z   CXX      leveldb/util/libleveldb_la-status.lo
+2025-07-30T13:56:30.1750828Z   CXX      leveldb/util/libleveldb_la-env_posix.lo
+2025-07-30T13:56:30.3017851Z   CXX      crc32c/src/libcrc32c_la-crc32c.lo
+2025-07-30T13:56:30.5665588Z   CXX      crc32c/src/libcrc32c_la-crc32c_portable.lo
+2025-07-30T13:56:30.8777329Z   CXXLD    crc32c/libcrc32c_sse42.la
+2025-07-30T13:56:30.9409380Z   CXX      leveldb/helpers/memenv/libmemenv_la-memenv.lo
+2025-07-30T13:56:30.9873524Z   CXX      compat/libbitcoin_cli_a-stdin.o
+2025-07-30T13:56:31.1206759Z   CXX      test/test_dash-main.o
+2025-07-30T13:56:31.1265411Z   CXX      test/test_dash-argsman_tests.o
+2025-07-30T13:56:32.7651550Z   CXX      test/test_dash-arith_uint256_tests.o
+2025-07-30T13:56:32.9812578Z   CXX      test/test_dash-addrman_tests.o
+2025-07-30T13:56:40.7653493Z   CXX      test/test_dash-amount_tests.o
+2025-07-30T13:56:44.5682784Z   CXX      test/test_dash-allocator_tests.o
+2025-07-30T13:56:47.4372764Z   CXX      test/test_dash-banman_tests.o
+2025-07-30T13:56:48.1849114Z   CXX      test/test_dash-base32_tests.o
+2025-07-30T13:56:49.7437492Z   CXX      test/test_dash-base58_tests.o
+2025-07-30T13:56:51.1052178Z   CXX      test/test_dash-base64_tests.o
+2025-07-30T13:56:54.1331949Z   CXX      test/test_dash-bech32_tests.o
+2025-07-30T13:56:54.2260666Z   CXX      test/test_dash-bip32_tests.o
+2025-07-30T13:56:57.2043613Z   CXX      test/test_dash-bip324_tests.o
+2025-07-30T13:56:57.3291362Z   CXX      test/test_dash-block_reward_reallocation_tests.o
+2025-07-30T13:56:57.3715213Z   CXX      test/test_dash-blockchain_tests.o
+2025-07-30T13:57:01.8189209Z   CXX      test/test_dash-blockencodings_tests.o
+2025-07-30T13:57:04.3678436Z   CXX      test/test_dash-blockfilter_tests.o
+2025-07-30T13:57:04.7396817Z   CXX      test/test_dash-blockfilter_index_tests.o
+2025-07-30T13:57:08.7171928Z   CXX      test/test_dash-blockmanager_tests.o
+2025-07-30T13:57:11.8143928Z   CXX      test/test_dash-bloom_tests.o
+2025-07-30T13:57:13.3868234Z   CXX      test/test_dash-bls_tests.o
+2025-07-30T13:57:14.9880877Z   CXX      test/test_dash-bswap_tests.o
+2025-07-30T13:57:15.9964287Z   CXX      test/test_dash-checkdatasig_tests.o
+2025-07-30T13:57:17.4925780Z   CXX      test/test_dash-checkqueue_tests.o
+2025-07-30T13:57:22.1575216Z   CXX      test/test_dash-cachemap_tests.o
+2025-07-30T13:57:23.7888664Z   CXX      test/test_dash-cachemultimap_tests.o
+2025-07-30T13:57:24.3660422Z   CXX      test/test_dash-coins_tests.o
+2025-07-30T13:57:25.8769297Z   CXX      test/test_dash-coinstatsindex_tests.o
+2025-07-30T13:57:27.5009434Z   CXX      test/test_dash-compilerbug_tests.o
+2025-07-30T13:57:27.9458735Z   CXX      test/test_dash-compress_tests.o
+2025-07-30T13:57:30.0317279Z   CXX      test/test_dash-crypto_tests.o
+2025-07-30T13:57:33.4064726Z   CXX      test/test_dash-cuckoocache_tests.o
+2025-07-30T13:57:35.6971572Z   CXX      test/test_dash-denialofservice_tests.o
+2025-07-30T13:57:36.3654782Z   CXX      test/test_dash-dip0020opcodes_tests.o
+2025-07-30T13:57:41.4994003Z   CXX      test/test_dash-descriptor_tests.o
+2025-07-30T13:57:41.5719634Z   CXX      test/test_dash-dynamic_activation_thresholds_tests.o
+2025-07-30T13:57:42.1577437Z   CXX      test/test_dash-evo_assetlocks_tests.o
+2025-07-30T13:57:46.1008421Z   CXX      test/test_dash-evo_deterministicmns_tests.o
+2025-07-30T13:57:50.4927817Z   CXX      test/test_dash-evo_islock_tests.o
+2025-07-30T13:57:52.1270454Z   CXX      test/test_dash-evo_mnhf_tests.o
+2025-07-30T13:57:52.5184835Z   CXX      test/test_dash-evo_netinfo_tests.o
+2025-07-30T13:57:56.3358206Z   CXX      test/test_dash-evo_simplifiedmns_tests.o
+2025-07-30T13:57:59.8812811Z   CXX      test/test_dash-evo_trivialvalidation.o
+2025-07-30T13:58:01.7168621Z   CXX      test/test_dash-evo_utils_tests.o
+2025-07-30T13:58:04.0185606Z   CXX      test/test_dash-flatfile_tests.o
+2025-07-30T13:58:04.2449164Z   CXX      test/test_dash-fs_tests.o
+2025-07-30T13:58:08.6949820Z   CXX      test/test_dash-getarg_tests.o
+2025-07-30T13:58:10.6707222Z   CXX      test/test_dash-governance_validators_tests.o
+2025-07-30T13:58:11.6735856Z   CXX      test/test_dash-hash_tests.o
+2025-07-30T13:58:12.6554421Z   CXX      test/test_dash-i2p_tests.o
+2025-07-30T13:58:17.5390403Z   CXX      test/test_dash-interfaces_tests.o
+2025-07-30T13:58:18.8172051Z   CXX      test/test_dash-key_io_tests.o
+2025-07-30T13:58:20.0002227Z   CXX      test/test_dash-key_tests.o
+2025-07-30T13:58:20.8269458Z   CXX      test/test_dash-limitedmap_tests.o
+2025-07-30T13:58:26.2367288Z   CXX      test/test_dash-llmq_dkg_tests.o
+2025-07-30T13:58:26.5761830Z   CXX      test/test_dash-llmq_chainlock_tests.o
+2025-07-30T13:58:27.6995984Z   CXX      test/test_dash-llmq_commitment_tests.o
+2025-07-30T13:58:29.0122353Z   CXX      test/test_dash-llmq_hash_tests.o
+2025-07-30T13:58:30.9387869Z   CXX      test/test_dash-llmq_params_tests.o
+2025-07-30T13:58:35.5009541Z   CXX      test/test_dash-llmq_snapshot_tests.o
+2025-07-30T13:58:37.1602665Z   CXX      test/test_dash-llmq_utils_tests.o
+2025-07-30T13:58:37.6123688Z   CXX      test/test_dash-logging_tests.o
+2025-07-30T13:58:39.0066991Z   CXX      test/test_dash-dbwrapper_tests.o
+2025-07-30T13:58:44.4174788Z   CXX      test/test_dash-validation_tests.o
+2025-07-30T13:58:44.8265970Z   CXX      test/test_dash-mempool_tests.o
+2025-07-30T13:58:46.9219934Z   CXX      test/test_dash-merkle_tests.o
+2025-07-30T13:58:48.5888929Z   CXX      test/test_dash-merkleblock_tests.o
+2025-07-30T13:58:51.7770496Z   CXX      test/test_dash-minisketch_tests.o
+2025-07-30T13:58:55.4590185Z   CXX      test/test_dash-miner_tests.o
+2025-07-30T13:58:55.5782007Z   CXX      test/test_dash-multisig_tests.o
+2025-07-30T13:58:55.6074877Z   CXX      test/test_dash-net_peer_connection_tests.o
+2025-07-30T13:58:58.3785669Z   CXX      test/test_dash-net_peer_eviction_tests.o
+2025-07-30T13:59:04.1443432Z   CXX      test/test_dash-net_tests.o
+2025-07-30T13:59:04.4480281Z   CXX      test/test_dash-netbase_tests.o
+2025-07-30T13:59:07.2258552Z   CXX      test/test_dash-orphanage_tests.o
+2025-07-30T13:59:08.6199898Z   CXX      test/test_dash-pmt_tests.o
+2025-07-30T13:59:14.9036838Z   CXX      test/test_dash-policyestimator_tests.o
+2025-07-30T13:59:16.0958848Z   CXX      test/test_dash-pool_tests.o
+2025-07-30T13:59:19.7639411Z   CXX      test/test_dash-pow_tests.o
+2025-07-30T13:59:22.1922776Z   CXX      test/test_dash-prevector_tests.o
+2025-07-30T13:59:22.4736792Z   CXX      test/test_dash-raii_event_tests.o
+2025-07-30T13:59:24.8168215Z   CXX      test/test_dash-random_tests.o
+2025-07-30T13:59:27.6871934Z   CXX      test/test_dash-ratecheck_tests.o
+2025-07-30T13:59:29.4197238Z   CXX      test/test_dash-reverselock_tests.o
+2025-07-30T13:59:30.1327298Z   CXX      test/test_dash-rpc_tests.o
+2025-07-30T13:59:32.8143997Z   CXX      test/test_dash-sanity_tests.o
+2025-07-30T13:59:33.2870314Z   CXX      test/test_dash-scheduler_tests.o
+2025-07-30T13:59:36.2936990Z   CXX      test/test_dash-script_p2sh_tests.o
+2025-07-30T13:59:38.0309575Z   CXX      test/test_dash-script_p2pk_tests.o
+2025-07-30T13:59:39.2832316Z   CXX      test/test_dash-script_p2pkh_tests.o
+2025-07-30T13:59:44.5410737Z   CXX      test/test_dash-script_parse_tests.o
+2025-07-30T13:59:45.8698707Z   CXX      test/test_dash-script_standard_tests.o
+2025-07-30T13:59:46.1042092Z   CXX      test/test_dash-script_tests.o
+2025-07-30T13:59:46.2493636Z   CXX      test/test_dash-scriptnum_tests.o
+2025-07-30T13:59:51.2948793Z   CXX      test/test_dash-serfloat_tests.o
+2025-07-30T13:59:53.3152520Z   CXX      test/test_dash-serialize_tests.o
+2025-07-30T13:59:54.4563369Z   CXX      test/test_dash-settings_tests.o
+2025-07-30T13:59:59.0680730Z   CXX      test/test_dash-sighash_tests.o
+2025-07-30T14:00:02.8170665Z   CXX      test/test_dash-sigopcount_tests.o
+2025-07-30T14:00:03.9747132Z   CXX      test/test_dash-skiplist_tests.o
+2025-07-30T14:00:05.5231616Z   CXX      test/test_dash-sock_tests.o
+2025-07-30T14:00:07.6731725Z   CXX      test/test_dash-streams_tests.o
+2025-07-30T14:00:09.4540795Z   CXX      test/test_dash-subsidy_tests.o
+2025-07-30T14:00:11.9263110Z   CXX      test/test_dash-sync_tests.o
+2025-07-30T14:00:13.1482334Z   CXX      test/test_dash-system_tests.o
+2025-07-30T14:00:16.4749831Z   CXX      test/test_dash-util_threadnames_tests.o
+2025-07-30T14:00:17.3254283Z   CXX      test/test_dash-timedata_tests.o
+2025-07-30T14:00:18.3594508Z   CXX      test/test_dash-torcontrol_tests.o
+2025-07-30T14:00:19.6120528Z   CXX      test/test_dash-transaction_tests.o
+2025-07-30T14:00:21.8800888Z   CXX      test/test_dash-txindex_tests.o
+2025-07-30T14:00:24.3926548Z   CXX      test/test_dash-txpackage_tests.o
+2025-07-30T14:00:24.7268468Z   CXX      test/test_dash-txreconciliation_tests.o
+2025-07-30T14:00:29.0596639Z   CXX      test/test_dash-txvalidation_tests.o
+2025-07-30T14:00:30.9455157Z   CXX      test/test_dash-txvalidationcache_tests.o
+2025-07-30T14:00:31.9757206Z   CXX      test/test_dash-uint256_tests.o
+2025-07-30T14:00:34.5024134Z   CXX      test/test_dash-util_tests.o
+2025-07-30T14:00:36.4034314Z   CXX      test/test_dash-validation_block_tests.o
+2025-07-30T14:00:40.0914171Z   CXX      test/test_dash-validation_chainstate_tests.o
+2025-07-30T14:00:41.0387971Z   CXX      test/test_dash-validation_chainstatemanager_tests.o
+2025-07-30T14:00:45.5625906Z   CXX      test/test_dash-validation_flush_tests.o
+2025-07-30T14:00:48.8101247Z   CXX      test/test_dash-validationinterface_tests.o
+2025-07-30T14:00:51.7641807Z   CXX      test/test_dash-versionbits_tests.o
+2025-07-30T14:00:53.2417096Z   CXX      test/test_dash-xoroshiro128plusplus_tests.o
+2025-07-30T14:00:55.5983244Z   CXX      test/util/libtest_util_a-blockfilter.o
+2025-07-30T14:00:59.7912974Z   CXX      test/util/libtest_util_a-index.o
+2025-07-30T14:01:00.4004314Z   CXX      test/util/libtest_util_a-json.o
+2025-07-30T14:01:01.3693316Z   CXX      test/util/libtest_util_a-logging.o
+2025-07-30T14:01:01.6231651Z   CXX      test/util/libtest_util_a-mining.o
+2025-07-30T14:01:01.6588987Z   CXX      test/util/libtest_util_a-net.o
+2025-07-30T14:01:02.5386556Z   CXX      test/util/libtest_util_a-script.o
+2025-07-30T14:01:02.7370749Z   CXX      test/util/libtest_util_a-setup_common.o
+2025-07-30T14:01:03.4791321Z   CXX      test/util/libtest_util_a-str.o
+2025-07-30T14:01:04.0390427Z   CXX      test/util/libtest_util_a-transaction_utils.o
+2025-07-30T14:01:04.1375396Z   CXX      test/util/libtest_util_a-validation.o
+2025-07-30T14:01:06.6214974Z   CXX      test/util/libtest_util_a-wallet.o
+2025-07-30T14:01:06.6575410Z   CXX      minisketch/src/fields/libminisketch_a-generic_1byte.o
+2025-07-30T14:01:06.7388324Z   CXX      minisketch/src/fields/libminisketch_a-generic_2bytes.o
+2025-07-30T14:01:06.8186965Z   CXX      minisketch/src/fields/libminisketch_a-generic_3bytes.o
+2025-07-30T14:01:06.8979273Z   CXX      minisketch/src/fields/libminisketch_a-generic_4bytes.o
+2025-07-30T14:01:08.4553483Z   CXX      minisketch/src/fields/libminisketch_a-generic_5bytes.o
+2025-07-30T14:01:08.5399514Z   CXX      minisketch/src/fields/libminisketch_a-generic_6bytes.o
+2025-07-30T14:01:08.6217844Z   CXX      minisketch/src/fields/libminisketch_a-generic_7bytes.o
+2025-07-30T14:01:08.7047467Z   CXX      minisketch/src/fields/libminisketch_a-generic_8bytes.o
+2025-07-30T14:01:08.7925331Z   CXX      minisketch/src/libminisketch_a-minisketch.o
+2025-07-30T14:01:09.5686170Z   AR       minisketch/libminisketch_clmul.a
+2025-07-30T14:01:09.6158472Z   CXX      bench/bench_dash-addrman.o
+2025-07-30T14:01:09.6305195Z   CXX      bench/bench_dash-bench_bitcoin.o
+2025-07-30T14:01:10.0016285Z   CXX      bench/bench_dash-bench.o
+2025-07-30T14:01:13.2633034Z   CXX      bench/bench_dash-bip324_ecdh.o
+2025-07-30T14:01:13.2942532Z   CXX      bench/bench_dash-block_assemble.o
+2025-07-30T14:01:16.0673881Z   CXX      bench/bench_dash-bls.o
+2025-07-30T14:01:16.6265638Z   CXX      bench/bench_dash-bls_dkg.o
+2025-07-30T14:01:19.7812243Z   CXX      bench/bench_dash-checkblock.o
+2025-07-30T14:01:21.5507470Z   CXX      bench/bench_dash-checkqueue.o
+2025-07-30T14:01:21.7561244Z   CXX      bench/bench_dash-data.o
+2025-07-30T14:01:21.9891874Z   GEN      qt/bitcoinamountfield.moc
+2025-07-30T14:01:22.0192969Z   GEN      qt/intro.moc
+2025-07-30T14:01:22.0665567Z   GEN      qt/overviewpage.moc
+2025-07-30T14:01:22.1083872Z   GEN      qt/rpcconsole.moc
+2025-07-30T14:01:22.1827128Z   GEN      qt/qrc_dash_locale.cpp
+2025-07-30T14:01:22.4649045Z   CXX      qt/test/test_dash_qt-apptests.o
+2025-07-30T14:01:25.2598783Z   CXX      qt/test/test_dash_qt-optiontests.o
+2025-07-30T14:01:26.6822259Z   CXX      qt/test/test_dash_qt-rpcnestedtests.o
+2025-07-30T14:01:28.5560210Z   CXX      qt/test/test_dash_qt-test_main.o
+2025-07-30T14:01:32.4455936Z   CXX      qt/test/test_dash_qt-trafficgraphdatatests.o
+2025-07-30T14:01:34.5903160Z   CXX      qt/test/test_dash_qt-uritests.o
+2025-07-30T14:01:37.3222017Z   CXX      qt/test/test_dash_qt-util.o
+2025-07-30T14:01:37.6130751Z   CXX      qt/test/test_dash_qt-moc_apptests.o
+2025-07-30T14:01:37.6448649Z   CXX      qt/test/test_dash_qt-moc_optiontests.o
+2025-07-30T14:01:40.5907420Z   CXX      qt/test/test_dash_qt-moc_rpcnestedtests.o
+2025-07-30T14:01:40.5949046Z   CXX      qt/test/test_dash_qt-moc_trafficgraphdatatests.o
+2025-07-30T14:01:40.7170165Z   CXX      qt/test/test_dash_qt-moc_uritests.o
+2025-07-30T14:01:40.7641218Z   CXX      test/fuzz/fuzz-addition_overflow.o
+2025-07-30T14:01:44.3645278Z   CXX      test/fuzz/fuzz-addrman.o
+2025-07-30T14:01:44.4397247Z   CXX      test/fuzz/fuzz-asmap.o
+2025-07-30T14:01:44.5781908Z   CXX      test/fuzz/fuzz-asmap_direct.o
+2025-07-30T14:01:47.3377146Z   CXX      test/fuzz/fuzz-autofile.o
+2025-07-30T14:01:47.4333917Z   CXX      test/fuzz/fuzz-banman.o
+2025-07-30T14:01:47.5176660Z   CXX      test/fuzz/fuzz-base_encode_decode.o
+2025-07-30T14:01:50.3013825Z   CXX      test/fuzz/fuzz-bech32.o
+2025-07-30T14:01:51.7029961Z   CXX      test/fuzz/fuzz-bip324.o
+2025-07-30T14:01:51.8571479Z   CXX      test/fuzz/fuzz-block.o
+2025-07-30T14:01:54.0721813Z   CXX      test/fuzz/fuzz-block_header.o
+2025-07-30T14:01:54.1678861Z   CXX      test/fuzz/fuzz-blockfilter.o
+2025-07-30T14:01:58.2632908Z   CXX      test/fuzz/fuzz-bloom_filter.o
+2025-07-30T14:01:58.4553464Z   CXX      test/fuzz/fuzz-buffered_file.o
+2025-07-30T14:02:00.7142375Z   CXX      test/fuzz/fuzz-chain.o
+2025-07-30T14:02:00.8335664Z   CXX      test/fuzz/fuzz-checkqueue.o
+2025-07-30T14:02:04.9373659Z   CXX      test/fuzz/fuzz-coins_view.o
+2025-07-30T14:02:05.1170028Z   CXX      test/fuzz/fuzz-coinscache_sim.o
+2025-07-30T14:02:07.1253615Z   CXX      test/fuzz/fuzz-connman.o
+2025-07-30T14:02:07.2372095Z   CXX      test/fuzz/fuzz-crypto.o
+2025-07-30T14:02:12.2875183Z   CXX      test/fuzz/fuzz-crypto_aes256.o
+2025-07-30T14:02:13.0576075Z   CXX      test/fuzz/fuzz-crypto_aes256cbc.o
+2025-07-30T14:02:13.6351911Z   CXX      test/fuzz/fuzz-crypto_chacha20.o
+2025-07-30T14:02:14.4675982Z   CXX      test/fuzz/fuzz-crypto_common.o
+2025-07-30T14:02:18.5083865Z   CXX      test/fuzz/fuzz-crypto_diff_fuzz_chacha20.o
+2025-07-30T14:02:19.3051339Z   CXX      test/fuzz/fuzz-crypto_hkdf_hmac_sha256_l32.o
+2025-07-30T14:02:20.2033479Z   CXX      test/fuzz/fuzz-crypto_poly1305.o
+2025-07-30T14:02:20.5244920Z   CXX      test/fuzz/fuzz-cuckoocache.o
+2025-07-30T14:02:24.9497200Z   CXX      test/fuzz/fuzz-decode_tx.o
+2025-07-30T14:02:25.4011091Z   CXX      test/fuzz/fuzz-descriptor_parse.o
+2025-07-30T14:02:26.5994360Z   CXX      test/fuzz/fuzz-deserialize.o
+2025-07-30T14:02:26.7548567Z   CXX      test/fuzz/fuzz-eval_script.o
+2025-07-30T14:02:26.9403680Z   CXX      test/fuzz/fuzz-fee_rate.o
+2025-07-30T14:02:28.3704057Z   CXX      test/fuzz/fuzz-fees.o
+2025-07-30T14:02:28.6455271Z   CXX      test/fuzz/fuzz-flatfile.o
+2025-07-30T14:02:33.0514849Z   CXX      test/fuzz/fuzz-float.o
+2025-07-30T14:02:34.3375735Z   CXX      test/fuzz/fuzz-golomb_rice.o
+2025-07-30T14:02:34.8202406Z   CXX      test/fuzz/fuzz-hex.o
+2025-07-30T14:02:38.3680657Z   CXX      test/fuzz/fuzz-http_request.o
+2025-07-30T14:02:39.2784250Z   CXX      test/fuzz/fuzz-integer.o
+2025-07-30T14:02:41.1320438Z   CXX      test/fuzz/fuzz-key.o
+2025-07-30T14:02:41.2271656Z   CXX      test/fuzz/fuzz-key_io.o
+2025-07-30T14:02:44.6419230Z   CXX      test/fuzz/fuzz-kitchen_sink.o
+2025-07-30T14:02:44.7903547Z   CXX      test/fuzz/fuzz-load_external_block_file.o
+2025-07-30T14:02:46.9559930Z   CXX      test/fuzz/fuzz-locale.o
+2025-07-30T14:02:48.7060673Z   CXX      test/fuzz/fuzz-merkleblock.o
+2025-07-30T14:02:49.5309464Z   CXX      test/fuzz/fuzz-message.o
+2025-07-30T14:02:51.0065823Z   CXX      test/fuzz/fuzz-minisketch.o
+2025-07-30T14:02:51.0207108Z   CXX      test/fuzz/fuzz-muhash.o
+2025-07-30T14:02:55.6613168Z   CXX      test/fuzz/fuzz-multiplication_overflow.o
+2025-07-30T14:02:56.0105556Z   CXX      test/fuzz/fuzz-net.o
+2025-07-30T14:02:57.2683431Z   CXX      test/fuzz/fuzz-net_permissions.o
+2025-07-30T14:02:57.4863322Z   CXX      test/fuzz/fuzz-netaddress.o
+2025-07-30T14:03:00.0450069Z   CXX      test/fuzz/fuzz-netbase_dns_lookup.o
+2025-07-30T14:03:01.8290923Z   CXX      test/fuzz/fuzz-node_eviction.o
+2025-07-30T14:03:02.7956162Z   CXX      test/fuzz/fuzz-p2p_transport_serialization.o
+2025-07-30T14:03:02.9668491Z   CXX      test/fuzz/fuzz-parse_hd_keypath.o
+2025-07-30T14:03:03.4899756Z   CXX      test/fuzz/fuzz-parse_iso8601.o
+2025-07-30T14:03:05.5623923Z   CXX      test/fuzz/fuzz-parse_numbers.o
+2025-07-30T14:03:06.9360137Z   CXX      test/fuzz/fuzz-parse_script.o
+2025-07-30T14:03:08.0712436Z   CXX      test/fuzz/fuzz-parse_univalue.o
+2025-07-30T14:03:08.4597027Z   CXX      test/fuzz/fuzz-policy_estimator.o
+2025-07-30T14:03:09.1559424Z   CXX      test/fuzz/fuzz-policy_estimator_io.o
+2025-07-30T14:03:10.8375116Z   CXX      test/fuzz/fuzz-poolresource.o
+2025-07-30T14:03:11.7154891Z   CXX      test/fuzz/fuzz-pow.o
+2025-07-30T14:03:15.4003943Z   CXX      test/fuzz/fuzz-prevector.o
+2025-07-30T14:03:15.6924122Z   CXX      test/fuzz/fuzz-primitives_transaction.o
+2025-07-30T14:03:18.2040905Z   CXX      test/fuzz/fuzz-process_message.o
+2025-07-30T14:03:18.4071902Z   CXX      test/fuzz/fuzz-process_messages.o
+2025-07-30T14:03:19.1456525Z   CXX      test/fuzz/fuzz-protocol.o
+2025-07-30T14:03:22.4279017Z   CXX      test/fuzz/fuzz-psbt.o
+2025-07-30T14:03:25.1999675Z   CXX      test/fuzz/fuzz-random.o
+2025-07-30T14:03:25.3669414Z   CXX      test/fuzz/fuzz-rolling_bloom_filter.o
+2025-07-30T14:03:26.7908799Z   CXX      test/fuzz/fuzz-rpc.o
+2025-07-30T14:03:27.1091102Z   CXX      test/fuzz/fuzz-script.o
+2025-07-30T14:03:31.2626882Z   CXX      test/fuzz/fuzz-script_bitcoin_consensus.o
+2025-07-30T14:03:31.4819388Z   CXX      test/fuzz/fuzz-script_descriptor_cache.o
+2025-07-30T14:03:34.0951530Z   CXX      test/fuzz/fuzz-script_flags.o
+2025-07-30T14:03:36.5684576Z   CXX      test/fuzz/fuzz-script_format.o
+2025-07-30T14:03:37.5667797Z   CXX      test/fuzz/fuzz-script_interpreter.o
+2025-07-30T14:03:37.8773941Z   CXX      test/fuzz/fuzz-script_ops.o
+2025-07-30T14:03:39.2222906Z   CXX      test/fuzz/fuzz-script_sigcache.o
+2025-07-30T14:03:42.7506036Z   CXX      test/fuzz/fuzz-script_sign.o
+2025-07-30T14:03:44.1607174Z   CXX      test/fuzz/fuzz-scriptnum_ops.o
+2025-07-30T14:03:44.1752924Z   CXX      test/fuzz/fuzz-secp256k1_ec_seckey_import_export_der.o
+2025-07-30T14:03:46.0944618Z   CXX      test/fuzz/fuzz-secp256k1_ecdsa_signature_parse_der_lax.o
+2025-07-30T14:03:50.3744848Z   CXX      test/fuzz/fuzz-signature_checker.o
+2025-07-30T14:03:50.3784766Z   CXX      test/fuzz/fuzz-socks5.o
+2025-07-30T14:03:52.2356319Z   CXX      test/fuzz/fuzz-span.o
+2025-07-30T14:03:52.2933411Z   CXX      test/fuzz/fuzz-spanparsing.o
+2025-07-30T14:03:53.3126890Z   CXX      test/fuzz/fuzz-string.o
+2025-07-30T14:03:56.6529119Z   CXX      test/fuzz/fuzz-strprintf.o
+2025-07-30T14:03:56.7155799Z   CXX      test/fuzz/fuzz-system.o
+2025-07-30T14:03:58.3889288Z   CXX      test/fuzz/fuzz-timedata.o
+2025-07-30T14:04:00.8175875Z   CXX      test/fuzz/fuzz-torcontrol.o
+2025-07-30T14:04:03.2511446Z   CXX      test/fuzz/fuzz-transaction.o
+2025-07-30T14:04:04.1137314Z   CXX      test/fuzz/fuzz-tx_in.o
+2025-07-30T14:04:04.8488027Z   CXX      test/fuzz/fuzz-tx_out.o
+2025-07-30T14:04:05.9954403Z   CXX      test/fuzz/fuzz-tx_pool.o
+2025-07-30T14:04:06.7997238Z   CXX      test/fuzz/fuzz-utxo_snapshot.o
+2025-07-30T14:04:07.3121621Z   CXX      test/fuzz/fuzz-validation_load_mempool.o
+2025-07-30T14:04:09.4591571Z   CXX      test/fuzz/fuzz-versionbits.o
+2025-07-30T14:04:13.4701575Z   CXX      test/fuzz/libtest_fuzz_a-fuzz.o
+2025-07-30T14:04:13.9356401Z   CXX      test/fuzz/util/libtest_fuzz_a-net.o
+2025-07-30T14:04:15.5950500Z   CXX      univalue/test/object-object.o
+2025-07-30T14:04:16.3335393Z   CXX      univalue/test/unitester-unitester.o
+2025-07-30T14:04:16.6334906Z test/fuzz/util/net.cpp: In function ‘CNetAddr ConsumeNetAddr(FuzzedDataProvider&, FastRandomContext*)’:
+2025-07-30T14:04:16.6337103Z test/fuzz/util/net.cpp:55:32: error: ‘PROTOCOL_VERSION’ was not declared in this scope
+2025-07-30T14:04:16.6338492Z    55 |     CDataStream s(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
+2025-07-30T14:04:16.6339257Z       |                                ^~~~~~~~~~~~~~~~
+2025-07-30T14:04:16.6372721Z make[2]: *** [Makefile:13257: test/fuzz/util/libtest_fuzz_a-net.o] Error 1
+2025-07-30T14:04:16.6379878Z make[2]: *** Waiting for unfinished jobs....
+2025-07-30T14:04:18.9286241Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T14:04:18.9296548Z make[1]: *** [Makefile:20633: install-recursive] Error 1
+2025-07-30T14:04:18.9298094Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T14:04:18.9308344Z make: *** [Makefile:788: install-recursive] Error 1
+2025-07-30T14:04:18.9314789Z Build failure. Verbose build follows.
+2025-07-30T14:04:18.9388658Z Making install in src
+2025-07-30T14:04:18.9632700Z make[1]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T14:04:18.9943109Z make[2]: Entering directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T14:04:18.9943948Z rm -f libbitcoin_node.a
+2025-07-30T14:04:18.9991024Z ar cr libbitcoin_node.a libbitcoin_node_a-addrdb.o libbitcoin_node_a-addressindex.o libbitcoin_node_a-addrman.o libbitcoin_node_a-banman.o libbitcoin_node_a-batchedlogger.o libbitcoin_node_a-bip324.o libbitcoin_node_a-blockencodings.o libbitcoin_node_a-blockfilter.o libbitcoin_node_a-chain.o coinjoin/libbitcoin_node_a-coinjoin.o coinjoin/libbitcoin_node_a-context.o coinjoin/libbitcoin_node_a-server.o consensus/libbitcoin_node_a-tx_verify.o libbitcoin_node_a-dbwrapper.o libbitcoin_node_a-deploymentstatus.o libbitcoin_node_a-dsnotificationinterface.o evo/libbitcoin_node_a-assetlocktx.o evo/libbitcoin_node_a-cbtx.o evo/libbitcoin_node_a-creditpool.o evo/libbitcoin_node_a-chainhelper.o evo/libbitcoin_node_a-deterministicmns.o evo/libbitcoin_node_a-dmnstate.o evo/libbitcoin_node_a-evodb.o evo/libbitcoin_node_a-mnauth.o evo/libbitcoin_node_a-mnhftx.o evo/libbitcoin_node_a-providertx.o evo/libbitcoin_node_a-simplifiedmns.o evo/libbitcoin_node_a-smldiff.o evo/libbitcoin_node_a-specialtx.o evo/libbitcoin_node_a-specialtxman.o libbitcoin_node_a-flatfile.o governance/libbitcoin_node_a-classes.o governance/libbitcoin_node_a-exceptions.o governance/libbitcoin_node_a-governance.o governance/libbitcoin_node_a-object.o governance/libbitcoin_node_a-validators.o governance/libbitcoin_node_a-vote.o governance/libbitcoin_node_a-votedb.o gsl/libbitcoin_node_a-assert.o libbitcoin_node_a-httprpc.o libbitcoin_node_a-httpserver.o libbitcoin_node_a-i2p.o index/libbitcoin_node_a-base.o index/libbitcoin_node_a-blockfilterindex.o index/libbitcoin_node_a-coinstatsindex.o index/libbitcoin_node_a-txindex.o libbitcoin_node_a-init.o instantsend/libbitcoin_node_a-db.o instantsend/libbitcoin_node_a-instantsend.o instantsend/libbitcoin_node_a-lock.o instantsend/libbitcoin_node_a-signing.o llmq/libbitcoin_node_a-blockprocessor.o llmq/libbitcoin_node_a-chainlocks.o llmq/libbitcoin_node_a-clsig.o llmq/libbitcoin_node_a-commitment.o llmq/libbitcoin_node_a-context.o llmq/libbitcoin_node_a-debug.o llmq/libbitcoin_node_a-dkgsession.o llmq/libbitcoin_node_a-dkgsessionhandler.o llmq/libbitcoin_node_a-dkgsessionmgr.o llmq/libbitcoin_node_a-ehf_signals.o llmq/libbitcoin_node_a-options.o llmq/libbitcoin_node_a-quorums.o llmq/libbitcoin_node_a-signing.o llmq/libbitcoin_node_a-signing_shares.o llmq/libbitcoin_node_a-snapshot.o llmq/libbitcoin_node_a-utils.o libbitcoin_node_a-mapport.o masternode/libbitcoin_node_a-node.o masternode/libbitcoin_node_a-meta.o masternode/libbitcoin_node_a-payments.o masternode/libbitcoin_node_a-sync.o masternode/libbitcoin_node_a-utils.o libbitcoin_node_a-net.o libbitcoin_node_a-netfulfilledman.o libbitcoin_node_a-netgroup.o libbitcoin_node_a-net_processing.o node/libbitcoin_node_a-blockstorage.o node/libbitcoin_node_a-caches.o node/libbitcoin_node_a-chainstate.o node/libbitcoin_node_a-coin.o node/libbitcoin_node_a-coinstats.o node/libbitcoin_node_a-connection_types.o node/libbitcoin_node_a-context.o node/libbitcoin_node_a-eviction.o node/libbitcoin_node_a-interfaces.o node/libbitcoin_node_a-miner.o node/libbitcoin_node_a-minisketchwrapper.o node/libbitcoin_node_a-psbt.o node/libbitcoin_node_a-transaction.o node/libbitcoin_node_a-txreconciliation.o node/libbitcoin_node_a-interface_ui.o libbitcoin_node_a-noui.o policy/libbitcoin_node_a-fees.o policy/libbitcoin_node_a-packages.o policy/libbitcoin_node_a-policy.o policy/libbitcoin_node_a-settings.o libbitcoin_node_a-pow.o libbitcoin_node_a-rest.o rpc/libbitcoin_node_a-blockchain.o rpc/libbitcoin_node_a-coinjoin.o rpc/libbitcoin_node_a-evo.o rpc/libbitcoin_node_a-fees.o rpc/libbitcoin_node_a-index_util.o rpc/libbitcoin_node_a-masternode.o rpc/libbitcoin_node_a-mempool.o rpc/libbitcoin_node_a-governance.o rpc/libbitcoin_node_a-mining.o rpc/libbitcoin_node_a-node.o rpc/libbitcoin_node_a-net.o rpc/libbitcoin_node_a-output_script.o rpc/libbitcoin_node_a-quorums.o rpc/libbitcoin_node_a-rawtransaction.o rpc/libbitcoin_node_a-server.o rpc/libbitcoin_node_a-server_util.o rpc/libbitcoin_node_a-signmessage.o rpc/libbitcoin_node_a-txoutproof.o script/libbitcoin_node_a-sigcache.o libbitcoin_node_a-shutdown.o libbitcoin_node_a-spork.o stats/libbitcoin_node_a-client.o stats/libbitcoin_node_a-rawsender.o libbitcoin_node_a-timedata.o libbitcoin_node_a-torcontrol.o libbitcoin_node_a-txdb.o libbitcoin_node_a-txmempool.o libbitcoin_node_a-txorphanage.o libbitcoin_node_a-validation.o libbitcoin_node_a-validationinterface.o libbitcoin_node_a-versionbits.o   libbitcoin_node_a-dummywallet.o 
+2025-07-30T14:04:19.3472175Z ranlib libbitcoin_node.a
+2025-07-30T14:04:19.7126893Z rm -f libbitcoin_common.a
+2025-07-30T14:04:19.7159047Z ar cr libbitcoin_common.a libbitcoin_common_a-base58.o libbitcoin_common_a-bech32.o libbitcoin_common_a-chainparams.o libbitcoin_common_a-coins.o common/libbitcoin_common_a-bloom.o libbitcoin_common_a-compressor.o libbitcoin_common_a-core_read.o libbitcoin_common_a-core_write.o libbitcoin_common_a-deploymentinfo.o evo/libbitcoin_common_a-core_write.o evo/libbitcoin_common_a-netinfo.o governance/libbitcoin_common_a-common.o init/libbitcoin_common_a-common.o libbitcoin_common_a-key.o libbitcoin_common_a-key_io.o libbitcoin_common_a-merkleblock.o libbitcoin_common_a-net_types.o libbitcoin_common_a-netaddress.o libbitcoin_common_a-netbase.o libbitcoin_common_a-net_permissions.o libbitcoin_common_a-outputtype.o policy/libbitcoin_common_a-feerate.o policy/libbitcoin_common_a-policy.o libbitcoin_common_a-protocol.o libbitcoin_common_a-psbt.o rpc/libbitcoin_common_a-evo_util.o rpc/libbitcoin_common_a-rawtransaction_util.o rpc/libbitcoin_common_a-util.o libbitcoin_common_a-saltedhasher.o libbitcoin_common_a-scheduler.o script/libbitcoin_common_a-descriptor.o script/libbitcoin_common_a-sign.o script/libbitcoin_common_a-signingprovider.o script/libbitcoin_common_a-standard.o libbitcoin_common_a-warnings.o  
+2025-07-30T14:04:19.7798058Z ranlib libbitcoin_common.a
+2025-07-30T14:04:19.9669626Z rm -f libbitcoin_util.a
+2025-07-30T14:04:19.9705573Z ar cr libbitcoin_util.a bls/libbitcoin_util_a-bls_ies.o bls/libbitcoin_util_a-bls_worker.o coinjoin/libbitcoin_util_a-common.o coinjoin/libbitcoin_util_a-options.o support/libbitcoin_util_a-lockedpool.o libbitcoin_util_a-chainparamsbase.o libbitcoin_util_a-clientversion.o libbitcoin_util_a-fs.o interfaces/libbitcoin_util_a-echo.o interfaces/libbitcoin_util_a-handler.o interfaces/libbitcoin_util_a-init.o libbitcoin_util_a-logging.o libbitcoin_util_a-messagesigner.o libbitcoin_util_a-random.o libbitcoin_util_a-randomenv.o rpc/libbitcoin_util_a-request.o libbitcoin_util_a-stacktraces.o support/libbitcoin_util_a-cleanse.o libbitcoin_util_a-sync.o util/libbitcoin_util_a-asmap.o util/libbitcoin_util_a-bip32.o util/libbitcoin_util_a-bytevectorhash.o util/libbitcoin_util_a-check.o util/libbitcoin_util_a-edge.o util/libbitcoin_util_a-error.o util/libbitcoin_util_a-fees.o util/libbitcoin_util_a-hasher.o util/libbitcoin_util_a-getuniquepath.o util/libbitcoin_util_a-sock.o util/libbitcoin_util_a-syserror.o util/libbitcoin_util_a-system.o util/libbitcoin_util_a-message.o util/libbitcoin_util_a-moneystr.o util/libbitcoin_util_a-readwritefile.o util/libbitcoin_util_a-settings.o util/libbitcoin_util_a-ranges_set.o util/libbitcoin_util_a-spanparsing.o util/libbitcoin_util_a-strencodings.o util/libbitcoin_util_a-time.o util/libbitcoin_util_a-serfloat.o util/libbitcoin_util_a-string.o util/libbitcoin_util_a-thread.o util/libbitcoin_util_a-threadinterrupt.o util/libbitcoin_util_a-threadnames.o util/libbitcoin_util_a-tokenpipe.o util/libbitcoin_util_a-wpipe.o  util/libbitcoin_util_a-url.o  
+2025-07-30T14:04:20.0393057Z ranlib libbitcoin_util.a
+2025-07-30T14:04:20.1102063Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -pipe -std=c++20 -O2   -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie    -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o libunivalue.la  univalue/lib/libunivalue_la-univalue.lo univalue/lib/libunivalue_la-univalue_get.lo univalue/lib/libunivalue_la-univalue_read.lo univalue/lib/libunivalue_la-univalue_write.lo    
+2025-07-30T14:04:20.2183967Z libtool: link: ar cr .libs/libunivalue.a univalue/lib/.libs/libunivalue_la-univalue.o univalue/lib/.libs/libunivalue_la-univalue_get.o univalue/lib/.libs/libunivalue_la-univalue_read.o univalue/lib/.libs/libunivalue_la-univalue_write.o 
+2025-07-30T14:04:20.2402441Z libtool: link: ranlib .libs/libunivalue.a
+2025-07-30T14:04:20.2648681Z libtool: link: ( cd ".libs" && rm -f "libunivalue.la" && ln -s "../libunivalue.la" "libunivalue.la" )
+2025-07-30T14:04:20.2679060Z rm -f libbitcoin_zmq.a
+2025-07-30T14:04:20.2704072Z ar cr libbitcoin_zmq.a zmq/libbitcoin_zmq_a-zmqabstractnotifier.o zmq/libbitcoin_zmq_a-zmqnotificationinterface.o zmq/libbitcoin_zmq_a-zmqpublishnotifier.o zmq/libbitcoin_zmq_a-zmqrpc.o zmq/libbitcoin_zmq_a-zmqutil.o 
+2025-07-30T14:04:20.2938362Z ranlib libbitcoin_zmq.a
+2025-07-30T14:04:20.3187476Z rm -f libbitcoin_consensus.a
+2025-07-30T14:04:20.3216730Z ar cr libbitcoin_consensus.a libbitcoin_consensus_a-arith_uint256.o bls/libbitcoin_consensus_a-bls.o consensus/libbitcoin_consensus_a-merkle.o consensus/libbitcoin_consensus_a-tx_check.o libbitcoin_consensus_a-hash.o primitives/libbitcoin_consensus_a-block.o primitives/libbitcoin_consensus_a-transaction.o libbitcoin_consensus_a-pubkey.o script/libbitcoin_consensus_a-bitcoinconsensus.o script/libbitcoin_consensus_a-interpreter.o script/libbitcoin_consensus_a-script.o script/libbitcoin_consensus_a-script_error.o libbitcoin_consensus_a-uint256.o util/libbitcoin_consensus_a-strencodings.o util/libbitcoin_consensus_a-string.o 
+2025-07-30T14:04:20.3512385Z ranlib libbitcoin_consensus.a
+2025-07-30T14:04:20.3832583Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -fPIC -static -pipe -std=c++20 -O2   -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie    -static -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o crypto/libbitcoin_crypto_base.la  crypto/libbitcoin_crypto_base_la-aes.lo crypto/libbitcoin_crypto_base_la-chacha20.lo crypto/libbitcoin_crypto_base_la-chacha20poly1305.lo crypto/libbitcoin_crypto_base_la-hkdf_sha256_32.lo crypto/libbitcoin_crypto_base_la-hmac_sha256.lo crypto/libbitcoin_crypto_base_la-hmac_sha512.lo crypto/libbitcoin_crypto_base_la-muhash.lo crypto/libbitcoin_crypto_base_la-poly1305.lo crypto/libbitcoin_crypto_base_la-pkcs5_pbkdf2_hmac_sha512.lo crypto/libbitcoin_crypto_base_la-ripemd160.lo crypto/libbitcoin_crypto_base_la-sha1.lo crypto/libbitcoin_crypto_base_la-sha256.lo crypto/libbitcoin_crypto_base_la-sha256_sse4.lo crypto/libbitcoin_crypto_base_la-sha3.lo crypto/libbitcoin_crypto_base_la-sha512.lo crypto/libbitcoin_crypto_base_la-siphash.lo crypto/x11/libbitcoin_crypto_base_la-aes_helper.lo crypto/x11/libbitcoin_crypto_base_la-blake.lo crypto/x11/libbitcoin_crypto_base_la-bmw.lo crypto/x11/libbitcoin_crypto_base_la-cubehash.lo crypto/x11/libbitcoin_crypto_base_la-echo.lo crypto/x11/libbitcoin_crypto_base_la-groestl.lo crypto/x11/libbitcoin_crypto_base_la-jh.lo crypto/x11/libbitcoin_crypto_base_la-keccak.lo crypto/x11/libbitcoin_crypto_base_la-luffa.lo crypto/x11/libbitcoin_crypto_base_la-shavite.lo crypto/x11/libbitcoin_crypto_base_la-simd.lo crypto/x11/libbitcoin_crypto_base_la-skein.lo  
+2025-07-30T14:04:20.6043177Z libtool: link: ar cr crypto/.libs/libbitcoin_crypto_base.a  crypto/libbitcoin_crypto_base_la-aes.o crypto/libbitcoin_crypto_base_la-chacha20.o crypto/libbitcoin_crypto_base_la-chacha20poly1305.o crypto/libbitcoin_crypto_base_la-hkdf_sha256_32.o crypto/libbitcoin_crypto_base_la-hmac_sha256.o crypto/libbitcoin_crypto_base_la-hmac_sha512.o crypto/libbitcoin_crypto_base_la-muhash.o crypto/libbitcoin_crypto_base_la-poly1305.o crypto/libbitcoin_crypto_base_la-pkcs5_pbkdf2_hmac_sha512.o crypto/libbitcoin_crypto_base_la-ripemd160.o crypto/libbitcoin_crypto_base_la-sha1.o crypto/libbitcoin_crypto_base_la-sha256.o crypto/libbitcoin_crypto_base_la-sha256_sse4.o crypto/libbitcoin_crypto_base_la-sha3.o crypto/libbitcoin_crypto_base_la-sha512.o crypto/libbitcoin_crypto_base_la-siphash.o crypto/x11/libbitcoin_crypto_base_la-aes_helper.o crypto/x11/libbitcoin_crypto_base_la-blake.o crypto/x11/libbitcoin_crypto_base_la-bmw.o crypto/x11/libbitcoin_crypto_base_la-cubehash.o crypto/x11/libbitcoin_crypto_base_la-echo.o crypto/x11/libbitcoin_crypto_base_la-groestl.o crypto/x11/libbitcoin_crypto_base_la-jh.o crypto/x11/libbitcoin_crypto_base_la-keccak.o crypto/x11/libbitcoin_crypto_base_la-luffa.o crypto/x11/libbitcoin_crypto_base_la-shavite.o crypto/x11/libbitcoin_crypto_base_la-simd.o crypto/x11/libbitcoin_crypto_base_la-skein.o
+2025-07-30T14:04:20.6319074Z libtool: link: ranlib crypto/.libs/libbitcoin_crypto_base.a
+2025-07-30T14:04:20.6615229Z libtool: link: ( cd "crypto/.libs" && rm -f "libbitcoin_crypto_base.la" && ln -s "../libbitcoin_crypto_base.la" "libbitcoin_crypto_base.la" )
+2025-07-30T14:04:20.6663200Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -static -pipe -std=c++20 -O2   -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie    -static -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o leveldb/libleveldb.la  leveldb/db/libleveldb_la-builder.lo leveldb/db/libleveldb_la-c.lo leveldb/db/libleveldb_la-dbformat.lo leveldb/db/libleveldb_la-db_impl.lo leveldb/db/libleveldb_la-db_iter.lo leveldb/db/libleveldb_la-dumpfile.lo leveldb/db/libleveldb_la-filename.lo leveldb/db/libleveldb_la-log_reader.lo leveldb/db/libleveldb_la-log_writer.lo leveldb/db/libleveldb_la-memtable.lo leveldb/db/libleveldb_la-repair.lo leveldb/db/libleveldb_la-table_cache.lo leveldb/db/libleveldb_la-version_edit.lo leveldb/db/libleveldb_la-version_set.lo leveldb/db/libleveldb_la-write_batch.lo leveldb/table/libleveldb_la-block_builder.lo leveldb/table/libleveldb_la-block.lo leveldb/table/libleveldb_la-filter_block.lo leveldb/table/libleveldb_la-format.lo leveldb/table/libleveldb_la-iterator.lo leveldb/table/libleveldb_la-merger.lo leveldb/table/libleveldb_la-table_builder.lo leveldb/table/libleveldb_la-table.lo leveldb/table/libleveldb_la-two_level_iterator.lo leveldb/util/libleveldb_la-arena.lo leveldb/util/libleveldb_la-bloom.lo leveldb/util/libleveldb_la-cache.lo leveldb/util/libleveldb_la-coding.lo leveldb/util/libleveldb_la-comparator.lo leveldb/util/libleveldb_la-crc32c.lo leveldb/util/libleveldb_la-env.lo leveldb/util/libleveldb_la-filter_policy.lo leveldb/util/libleveldb_la-hash.lo leveldb/util/libleveldb_la-histogram.lo leveldb/util/libleveldb_la-logging.lo leveldb/util/libleveldb_la-options.lo leveldb/util/libleveldb_la-status.lo  leveldb/util/libleveldb_la-env_posix.lo  
+2025-07-30T14:04:20.9365055Z libtool: link: ar cr leveldb/.libs/libleveldb.a  leveldb/db/libleveldb_la-builder.o leveldb/db/libleveldb_la-c.o leveldb/db/libleveldb_la-dbformat.o leveldb/db/libleveldb_la-db_impl.o leveldb/db/libleveldb_la-db_iter.o leveldb/db/libleveldb_la-dumpfile.o leveldb/db/libleveldb_la-filename.o leveldb/db/libleveldb_la-log_reader.o leveldb/db/libleveldb_la-log_writer.o leveldb/db/libleveldb_la-memtable.o leveldb/db/libleveldb_la-repair.o leveldb/db/libleveldb_la-table_cache.o leveldb/db/libleveldb_la-version_edit.o leveldb/db/libleveldb_la-version_set.o leveldb/db/libleveldb_la-write_batch.o leveldb/table/libleveldb_la-block_builder.o leveldb/table/libleveldb_la-block.o leveldb/table/libleveldb_la-filter_block.o leveldb/table/libleveldb_la-format.o leveldb/table/libleveldb_la-iterator.o leveldb/table/libleveldb_la-merger.o leveldb/table/libleveldb_la-table_builder.o leveldb/table/libleveldb_la-table.o leveldb/table/libleveldb_la-two_level_iterator.o leveldb/util/libleveldb_la-arena.o leveldb/util/libleveldb_la-bloom.o leveldb/util/libleveldb_la-cache.o leveldb/util/libleveldb_la-coding.o leveldb/util/libleveldb_la-comparator.o leveldb/util/libleveldb_la-crc32c.o leveldb/util/libleveldb_la-env.o leveldb/util/libleveldb_la-filter_policy.o leveldb/util/libleveldb_la-hash.o leveldb/util/libleveldb_la-histogram.o leveldb/util/libleveldb_la-logging.o leveldb/util/libleveldb_la-options.o leveldb/util/libleveldb_la-status.o leveldb/util/libleveldb_la-env_posix.o
+2025-07-30T14:04:20.9762052Z libtool: link: ranlib leveldb/.libs/libleveldb.a
+2025-07-30T14:04:21.0178329Z libtool: link: ( cd "leveldb/.libs" && rm -f "libleveldb.la" && ln -s "../libleveldb.la" "libleveldb.la" )
+2025-07-30T14:04:21.0215077Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -static -pipe -std=c++20 -O2   -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie    -static -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o crc32c/libcrc32c.la  crc32c/src/libcrc32c_la-crc32c.lo crc32c/src/libcrc32c_la-crc32c_portable.lo  
+2025-07-30T14:04:21.1212527Z libtool: link: ar cr crc32c/.libs/libcrc32c.a  crc32c/src/libcrc32c_la-crc32c.o crc32c/src/libcrc32c_la-crc32c_portable.o
+2025-07-30T14:04:21.1404835Z libtool: link: ranlib crc32c/.libs/libcrc32c.a
+2025-07-30T14:04:21.1621959Z libtool: link: ( cd "crc32c/.libs" && rm -f "libcrc32c.la" && ln -s "../libcrc32c.la" "libcrc32c.la" )
+2025-07-30T14:04:21.1660519Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -static -pipe -std=c++20 -O2   -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie    -static -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o leveldb/libmemenv.la  leveldb/helpers/memenv/libmemenv_la-memenv.lo  
+2025-07-30T14:04:21.2613950Z libtool: link: ar cr leveldb/.libs/libmemenv.a  leveldb/helpers/memenv/libmemenv_la-memenv.o
+2025-07-30T14:04:21.2811100Z libtool: link: ranlib leveldb/.libs/libmemenv.a
+2025-07-30T14:04:21.3046245Z libtool: link: ( cd "leveldb/.libs" && rm -f "libmemenv.la" && ln -s "../libmemenv.la" "libmemenv.la" )
+2025-07-30T14:04:21.3156625Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2   -Wl,--exclude-libs,ALL  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie     -pthread -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o dashd dashd-bitcoind.o  init/dashd-bitcoind.o libbitcoin_node.a  libbitcoin_common.a libbitcoin_util.a libunivalue.la libbitcoin_zmq.a libbitcoin_consensus.a crypto/libbitcoin_crypto_base.la crypto/libbitcoin_crypto_sse41.la crypto/libbitcoin_crypto_x86_shani.la crypto/libbitcoin_crypto_avx2.la  dashbls/libdashbls.la leveldb/libleveldb.la crc32c/libcrc32c.la crc32c/libcrc32c_sse42.la  leveldb/libmemenv.la secp256k1/libsecp256k1.la -lbacktrace  -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent_pthreads -levent  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lzmq  -lgmp 
+2025-07-30T14:04:21.6304702Z libtool: link: /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2 -Wl,--exclude-libs -Wl,ALL -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,separate-code -pie -o dashd dashd-bitcoind.o init/dashd-bitcoind.o  -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib libbitcoin_node.a libbitcoin_common.a libbitcoin_util.a ./.libs/libunivalue.a libbitcoin_zmq.a libbitcoin_consensus.a crypto/.libs/libbitcoin_crypto_base.a crypto/.libs/libbitcoin_crypto_sse41.a crypto/.libs/libbitcoin_crypto_x86_shani.a crypto/.libs/libbitcoin_crypto_avx2.a dashbls/.libs/libdashbls.a leveldb/.libs/libleveldb.a crc32c/.libs/libcrc32c.a crc32c/.libs/libcrc32c_sse42.a leveldb/.libs/libmemenv.a secp256k1/.libs/libsecp256k1.a -lbacktrace -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp -levent_pthreads -levent -levent -lzmq -lgmp -pthread
+2025-07-30T14:04:22.5090178Z rm -f libbitcoin_cli.a
+2025-07-30T14:04:22.5113829Z ar cr libbitcoin_cli.a compat/libbitcoin_cli_a-stdin.o rpc/libbitcoin_cli_a-client.o  
+2025-07-30T14:04:22.5291156Z ranlib libbitcoin_cli.a
+2025-07-30T14:04:22.5491965Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2   -Wl,--exclude-libs,ALL  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie     -pthread -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o dash-cli dash_cli-bitcoin-cli.o  libbitcoin_cli.a libunivalue.la libbitcoin_util.a crypto/libbitcoin_crypto_base.la crypto/libbitcoin_crypto_sse41.la crypto/libbitcoin_crypto_x86_shani.la crypto/libbitcoin_crypto_avx2.la  -lbacktrace -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent  -lgmp 
+2025-07-30T14:04:22.7348040Z libtool: link: /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2 -Wl,--exclude-libs -Wl,ALL -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,separate-code -pie -o dash-cli dash_cli-bitcoin-cli.o  -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib libbitcoin_cli.a ./.libs/libunivalue.a libbitcoin_util.a crypto/.libs/libbitcoin_crypto_base.a crypto/.libs/libbitcoin_crypto_sse41.a crypto/.libs/libbitcoin_crypto_x86_shani.a crypto/.libs/libbitcoin_crypto_avx2.a -lbacktrace -levent -lgmp -pthread
+2025-07-30T14:04:22.8609211Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2   -Wl,--exclude-libs,ALL  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie     -pthread -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o dash-tx dash_tx-bitcoin-tx.o  libunivalue.la libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/libbitcoin_crypto_base.la crypto/libbitcoin_crypto_sse41.la crypto/libbitcoin_crypto_x86_shani.la crypto/libbitcoin_crypto_avx2.la  dashbls/libdashbls.la secp256k1/libsecp256k1.la -lbacktrace -lgmp 
+2025-07-30T14:04:23.0870212Z libtool: link: /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2 -Wl,--exclude-libs -Wl,ALL -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,separate-code -pie -o dash-tx dash_tx-bitcoin-tx.o  -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib ./.libs/libunivalue.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/.libs/libbitcoin_crypto_base.a crypto/.libs/libbitcoin_crypto_sse41.a crypto/.libs/libbitcoin_crypto_x86_shani.a crypto/.libs/libbitcoin_crypto_avx2.a dashbls/.libs/libdashbls.a secp256k1/.libs/libsecp256k1.a -lbacktrace -lgmp -pthread
+2025-07-30T14:04:23.3086980Z rm -f libtest_util.a
+2025-07-30T14:04:23.3115340Z ar cr libtest_util.a test/util/libtest_util_a-blockfilter.o test/util/libtest_util_a-index.o test/util/libtest_util_a-json.o test/util/libtest_util_a-logging.o test/util/libtest_util_a-mining.o test/util/libtest_util_a-net.o test/util/libtest_util_a-script.o test/util/libtest_util_a-setup_common.o test/util/libtest_util_a-str.o test/util/libtest_util_a-transaction_utils.o test/util/libtest_util_a-validation.o test/util/libtest_util_a-wallet.o  
+2025-07-30T14:04:23.3384444Z ranlib libtest_util.a
+2025-07-30T14:04:23.3672111Z rm -f minisketch/libminisketch.a
+2025-07-30T14:04:23.3697520Z ar cr minisketch/libminisketch.a minisketch/src/fields/libminisketch_a-generic_1byte.o minisketch/src/fields/libminisketch_a-generic_2bytes.o minisketch/src/fields/libminisketch_a-generic_3bytes.o minisketch/src/fields/libminisketch_a-generic_4bytes.o minisketch/src/fields/libminisketch_a-generic_5bytes.o minisketch/src/fields/libminisketch_a-generic_6bytes.o minisketch/src/fields/libminisketch_a-generic_7bytes.o minisketch/src/fields/libminisketch_a-generic_8bytes.o minisketch/src/libminisketch_a-minisketch.o    
+2025-07-30T14:04:23.3881341Z ranlib minisketch/libminisketch.a
+2025-07-30T14:04:23.4119631Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2   -Wl,--exclude-libs,ALL  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie     -pthread -lpthread -static -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o test/test_dash test/test_dash-main.o   test/test_dash-argsman_tests.o test/test_dash-arith_uint256_tests.o test/test_dash-addrman_tests.o test/test_dash-amount_tests.o test/test_dash-allocator_tests.o test/test_dash-banman_tests.o test/test_dash-base32_tests.o test/test_dash-base58_tests.o test/test_dash-base64_tests.o test/test_dash-bech32_tests.o test/test_dash-bip32_tests.o test/test_dash-bip324_tests.o test/test_dash-block_reward_reallocation_tests.o test/test_dash-blockchain_tests.o test/test_dash-blockencodings_tests.o test/test_dash-blockfilter_tests.o test/test_dash-blockfilter_index_tests.o test/test_dash-blockmanager_tests.o test/test_dash-bloom_tests.o test/test_dash-bls_tests.o test/test_dash-bswap_tests.o test/test_dash-checkdatasig_tests.o test/test_dash-checkqueue_tests.o test/test_dash-cachemap_tests.o test/test_dash-cachemultimap_tests.o test/test_dash-coins_tests.o test/test_dash-coinstatsindex_tests.o test/test_dash-compilerbug_tests.o test/test_dash-compress_tests.o test/test_dash-crypto_tests.o test/test_dash-cuckoocache_tests.o test/test_dash-denialofservice_tests.o test/test_dash-dip0020opcodes_tests.o test/test_dash-descriptor_tests.o test/test_dash-dynamic_activation_thresholds_tests.o test/test_dash-evo_assetlocks_tests.o test/test_dash-evo_deterministicmns_tests.o test/test_dash-evo_islock_tests.o test/test_dash-evo_mnhf_tests.o test/test_dash-evo_netinfo_tests.o test/test_dash-evo_simplifiedmns_tests.o test/test_dash-evo_trivialvalidation.o test/test_dash-evo_utils_tests.o test/test_dash-flatfile_tests.o test/test_dash-fs_tests.o test/test_dash-getarg_tests.o test/test_dash-governance_validators_tests.o test/test_dash-hash_tests.o test/test_dash-i2p_tests.o test/test_dash-interfaces_tests.o test/test_dash-key_io_tests.o test/test_dash-key_tests.o test/test_dash-limitedmap_tests.o test/test_dash-llmq_dkg_tests.o test/test_dash-llmq_chainlock_tests.o test/test_dash-llmq_commitment_tests.o test/test_dash-llmq_hash_tests.o test/test_dash-llmq_params_tests.o test/test_dash-llmq_snapshot_tests.o test/test_dash-llmq_utils_tests.o test/test_dash-logging_tests.o test/test_dash-dbwrapper_tests.o test/test_dash-validation_tests.o test/test_dash-mempool_tests.o test/test_dash-merkle_tests.o test/test_dash-merkleblock_tests.o test/test_dash-minisketch_tests.o test/test_dash-miner_tests.o test/test_dash-multisig_tests.o test/test_dash-net_peer_connection_tests.o test/test_dash-net_peer_eviction_tests.o test/test_dash-net_tests.o test/test_dash-netbase_tests.o test/test_dash-orphanage_tests.o test/test_dash-pmt_tests.o test/test_dash-policyestimator_tests.o test/test_dash-pool_tests.o test/test_dash-pow_tests.o test/test_dash-prevector_tests.o test/test_dash-raii_event_tests.o test/test_dash-random_tests.o test/test_dash-ratecheck_tests.o test/test_dash-reverselock_tests.o test/test_dash-rpc_tests.o test/test_dash-sanity_tests.o test/test_dash-scheduler_tests.o test/test_dash-script_p2sh_tests.o test/test_dash-script_p2pk_tests.o test/test_dash-script_p2pkh_tests.o test/test_dash-script_parse_tests.o test/test_dash-script_standard_tests.o test/test_dash-script_tests.o test/test_dash-scriptnum_tests.o test/test_dash-serfloat_tests.o test/test_dash-serialize_tests.o test/test_dash-settings_tests.o test/test_dash-sighash_tests.o test/test_dash-sigopcount_tests.o test/test_dash-skiplist_tests.o test/test_dash-sock_tests.o test/test_dash-streams_tests.o test/test_dash-subsidy_tests.o test/test_dash-sync_tests.o test/test_dash-system_tests.o test/test_dash-util_threadnames_tests.o test/test_dash-timedata_tests.o test/test_dash-torcontrol_tests.o test/test_dash-transaction_tests.o test/test_dash-txindex_tests.o test/test_dash-txpackage_tests.o test/test_dash-txreconciliation_tests.o test/test_dash-txvalidation_tests.o test/test_dash-txvalidationcache_tests.o test/test_dash-uint256_tests.o test/test_dash-util_tests.o test/test_dash-validation_block_tests.o test/test_dash-validation_chainstate_tests.o test/test_dash-validation_chainstatemanager_tests.o test/test_dash-validation_flush_tests.o test/test_dash-validationinterface_tests.o test/test_dash-versionbits_tests.o test/test_dash-xoroshiro128plusplus_tests.o       libtest_util.a  libbitcoin_node.a libbitcoin_cli.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/libbitcoin_crypto_base.la crypto/libbitcoin_crypto_sse41.la crypto/libbitcoin_crypto_x86_shani.la crypto/libbitcoin_crypto_avx2.la  libunivalue.la dashbls/libdashbls.la leveldb/libleveldb.la crc32c/libcrc32c.la crc32c/libcrc32c_sse42.la  leveldb/libmemenv.la -lbacktrace secp256k1/libsecp256k1.la -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent_pthreads -levent  minisketch/libminisketch.a minisketch/libminisketch_clmul.a  -lminiupnpc -lminiupnpc -lminiupnpc  -lnatpmp -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent_pthreads -levent  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent  -lgmp libbitcoin_zmq.a -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lzmq  
+2025-07-30T14:04:23.7723801Z libtool: link: /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2 -Wl,--exclude-libs -Wl,ALL -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,separate-code -pie -o test/test_dash test/test_dash-main.o test/test_dash-argsman_tests.o test/test_dash-arith_uint256_tests.o test/test_dash-addrman_tests.o test/test_dash-amount_tests.o test/test_dash-allocator_tests.o test/test_dash-banman_tests.o test/test_dash-base32_tests.o test/test_dash-base58_tests.o test/test_dash-base64_tests.o test/test_dash-bech32_tests.o test/test_dash-bip32_tests.o test/test_dash-bip324_tests.o test/test_dash-block_reward_reallocation_tests.o test/test_dash-blockchain_tests.o test/test_dash-blockencodings_tests.o test/test_dash-blockfilter_tests.o test/test_dash-blockfilter_index_tests.o test/test_dash-blockmanager_tests.o test/test_dash-bloom_tests.o test/test_dash-bls_tests.o test/test_dash-bswap_tests.o test/test_dash-checkdatasig_tests.o test/test_dash-checkqueue_tests.o test/test_dash-cachemap_tests.o test/test_dash-cachemultimap_tests.o test/test_dash-coins_tests.o test/test_dash-coinstatsindex_tests.o test/test_dash-compilerbug_tests.o test/test_dash-compress_tests.o test/test_dash-crypto_tests.o test/test_dash-cuckoocache_tests.o test/test_dash-denialofservice_tests.o test/test_dash-dip0020opcodes_tests.o test/test_dash-descriptor_tests.o test/test_dash-dynamic_activation_thresholds_tests.o test/test_dash-evo_assetlocks_tests.o test/test_dash-evo_deterministicmns_tests.o test/test_dash-evo_islock_tests.o test/test_dash-evo_mnhf_tests.o test/test_dash-evo_netinfo_tests.o test/test_dash-evo_simplifiedmns_tests.o test/test_dash-evo_trivialvalidation.o test/test_dash-evo_utils_tests.o test/test_dash-flatfile_tests.o test/test_dash-fs_tests.o test/test_dash-getarg_tests.o test/test_dash-governance_validators_tests.o test/test_dash-hash_tests.o test/test_dash-i2p_tests.o test/test_dash-interfaces_tests.o test/test_dash-key_io_tests.o test/test_dash-key_tests.o test/test_dash-limitedmap_tests.o test/test_dash-llmq_dkg_tests.o test/test_dash-llmq_chainlock_tests.o test/test_dash-llmq_commitment_tests.o test/test_dash-llmq_hash_tests.o test/test_dash-llmq_params_tests.o test/test_dash-llmq_snapshot_tests.o test/test_dash-llmq_utils_tests.o test/test_dash-logging_tests.o test/test_dash-dbwrapper_tests.o test/test_dash-validation_tests.o test/test_dash-mempool_tests.o test/test_dash-merkle_tests.o test/test_dash-merkleblock_tests.o test/test_dash-minisketch_tests.o test/test_dash-miner_tests.o test/test_dash-multisig_tests.o test/test_dash-net_peer_connection_tests.o test/test_dash-net_peer_eviction_tests.o test/test_dash-net_tests.o test/test_dash-netbase_tests.o test/test_dash-orphanage_tests.o test/test_dash-pmt_tests.o test/test_dash-policyestimator_tests.o test/test_dash-pool_tests.o test/test_dash-pow_tests.o test/test_dash-prevector_tests.o test/test_dash-raii_event_tests.o test/test_dash-random_tests.o test/test_dash-ratecheck_tests.o test/test_dash-reverselock_tests.o test/test_dash-rpc_tests.o test/test_dash-sanity_tests.o test/test_dash-scheduler_tests.o test/test_dash-script_p2sh_tests.o test/test_dash-script_p2pk_tests.o test/test_dash-script_p2pkh_tests.o test/test_dash-script_parse_tests.o test/test_dash-script_standard_tests.o test/test_dash-script_tests.o test/test_dash-scriptnum_tests.o test/test_dash-serfloat_tests.o test/test_dash-serialize_tests.o test/test_dash-settings_tests.o test/test_dash-sighash_tests.o test/test_dash-sigopcount_tests.o test/test_dash-skiplist_tests.o test/test_dash-sock_tests.o test/test_dash-streams_tests.o test/test_dash-subsidy_tests.o test/test_dash-sync_tests.o test/test_dash-system_tests.o test/test_dash-util_threadnames_tests.o test/test_dash-timedata_tests.o test/test_dash-torcontrol_tests.o test/test_dash-transaction_tests.o test/test_dash-txindex_tests.o test/test_dash-txpackage_tests.o test/test_dash-txreconciliation_tests.o test/test_dash-txvalidation_tests.o test/test_dash-txvalidationcache_tests.o test/test_dash-uint256_tests.o test/test_dash-util_tests.o test/test_dash-validation_block_tests.o test/test_dash-validation_chainstate_tests.o test/test_dash-validation_chainstatemanager_tests.o test/test_dash-validation_flush_tests.o test/test_dash-validationinterface_tests.o test/test_dash-versionbits_tests.o test/test_dash-xoroshiro128plusplus_tests.o  -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib libtest_util.a libbitcoin_node.a libbitcoin_cli.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/.libs/libbitcoin_crypto_base.a crypto/.libs/libbitcoin_crypto_sse41.a crypto/.libs/libbitcoin_crypto_x86_shani.a crypto/.libs/libbitcoin_crypto_avx2.a ./.libs/libunivalue.a dashbls/.libs/libdashbls.a leveldb/.libs/libleveldb.a crc32c/.libs/libcrc32c.a crc32c/.libs/libcrc32c_sse42.a leveldb/.libs/libmemenv.a -lbacktrace secp256k1/.libs/libsecp256k1.a -levent -levent_pthreads -levent minisketch/libminisketch.a minisketch/libminisketch_clmul.a -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp -levent_pthreads -levent -levent -lgmp libbitcoin_zmq.a -lzmq -pthread
+2025-07-30T14:04:25.0561543Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2   -Wl,--exclude-libs,ALL  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie     -pthread -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o bench/bench_dash  bench/bench_dash-addrman.o bench/bench_dash-bench_bitcoin.o bench/bench_dash-bench.o bench/bench_dash-bip324_ecdh.o bench/bench_dash-block_assemble.o bench/bench_dash-bls.o bench/bench_dash-bls_dkg.o bench/bench_dash-checkblock.o bench/bench_dash-checkqueue.o bench/bench_dash-data.o bench/bench_dash-duplicate_inputs.o bench/bench_dash-ecdsa.o bench/bench_dash-ellswift.o bench/bench_dash-examples.o bench/bench_dash-rollingbloom.o bench/bench_dash-chacha20.o bench/bench_dash-crypto_hash.o bench/bench_dash-ccoins_caching.o bench/bench_dash-gcs_filter.o bench/bench_dash-hashpadding.o bench/bench_dash-load_external.o bench/bench_dash-merkle_root.o bench/bench_dash-mempool_eviction.o bench/bench_dash-mempool_stress.o bench/bench_dash-nanobench.o bench/bench_dash-peer_eviction.o bench/bench_dash-pool.o bench/bench_dash-rpc_blockchain.o bench/bench_dash-rpc_mempool.o bench/bench_dash-strencodings.o bench/bench_dash-util_time.o bench/bench_dash-base58.o bench/bench_dash-bech32.o bench/bench_dash-lockedpool.o bench/bench_dash-poly1305.o bench/bench_dash-prevector.o bench/bench_dash-string_cast.o bench/bench_dash-verify_script.o   libtest_util.a libbitcoin_node.a  libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/libbitcoin_crypto_base.la crypto/libbitcoin_crypto_sse41.la crypto/libbitcoin_crypto_x86_shani.la crypto/libbitcoin_crypto_avx2.la  dashbls/libdashbls.la leveldb/libleveldb.la crc32c/libcrc32c.la crc32c/libcrc32c_sse42.la  leveldb/libmemenv.la secp256k1/libsecp256k1.la libunivalue.la -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent_pthreads -levent  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent  -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp -lgmp -lbacktrace libbitcoin_zmq.a -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lzmq   
+2025-07-30T14:04:25.3852682Z libtool: link: /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2 -Wl,--exclude-libs -Wl,ALL -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,separate-code -pie -o bench/bench_dash bench/bench_dash-addrman.o bench/bench_dash-bench_bitcoin.o bench/bench_dash-bench.o bench/bench_dash-bip324_ecdh.o bench/bench_dash-block_assemble.o bench/bench_dash-bls.o bench/bench_dash-bls_dkg.o bench/bench_dash-checkblock.o bench/bench_dash-checkqueue.o bench/bench_dash-data.o bench/bench_dash-duplicate_inputs.o bench/bench_dash-ecdsa.o bench/bench_dash-ellswift.o bench/bench_dash-examples.o bench/bench_dash-rollingbloom.o bench/bench_dash-chacha20.o bench/bench_dash-crypto_hash.o bench/bench_dash-ccoins_caching.o bench/bench_dash-gcs_filter.o bench/bench_dash-hashpadding.o bench/bench_dash-load_external.o bench/bench_dash-merkle_root.o bench/bench_dash-mempool_eviction.o bench/bench_dash-mempool_stress.o bench/bench_dash-nanobench.o bench/bench_dash-peer_eviction.o bench/bench_dash-pool.o bench/bench_dash-rpc_blockchain.o bench/bench_dash-rpc_mempool.o bench/bench_dash-strencodings.o bench/bench_dash-util_time.o bench/bench_dash-base58.o bench/bench_dash-bech32.o bench/bench_dash-lockedpool.o bench/bench_dash-poly1305.o bench/bench_dash-prevector.o bench/bench_dash-string_cast.o bench/bench_dash-verify_script.o  -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib libtest_util.a libbitcoin_node.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/.libs/libbitcoin_crypto_base.a crypto/.libs/libbitcoin_crypto_sse41.a crypto/.libs/libbitcoin_crypto_x86_shani.a crypto/.libs/libbitcoin_crypto_avx2.a dashbls/.libs/libdashbls.a leveldb/.libs/libleveldb.a crc32c/.libs/libcrc32c.a crc32c/.libs/libcrc32c_sse42.a leveldb/.libs/libmemenv.a secp256k1/.libs/libsecp256k1.a ./.libs/libunivalue.a -levent_pthreads -levent -levent -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp -lgmp -lbacktrace libbitcoin_zmq.a -lzmq -pthread
+2025-07-30T14:04:26.2917193Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/dash_qt-main.o `test -f 'qt/main.cpp' || echo './'`qt/main.cpp
+2025-07-30T14:04:29.4864559Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o init/qt_dash_qt-bitcoind.o `test -f 'init/bitcoind.cpp' || echo './'`init/bitcoind.cpp
+2025-07-30T14:04:29.8037931Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-appearancewidget.o `test -f 'qt/appearancewidget.cpp' || echo './'`qt/appearancewidget.cpp
+2025-07-30T14:04:33.6256849Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-bantablemodel.o `test -f 'qt/bantablemodel.cpp' || echo './'`qt/bantablemodel.cpp
+2025-07-30T14:04:37.4707564Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-bitcoin.o `test -f 'qt/bitcoin.cpp' || echo './'`qt/bitcoin.cpp
+2025-07-30T14:04:45.5526082Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-bitcoinaddressvalidator.o `test -f 'qt/bitcoinaddressvalidator.cpp' || echo './'`qt/bitcoinaddressvalidator.cpp
+2025-07-30T14:04:49.0773359Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-bitcoinamountfield.o `test -f 'qt/bitcoinamountfield.cpp' || echo './'`qt/bitcoinamountfield.cpp
+2025-07-30T14:04:52.8770189Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-bitcoingui.o `test -f 'qt/bitcoingui.cpp' || echo './'`qt/bitcoingui.cpp
+2025-07-30T14:05:00.2881184Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-bitcoinunits.o `test -f 'qt/bitcoinunits.cpp' || echo './'`qt/bitcoinunits.cpp
+2025-07-30T14:05:02.9452197Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-clientmodel.o `test -f 'qt/clientmodel.cpp' || echo './'`qt/clientmodel.cpp
+2025-07-30T14:05:09.6118794Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-csvmodelwriter.o `test -f 'qt/csvmodelwriter.cpp' || echo './'`qt/csvmodelwriter.cpp
+2025-07-30T14:05:11.6776658Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-guiutil.o `test -f 'qt/guiutil.cpp' || echo './'`qt/guiutil.cpp
+2025-07-30T14:05:20.2458915Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-initexecutor.o `test -f 'qt/initexecutor.cpp' || echo './'`qt/initexecutor.cpp
+2025-07-30T14:05:23.6230065Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-intro.o `test -f 'qt/intro.cpp' || echo './'`qt/intro.cpp
+2025-07-30T14:05:29.7292433Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-modaloverlay.o `test -f 'qt/modaloverlay.cpp' || echo './'`qt/modaloverlay.cpp
+2025-07-30T14:05:33.7116337Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-networkstyle.o `test -f 'qt/networkstyle.cpp' || echo './'`qt/networkstyle.cpp
+2025-07-30T14:05:37.5254436Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-notificator.o `test -f 'qt/notificator.cpp' || echo './'`qt/notificator.cpp
+2025-07-30T14:05:41.0743594Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-optionsdialog.o `test -f 'qt/optionsdialog.cpp' || echo './'`qt/optionsdialog.cpp
+2025-07-30T14:05:48.0808721Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-optionsmodel.o `test -f 'qt/optionsmodel.cpp' || echo './'`qt/optionsmodel.cpp
+2025-07-30T14:05:54.5493078Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-peertablemodel.o `test -f 'qt/peertablemodel.cpp' || echo './'`qt/peertablemodel.cpp
+2025-07-30T14:05:58.5445623Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-peertablesortproxy.o `test -f 'qt/peertablesortproxy.cpp' || echo './'`qt/peertablesortproxy.cpp
+2025-07-30T14:06:01.8128657Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-qvalidatedlineedit.o `test -f 'qt/qvalidatedlineedit.cpp' || echo './'`qt/qvalidatedlineedit.cpp
+2025-07-30T14:06:05.4270902Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-qvaluecombobox.o `test -f 'qt/qvaluecombobox.cpp' || echo './'`qt/qvaluecombobox.cpp
+2025-07-30T14:06:07.6580225Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-rpcconsole.o `test -f 'qt/rpcconsole.cpp' || echo './'`qt/rpcconsole.cpp
+2025-07-30T14:06:16.9137522Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-splashscreen.o `test -f 'qt/splashscreen.cpp' || echo './'`qt/splashscreen.cpp
+2025-07-30T14:06:21.3298637Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-trafficgraphdata.o `test -f 'qt/trafficgraphdata.cpp' || echo './'`qt/trafficgraphdata.cpp
+2025-07-30T14:06:22.6327516Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-trafficgraphwidget.o `test -f 'qt/trafficgraphwidget.cpp' || echo './'`qt/trafficgraphwidget.cpp
+2025-07-30T14:06:26.5457773Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-utilitydialog.o `test -f 'qt/utilitydialog.cpp' || echo './'`qt/utilitydialog.cpp
+2025-07-30T14:06:30.7841227Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_addressbookpage.o `test -f 'qt/moc_addressbookpage.cpp' || echo './'`qt/moc_addressbookpage.cpp
+2025-07-30T14:06:32.8397959Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_addresstablemodel.o `test -f 'qt/moc_addresstablemodel.cpp' || echo './'`qt/moc_addresstablemodel.cpp
+2025-07-30T14:06:34.9583574Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_appearancewidget.o `test -f 'qt/moc_appearancewidget.cpp' || echo './'`qt/moc_appearancewidget.cpp
+2025-07-30T14:06:38.4325146Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_askpassphrasedialog.o `test -f 'qt/moc_askpassphrasedialog.cpp' || echo './'`qt/moc_askpassphrasedialog.cpp
+2025-07-30T14:06:40.4961177Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_createwalletdialog.o `test -f 'qt/moc_createwalletdialog.cpp' || echo './'`qt/moc_createwalletdialog.cpp
+2025-07-30T14:06:42.5442599Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_bantablemodel.o `test -f 'qt/moc_bantablemodel.cpp' || echo './'`qt/moc_bantablemodel.cpp
+2025-07-30T14:06:45.6496038Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_bitcoin.o `test -f 'qt/moc_bitcoin.cpp' || echo './'`qt/moc_bitcoin.cpp
+2025-07-30T14:06:48.9105754Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_bitcoinaddressvalidator.o `test -f 'qt/moc_bitcoinaddressvalidator.cpp' || echo './'`qt/moc_bitcoinaddressvalidator.cpp
+2025-07-30T14:06:50.8878653Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_bitcoinamountfield.o `test -f 'qt/moc_bitcoinamountfield.cpp' || echo './'`qt/moc_bitcoinamountfield.cpp
+2025-07-30T14:06:53.0530822Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_bitcoingui.o `test -f 'qt/moc_bitcoingui.cpp' || echo './'`qt/moc_bitcoingui.cpp
+2025-07-30T14:06:55.3902578Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_bitcoinunits.o `test -f 'qt/moc_bitcoinunits.cpp' || echo './'`qt/moc_bitcoinunits.cpp
+2025-07-30T14:06:57.3596674Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_clientmodel.o `test -f 'qt/moc_clientmodel.cpp' || echo './'`qt/moc_clientmodel.cpp
+2025-07-30T14:07:00.4611401Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_coincontroldialog.o `test -f 'qt/moc_coincontroldialog.cpp' || echo './'`qt/moc_coincontroldialog.cpp
+2025-07-30T14:07:02.7772333Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_coincontroltreewidget.o `test -f 'qt/moc_coincontroltreewidget.cpp' || echo './'`qt/moc_coincontroltreewidget.cpp
+2025-07-30T14:07:05.0768589Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_csvmodelwriter.o `test -f 'qt/moc_csvmodelwriter.cpp' || echo './'`qt/moc_csvmodelwriter.cpp
+2025-07-30T14:07:06.9356232Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_editaddressdialog.o `test -f 'qt/moc_editaddressdialog.cpp' || echo './'`qt/moc_editaddressdialog.cpp
+2025-07-30T14:07:09.0007821Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_governancelist.o `test -f 'qt/moc_governancelist.cpp' || echo './'`qt/moc_governancelist.cpp
+2025-07-30T14:07:12.1343101Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_guiutil.o `test -f 'qt/moc_guiutil.cpp' || echo './'`qt/moc_guiutil.cpp
+2025-07-30T14:07:15.6559303Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_initexecutor.o `test -f 'qt/moc_initexecutor.cpp' || echo './'`qt/moc_initexecutor.cpp
+2025-07-30T14:07:18.7833315Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_intro.o `test -f 'qt/moc_intro.cpp' || echo './'`qt/moc_intro.cpp
+2025-07-30T14:07:21.0081912Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_macdockiconhandler.o `test -f 'qt/moc_macdockiconhandler.cpp' || echo './'`qt/moc_macdockiconhandler.cpp
+2025-07-30T14:07:22.8822886Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_macnotificationhandler.o `test -f 'qt/moc_macnotificationhandler.cpp' || echo './'`qt/moc_macnotificationhandler.cpp
+2025-07-30T14:07:24.7482910Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_modaloverlay.o `test -f 'qt/moc_modaloverlay.cpp' || echo './'`qt/moc_modaloverlay.cpp
+2025-07-30T14:07:26.9035687Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_masternodelist.o `test -f 'qt/moc_masternodelist.cpp' || echo './'`qt/moc_masternodelist.cpp
+2025-07-30T14:07:29.7480530Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_notificator.o `test -f 'qt/moc_notificator.cpp' || echo './'`qt/moc_notificator.cpp
+2025-07-30T14:07:31.7603435Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_openuridialog.o `test -f 'qt/moc_openuridialog.cpp' || echo './'`qt/moc_openuridialog.cpp
+2025-07-30T14:07:33.8372243Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_optionsdialog.o `test -f 'qt/moc_optionsdialog.cpp' || echo './'`qt/moc_optionsdialog.cpp
+2025-07-30T14:07:36.0188530Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_optionsmodel.o `test -f 'qt/moc_optionsmodel.cpp' || echo './'`qt/moc_optionsmodel.cpp
+2025-07-30T14:07:38.0120654Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_overviewpage.o `test -f 'qt/moc_overviewpage.cpp' || echo './'`qt/moc_overviewpage.cpp
+2025-07-30T14:07:41.1164855Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_peertablemodel.o `test -f 'qt/moc_peertablemodel.cpp' || echo './'`qt/moc_peertablemodel.cpp
+2025-07-30T14:07:44.2517280Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_peertablesortproxy.o `test -f 'qt/moc_peertablesortproxy.cpp' || echo './'`qt/moc_peertablesortproxy.cpp
+2025-07-30T14:07:46.2263435Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_paymentserver.o `test -f 'qt/moc_paymentserver.cpp' || echo './'`qt/moc_paymentserver.cpp
+2025-07-30T14:07:48.2178709Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_psbtoperationsdialog.o `test -f 'qt/moc_psbtoperationsdialog.cpp' || echo './'`qt/moc_psbtoperationsdialog.cpp
+2025-07-30T14:07:51.7029511Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_qrdialog.o `test -f 'qt/moc_qrdialog.cpp' || echo './'`qt/moc_qrdialog.cpp
+2025-07-30T14:07:54.6848068Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_qrimagewidget.o `test -f 'qt/moc_qrimagewidget.cpp' || echo './'`qt/moc_qrimagewidget.cpp
+2025-07-30T14:07:56.7206602Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_qvalidatedlineedit.o `test -f 'qt/moc_qvalidatedlineedit.cpp' || echo './'`qt/moc_qvalidatedlineedit.cpp
+2025-07-30T14:07:58.9830029Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_qvaluecombobox.o `test -f 'qt/moc_qvaluecombobox.cpp' || echo './'`qt/moc_qvaluecombobox.cpp
+2025-07-30T14:08:01.2321478Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_receivecoinsdialog.o `test -f 'qt/moc_receivecoinsdialog.cpp' || echo './'`qt/moc_receivecoinsdialog.cpp
+2025-07-30T14:08:04.7662521Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_receiverequestdialog.o `test -f 'qt/moc_receiverequestdialog.cpp' || echo './'`qt/moc_receiverequestdialog.cpp
+2025-07-30T14:08:06.9339699Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_recentrequeststablemodel.o `test -f 'qt/moc_recentrequeststablemodel.cpp' || echo './'`qt/moc_recentrequeststablemodel.cpp
+2025-07-30T14:08:08.9906172Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_rpcconsole.o `test -f 'qt/moc_rpcconsole.cpp' || echo './'`qt/moc_rpcconsole.cpp
+2025-07-30T14:08:12.6508690Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_sendcoinsdialog.o `test -f 'qt/moc_sendcoinsdialog.cpp' || echo './'`qt/moc_sendcoinsdialog.cpp
+2025-07-30T14:08:15.8193383Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_sendcoinsentry.o `test -f 'qt/moc_sendcoinsentry.cpp' || echo './'`qt/moc_sendcoinsentry.cpp
+2025-07-30T14:08:18.0246608Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_signverifymessagedialog.o `test -f 'qt/moc_signverifymessagedialog.cpp' || echo './'`qt/moc_signverifymessagedialog.cpp
+2025-07-30T14:08:20.0747534Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_splashscreen.o `test -f 'qt/moc_splashscreen.cpp' || echo './'`qt/moc_splashscreen.cpp
+2025-07-30T14:08:22.1201175Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_trafficgraphwidget.o `test -f 'qt/moc_trafficgraphwidget.cpp' || echo './'`qt/moc_trafficgraphwidget.cpp
+2025-07-30T14:08:24.2332029Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_transactiondesc.o `test -f 'qt/moc_transactiondesc.cpp' || echo './'`qt/moc_transactiondesc.cpp
+2025-07-30T14:08:26.2219645Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_transactiondescdialog.o `test -f 'qt/moc_transactiondescdialog.cpp' || echo './'`qt/moc_transactiondescdialog.cpp
+2025-07-30T14:08:28.3074695Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_transactionfilterproxy.o `test -f 'qt/moc_transactionfilterproxy.cpp' || echo './'`qt/moc_transactionfilterproxy.cpp
+2025-07-30T14:08:30.2912775Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_transactionoverviewwidget.o `test -f 'qt/moc_transactionoverviewwidget.cpp' || echo './'`qt/moc_transactionoverviewwidget.cpp
+2025-07-30T14:08:32.5400805Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_transactiontablemodel.o `test -f 'qt/moc_transactiontablemodel.cpp' || echo './'`qt/moc_transactiontablemodel.cpp
+2025-07-30T14:08:34.5043498Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_transactionview.o `test -f 'qt/moc_transactionview.cpp' || echo './'`qt/moc_transactionview.cpp
+2025-07-30T14:08:38.0650815Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_utilitydialog.o `test -f 'qt/moc_utilitydialog.cpp' || echo './'`qt/moc_utilitydialog.cpp
+2025-07-30T14:08:40.1744684Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_walletcontroller.o `test -f 'qt/moc_walletcontroller.cpp' || echo './'`qt/moc_walletcontroller.cpp
+2025-07-30T14:08:42.7621894Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_walletframe.o `test -f 'qt/moc_walletframe.cpp' || echo './'`qt/moc_walletframe.cpp
+2025-07-30T14:08:44.8938658Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_walletmodel.o `test -f 'qt/moc_walletmodel.cpp' || echo './'`qt/moc_walletmodel.cpp
+2025-07-30T14:08:47.7827040Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-moc_walletview.o `test -f 'qt/moc_walletview.cpp' || echo './'`qt/moc_walletview.cpp
+2025-07-30T14:08:50.8792573Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-qrc_bitcoin.o `test -f 'qt/qrc_bitcoin.cpp' || echo './'`qt/qrc_bitcoin.cpp
+2025-07-30T14:08:57.4201204Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER -DQT_NETWORK_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_WIDGETS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -DQT_GUI_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtGui -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -DQT_DBUS_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtDBus -DQT_CORE_LIB -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include  -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o qt/libbitcoinqt_a-qrc_dash_locale.o `test -f 'qt/qrc_dash_locale.cpp' || echo './'`qt/qrc_dash_locale.cpp
+2025-07-30T14:09:00.3038930Z rm -f qt/libbitcoinqt.a
+2025-07-30T14:09:00.3076987Z ar cr qt/libbitcoinqt.a qt/libbitcoinqt_a-appearancewidget.o qt/libbitcoinqt_a-bantablemodel.o qt/libbitcoinqt_a-bitcoin.o qt/libbitcoinqt_a-bitcoinaddressvalidator.o qt/libbitcoinqt_a-bitcoinamountfield.o qt/libbitcoinqt_a-bitcoingui.o qt/libbitcoinqt_a-bitcoinunits.o qt/libbitcoinqt_a-clientmodel.o qt/libbitcoinqt_a-csvmodelwriter.o qt/libbitcoinqt_a-guiutil.o qt/libbitcoinqt_a-initexecutor.o qt/libbitcoinqt_a-intro.o qt/libbitcoinqt_a-modaloverlay.o qt/libbitcoinqt_a-networkstyle.o qt/libbitcoinqt_a-notificator.o qt/libbitcoinqt_a-optionsdialog.o qt/libbitcoinqt_a-optionsmodel.o qt/libbitcoinqt_a-peertablemodel.o qt/libbitcoinqt_a-peertablesortproxy.o qt/libbitcoinqt_a-qvalidatedlineedit.o qt/libbitcoinqt_a-qvaluecombobox.o qt/libbitcoinqt_a-rpcconsole.o qt/libbitcoinqt_a-splashscreen.o qt/libbitcoinqt_a-trafficgraphdata.o qt/libbitcoinqt_a-trafficgraphwidget.o qt/libbitcoinqt_a-utilitydialog.o              qt/libbitcoinqt_a-moc_addressbookpage.o qt/libbitcoinqt_a-moc_addresstablemodel.o qt/libbitcoinqt_a-moc_appearancewidget.o qt/libbitcoinqt_a-moc_askpassphrasedialog.o qt/libbitcoinqt_a-moc_createwalletdialog.o qt/libbitcoinqt_a-moc_bantablemodel.o qt/libbitcoinqt_a-moc_bitcoin.o qt/libbitcoinqt_a-moc_bitcoinaddressvalidator.o qt/libbitcoinqt_a-moc_bitcoinamountfield.o qt/libbitcoinqt_a-moc_bitcoingui.o qt/libbitcoinqt_a-moc_bitcoinunits.o qt/libbitcoinqt_a-moc_clientmodel.o qt/libbitcoinqt_a-moc_coincontroldialog.o qt/libbitcoinqt_a-moc_coincontroltreewidget.o qt/libbitcoinqt_a-moc_csvmodelwriter.o qt/libbitcoinqt_a-moc_editaddressdialog.o qt/libbitcoinqt_a-moc_governancelist.o qt/libbitcoinqt_a-moc_guiutil.o qt/libbitcoinqt_a-moc_initexecutor.o qt/libbitcoinqt_a-moc_intro.o qt/libbitcoinqt_a-moc_macdockiconhandler.o qt/libbitcoinqt_a-moc_macnotificationhandler.o qt/libbitcoinqt_a-moc_modaloverlay.o qt/libbitcoinqt_a-moc_masternodelist.o qt/libbitcoinqt_a-moc_notificator.o qt/libbitcoinqt_a-moc_openuridialog.o qt/libbitcoinqt_a-moc_optionsdialog.o qt/libbitcoinqt_a-moc_optionsmodel.o qt/libbitcoinqt_a-moc_overviewpage.o qt/libbitcoinqt_a-moc_peertablemodel.o qt/libbitcoinqt_a-moc_peertablesortproxy.o qt/libbitcoinqt_a-moc_paymentserver.o qt/libbitcoinqt_a-moc_psbtoperationsdialog.o qt/libbitcoinqt_a-moc_qrdialog.o qt/libbitcoinqt_a-moc_qrimagewidget.o qt/libbitcoinqt_a-moc_qvalidatedlineedit.o qt/libbitcoinqt_a-moc_qvaluecombobox.o qt/libbitcoinqt_a-moc_receivecoinsdialog.o qt/libbitcoinqt_a-moc_receiverequestdialog.o qt/libbitcoinqt_a-moc_recentrequeststablemodel.o qt/libbitcoinqt_a-moc_rpcconsole.o qt/libbitcoinqt_a-moc_sendcoinsdialog.o qt/libbitcoinqt_a-moc_sendcoinsentry.o qt/libbitcoinqt_a-moc_signverifymessagedialog.o qt/libbitcoinqt_a-moc_splashscreen.o qt/libbitcoinqt_a-moc_trafficgraphwidget.o qt/libbitcoinqt_a-moc_transactiondesc.o qt/libbitcoinqt_a-moc_transactiondescdialog.o qt/libbitcoinqt_a-moc_transactionfilterproxy.o qt/libbitcoinqt_a-moc_transactionoverviewwidget.o qt/libbitcoinqt_a-moc_transactiontablemodel.o qt/libbitcoinqt_a-moc_transactionview.o qt/libbitcoinqt_a-moc_utilitydialog.o qt/libbitcoinqt_a-moc_walletcontroller.o qt/libbitcoinqt_a-moc_walletframe.o qt/libbitcoinqt_a-moc_walletmodel.o qt/libbitcoinqt_a-moc_walletview.o  qt/libbitcoinqt_a-qrc_bitcoin.o qt/libbitcoinqt_a-qrc_dash_locale.o 
+2025-07-30T14:09:00.3891883Z ranlib qt/libbitcoinqt.a
+2025-07-30T14:09:00.4839132Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps --tag CXX  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2   -Wl,--exclude-libs,ALL  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie      -pthread -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o qt/dash-qt qt/dash_qt-main.o  init/qt_dash_qt-bitcoind.o qt/libbitcoinqt.a libbitcoin_node.a  libbitcoin_zmq.a -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lzmq  libbitcoin_cli.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/libbitcoin_crypto_base.la crypto/libbitcoin_crypto_sse41.la crypto/libbitcoin_crypto_x86_shani.la crypto/libbitcoin_crypto_avx2.la  dashbls/libdashbls.la libunivalue.la leveldb/libleveldb.la crc32c/libcrc32c.la crc32c/libcrc32c_sse42.la  leveldb/libmemenv.la -lbacktrace -lqxcb -lqminimal -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5XcbQpa /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ServiceSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ThemeSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5FontDatabaseSupport.a -lfontconfig -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lfreetype /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5XkbCommonSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5EdidSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxcb-icccm -lxcb-image -lxcb-shm -lxcb-keysyms -lxcb-randr -lxcb-render-util -lxcb-render -lxcb-shape -lxcb-sync -lxcb-xfixes -lxcb-xinerama -lxcb-xkb -lxcb -lxkbcommon-x11 -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5InputSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DeviceDiscoverySupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5FbSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5EventDispatcherSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5AccessibilitySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Network /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Widgets /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/plugins/platforms -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lqrencode   -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp  secp256k1/libsecp256k1.la -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent_pthreads -levent  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent  -lgmp 
+2025-07-30T14:09:01.4776608Z libtool: link: /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2 -Wl,--exclude-libs -Wl,ALL -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,separate-code -pie -o qt/dash-qt qt/dash_qt-main.o init/qt_dash_qt-bitcoind.o  -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib qt/libbitcoinqt.a libbitcoin_node.a libbitcoin_zmq.a -lzmq libbitcoin_cli.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/.libs/libbitcoin_crypto_base.a crypto/.libs/libbitcoin_crypto_sse41.a crypto/.libs/libbitcoin_crypto_x86_shani.a crypto/.libs/libbitcoin_crypto_avx2.a dashbls/.libs/libdashbls.a ./.libs/libunivalue.a leveldb/.libs/libleveldb.a crc32c/.libs/libcrc32c.a crc32c/.libs/libcrc32c_sse42.a leveldb/.libs/libmemenv.a -lbacktrace -lqxcb -lqminimal -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5XcbQpa /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ServiceSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ThemeSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5FontDatabaseSupport.a -lfontconfig -lfreetype /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5XkbCommonSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5EdidSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxcb-icccm -lxcb-image -lxcb-shm -lxcb-keysyms -lxcb-randr -lxcb-render-util -lxcb-render -lxcb-shape -lxcb-sync -lxcb-xfixes -lxcb-xinerama -lxcb-xkb -lxcb -lxkbcommon-x11 -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5InputSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DeviceDiscoverySupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FbSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EventDispatcherSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5AccessibilitySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Network /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Widgets /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/plugins/platforms -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lqrencode -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp secp256k1/.libs/libsecp256k1.a -levent_pthreads -levent -levent -lgmp -pthread
+2025-07-30T14:09:03.5156381Z /bin/bash ../libtool  --tag=CXX --preserve-dup-deps  --mode=link /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2   -Wl,--exclude-libs,ALL  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie      -pthread -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib  -o qt/test/test_dash-qt init/qt_test_test_dash_qt-bitcoind.o qt/test/test_dash_qt-apptests.o qt/test/test_dash_qt-optiontests.o qt/test/test_dash_qt-rpcnestedtests.o qt/test/test_dash_qt-test_main.o qt/test/test_dash_qt-trafficgraphdatatests.o qt/test/test_dash_qt-uritests.o qt/test/test_dash_qt-util.o   qt/test/test_dash_qt-moc_apptests.o qt/test/test_dash_qt-moc_optiontests.o qt/test/test_dash_qt-moc_rpcnestedtests.o qt/test/test_dash_qt-moc_trafficgraphdatatests.o qt/test/test_dash_qt-moc_uritests.o  qt/libbitcoinqt.a libbitcoin_node.a libtest_util.a  libbitcoin_zmq.a -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lzmq  libbitcoin_cli.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/libbitcoin_crypto_base.la crypto/libbitcoin_crypto_sse41.la crypto/libbitcoin_crypto_x86_shani.la crypto/libbitcoin_crypto_avx2.la  dashbls/libdashbls.la libunivalue.la leveldb/libleveldb.la crc32c/libcrc32c.la crc32c/libcrc32c_sse42.la  leveldb/libmemenv.la -lbacktrace -lqxcb -lqminimal -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5XcbQpa /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ServiceSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ThemeSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5FontDatabaseSupport.a -lfontconfig -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lfreetype /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5XkbCommonSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5EdidSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxcb-icccm -lxcb-image -lxcb-shm -lxcb-keysyms -lxcb-randr -lxcb-render-util -lxcb-render -lxcb-shape -lxcb-sync -lxcb-xfixes -lxcb-xinerama -lxcb-xkb -lxcb -lxkbcommon-x11 -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5InputSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DeviceDiscoverySupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5FbSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5EventDispatcherSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5AccessibilitySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Network /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Widgets /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a   -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/plugins/platforms -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Test /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -lqrencode   -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp  secp256k1/libsecp256k1.la -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent_pthreads -levent  -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib -levent  -lgmp 
+2025-07-30T14:09:04.5307292Z libtool: link: /usr/bin/ccache g++-14 -std=c++20 -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2 -Wl,--exclude-libs -Wl,ALL -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,separate-code -pie -o qt/test/test_dash-qt init/qt_test_test_dash_qt-bitcoind.o qt/test/test_dash_qt-apptests.o qt/test/test_dash_qt-optiontests.o qt/test/test_dash_qt-rpcnestedtests.o qt/test/test_dash_qt-test_main.o qt/test/test_dash_qt-trafficgraphdatatests.o qt/test/test_dash_qt-uritests.o qt/test/test_dash_qt-util.o qt/test/test_dash_qt-moc_apptests.o qt/test/test_dash_qt-moc_optiontests.o qt/test/test_dash_qt-moc_rpcnestedtests.o qt/test/test_dash_qt-moc_trafficgraphdatatests.o qt/test/test_dash_qt-moc_uritests.o  -lpthread -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/lib qt/libbitcoinqt.a libbitcoin_node.a libtest_util.a libbitcoin_zmq.a -lzmq libbitcoin_cli.a libbitcoin_common.a libbitcoin_util.a libbitcoin_consensus.a crypto/.libs/libbitcoin_crypto_base.a crypto/.libs/libbitcoin_crypto_sse41.a crypto/.libs/libbitcoin_crypto_x86_shani.a crypto/.libs/libbitcoin_crypto_avx2.a dashbls/.libs/libdashbls.a ./.libs/libunivalue.a leveldb/.libs/libleveldb.a crc32c/.libs/libcrc32c.a crc32c/.libs/libcrc32c_sse42.a leveldb/.libs/libmemenv.a -lbacktrace -lqxcb -lqminimal -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5XcbQpa /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ServiceSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5ThemeSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5FontDatabaseSupport.a -lfontconfig -lfreetype /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5XkbCommonSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5EdidSupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxcb-icccm -lxcb-image -lxcb-shm -lxcb-keysyms -lxcb-randr -lxcb-render-util -lxcb-render -lxcb-shape -lxcb-sync -lxcb-xfixes -lxcb-xinerama -lxcb-xkb -lxcb -lxkbcommon-x11 -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5XkbCommonSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lxkbcommon -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ServiceSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5InputSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DeviceDiscoverySupport.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5ThemeSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5DBus.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FontDatabaseSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lfontconfig -lfreetype -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5FbSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EventDispatcherSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5EdidSupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5DeviceDiscoverySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5AccessibilitySupport /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Network /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Widgets /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Gui.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Gui /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtlibpng.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtharfbuzz.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -L/__w/dash/dash/depends/x86_64-pc-linux-gnu/plugins/platforms -lQt5DBus /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lQt5Test /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libQt5Core.a /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lpthread -lQt5Core -lpthread /__w/dash/dash/depends/x86_64-pc-linux-gnu/lib/libqtpcre2.a -lqrencode -lminiupnpc -lminiupnpc -lminiupnpc -lnatpmp secp256k1/.libs/libsecp256k1.a -levent_pthreads -levent -levent -lgmp -pthread
+2025-07-30T14:09:06.6278097Z /usr/bin/ccache g++-14 -std=c++20 -DHAVE_CONFIG_H -I. -I../src/config  -fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DHAVE_BUILD_INFO -DGSL_NO_IOSTREAMS -DPROVIDE_FUZZ_MAIN_FUNCTION -I. -I./minisketch/include -I./secp256k1/include -I./univalue/include -I./leveldb/include -isystem./dashbls/include -isystem./dashbls/depends/relic/include -isystem./dashbls/depends/minialloc/include -isystem./immer -isystem /__w/dash/dash/depends/x86_64-pc-linux-gnu/include -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/  -g1 -fno-omit-frame-pointer -fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_nowallet=. -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wreorder -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wno-array-bounds -Wno-stringop-overread -Wno-stringop-overflow -Wno-unused-parameter -Werror   -fno-extended-identifiers -fstack-reuse=none -fvisibility=hidden -fPIE -pipe -std=c++20 -O2  -c -o test/fuzz/util/libtest_fuzz_a-net.o `test -f 'test/fuzz/util/net.cpp' || echo './'`test/fuzz/util/net.cpp
+2025-07-30T14:09:08.4439500Z test/fuzz/util/net.cpp: In function ‘CNetAddr ConsumeNetAddr(FuzzedDataProvider&, FastRandomContext*)’:
+2025-07-30T14:09:08.4440708Z test/fuzz/util/net.cpp:55:32: error: ‘PROTOCOL_VERSION’ was not declared in this scope
+2025-07-30T14:09:08.4441310Z    55 |     CDataStream s(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
+2025-07-30T14:09:08.4441957Z       |                                ^~~~~~~~~~~~~~~~
+2025-07-30T14:09:08.4454156Z make[2]: *** [Makefile:13257: test/fuzz/util/libtest_fuzz_a-net.o] Error 1
+2025-07-30T14:09:08.4455670Z make[2]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T14:09:08.4464113Z make[1]: *** [Makefile:20633: install-recursive] Error 1
+2025-07-30T14:09:08.4464737Z make[1]: Leaving directory '/__w/dash/dash/build-ci/dashcore-linux64_nowallet/src'
+2025-07-30T14:09:08.4472242Z make: *** [Makefile:788: install-recursive] Error 1
+2025-07-30T14:09:08.4592625Z ##[error]Process completed with exit code 2.
+2025-07-30T14:09:08.4677379Z Post job cleanup.
+2025-07-30T14:09:08.4681348Z ##[command]/usr/bin/docker exec  a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5 sh -c "cat /etc/*release | grep ^ID"
+2025-07-30T14:09:08.6956804Z [command]/usr/bin/git version
+2025-07-30T14:09:08.7016597Z git version 2.43.0
+2025-07-30T14:09:08.7068896Z Copying '/github/home/.gitconfig' to '/__w/_temp/08fa9101-12f9-4199-86d0-a48b5bae034d/.gitconfig'
+2025-07-30T14:09:08.7083633Z Temporarily overriding HOME='/__w/_temp/08fa9101-12f9-4199-86d0-a48b5bae034d' before making global git config changes
+2025-07-30T14:09:08.7084599Z Adding repository directory to the temporary git global config as a safe directory
+2025-07-30T14:09:08.7091219Z [command]/usr/bin/git config --global --add safe.directory /__w/dash/dash
+2025-07-30T14:09:08.7138678Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-07-30T14:09:08.7191022Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-07-30T14:09:08.7431573Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-07-30T14:09:08.7458536Z http.https://github.com/.extraheader
+2025-07-30T14:09:08.7471725Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-07-30T14:09:08.7505412Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-07-30T14:09:08.7860556Z Stop and remove container: 4666d9babae14c91ae729dba7059fae0_ghcriodashcoreautoguixdashdashcorecirunnerbackport027batch556pr26859_20564f
+2025-07-30T14:09:08.7865958Z ##[command]/usr/bin/docker rm --force a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5
+2025-07-30T14:09:09.2531939Z a7572a0f09510ce5bd043439434a17a3dc717b28325380bb48efde15762213f5
+2025-07-30T14:09:09.2565053Z Remove container network: github_network_9ade282e830c415fb855ca0a07641eca
+2025-07-30T14:09:09.2569753Z ##[command]/usr/bin/docker network rm github_network_9ade282e830c415fb855ca0a07641eca
+2025-07-30T14:09:09.3574859Z github_network_9ade282e830c415fb855ca0a07641eca
+2025-07-30T14:09:09.3637101Z Evaluate and set job outputs
+2025-07-30T14:09:09.3643536Z Cleaning up orphan processes

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -267,6 +267,18 @@ public:
         }
     }
 
+    /**
+     * BIP155 network ids recognized by this software.
+     */
+    enum BIP155Network : uint8_t {
+        IPV4 = 1,
+        IPV6 = 2,
+        TORV2 = 3,
+        TORV3 = 4,
+        I2P = 5,
+        CJDNS = 6,
+    };
+
     friend class CSubNet;
 
 private:
@@ -287,18 +299,6 @@ private:
      * @see CNetAddr::IsI2P()
      */
     bool SetI2P(const std::string& addr);
-
-    /**
-     * BIP155 network ids recognized by this software.
-     */
-    enum BIP155Network : uint8_t {
-        IPV4 = 1,
-        IPV6 = 2,
-        TORV2 = 3,
-        TORV3 = 4,
-        I2P = 5,
-        CJDNS = 6,
-    };
 
     /**
      * Size of CNetAddr when serialized as ADDRv1 (pre-BIP155) (in bytes).

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -63,26 +63,13 @@ FUZZ_TARGET(data_stream_addr_man, .init = initialize_addrman)
 CNetAddr RandAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext& fast_random_context)
 {
     CNetAddr addr;
-    if (fuzzed_data_provider.remaining_bytes() > 1 && fuzzed_data_provider.ConsumeBool()) {
-        addr = ConsumeNetAddr(fuzzed_data_provider);
-    } else {
-        // The networks [1..6] correspond to CNetAddr::BIP155Network (private).
-        static const std::map<uint8_t, uint8_t> net_len_map = {{1, ADDR_IPV4_SIZE},
-                                                               {2, ADDR_IPV6_SIZE},
-                                                               {4, ADDR_TORV3_SIZE},
-                                                               {5, ADDR_I2P_SIZE},
-                                                               {6, ADDR_CJDNS_SIZE}};
-        uint8_t net = fast_random_context.randrange(5) + 1; // [1..5]
-        if (net == 3) {
-            net = 6;
+    assert(!addr.IsValid());
+    for (size_t i = 0; i < 8 && !addr.IsValid(); ++i) {
+        if (fuzzed_data_provider.remaining_bytes() > 1 && fuzzed_data_provider.ConsumeBool()) {
+            addr = ConsumeNetAddr(fuzzed_data_provider);
+        } else {
+            addr = ConsumeNetAddr(fuzzed_data_provider, &fast_random_context);
         }
-
-        CDataStream s(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
-
-        s << net;
-        s << fast_random_context.randbytes(net_len_map.at(net));
-
-        s >> addr;
     }
 
     // Return a dummy IPv4 5.5.5.5 if we generated an invalid address.

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -63,17 +63,30 @@ FUZZ_TARGET(banman, .init = initialize_banman)
         // The complexity is O(N^2), where N is the input size, because each call
         // might call DumpBanlist (or other methods that are at least linear
         // complexity of the input size).
+        bool contains_invalid{false};
         LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 300)
         {
             CallOneOf(
                 fuzzed_data_provider,
                 [&] {
-                    ban_man.Ban(ConsumeNetAddr(fuzzed_data_provider),
-                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                    CNetAddr net_addr{ConsumeNetAddr(fuzzed_data_provider)};
+                    if (!net_addr.IsCJDNS() || !net_addr.IsValid()) {
+                        const std::optional<CNetAddr>& addr{LookupHost(net_addr.ToStringAddr(), /*fAllowLookup=*/false)};
+                        if (addr.has_value() && addr->IsValid()) {
+                            net_addr = *addr;
+                        } else {
+                            contains_invalid = true;
+                        }
+                    }
+                    ban_man.Ban(net_addr, ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },
                 [&] {
-                    ban_man.Ban(ConsumeSubNet(fuzzed_data_provider),
-                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                    CSubNet subnet{ConsumeSubNet(fuzzed_data_provider)};
+                    subnet = LookupSubNet(subnet.ToString());
+                    if (!subnet.IsValid()) {
+                        contains_invalid = true;
+                    }
+                    ban_man.Ban(subnet, ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },
                 [&] {
                     ban_man.ClearBanned();
@@ -109,7 +122,9 @@ FUZZ_TARGET(banman, .init = initialize_banman)
             BanMan ban_man_read{banlist_file, /*client_interface=*/nullptr, /*default_ban_time=*/0};
             banmap_t banmap_read;
             ban_man_read.GetBanned(banmap_read);
-            assert(banmap == banmap_read);
+            if (!contains_invalid) {
+                assert(banmap == banmap_read);
+            }
         }
     }
     fs::remove(fs::PathToString(banlist_file + ".json"));

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -26,6 +26,12 @@ FUZZ_TARGET(netaddress)
     if (net_addr.GetNetwork() == Network::NET_ONION) {
         assert(net_addr.IsTor());
     }
+    if (net_addr.GetNetwork() == Network::NET_I2P) {
+        assert(net_addr.IsI2P());
+    }
+    if (net_addr.GetNetwork() == Network::NET_CJDNS) {
+        assert(net_addr.IsCJDNS());
+    }
     if (net_addr.GetNetwork() == Network::NET_INTERNAL) {
         assert(net_addr.IsInternal());
     }
@@ -68,6 +74,12 @@ FUZZ_TARGET(netaddress)
     }
     if (net_addr.IsTor()) {
         assert(net_addr.GetNetwork() == Network::NET_ONION);
+    }
+    if (net_addr.IsI2P()) {
+        assert(net_addr.GetNetwork() == Network::NET_I2P);
+    }
+    if (net_addr.IsCJDNS()) {
+        assert(net_addr.GetNetwork() == Network::NET_CJDNS);
     }
     (void)net_addr.IsValid();
     (void)net_addr.ToStringAddr();

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -2,11 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <test/fuzz/util/net.h>
+
 #include <compat/compat.h>
 #include <netaddress.h>
+#include <protocol.h>
 #include <random.h>
+#include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/util/net.h>
 #include <util/strencodings.h>
 
 #include <cstdint>
@@ -49,7 +52,7 @@ CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomCont
         return addr;
     }
 
-    DataStream s;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
 
     s << static_cast<uint8_t>(aux.bip155);
 
@@ -68,7 +71,7 @@ CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomCont
     }
     s << addr_bytes;
 
-    s >> CAddress::V2_NETWORK(addr);
+    s >> addr;
 
     return addr;
 }

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -11,6 +11,7 @@
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <util/strencodings.h>
+#include <version.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -4,37 +4,71 @@
 
 #include <compat/compat.h>
 #include <netaddress.h>
+#include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/util/net.h>
 #include <util/strencodings.h>
 
 #include <cstdint>
 #include <vector>
 
-CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
+class CNode;
+
+CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext* rand) noexcept
 {
-    const Network network = fuzzed_data_provider.PickValueInArray({Network::NET_IPV4, Network::NET_IPV6, Network::NET_INTERNAL, Network::NET_ONION});
-    CNetAddr net_addr;
-    if (network == Network::NET_IPV4) {
-        in_addr v4_addr = {};
-        v4_addr.s_addr = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
-        net_addr = CNetAddr{v4_addr};
-    } else if (network == Network::NET_IPV6) {
-        if (fuzzed_data_provider.remaining_bytes() >= 16) {
-            in6_addr v6_addr = {};
-            auto addr_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(16);
-            if (addr_bytes[0] == CJDNS_PREFIX) { // Avoid generating IPv6 addresses that look like CJDNS.
-                addr_bytes[0] = 0x55; // Just an arbitrary number, anything != CJDNS_PREFIX would do.
-            }
-            memcpy(v6_addr.s6_addr, addr_bytes.data(), 16);
-            net_addr = CNetAddr{v6_addr, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+    struct NetAux {
+        Network net;
+        CNetAddr::BIP155Network bip155;
+        size_t len;
+    };
+
+    static constexpr std::array<NetAux, 6> nets{
+        NetAux{.net = Network::NET_IPV4, .bip155 = CNetAddr::BIP155Network::IPV4, .len = ADDR_IPV4_SIZE},
+        NetAux{.net = Network::NET_IPV6, .bip155 = CNetAddr::BIP155Network::IPV6, .len = ADDR_IPV6_SIZE},
+        NetAux{.net = Network::NET_ONION, .bip155 = CNetAddr::BIP155Network::TORV3, .len = ADDR_TORV3_SIZE},
+        NetAux{.net = Network::NET_I2P, .bip155 = CNetAddr::BIP155Network::I2P, .len = ADDR_I2P_SIZE},
+        NetAux{.net = Network::NET_CJDNS, .bip155 = CNetAddr::BIP155Network::CJDNS, .len = ADDR_CJDNS_SIZE},
+        NetAux{.net = Network::NET_INTERNAL, .bip155 = CNetAddr::BIP155Network{0}, .len = 0},
+    };
+
+    const size_t nets_index{rand == nullptr
+        ? fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, nets.size() - 1)
+        : static_cast<size_t>(rand->randrange(nets.size()))};
+
+    const auto& aux = nets[nets_index];
+
+    CNetAddr addr;
+
+    if (aux.net == Network::NET_INTERNAL) {
+        if (rand == nullptr) {
+            addr.SetInternal(fuzzed_data_provider.ConsumeBytesAsString(32));
+        } else {
+            const auto v = rand->randbytes(32);
+            addr.SetInternal(std::string{v.begin(), v.end()});
         }
-    } else if (network == Network::NET_INTERNAL) {
-        net_addr.SetInternal(fuzzed_data_provider.ConsumeBytesAsString(32));
-    } else if (network == Network::NET_ONION) {
-        auto pub_key{fuzzed_data_provider.ConsumeBytes<uint8_t>(ADDR_TORV3_SIZE)};
-        pub_key.resize(ADDR_TORV3_SIZE);
-        const bool ok{net_addr.SetSpecial(OnionToString(pub_key))};
-        assert(ok);
+        return addr;
     }
-    return net_addr;
+
+    DataStream s;
+
+    s << static_cast<uint8_t>(aux.bip155);
+
+    std::vector<uint8_t> addr_bytes;
+    if (rand == nullptr) {
+        addr_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(aux.len);
+        addr_bytes.resize(aux.len);
+    } else {
+        addr_bytes = rand->randbytes(aux.len);
+    }
+    if (aux.net == NET_IPV6 && addr_bytes[0] == CJDNS_PREFIX) { // Avoid generating IPv6 addresses that look like CJDNS.
+        addr_bytes[0] = 0x55; // Just an arbitrary number, anything != CJDNS_PREFIX would do.
+    }
+    if (aux.net == NET_CJDNS) { // Avoid generating CJDNS addresses that don't start with CJDNS_PREFIX because those are !IsValid().
+        addr_bytes[0] = CJDNS_PREFIX;
+    }
+    s << addr_bytes;
+
+    s >> CAddress::V2_NETWORK(addr);
+
+    return addr;
 }

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -8,7 +8,16 @@
 #include <netaddress.h>
 
 class FuzzedDataProvider;
+class FastRandomContext;
 
-CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept;
+/**
+ * Create a CNetAddr. It may have `addr.IsValid() == false`.
+ * @param[in,out] fuzzed_data_provider Take data for the address from this, if `rand` is `nullptr`.
+ * @param[in,out] rand If not nullptr, take data from it instead of from `fuzzed_data_provider`.
+ * Prefer generating addresses using `fuzzed_data_provider` because it is not uniform. Only use
+ * `rand` if `fuzzed_data_provider` is exhausted or its data is needed for other things.
+ * @return a "random" network address.
+ */
+CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext* rand = nullptr) noexcept;
 
 #endif // BITCOIN_TEST_FUZZ_UTIL_NET_H


### PR DESCRIPTION
Backports bitcoin/bitcoin#26859

Original commit: aa9231fafe45513134ec8953a217cda07446fae8

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded fuzz testing to support additional network address types, including I2P and CJDNS.

* **Bug Fixes**
  * Improved handling of invalid addresses and subnets during fuzz testing to prevent false assertion failures.

* **Refactor**
  * Simplified and unified the logic for generating random network addresses in tests.
  * Updated function signatures to support enhanced random address generation using an optional random context.
  * Made network ID enumeration publicly accessible for broader use in network address handling.

* **Tests**
  * Added assertions to verify correct behavior for I2P and CJDNS network addresses in fuzz tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->