### PR TITLE
Merge bitcoin/bitcoin#29459: test: check_mempool_result negative feerate

### DIFF
--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -77,6 +77,19 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         txid_in_block = self.wallet.sendrawtransaction(from_node=node, tx_hex=raw_tx_in_block)
         self.generate(node, 1)
         self.mempool_size = 0
+        # Also check feerate. 1BTC/kvB fails
+        assert_raises_rpc_error(-8, "Fee rates larger than or equal to 1BTC/kvB are not accepted", lambda: self.check_mempool_result(
+            result_expected=None,
+            rawtxs=[raw_tx_in_block],
+            maxfeerate=1,
+        ))
+        # Check negative feerate
+        assert_raises_rpc_error(-3, "Amount out of range", lambda: self.check_mempool_result(
+            result_expected=None,
+            rawtxs=[raw_tx_in_block],
+            maxfeerate=-0.01,
+        ))
+        # ... 0.99 passes
         self.check_mempool_result(
             result_expected=[{'txid': txid_in_block, 'allowed': False, 'reject-reason': 'txn-already-known'}],
             rawtxs=[raw_tx_in_block],

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -77,12 +77,6 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         txid_in_block = self.wallet.sendrawtransaction(from_node=node, tx_hex=raw_tx_in_block)
         self.generate(node, 1)
         self.mempool_size = 0
-        # Also check feerate. 1BTC/kvB fails
-        assert_raises_rpc_error(-8, "Fee rates larger than or equal to 1BTC/kvB are not accepted", lambda: self.check_mempool_result(
-            result_expected=None,
-            rawtxs=[raw_tx_in_block],
-            maxfeerate=1,
-        ))
         # Check negative feerate
         assert_raises_rpc_error(-3, "Amount out of range", lambda: self.check_mempool_result(
             result_expected=None,


### PR DESCRIPTION
Backports bitcoin/bitcoin#29459

Original commit: 3d255dfb67aede71ed39aaa54f4bcad550910cb7

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced mempool acceptance tests to verify correct error handling for negative fee rates and transactions already included in the blockchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->