### PR TITLE
Merge bitcoin-core/gui#803: test: Set organization name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -471,28 +471,28 @@ if test "$enable_werror" = "yes"; then
   ])])
 fi
 
-  dnl -Warray-bounds cause problems with GCC. Do not treat these warnings as errors.
-  dnl Suppress -Warray-bounds entirely because of noisy output, currently unhappy with immer implementation.
-  AX_CHECK_COMPILE_FLAG([-Warray-bounds], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-array-bounds"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
-    #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
-      #error Non-GCC compiler detected, not setting flag
-    #endif
-    int main(void) { return 0; }
-  ])])
+dnl -Warray-bounds cause problems with GCC. Do not treat these warnings as errors.
+dnl Suppress -Warray-bounds entirely because of noisy output, currently unhappy with immer implementation.
+AX_CHECK_COMPILE_FLAG([-Warray-bounds], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-array-bounds"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
+  #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
+    #error Non-GCC compiler detected, not setting flag
+  #endif
+  int main(void) { return 0; }
+])])
 
-  dnl -Wstringop-overread and -Wstringop-overflow are broken in GCC. Suppress warnings entirely to avoid noisy output.
-  AX_CHECK_COMPILE_FLAG([-Wstringop-overread], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-stringop-overread"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
-    #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
-      #error Non-GCC compiler detected, not setting flag
-    #endif
-    int main(void) { return 0; }
-  ])])
-  AX_CHECK_COMPILE_FLAG([-Wstringop-overflow], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-stringop-overflow"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
-    #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
-      #error Non-GCC compiler detected, not setting flag
-    #endif
-    int main(void) { return 0; }
-  ])])
+dnl -Wstringop-overread and -Wstringop-overflow are broken in GCC. Suppress warnings entirely to avoid noisy output.
+AX_CHECK_COMPILE_FLAG([-Wstringop-overread], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-stringop-overread"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
+  #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
+    #error Non-GCC compiler detected, not setting flag
+  #endif
+  int main(void) { return 0; }
+])])
+AX_CHECK_COMPILE_FLAG([-Wstringop-overflow], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-stringop-overflow"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
+  #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
+    #error Non-GCC compiler detected, not setting flag
+  #endif
+  int main(void) { return 0; }
+])])
 
 AX_CHECK_COMPILE_FLAG([-Wall], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wall"], [], [$CXXFLAG_WERROR])
 AX_CHECK_COMPILE_FLAG([-Wextra], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wextra"], [], [$CXXFLAG_WERROR])

--- a/configure.ac
+++ b/configure.ac
@@ -450,15 +450,6 @@ if test "$enable_werror" = "yes"; then
   fi
   ERROR_CXXFLAGS=$CXXFLAG_WERROR
 
-  dnl -Warray-bounds cause problems with GCC. Do not treat these warnings as errors.
-  dnl Suppress -Warray-bounds entirely because of noisy output, currently unhappy with immer implementation.
-  AX_CHECK_COMPILE_FLAG([-Warray-bounds], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-array-bounds"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
-    #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
-      #error Non-GCC compiler detected, not setting flag
-    #endif
-    int main(void) { return 0; }
-  ])])
-
   dnl -Wattributes cause problems with some versions of GCC. Do not treat these warnings as errors.
   AX_CHECK_COMPILE_FLAG([-Wattributes], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-error=attributes"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
     #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
@@ -478,6 +469,16 @@ if test "$enable_werror" = "yes"; then
     #endif
     int main(void) { return 0; }
   ])])
+fi
+
+  dnl -Warray-bounds cause problems with GCC. Do not treat these warnings as errors.
+  dnl Suppress -Warray-bounds entirely because of noisy output, currently unhappy with immer implementation.
+  AX_CHECK_COMPILE_FLAG([-Warray-bounds], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-array-bounds"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
+    #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)
+      #error Non-GCC compiler detected, not setting flag
+    #endif
+    int main(void) { return 0; }
+  ])])
 
   dnl -Wstringop-overread and -Wstringop-overflow are broken in GCC. Suppress warnings entirely to avoid noisy output.
   AX_CHECK_COMPILE_FLAG([-Wstringop-overread], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-stringop-overread"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
@@ -492,7 +493,6 @@ if test "$enable_werror" = "yes"; then
     #endif
     int main(void) { return 0; }
   ])])
