### PR TITLE
Merge bitcoin/bitcoin#29094: ci: Better tidy errors

### DIFF
--- a/ci/dash/lint-tidy.sh
+++ b/ci/dash/lint-tidy.sh
@@ -12,7 +12,11 @@ set -eo pipefail
 #          that *before* running this script.
 
 cd "${BASE_ROOT_DIR}/build-ci/dashcore-${BUILD_TARGET}/src"
-( run-clang-tidy -quiet "${MAKEJOBS}" ) | grep -C5 "error"
+if ! ( run-clang-tidy -quiet "${MAKEJOBS}" | tee tmp.tidy-out.txt ); then
+  grep -C5 "error: " tmp.tidy-out.txt
+  echo "^^^ ⚠️ Failure generated from clang-tidy"
+  false
+fi
 
 cd "${BASE_ROOT_DIR}/build-ci/dashcore-${BUILD_TARGET}"
 iwyu_tool.py \


### PR DESCRIPTION
Backports bitcoin/bitcoin#29094

Original commit: 8e95a9cd7ad6c448ed91f1c30e582c31e96c9df3

Backported from Bitcoin Core v0.28

This improves clang-tidy error reporting in CI by:
- Using `tee` to save output to a file
- Checking the exit status properly
- Printing a clearer error message when tidy fails

Note: Applied to Dash's equivalent file `ci/dash/lint-tidy.sh` instead of `ci/test/03_test_script.sh` which doesn't exist in Dash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error detection and reporting in the linting process for more accurate feedback during code checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->