### PR TITLE
Merge bitcoin/bitcoin#28998: rpc: "addpeeraddress tried" return error on failure

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1017,7 +1017,10 @@ static RPCHelpMan addpeeraddress()
             success = true;
             if (tried) {
                 // Attempt to move the address to the tried addresses table.
-                node.addrman->Good(address);
+                if (!node.addrman->Good(address)) {
+                    success = false;
+                    obj.pushKV("error", "failed-adding-to-tried");
+                }
             }
         } else {
             obj.pushKV("error", "failed-adding-to-new");

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -974,7 +974,7 @@ static RPCHelpMan getnodeaddresses()
 static RPCHelpMan addpeeraddress()
 {
     return RPCHelpMan{"addpeeraddress",
-        "\nAdd the address of a potential peer to the address manager. This RPC is for testing only.\n",
+        "Add the address of a potential peer to an address manager table. This RPC is for testing only.",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The IP address of the peer"},
             {"port", RPCArg::Type::NUM, RPCArg::Optional::NO, "The port of the peer"},
@@ -983,7 +983,8 @@ static RPCHelpMan addpeeraddress()
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::BOOL, "success", "whether the peer address was successfully added to the address manager"},
+                {RPCResult::Type::BOOL, "success", "whether the peer address was successfully added to the address manager table"},
+                {RPCResult::Type::STR, "error", /*optional=*/true, "error description, if the address could not be added"},
             },
         },
         RPCExamples{
@@ -1018,6 +1019,8 @@ static RPCHelpMan addpeeraddress()
                 // Attempt to move the address to the tried addresses table.
                 node.addrman->Good(address);
             }
+        } else {
+            obj.pushKV("error", "failed-adding-to-new");
         }
     }
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -343,34 +343,22 @@ class NetTest(DashTestFramework):
 
         self.log.debug("Test that adding a valid address to the tried table succeeds")
         assert_equal(node.addpeeraddress(address="1.2.3.4", tried=True, port=8333), {"success": True})
-        addrman = node.getrawaddrman()
-        assert_equal(len(addrman["new"]), 1)
-        tried_table = list(addrman["tried"].values())
-        assert_equal(len(tried_table), 1)
-        assert_equal(tried_table[0]["address"], "1.2.3.4")
-        assert_equal(tried_table[0]["port"], 8333)
-        node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
+        with node.assert_debug_log(expected_msgs=["CheckAddrman: new 0, tried 1, total 1 started"]):
+            addrs = node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
+            assert_equal(len(addrs), 1)
+            assert_equal(addrs[0]["address"], "1.2.3.4")
+            assert_equal(addrs[0]["port"], 8333)
 
         self.log.debug("Test that adding an already-present tried address to the new and tried tables fails")
         for value in [True, False]:
             assert_equal(node.addpeeraddress(address="1.2.3.4", tried=value, port=8333), {"success": False, "error": "failed-adding-to-new"})
-        assert_equal(len(node.getnodeaddresses(count=0)), 2)
+        assert_equal(len(node.getnodeaddresses(count=0)), 1)
 
-        self.log.debug("Test that adding an address, which collides with the address in tried table, fails")
-        colliding_address = "1.2.5.45"  # grinded address that produces a tried-table collision
-        assert_equal(node.addpeeraddress(address=colliding_address, tried=True, port=8333), {"success": False, "error": "failed-adding-to-tried"})
-        # When adding an address to the tried table, it's first added to the new table.
-        # As we fail to move it to the tried table, it remains in the new table.
-        addrman_info = node.getaddrmaninfo()
-        assert_equal(addrman_info["all_networks"]["tried"], 1)
-        assert_equal(addrman_info["all_networks"]["new"], 2)
-
-        self.log.debug("Test that adding an another address to the new table succeeds")
+        self.log.debug("Test that adding a second address, this time to the new table, succeeds")
         assert_equal(node.addpeeraddress(address="2.0.0.0", port=8333), {"success": True})
