### PR TITLE
Merge bitcoin/bitcoin#29805: test: Fix debug recommendation in argsman_tests

### DIFF
--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -903,7 +903,7 @@ BOOST_FIXTURE_TEST_CASE(util_ArgsMerge, ArgsMergeTestingSetup)
 
     // If check below fails, should manually dump the results with:
     //
-    //   ARGS_MERGE_TEST_OUT=results.txt ./test_dash --run_test=util_tests/util_ArgsMerge
+    //   ARGS_MERGE_TEST_OUT=results.txt ./test_dash --run_test=argsman_tests/util_ArgsMerge
     //
     // And verify diff against previous results to make sure the changes are expected.
     //
@@ -1006,7 +1006,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
 
     // If check below fails, should manually dump the results with:
     //
-    //   CHAIN_MERGE_TEST_OUT=results.txt ./test_dash --run_test=util_tests/util_ChainMerge
+    //   CHAIN_MERGE_TEST_OUT=results.txt ./test_dash --run_test=argsman_tests/util_ChainMerge
     //
     // And verify diff against previous results to make sure the changes are expected.
     //


### PR DESCRIPTION
Backports bitcoin/bitcoin#29805

Original commit: 561a650e0f669159699224ddd4eb5b1c91cf9ac3

Backported from Bitcoin Core v0.28

This PR fixes debug recommendations in argsman_tests comments that were pointing to the wrong test paths. The commands were trying to run tests in util_tests but these tests are actually in argsman_tests.