### PR TITLE
Merge bitcoin/bitcoin#29489: test: Remove Windows-specific code from `system_tests/run_command`

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -15,10 +15,10 @@ testing compared to other parts of the codebase. If you want to keep the work tr
 system in a virtual machine with a Linux operating system of your choice.
 
 To allow for a wide range of tested environments, but also ensure reproducibility to some extent, the test stage
-requires `docker` to be installed. To install all requirements on Ubuntu, run
+requires `bash`, `docker`, and `python3` to be installed. To run on architectures different from the host, `qemu` is also required. To install all requirements on Ubuntu, run
 
-```
-sudo apt install docker.io bash
+```bash
+sudo apt install bash docker.io python3 qemu-user-static
 ```
 
 To run the default test stage,

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -30,11 +30,7 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(result.isNull());
     }
     {
-#ifdef WIN32
-        const UniValue result = RunCommandParseJSON("cmd.exe /c echo {\"success\": true}");
-#else
         const UniValue result = RunCommandParseJSON("echo \"{\"success\": true}\"");
-#endif
         BOOST_CHECK(result.isObject());
         const UniValue& success = result.find_value("success");
         BOOST_CHECK(!success.isNull());
@@ -42,6 +38,10 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // An invalid command is handled by Boost
+<<<<<<< HEAD
+=======
+        const int expected_error{2};
+>>>>>>> dfbad09c60 (Merge bitcoin/bitcoin#29489: test: Remove Windows-specific code from `system_tests/run_command`)
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON("invalid_command"), boost::process::process_error, [&](const boost::process::process_error& e) {
             BOOST_CHECK(std::string(e.what()).find("RunCommandParseJSON error:") == std::string::npos);
             BOOST_CHECK_EQUAL(e.code().value(), 2);
@@ -50,11 +50,13 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Return non-zero exit code, no output to stderr
+<<<<<<< HEAD
 #ifdef WIN32
         const std::string command{"cmd.exe /c call"};
 #else
+=======
+>>>>>>> dfbad09c60 (Merge bitcoin/bitcoin#29489: test: Remove Windows-specific code from `system_tests/run_command`)
         const std::string command{"false"};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {
             BOOST_CHECK(std::string(e.what()).find(strprintf("RunCommandParseJSON error: process(%s) returned 1: \n", command)) != std::string::npos);
             return true;
@@ -62,13 +64,15 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Return non-zero exit code, with error message for stderr
+<<<<<<< HEAD
 #ifdef WIN32
         const std::string command{"cmd.exe /c dir nosuchfile"};
         const std::string expected{"File Not Found"};
 #else
+=======
+>>>>>>> dfbad09c60 (Merge bitcoin/bitcoin#29489: test: Remove Windows-specific code from `system_tests/run_command`)
         const std::string command{"ls nosuchfile"};
         const std::string expected{"No such file or directory"};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {
             const std::string what(e.what());
             BOOST_CHECK(what.find(strprintf("RunCommandParseJSON error: process(%s) returned", command)) != std::string::npos);
@@ -78,15 +82,10 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Unable to parse JSON
-#ifdef WIN32
-        const std::string command{"cmd.exe /c echo {"};
-#else
         const std::string command{"echo {"};
-#endif
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, HasReason("Unable to parse JSON: {"));
     }
-    // Test std::in, except for Windows
-#ifndef WIN32
+    // Test std::in
     {
         const UniValue result = RunCommandParseJSON("cat", "{\"success\": true}");
         BOOST_CHECK(result.isObject());
@@ -94,7 +93,6 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(!success.isNull());
         BOOST_CHECK_EQUAL(success.getBool(), true);
     }
-#endif
 }
 #endif // HAVE_BOOST_PROCESS
 

--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -38,24 +38,15 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // An invalid command is handled by Boost
-<<<<<<< HEAD
-=======
         const int expected_error{2};
->>>>>>> dfbad09c60 (Merge bitcoin/bitcoin#29489: test: Remove Windows-specific code from `system_tests/run_command`)
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON("invalid_command"), boost::process::process_error, [&](const boost::process::process_error& e) {
             BOOST_CHECK(std::string(e.what()).find("RunCommandParseJSON error:") == std::string::npos);
-            BOOST_CHECK_EQUAL(e.code().value(), 2);
+            BOOST_CHECK_EQUAL(e.code().value(), expected_error);
             return true;
         });
     }
     {
         // Return non-zero exit code, no output to stderr
-<<<<<<< HEAD
-#ifdef WIN32
-        const std::string command{"cmd.exe /c call"};
-#else
-=======
->>>>>>> dfbad09c60 (Merge bitcoin/bitcoin#29489: test: Remove Windows-specific code from `system_tests/run_command`)
         const std::string command{"false"};
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {
             BOOST_CHECK(std::string(e.what()).find(strprintf("RunCommandParseJSON error: process(%s) returned 1: \n", command)) != std::string::npos);
@@ -64,13 +55,6 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
         // Return non-zero exit code, with error message for stderr
-<<<<<<< HEAD
-#ifdef WIN32
-        const std::string command{"cmd.exe /c dir nosuchfile"};
-        const std::string expected{"File Not Found"};
-#else
-=======
->>>>>>> dfbad09c60 (Merge bitcoin/bitcoin#29489: test: Remove Windows-specific code from `system_tests/run_command`)
         const std::string command{"ls nosuchfile"};
         const std::string expected{"No such file or directory"};
         BOOST_CHECK_EXCEPTION(RunCommandParseJSON(command), std::runtime_error, [&](const std::runtime_error& e) {


### PR DESCRIPTION
Backports bitcoin/bitcoin#29489

Original commit: dfbad09c60

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI documentation to clarify prerequisites, including requirements for bash, docker, python3, and qemu for cross-architecture testing. Expanded example installation commands.

* **Tests**
  * Simplified system test cases by removing Windows-specific logic and standardizing commands for Unix-like platforms. Improved consistency in error handling within tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->