### PR TITLE
Merge bitcoin/bitcoin#29647: Avoid divide-by-zero in header sync logs when NodeClock is behind

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4207,7 +4207,8 @@ bool ChainstateManager::ProcessNewBlockHeaders(const std::vector<CBlockHeader>& 
     if (NotifyHeaderTip(ActiveChainstate())) {
         if (ActiveChainstate().IsInitialBlockDownload() && ppindex && *ppindex) {
             const CBlockIndex& last_accepted{**ppindex};
-            const int64_t blocks_left{(GetTime() - last_accepted.GetBlockTime()) / chainparams.GetConsensus().nPowTargetSpacing};
+            int64_t blocks_left{(GetTime() - last_accepted.GetBlockTime()) / chainparams.GetConsensus().nPowTargetSpacing};
+            blocks_left = std::max<int64_t>(0, blocks_left);
             const double progress{100.0 * last_accepted.nHeight / (last_accepted.nHeight + blocks_left)};
             LogPrintf("Synchronizing blockheaders, height: %d (~%.2f%%)\n", last_accepted.nHeight, progress);
         }


### PR DESCRIPTION
Backports bitcoin/bitcoin#29647

Original commit: 85c8a5ec48b5e2a0ba26bec0acb572dce37271ff

Backported from Bitcoin Core v0.28

**Note**: This backport only includes the fix for `ProcessNewBlockHeaders` function. The `ReportHeadersPresync` function that was also fixed in the Bitcoin commit does not exist in Dash, so that portion of the fix could not be applied.

The change adds a check to ensure `blocks_left` is never negative, preventing potential divide-by-zero errors when calculating synchronization progress.