### PR TITLE
Merge bitcoin/bitcoin#29610: ci: Fix "macOS native" job

### DIFF
--- a/ci/test/00_setup_env_mac_native_x86_64.sh
+++ b/ci/test/00_setup_env_mac_native_x86_64.sh
@@ -8,7 +8,9 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_macos
 export HOST=x86_64-apple-darwin
-export PIP_PACKAGES="zmq lief"
+# Homebrew's python@3.12 is marked as externally managed (PEP 668).
+# Therefore, `--break-system-packages` is needed.
+export PIP_PACKAGES="--break-system-packages zmq lief"
 export GOAL="install"
 export BITCOIN_CONFIG="--with-gui --enable-reduce-exports --disable-miner --with-boost-process"
 export CI_OS_NAME="macos"


### PR DESCRIPTION
Backports bitcoin/bitcoin#29610

Original commit: bd55b7a528

This PR fixes macOS CI issues related to Homebrew's Python 3.12 being marked as externally managed (PEP 668). The fix adds the `--break-system-packages` flag to pip installations in the macOS native CI setup.

Note: GitHub Actions workflow changes were not applied as Dash uses a different CI system.

Backported from Bitcoin Core v0.28