### PR TITLE
Merge bitcoin/bitcoin#29402: mempool: Log added for dumping mempool transactions to disk

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -19,6 +19,7 @@
 #include <cuckoocache.h>
 #include <deploymentstatus.h>
 #include <flatfile.h>
+#include <fs.h>
 #include <hash.h>
 #include <logging.h>
 #include <logging/timer.h>
@@ -5365,7 +5366,7 @@ bool LoadMempool(CTxMemPool& pool, CChainState& active_chainstate, FopenFn mocka
     FILE* filestr{mockable_fopen_function(gArgs.GetDataDirNet() / "mempool.dat", "rb")};
     CAutoFile file(filestr, SER_DISK, CLIENT_VERSION);
     if (file.IsNull()) {
-        LogPrintf("Failed to open mempool file from disk. Continuing anyway.\n");
+        LogPrintf("Failed to open mempool file. Continuing anyway.\n");
         return false;
     }
 
@@ -5436,11 +5437,11 @@ bool LoadMempool(CTxMemPool& pool, CChainState& active_chainstate, FopenFn mocka
         }
 
     } catch (const std::exception& e) {
-        LogPrintf("Failed to deserialize mempool data on disk: %s. Continuing anyway.\n", e.what());
+        LogPrintf("Failed to deserialize mempool data on file: %s. Continuing anyway.\n", e.what());
         return false;
     }
 
-    LogPrintf("Imported mempool transactions from disk: %i succeeded, %i failed, %i expired, %i already there, %i waiting for initial broadcast\n", count, failed, expired, already_there, unbroadcast);
+    LogPrintf("Imported mempool transactions from file: %i succeeded, %i failed, %i expired, %i already there, %i waiting for initial broadcast\n", count, failed, expired, already_there, unbroadcast);
     return true;
 }
 
@@ -5477,7 +5478,9 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
         uint64_t version = MEMPOOL_DUMP_VERSION;
         file << version;
 
-        file << (uint64_t)vinfo.size();
+        uint64_t mempool_transactions_to_write = vinfo.size();
+        file << mempool_transactions_to_write;
+        LogPrintf("Writing %u mempool transactions to file...\n", mempool_transactions_to_write);
         for (const auto& i : vinfo) {
             file << *(i.tx);
             file << int64_t{count_seconds(i.m_time)};
@@ -5487,7 +5490,7 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
 
         file << mapDeltas;
 
-        LogPrintf("Writing %d unbroadcast transactions to disk.\n", unbroadcast_txids.size());
+        LogPrintf("Writing %d unbroadcast transactions to file.\n", unbroadcast_txids.size());
         file << unbroadcast_txids;
 
         if (!skip_file_commit && !FileCommit(file.Get()))
@@ -5497,7 +5500,9 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
             throw std::runtime_error("Rename failed");
         }
         int64_t last = GetTimeMicros();
-        LogPrintf("Dumped mempool: %gs to copy, %gs to dump\n", (mid-start)*MICRO, (last-mid)*MICRO);
+        std::error_code ec;
+        auto file_size = fs::file_size(gArgs.GetDataDirNet() / "mempool.dat", ec);
+        LogPrintf("Dumped mempool: %gs to copy, %gs to dump, %.2f MB dumped to file\n", (mid-start)*MICRO, (last-mid)*MICRO, file_size / 1e6);
     } catch (const std::exception& e) {
         LogPrintf("Failed to dump mempool: %s. Continuing anyway.\n", e.what());
         return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5480,7 +5480,7 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
 
         uint64_t mempool_transactions_to_write = vinfo.size();
         file << mempool_transactions_to_write;
-        LogPrintf("Writing %u mempool transactions to file...\n", mempool_transactions_to_write);
+        LogPrintf("Writing %" PRIu64 " mempool transactions to file...\n", mempool_transactions_to_write);
         for (const auto& i : vinfo) {
             file << *(i.tx);
             file << int64_t{count_seconds(i.m_time)};
@@ -5490,7 +5490,8 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
 
         file << mapDeltas;
 
-        LogPrintf("Writing %d unbroadcast transactions to file.\n", unbroadcast_txids.size());
+        LogPrintf("Writing %" PRIu64 " unbroadcast transactions to file.\n",
+                  static_cast<uint64_t>(unbroadcast_txids.size()));
         file << unbroadcast_txids;
 
         if (!skip_file_commit && !FileCommit(file.Get()))
@@ -5501,8 +5502,15 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
         }
         int64_t last = GetTimeMicros();
         std::error_code ec;
-        auto file_size = fs::file_size(gArgs.GetDataDirNet() / "mempool.dat", ec);
-        LogPrintf("Dumped mempool: %gs to copy, %gs to dump, %.2f MB dumped to file\n", (mid-start)*MICRO, (last-mid)*MICRO, file_size / 1e6);
+        const auto file_size = fs::file_size(gArgs.GetDataDirNet() / "mempool.dat", ec);
+        if (ec) {
+            LogPrintf("Dumped mempool: %gs to copy, %gs to dump, <unknown size> (err: %s)\n",
+                      (mid-start)*MICRO, (last-mid)*MICRO, ec.message());
+        } else {
+            LogPrintf("Dumped mempool: %gs to copy, %gs to dump, %.2f MB dumped to file\n",
+                      (mid-start)*MICRO, (last-mid)*MICRO,
+                      static_cast<double>(file_size) / 1e6);
+        }
     } catch (const std::exception& e) {
         LogPrintf("Failed to dump mempool: %s. Continuing anyway.\n", e.what());
         return false;


### PR DESCRIPTION
Backports bitcoin/bitcoin#29402

Original commit: d1e9a02126634f9e2ca0b916b69b173a8646524d

Backported from Bitcoin Core v0.28

## Summary
This PR adds additional logging when dumping mempool transactions to disk during shutdown:
- Adds a log line showing how many transactions are being written
- Updates the final dump log to include the file size
- Changes "disk" to "file" in log messages for consistency

## Changes
Since Dash doesn't have the `src/kernel/mempool_persist.cpp` file that Bitcoin uses, the changes were applied to `src/validation.cpp` where the `DumpMempool` and `LoadMempool` functions are located in Dash.

The backport is functionally complete despite the lower size ratio (73.9%) due to the different file structure between Bitcoin and Dash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced log messages for mempool file operations with clearer terminology.
  * Added reporting of the mempool dump file size in log messages.
  * Log messages now indicate the number of transactions being written to the file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->