### PR TITLE
Merge bitcoin/bitcoin#29756: doc: Override `-g` properly to skip debugging information

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -43,6 +43,18 @@ tuned to conserve memory with additional CXXFLAGS:
 ```
 
 
+Alternatively, or in addition, debugging information can be skipped for compilation. The default compile flags are
+`-g -O2`, and can be changed with:
+
+```sh
+./configure CXXFLAGS="-g0"
+```
+
+Finally, clang (often less resource hungry) can be used instead of gcc, which is used by default:
+
+```sh
+./configure CXX=clang++ CC=clang
+```
 ## Linux Distribution Specific Instructions
 
 ### Ubuntu & Debian


### PR DESCRIPTION
Backports bitcoin/bitcoin#29756

Original commit: 90224fbf61

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions to include options for controlling debugging information during compilation.
  * Added guidance on using clang as an alternative compiler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->