-        addrman_info = node.getaddrmaninfo()
-        assert_equal(addrman_info["all_networks"]["tried"], 1)
-        assert_equal(addrman_info["all_networks"]["new"], 3)
-        node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
+        with node.assert_debug_log(expected_msgs=["CheckAddrman: new 1, tried 1, total 2 started"]):
+            addrs = node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
+            assert_equal(len(addrs), 2)
 
     def test_sendmsgtopeer(self):
         node = self.nodes[0]

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -341,24 +341,50 @@ class NetTest(DashTestFramework):
         assert_equal(node.addpeeraddress(address="", port=8333), {"success": False})
         assert_equal(node.getnodeaddresses(count=0), [])
 
+        self.log.debug("Test that adding a valid address to the new table succeeds")
+        assert_equal(node.addpeeraddress(address="1.0.0.0", tried=False, port=8333), {"success": True})
+        addrman = node.getrawaddrman()
+        assert_equal(len(addrman["tried"]), 0)
+        new_table = list(addrman["new"].values())
+        assert_equal(len(new_table), 1)
+        assert_equal(new_table[0]["address"], "1.0.0.0")
+        assert_equal(new_table[0]["port"], 8333)
+
+        self.log.debug("Test that adding an already-present new address to the new and tried tables fails")
+        for value in [True, False]:
+            assert_equal(node.addpeeraddress(address="1.0.0.0", tried=value, port=8333), {"success": False, "error": "failed-adding-to-new"})
+        assert_equal(len(node.getnodeaddresses(count=0)), 1)
+
         self.log.debug("Test that adding a valid address to the tried table succeeds")
         assert_equal(node.addpeeraddress(address="1.2.3.4", tried=True, port=8333), {"success": True})
-        with node.assert_debug_log(expected_msgs=["CheckAddrman: new 0, tried 1, total 1 started"]):
-            addrs = node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
-            assert_equal(len(addrs), 1)
-            assert_equal(addrs[0]["address"], "1.2.3.4")
-            assert_equal(addrs[0]["port"], 8333)
+        addrman = node.getrawaddrman()
+        assert_equal(len(addrman["new"]), 1)
+        tried_table = list(addrman["tried"].values())
+        assert_equal(len(tried_table), 1)
+        assert_equal(tried_table[0]["address"], "1.2.3.4")
+        assert_equal(tried_table[0]["port"], 8333)
+        node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
 
         self.log.debug("Test that adding an already-present tried address to the new and tried tables fails")
         for value in [True, False]:
             assert_equal(node.addpeeraddress(address="1.2.3.4", tried=value, port=8333), {"success": False, "error": "failed-adding-to-new"})
-        assert_equal(len(node.getnodeaddresses(count=0)), 1)
+        assert_equal(len(node.getnodeaddresses(count=0)), 2)
 
-        self.log.debug("Test that adding a second address, this time to the new table, succeeds")
+        self.log.debug("Test that adding an address, which collides with the address in tried table, fails")
+        colliding_address = "1.2.5.45"  # grinded address that produces a tried-table collision
+        assert_equal(node.addpeeraddress(address=colliding_address, tried=True, port=8333), {"success": False, "error": "failed-adding-to-tried"})
+        # When adding an address to the tried table, it's first added to the new table.
+        # As we fail to move it to the tried table, it remains in the new table.
+        addrman_info = node.getaddrmaninfo()
+        assert_equal(addrman_info["all_networks"]["tried"], 1)
+        assert_equal(addrman_info["all_networks"]["new"], 2)
+
+        self.log.debug("Test that adding an another address to the new table succeeds")
         assert_equal(node.addpeeraddress(address="2.0.0.0", port=8333), {"success": True})
-        with node.assert_debug_log(expected_msgs=["CheckAddrman: new 1, tried 1, total 2 started"]):
-            addrs = node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
-            assert_equal(len(addrs), 2)
+        addrman_info = node.getaddrmaninfo()
+        assert_equal(addrman_info["all_networks"]["tried"], 1)
+        assert_equal(addrman_info["all_networks"]["new"], 3)
+        node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
 
     def test_sendmsgtopeer(self):
         node = self.nodes[0]

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -332,10 +332,10 @@ class NetTest(DashTestFramework):
         self.restart_node(1, ["-checkaddrman=1"])
         node = self.nodes[1]
 
-        self.log.debug("Test that addpeerinfo is a hidden RPC")
+        self.log.debug("Test that addpeeraddress is a hidden RPC")
         # It is hidden from general help, but its detailed help may be called directly.
