### PR TITLE
Merge bitcoin-core/gui#658: Intro: Never change the prune checkbox after the user has touched it

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -143,8 +143,9 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
 
     const int min_prune_target_GB = std::ceil(MIN_DISK_SPACE_FOR_BLOCK_FILES / 1e9);
     ui->pruneGB->setRange(min_prune_target_GB, std::numeric_limits<int>::max());
-    if (gArgs.GetIntArg("-prune", 0) > 1) { // -prune=1 means enabled, above that it's a size in MiB
-        ui->prune->setChecked(true);
+    if (gArgs.IsArgSet("-prune")) {
+        m_prune_checkbox_is_default = false;
+        ui->prune->setChecked(gArgs.GetIntArg("-prune", 0) >= 1);
         ui->prune->setEnabled(false);
     }
     ui->pruneGB->setValue(m_prune_target_gb);
@@ -153,6 +154,7 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     UpdatePruneLabels(ui->prune->isChecked());
 
     connect(ui->prune, &QCheckBox::toggled, [this](bool prune_checked) {
+        m_prune_checkbox_is_default = false;
         UpdatePruneLabels(prune_checked);
         UpdateFreeSpaceLabel();
     });
@@ -293,7 +295,7 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
         ui->freeSpace->setText("");
     } else {
         m_bytes_available = bytesAvailable;
-        if (ui->prune->isEnabled() && !(gArgs.IsArgSet("-prune") && gArgs.GetIntArg("-prune", 0) == 0)) {
+        if (ui->prune->isEnabled() && m_prune_checkbox_is_default) {
             ui->prune->setChecked(m_bytes_available < (m_blockchain_size_gb + m_chain_state_size_gb + 10) * GB_BYTES);
         }
         UpdateFreeSpaceLabel();

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -64,6 +64,7 @@ private Q_SLOTS:
 
 private:
     Ui::Intro *ui;
+    bool m_prune_checkbox_is_default{true};
     QThread *thread;
     QMutex mutex;
     bool signalled;


### PR DESCRIPTION
Backports bitcoin-core/gui#658

Original commit: 2afbacc4b17871e46ad8e412d4908f7154b11f17

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of the prune checkbox to better respect user choices. The checkbox state now remains unchanged after user interaction, even when free space updates occur.

* **Bug Fixes**
  * Prevented automatic resetting of the prune checkbox when the user has manually changed its state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->