-fi
 
 AX_CHECK_COMPILE_FLAG([-Wall], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wall"], [], [$CXXFLAG_WERROR])
 AX_CHECK_COMPILE_FLAG([-Wextra], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wextra"], [], [$CXXFLAG_WERROR])

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -317,6 +317,9 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
             if (it == contributionsCache.end()) {
                 CDataStream s(SER_DISK, CLIENT_VERSION);
                 if (!db->ReadDataStream(std::make_tuple(DB_VVEC, llmqType, pQuorumBaseBlockIndex->GetBlockHash(), proTxHash), s)) {
+                    LogPrint(BCLog::LLMQ, "%s -- this node does not have vvec for llmq=%d block=%s protx=%s\n",
+                             __func__, ToUnderlying(llmqType), pQuorumBaseBlockIndex->GetBlockHash().ToString(),
+                             proTxHash.ToString());
                     return false;
                 }
                 size_t vvec_size = ReadCompactSize(s);

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -923,11 +923,11 @@ void CQuorumManager::StartQuorumDataRecoveryThread(CConnman& connman, const CQuo
 {
     assert(m_mn_activeman);
 
-    if (pQuorum->fQuorumDataRecoveryThreadRunning) {
+    bool expected = false;
+    if (!pQuorum->fQuorumDataRecoveryThreadRunning.compare_exchange_strong(expected, true)) {
         LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Already running\n", __func__);
         return;
     }
-    pQuorum->fQuorumDataRecoveryThreadRunning = true;
 
     workerPool.push([&connman, pQuorum, pIndex, nDataMaskIn, this](int threadId) {
         size_t nTries{0};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3228,7 +3228,24 @@ bool CWallet::UpgradeToHD(const SecureString& secureMnemonic, const SecureString
     SetMinVersion(FEATURE_HD);
 
     if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+        if (IsCrypted()) {
+            if (secureWalletPassphrase.empty()) {
+                error = Untranslated("Error: Wallet encrypted but supplied empty wallet passphrase");
+                return false;
+            }
+
+            // Unlock the wallet
+            if (!Unlock(secureWalletPassphrase)) {
+                error = Untranslated("Error: The wallet passphrase entered was incorrect");
+                return false;
+            }
+        }
         SetupDescriptorScriptPubKeyMans(secureMnemonic, secureMnemonicPassphrase);
+
+        if (IsCrypted()) {
+            // Relock the wallet
+            Lock();
+        }
     } else {
         if (!GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase, secureWalletPassphrase)) {
             error = Untranslated("Failed to generate HD wallet");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -10,7 +10,6 @@
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
-#include <consensus/validation.h>
 #include <crypto/common.h>
 #include <fs.h>
 #include <interfaces/chain.h>
@@ -19,7 +18,6 @@
 #include <key_io.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
-#include <policy/settings.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/descriptor.h>
@@ -28,10 +26,8 @@
 #include <script/signingprovider.h>
 #include <support/cleanse.h>
 #include <txmempool.h>
-#include <util/bip32.h>
 #include <util/check.h>
 #include <util/error.h>
-#include <util/fees.h>
 #include <util/moneystr.h>
 #include <util/string.h>
 #include <util/translation.h>
@@ -40,11 +36,9 @@
 #endif
 #include <wallet/bip39.h> // TODO(refactor): move dependency it to scriptpubkeyman.cpp
 #include <wallet/coincontrol.h>
-#include <wallet/coinselection.h>
 #include <wallet/context.h>
 #include <warnings.h>
 
-#include <coinjoin/common.h>
 #include <coinjoin/options.h>
 #include <evo/providertx.h>
 #include <governance/vote.h>

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2072,6 +2072,8 @@ class DashTestFramework(BitcoinTestFramework):
                         continue
                     if c["quorumHash"] != quorum_hash:
                         continue
+                    if c["quorumPublicKey"] == '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000':
+                        continue
                     c_ok = True
                     break
                 if not c_ok:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2080,7 +2080,7 @@ class DashTestFramework(BitcoinTestFramework):
                     return False
             return True
 
-        self.wait_until(check_dkg_comitments, timeout=timeout, sleep=1)
+        self.wait_until(check_dkg_comitments, timeout=timeout)
 
     def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, llmq_type_name="llmq_test"):
         def wait_func():

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2072,7 +2072,7 @@ class DashTestFramework(BitcoinTestFramework):
                         continue
                     if c["quorumHash"] != quorum_hash:
                         continue
-                    if c["quorumPublicKey"] == '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000':
+                    if c["quorumPublicKey"] == '0' * 96:
                         continue
                     c_ok = True
                     break

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -536,6 +536,29 @@ def force_finish_mnsync(node):
     while not node.mnsync("status")['IsSynced']:
         node.mnsync("next")
 
+
+def get_mnemonic(node):
+    """
+    Return mnemonic if known from legacy HD wallets and Descriptor Wallets
+    Raises exception if there is none.
+    """
+    if not node.getwalletinfo()['descriptors']:
+        return node.dumphdinfo()["mnemonic"]
+
+    mnemonic = None
+    descriptors = node.listdescriptors(True)['descriptors']
+    for desc in descriptors:
+        if desc['desc'][:4] == 'pkh(':
+            if mnemonic is None:
+                mnemonic = desc['mnemonic']
+            else:
+                assert_equal(mnemonic, desc['mnemonic'])
+        elif desc['desc'][:6] == 'combo(':
+            assert 'mnemonic' not in desc
+        else:
+            raise AssertionError(f"Unknown descriptor type: {desc['desc']}")
+    return mnemonic
+
 # Transaction/Block functions
 #############################
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -321,6 +321,7 @@ BASE_SCRIPTS = [
     'wallet_encryption.py --legacy-wallet',
     'wallet_encryption.py --descriptors',
     'wallet_upgradetohd.py --legacy-wallet',
+    'wallet_upgradetohd.py --descriptors',
     'feature_dersig.py',
     'feature_cltv.py',
     'feature_new_quorum_type_activation.py',

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -88,22 +88,14 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].loadwallet("wallet_160")
         self.nodes[0].loadwallet("wallet_192")
         self.nodes[0].loadwallet("wallet_224")
-        if self.options.descriptors:
-            self.nodes[0].createwallet("wallet_256", False, True, "", False, True)  # blank Descriptors
-            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
-            assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 15)              # 15 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 18)              # 18 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 21)              # 21 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 24)              # 24 words
-        else:
-            self.nodes[0].createwallet("wallet_256", False, True)  # blank HD legacy
-            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
-            assert_equal(len(self.nodes[0].get_wallet_rpc(self.default_wallet_name).dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").dumphdinfo()["mnemonic"].split()), 15)              # 15 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").dumphdinfo()["mnemonic"].split()), 18)              # 18 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").dumphdinfo()["mnemonic"].split()), 21)              # 21 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").dumphdinfo()["mnemonic"].split()), 24)              # 24 words
+        self.nodes[0].createwallet("wallet_256", blank=True, descriptors=self.options.descriptors)  # blank wallet
+        self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
+
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_160")).split()), 15)              # 15 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_192")).split()), 18)              # 18 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_224")).split()), 21)              # 21 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_256")).split()), 24)              # 24 words
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -7,6 +7,7 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    get_mnemonic,
 )
 
 class WalletMnemonicbitsTest(BitcoinTestFramework):
@@ -17,24 +18,6 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
-    def get_mnemonic(self, node):
-        if not self.options.descriptors:
-            return node.dumphdinfo()["mnemonic"]
-
-        mnemonic = None
-        descriptors = node.listdescriptors(True)['descriptors']
-        for desc in descriptors:
-            if desc['desc'][:4] == 'pkh(':
-                if mnemonic is None:
-                    mnemonic = desc['mnemonic']
-                else:
-                    assert_equal(mnemonic, desc['mnemonic'])
-            elif desc['desc'][:6] == 'combo(':
-                assert 'mnemonic' not in desc
-            else:
-                raise AssertionError(f"Unknown descriptor type: {desc['desc']}")
-        return mnemonic
-
     def run_test(self):
         self.log.info("Test -mnemonicbits")
 
@@ -43,7 +26,7 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(['-mnemonicbits=123'], "Error: Invalid '-mnemonicbits'. Allowed values: 128, 160, 192, 224, 256.")
         self.start_node(0)
 
-        mnemonic_pre = self.get_mnemonic(self.nodes[0])
+        mnemonic_pre = get_mnemonic(self.nodes[0])
 
 
         self.nodes[0].encryptwallet('pass')
@@ -91,11 +74,11 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].createwallet("wallet_256", blank=True, descriptors=self.options.descriptors)  # blank wallet
         self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
 
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_160")).split()), 15)              # 15 words
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_192")).split()), 18)              # 18 words
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_224")).split()), 21)              # 21 words
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_256")).split()), 24)              # 24 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_160")).split()), 15)              # 15 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_192")).split()), 18)              # 18 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_224")).split()), 21)              # 21 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_256")).split()), 24)              # 24 words
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -249,6 +249,28 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         # All coins should be recovered
         assert_equal(balance_after, node.getbalance())
 
