### PR TITLE
Merge bitcoin/bitcoin#29693: [27.x] Further Backports

### DIFF
--- a/ci/test/00_setup_env_mac_native_x86_64.sh
+++ b/ci/test/00_setup_env_mac_native_x86_64.sh
@@ -8,7 +8,9 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_macos
 export HOST=x86_64-apple-darwin
-export PIP_PACKAGES="zmq lief"
+# Homebrew's python@3.12 is marked as externally managed (PEP 668).
+# Therefore, `--break-system-packages` is needed.
+export PIP_PACKAGES="--break-system-packages zmq lief"
 export GOAL="install"
 export BITCOIN_CONFIG="--with-gui --enable-reduce-exports --disable-miner --with-boost-process"
 export CI_OS_NAME="macos"


### PR DESCRIPTION
Backports bitcoin/bitcoin#29693

Original commit: b3cd952495

This PR backports CI improvements from Bitcoin Core v0.27:
- Updates macOS CI to use `--break-system-packages` flag for Homebrew's Python 3.12
- Other CI updates (MSAN to LLVM 18, brew link workaround) were already present in Dash

Note: Only the macOS CI file change was needed as the other changes were already present in Dash Core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation process to ensure compatibility with the latest Python version on macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->