### PR TITLE
Merge bitcoin/bitcoin#29412: p2p: Don't process mutated blocks

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4932,6 +4932,16 @@ void PeerManagerImpl::ProcessMessage(
 
         LogPrint(BCLog::NET, "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom.GetId());
 
+        const CBlockIndex* prev_block{WITH_LOCK(cs_main, return LookupBlockIndex(pblock->hashPrevBlock))};
+
+        if (IsBlockMutated(/*block=*/*pblock,
+                           /*check_witness_root=*/false)) { // Always false for Dash - no witness support
+            LogDebug(BCLog::NET, "Received mutated block from peer=%d\n", pfrom.GetId());
+            Misbehaving(pfrom, 100, "mutated block");
+            WITH_LOCK(cs_main, RemoveBlockRequest(pblock->GetHash()));
+            return;
+        }
+
         bool forceProcessing = false;
         const uint256 hash(pblock->GetHash());
         {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -189,8 +189,9 @@ public:
     // network and disk
     std::vector<CTransactionRef> vtx;
 
-    // memory only
-    mutable bool fChecked;
+    // Memory-only flags for caching expensive checks
+    mutable bool fChecked;                            // CheckBlock()
+    mutable bool m_checked_merkle_root{false};        // CheckMerkleRoot()
 
     CBlock()
     {
@@ -214,6 +215,7 @@ public:
         CBlockHeader::SetNull();
         vtx.clear();
         fChecked = false;
+        m_checked_merkle_root = false;
     }
 
     CBlockHeader GetBlockHeader() const

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -36,4 +36,87 @@ BOOST_AUTO_TEST_CASE(test_assumeutxo)
     BOOST_CHECK_EQUAL(out210.nChainTx, 200U);
 }
 
+BOOST_AUTO_TEST_CASE(block_malleation)
+{
+    // Test utility that calls `IsBlockMutated` and then clears the validity
+    // cache flags on `CBlock`.
+    auto is_mutated = [](CBlock& block, bool check_witness_root) {
+        bool mutated{IsBlockMutated(block, check_witness_root)};
+        block.fChecked = false;
+        block.m_checked_merkle_root = false;
+        return mutated;
+    };
+    auto is_not_mutated = [&is_mutated](CBlock& block, bool check_witness_root) {
+        return !is_mutated(block, check_witness_root);
+    };
+
+    // Test utility to create coinbase transactions
+    auto create_coinbase_tx = []() {
+        CMutableTransaction coinbase;
+        coinbase.vin.resize(1);
+        coinbase.vout.resize(1);
+        coinbase.vout[0].scriptPubKey.resize(4);
+        auto tx = MakeTransactionRef(coinbase);
+        assert(tx->IsCoinBase());
+        return tx;
+    };
+
+    {
+        CBlock block;
+
+        // Empty block is expected to have merkle root of 0x0.
+        BOOST_CHECK(block.vtx.empty());
+        block.hashMerkleRoot = uint256{1};
+        BOOST_CHECK(is_mutated(block, /*check_witness_root=*/false));
+        block.hashMerkleRoot = uint256{};
+        BOOST_CHECK(is_not_mutated(block, /*check_witness_root=*/false));
+
+        // Block with a single coinbase tx is mutated if the merkle root is not
+        // equal to the coinbase tx's hash.
+        block.vtx.push_back(create_coinbase_tx());
+        BOOST_CHECK(block.vtx[0]->GetHash() != block.hashMerkleRoot);
+        BOOST_CHECK(is_mutated(block, /*check_witness_root=*/false));
+        block.hashMerkleRoot = block.vtx[0]->GetHash();
+        BOOST_CHECK(is_not_mutated(block, /*check_witness_root=*/false));
+
+        // Block with two transactions is mutated if the merkle root does not
+        // match the double sha256 of the concatenation of the two transaction
+        // hashes.
+        block.vtx.push_back(MakeTransactionRef(CMutableTransaction{}));
+        BOOST_CHECK(is_mutated(block, /*check_witness_root=*/false));
+        HashWriter hasher;
+        hasher.write(block.vtx[0]->GetHash());
+        hasher.write(block.vtx[1]->GetHash());
+        block.hashMerkleRoot = hasher.GetHash();
+        BOOST_CHECK(is_not_mutated(block, /*check_witness_root=*/false));
+
+        // Block with two transactions is mutated if any node is duplicate.
+        {
+            block.vtx[1] = block.vtx[0];
+            BOOST_CHECK(is_mutated(block, /*check_witness_root=*/false));
+            HashWriter hasher;
+            hasher.write(block.vtx[0]->GetHash());
+            hasher.write(block.vtx[1]->GetHash());
+            block.hashMerkleRoot = hasher.GetHash();
+            BOOST_CHECK(is_mutated(block, /*check_witness_root=*/false));
+        }
+
+        // Blocks with 64-byte coinbase transactions are not considered mutated
+        block.vtx.clear();
+        {
+            CMutableTransaction mtx;
+            mtx.vin.resize(1);
+            mtx.vout.resize(1);
+            mtx.vout[0].scriptPubKey.resize(4);
+            block.vtx.push_back(MakeTransactionRef(mtx));
+            block.hashMerkleRoot = block.vtx.back()->GetHash();
+            assert(block.vtx.back()->IsCoinBase());
+            assert(GetSerializeSize(*block.vtx.back(), PROTOCOL_VERSION) == 64);
+        }
+        BOOST_CHECK(is_not_mutated(block, /*check_witness_root=*/false));
+    }
+
+    // Note: Witness-related tests are omitted as Dash doesn't support witness transactions
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3934,6 +3934,45 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     return true;
 }
 
+bool IsBlockMutated(const CBlock& block, bool check_witness_root)
+{
+    BlockValidationState state;
+    
+    // Check the merkle root for mutations
+    bool mutated;
+    uint256 hashMerkleRoot2 = BlockMerkleRoot(block, &mutated);
+    if (block.hashMerkleRoot != hashMerkleRoot2) {
+        LogDebug(BCLog::VALIDATION, "Block mutated: hashMerkleRoot mismatch\n");
+        return true;
+    }
+    
+    // Check for merkle tree malleability (CVE-2012-2459)
+    if (mutated) {
+        LogDebug(BCLog::VALIDATION, "Block mutated: duplicate transaction\n");
+        return true;
+    }
+
+    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
+        // Consider the block mutated if any transaction is 64 bytes in size (see 3.1
+        // in "Weaknesses in Bitcoin's Merkle Root Construction":
+        // https://lists.linuxfoundation.org/pipermail/bitcoin-dev/attachments/20190225/a27d8837/attachment-0001.pdf).
+        //
+        // Note: This is not a consensus change as this only applies to blocks that
+        // don't have a coinbase transaction and would therefore already be invalid.
+        return std::any_of(block.vtx.begin(), block.vtx.end(),
+                           [](auto& tx) { return GetSerializeSize(*tx, PROTOCOL_VERSION) == 64; });
+    } else {
+        // Theoretically it is still possible for a block with a 64 byte
+        // coinbase transaction to be mutated but we neglect that possibility
+        // here as it requires at least 224 bits of work.
+    }
+
+    // Note: We skip witness malleation checks since Dash doesn't support witness transactions
+    // The check_witness_root parameter is ignored for Dash compatibility
+
+    return false;
+}
+
 /** Context-dependent validity checks.
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock().

--- a/src/validation.h
+++ b/src/validation.h
@@ -363,6 +363,9 @@ bool TestBlockValidity(BlockValidationState& state,
                        bool fCheckPOW = true,
                        bool fCheckMerkleRoot = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+/** Check if a block has been mutated (with respect to its merkle root and witness commitments). */
+bool IsBlockMutated(const CBlock& block, bool check_witness_root);
+
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB {
 public:

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test that an attacker can't degrade compact block relay by sending unsolicited
+mutated blocks to clear in-flight blocktxn requests from other honest peers.
+"""
+
+from test_framework.p2p import P2PInterface
+from test_framework.messages import (
+    BlockTransactions,
+    msg_cmpctblock,
+    msg_block,
+    msg_blocktxn,
+    HeaderAndShortIDs,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    create_block,
+    add_witness_commitment,
+    NORMAL_GBT_REQUEST_PARAMS,
+)
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+import copy
+
+class MutatedBlocksTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+        self.generate(self.wallet, COINBASE_MATURITY)
+
+        honest_relayer = self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="outbound-full-relay")
+        attacker = self.nodes[0].add_p2p_connection(P2PInterface())
+
+        # Create new block with two transactions (coinbase + 1 self-transfer).
+        # The self-transfer transaction is needed to trigger a compact block
+        # `getblocktxn` roundtrip.
+        tx = self.wallet.create_self_transfer()["tx"]
+        block = create_block(tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS), txlist=[tx])
+        add_witness_commitment(block)
+        block.solve()
+
+        # Create mutated version of the block by changing the transaction
+        # version on the self-transfer.
+        mutated_block = copy.deepcopy(block)
+        mutated_block.vtx[1].nVersion = 4
+
+        # Announce the new block via a compact block through the honest relayer
+        cmpctblock = HeaderAndShortIDs()
+        cmpctblock.initialize_from_block(block, use_witness=True)
+        honest_relayer.send_message(msg_cmpctblock(cmpctblock.to_p2p()))
+
+        # Wait for a `getblocktxn` that attempts to fetch the self-transfer
+        def self_transfer_requested():
+            if not honest_relayer.last_message.get('getblocktxn'):
+                return False
+
+            get_block_txn = honest_relayer.last_message['getblocktxn']
+            return get_block_txn.block_txn_request.blockhash == block.sha256 and \
+                   get_block_txn.block_txn_request.indexes == [1]
+        honest_relayer.wait_until(self_transfer_requested, timeout=5)
+
+        # Block at height 101 should be the only one in flight from peer 0
+        peer_info_prior_to_attack = self.nodes[0].getpeerinfo()
+        assert_equal(peer_info_prior_to_attack[0]['id'], 0)
+        assert_equal([101], peer_info_prior_to_attack[0]["inflight"])
+
+        # Attempt to clear the honest relayer's download request by sending the
+        # mutated block (as the attacker).
+        with self.nodes[0].assert_debug_log(expected_msgs=["bad-txnmrklroot, hashMerkleRoot mismatch"]):
+            attacker.send_message(msg_block(mutated_block))
+        # Attacker should get disconnected for sending a mutated block
+        attacker.wait_for_disconnect(timeout=5)
+
+        # Block at height 101 should *still* be the only block in-flight from
+        # peer 0
+        peer_info_after_attack = self.nodes[0].getpeerinfo()
+        assert_equal(peer_info_after_attack[0]['id'], 0)
+        assert_equal([101], peer_info_after_attack[0]["inflight"])
+
+        # The honest relayer should be able to complete relaying the block by
+        # sending the blocktxn that was requested.
+        block_txn = msg_blocktxn()
+        block_txn.block_transactions = BlockTransactions(blockhash=block.sha256, transactions=[tx])
+        honest_relayer.send_and_ping(block_txn)
+        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+
+if __name__ == '__main__':
+    MutatedBlocksTest().main()

--- a/test/functional/p2p_mutated_blocks.py
+++ b/test/functional/p2p_mutated_blocks.py
@@ -20,7 +20,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.blocktools import (
     COINBASE_MATURITY,
     create_block,
-    add_witness_commitment,
     NORMAL_GBT_REQUEST_PARAMS,
 )
 from test_framework.util import assert_equal
@@ -44,7 +43,6 @@ class MutatedBlocksTest(BitcoinTestFramework):
         # `getblocktxn` roundtrip.
         tx = self.wallet.create_self_transfer()["tx"]
         block = create_block(tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS), txlist=[tx])
-        add_witness_commitment(block)
         block.solve()
 
         # Create mutated version of the block by changing the transaction
@@ -54,7 +52,7 @@ class MutatedBlocksTest(BitcoinTestFramework):
 
         # Announce the new block via a compact block through the honest relayer
         cmpctblock = HeaderAndShortIDs()
-        cmpctblock.initialize_from_block(block, use_witness=True)
+        cmpctblock.initialize_from_block(block)
         honest_relayer.send_message(msg_cmpctblock(cmpctblock.to_p2p()))
 
         # Wait for a `getblocktxn` that attempts to fetch the self-transfer

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -304,7 +304,7 @@ BASE_SCRIPTS = [
     'rpc_bind.py --ipv6',
     'rpc_bind.py --nonloopback',
     'mining_basic.py',
-    'rpc_named_arguments.py',
+    'p2p_mutated_blocks.py',    'rpc_named_arguments.py',
     'feature_startupnotify.py',
     'wallet_simulaterawtx.py --legacy-wallet',
     'wallet_simulaterawtx.py --descriptors',


### PR DESCRIPTION
Backports bitcoin/bitcoin#29412

Original commit: 2649e655b9

Note: This is a partial backport. The full implementation of IsBlockMutated and related changes require significant adaptation due to differences between Bitcoin and Dash codebases, particularly around transaction identifier handling and validation logic. This commit adds the declaration and test infrastructure, but the core validation changes would need manual implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new functional test to verify that mutated blocks are properly rejected, ensuring robust handling of unsolicited mutated blocks during block relay.
  * Introduced a function to detect mutated blocks by validating their Merkle roots and transaction integrity.
  * Enhanced block processing to reject mutated blocks immediately and penalize misbehaving peers.

* **Tests**
  * Introduced a comprehensive test scenario simulating an attack with mutated blocks and confirming correct block relay behavior and peer disconnection.
  * Included the new test in the default set of functional tests.
  * Added unit tests to verify mutation detection logic under various block conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->