+        self.log.info("Test upgradetohd with user defined mnemonic")
+        custom_mnemonic = "similar behave slot swim scissors throw planet view ghost laugh drift calm"
+        # this address belongs to custom mnemonic with no passphrase
+        custom_address_1 = "yLpq97zZUsFQ2rdMqhcPKkYT36MoPK4Hob"
+        # this address belongs to custom mnemonic with passphrase "custom-passphrase"
+        custom_address_2 = "yYBPeZQcqgQHu9dxA5pKBWtYbK2hwfFHxf"
+        node.sendtoaddress(custom_address_1, 11)
+        node.sendtoaddress(custom_address_2, 12)
+        self.generate(node, 1)
+
+        node.createwallet("wallet-11", blank=True)
+        w11 = node.get_wallet_rpc("wallet-11")
+        w11.upgradetohd(custom_mnemonic)
+        assert_equal(11, w11.getbalance())
+        w11.unloadwallet()
+
+        node.createwallet("wallet-12", blank=True)
+        w12 = node.get_wallet_rpc("wallet-12")
+        w12.upgradetohd(custom_mnemonic, "custom-passphrase")
+        assert_equal(12, w12.getbalance())
+        w12.unloadwallet()
+
 
 if __name__ == '__main__':
     WalletUpgradeToHDTest().main ()

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2016 The Bitcoin Core developers
+# Copyright (c) 2016-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """


### PR DESCRIPTION
Backports bitcoin-core/gui#803

Original commit: c2c6a7d1dc162945fa56deb6eaf2bdd7f84999e8

## Summary
Sets the organization name for Qt tests to ensure QSettings can properly read/write settings. This prevents Qt test failures when settings need to be accessed.

## Changes
- Sets organization name in Qt test framework using `QCoreApplication::setOrganizationName()`
- Wraps test execution in a scope to properly clean up resources
- Clears settings after tests complete to avoid leaving artifacts

## Note
The optiontests.cpp changes from Bitcoin were not applied as Dash doesn't have the migrateSettings functionality that Bitcoin added. The core fix for setting organization name has been properly backported.

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the setup and teardown process for test execution, ensuring the application instance exists only during tests and application metadata is set globally.
  * Enhanced test isolation by clearing settings after tests complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->