### PR TITLE
Merge bitcoin/bitcoin#29791: test: Bump timeouts in feature_index_prune and wallet_importdescriptors

### DIFF
--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -36,7 +36,7 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         expected_stats = {
             'coinstatsindex': {'synced': True, 'best_block_height': height}
         }
-        self.wait_until(lambda: self.nodes[1].getindexinfo() == expected_stats)
+        self.wait_until(lambda: self.nodes[1].getindexinfo() == expected_stats, timeout=150)
 
         expected = {**expected_filter, **expected_stats}
         self.wait_until(lambda: self.nodes[2].getindexinfo() == expected)


### PR DESCRIPTION
Backports bitcoin/bitcoin#29791

Original commit: 03e94f8b90

Backported from Bitcoin Core v0.28

Note: Only the feature_index_prune.py timeout change was applicable to Dash. The wallet_importdescriptors.py change was not applied as the corresponding encrypted wallet test functionality does not exist in Dash's version of this test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout duration for a wait condition in functional tests to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->