### PR TITLE
Merge bitcoin/bitcoin#29764: doc: Suggest installing dev packages for debian/ubuntu qt5 build

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -107,7 +107,7 @@ To build without GUI pass `--without-gui`.
 To build with Qt 5 you need the following:
 
 ```sh
-sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
+sudo apt-get install qtbase5-dev qttools5-dev qttools5-dev-tools
 ```
 
 Additionally, to support Wayland protocol for modern desktop environments:


### PR DESCRIPTION
Backports bitcoin/bitcoin#29764

Original commit: b8420e4603094433deb9dd4e4fabd12dc3921c4a

## Description
This commit updates the Qt5 package installation instructions for Debian/Ubuntu in the build documentation. It suggests using the `-dev` packages (qtbase5-dev) instead of individual library packages, which is the correct approach as these development packages contain the necessary headers and pull in required dependencies.

## Notes
- The Bitcoin commit also modified CI files (.github/workflows/ci.yml and ci/test/00_setup_env_native_tidy.sh) which don't exist in Dash, so only the documentation change was applied.
- This change is important for Ubuntu 24.04 and Debian Testing where library packages were renamed with `t64` suffix.

Backported from Bitcoin Core v0.28