### PR TITLE
Merge bitcoin/bitcoin#29541: test: remove file-wide interpreter.cpp ubsan suppression

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -51,7 +51,7 @@ unsigned-integer-overflow:hash.cpp
 unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:pubkey.h
-unsigned-integer-overflow:script/interpreter.cpp
+unsigned-integer-overflow:EvalScript
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h


### PR DESCRIPTION
Backports bitcoin/bitcoin#29541

Original commit: faff279fdc

Backported from Bitcoin Core v0.27

This PR replaces a file-wide ubsan suppression for `script/interpreter.cpp` with a more specific function-level suppression for `EvalScript`, improving the granularity of sanitizer suppressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sanitizer suppression to target a specific symbol instead of a file path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->