### PR TITLE
Merge bitcoin/bitcoin#29479: test: Refactor subtree exclusion in lint tests

### DIFF
--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -59,3 +59,7 @@ git remote add --fetch secp256k1 https://github.com/bitcoin-core/secp256k1.git
 all-lint.py
 ===========
 Calls other scripts with the `lint-` prefix.
+
+lint_ignore_dirs.py
+===================
+Add list of common directories to ignore when running tests

--- a/test/lint/lint-include-guards.py
+++ b/test/lint/lint-include-guards.py
@@ -19,9 +19,7 @@ from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
 HEADER_ID_PREFIX = 'BITCOIN_'
 HEADER_ID_SUFFIX = '_H'
 
-EXCLUDE_FILES_WITH_PREFIX = ['contrib/devtools/bitcoin-tidy',
-                             'src/crypto/ctaes',
-                             'src/tinyformat.h',
+EXCLUDE_FILES_WITH_PREFIX = ['src/tinyformat.h',
                              'src/bench/nanobench.h',
                              'src/test/fuzz/FuzzedDataProvider.h',
                              'src/bls',

--- a/test/lint/lint-include-guards.py
+++ b/test/lint/lint-include-guards.py
@@ -13,15 +13,14 @@ import sys
 from subprocess import check_output
 from typing import List
 
+from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
+
 
 HEADER_ID_PREFIX = 'BITCOIN_'
 HEADER_ID_SUFFIX = '_H'
 
-EXCLUDE_FILES_WITH_PREFIX = ['src/crypto/ctaes',
-                             'src/leveldb',
-                             'src/crc32c',
-                             'src/secp256k1',
-                             'src/minisketch',
+EXCLUDE_FILES_WITH_PREFIX = ['contrib/devtools/bitcoin-tidy',
+                             'src/crypto/ctaes',
                              'src/tinyformat.h',
                              'src/bench/nanobench.h',
                              'src/test/fuzz/FuzzedDataProvider.h',
@@ -31,7 +30,7 @@ EXCLUDE_FILES_WITH_PREFIX = ['src/crypto/ctaes',
                              'src/dashbls',
                              'src/gsl',
                              'src/immer',
-                             'src/util/expected.h']
+                             'src/util/expected.h'] + SHARED_EXCLUDED_SUBTREES
 
 
 def _get_header_file_lst() -> List[str]:

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -14,14 +14,13 @@ import sys
 
 from subprocess import check_output, CalledProcessError
 
+from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
 
-EXCLUDED_DIRS = ["src/leveldb/",
-                 "src/crc32c/",
-                 "src/secp256k1/",
-                 "src/minisketch/",
+
+EXCLUDED_DIRS = ["contrib/devtools/bitcoin-tidy/",
                  "src/dashbls/",
                  "src/immer/",
-                 "src/crypto/x11/"]
+                 "src/crypto/x11/"] + SHARED_EXCLUDED_SUBTREES
 
 EXPECTED_BOOST_INCLUDES = ["boost/date_time/posix_time/posix_time.hpp",
                            "boost/hana/for_each.hpp",

--- a/test/lint/lint-spelling.py
+++ b/test/lint/lint-spelling.py
@@ -11,8 +11,12 @@ Note: Will exit successfully regardless of spelling errors.
 
 from subprocess import check_output, STDOUT, CalledProcessError
 
+from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
+
 IGNORE_WORDS_FILE = 'test/lint/spelling.ignore-words.txt'
-FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)build-aux/m4/", ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)src/bip39_english.h", ":(exclude)src/dashbls/", ":(exclude)src/crc32c/", ":(exclude)src/crypto/", ":(exclude)src/ctpl_stl.h", ":(exclude)src/cxxtimer.hpp", ":(exclude)src/util/expected.h", ":(exclude)src/immer/", ":(exclude)src/leveldb/", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)src/secp256k1/", ":(exclude)src/minisketch/", ":(exclude)contrib/builder-keys/", ":(exclude)contrib/guix/patches"]
+FILES_ARGS = ['git', 'ls-files', '--', ":(exclude)build-aux/m4/", ":(exclude)contrib/seeds/*.txt", ":(exclude)depends/", ":(exclude)doc/release-notes/", ":(exclude)src/bip39_english.h", ":(exclude)src/crypto/", ":(exclude)src/ctpl_stl.h", ":(exclude)src/cxxtimer.hpp", ":(exclude)src/util/expected.h", ":(exclude)src/qt/locale/", ":(exclude)src/qt/*.qrc", ":(exclude)contrib/builder-keys/", ":(exclude)contrib/guix/patches"]
+FILES_ARGS += [f":(exclude){dir}" for dir in SHARED_EXCLUDED_SUBTREES]
+FILES_ARGS += [":(exclude)src/dashbls/", ":(exclude)src/immer/"]
 
 
 def check_codespell_install():

--- a/test/lint/lint_ignore_dirs.py
+++ b/test/lint/lint_ignore_dirs.py
@@ -1,0 +1,5 @@
+SHARED_EXCLUDED_SUBTREES = ["src/leveldb/",
+                 "src/crc32c/",
+                 "src/secp256k1/",
+                 "src/minisketch/",
+                ]


### PR DESCRIPTION
Backports bitcoin/bitcoin#29479

Original commit: 28f2ca675f

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated lint scripts documentation to describe a new shared exclusion script.
* **Chores**
  * Centralized directory exclusion lists for multiple lint scripts by introducing a shared list.
  * Updated lint scripts to use the new shared exclusion list, simplifying and unifying exclusion configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->