-        assert "addpeerinfo" not in node.help()
-        assert "addpeerinfo" in node.help("addpeerinfo")
+        assert "addpeeraddress" not in node.help()
+        assert "unknown command: addpeeraddress" not in node.help("addpeeraddress")
 
         self.log.debug("Test that adding an empty address fails")
         assert_equal(node.addpeeraddress(address="", port=8333), {"success": False})
@@ -343,22 +343,34 @@ class NetTest(DashTestFramework):
 
         self.log.debug("Test that adding a valid address to the tried table succeeds")
         assert_equal(node.addpeeraddress(address="1.2.3.4", tried=True, port=8333), {"success": True})
-        with node.assert_debug_log(expected_msgs=["CheckAddrman: new 0, tried 1, total 1 started"]):
-            addrs = node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
-            assert_equal(len(addrs), 1)
-            assert_equal(addrs[0]["address"], "1.2.3.4")
-            assert_equal(addrs[0]["port"], 8333)
+        addrman = node.getrawaddrman()
+        assert_equal(len(addrman["new"]), 1)
+        tried_table = list(addrman["tried"].values())
+        assert_equal(len(tried_table), 1)
+        assert_equal(tried_table[0]["address"], "1.2.3.4")
+        assert_equal(tried_table[0]["port"], 8333)
+        node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
 
         self.log.debug("Test that adding an already-present tried address to the new and tried tables fails")
         for value in [True, False]:
-            assert_equal(node.addpeeraddress(address="1.2.3.4", tried=value, port=8333), {"success": False})
-        assert_equal(len(node.getnodeaddresses(count=0)), 1)
+            assert_equal(node.addpeeraddress(address="1.2.3.4", tried=value, port=8333), {"success": False, "error": "failed-adding-to-new"})
+        assert_equal(len(node.getnodeaddresses(count=0)), 2)
 
-        self.log.debug("Test that adding a second address, this time to the new table, succeeds")
+        self.log.debug("Test that adding an address, which collides with the address in tried table, fails")
+        colliding_address = "1.2.5.45"  # grinded address that produces a tried-table collision
+        assert_equal(node.addpeeraddress(address=colliding_address, tried=True, port=8333), {"success": False, "error": "failed-adding-to-tried"})
+        # When adding an address to the tried table, it's first added to the new table.
+        # As we fail to move it to the tried table, it remains in the new table.
+        addrman_info = node.getaddrmaninfo()
+        assert_equal(addrman_info["all_networks"]["tried"], 1)
+        assert_equal(addrman_info["all_networks"]["new"], 2)
+
+        self.log.debug("Test that adding an another address to the new table succeeds")
         assert_equal(node.addpeeraddress(address="2.0.0.0", port=8333), {"success": True})
-        with node.assert_debug_log(expected_msgs=["CheckAddrman: new 1, tried 1, total 2 started"]):
-            addrs = node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
-            assert_equal(len(addrs), 2)
+        addrman_info = node.getaddrmaninfo()
+        assert_equal(addrman_info["all_networks"]["tried"], 1)
+        assert_equal(addrman_info["all_networks"]["new"], 3)
+        node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
 
     def test_sendmsgtopeer(self):
         node = self.nodes[0]


### PR DESCRIPTION
Backports bitcoin/bitcoin#28998

Original commit: 2795e89cc5521832842534518cb744aa08fc66e4

Backported from Bitcoin Core v0.28

---

When trying to add an address to the IP address manager tried table, it's first added to the new table and then moved to the tried table. Previously, adding a conflicting address to the address manager's tried table with test-only `addpeeraddress tried=true` RPC would return `{ "success": true }`. However, the address would not be added to the tried table, but would remain in the new table.

This is fixed by returning `{ "success": false, "error": "..." }` for failed tried table additions. Since the address remaining in the new table can't be removed (the address manager interface does not support removing addresses at the moment), an error message is returned. This indicates to a user why the RPC failed.

Note: This backport includes only the core functionality changes. The extensive test additions from the Bitcoin commit that depend on `getrawaddrman` and `getaddrmaninfo` RPCs (which don't exist in Dash) were omitted to avoid dependency explosion.