### PR TITLE
Merge bitcoin/bitcoin#29803: Update libsecp256k1 subtree to latest master

### DIFF
--- a/src/secp256k1/CMakeLists.txt
+++ b/src/secp256k1/CMakeLists.txt
@@ -51,29 +51,40 @@ endif()
 
 option(SECP256K1_INSTALL "Enable installation." ${PROJECT_IS_TOP_LEVEL})
 
+## Modules
+
+# We declare all options before processing them, to make sure we can express
+# dependendencies while processing.
 option(SECP256K1_ENABLE_MODULE_ECDH "Enable ECDH module." ON)
-if(SECP256K1_ENABLE_MODULE_ECDH)
-  add_compile_definitions(ENABLE_MODULE_ECDH=1)
-endif()
-
 option(SECP256K1_ENABLE_MODULE_RECOVERY "Enable ECDSA pubkey recovery module." OFF)
-if(SECP256K1_ENABLE_MODULE_RECOVERY)
-  add_compile_definitions(ENABLE_MODULE_RECOVERY=1)
-endif()
-
 option(SECP256K1_ENABLE_MODULE_EXTRAKEYS "Enable extrakeys module." ON)
 option(SECP256K1_ENABLE_MODULE_SCHNORRSIG "Enable schnorrsig module." ON)
+option(SECP256K1_ENABLE_MODULE_ELLSWIFT "Enable ElligatorSwift module." ON)
+
+# Processing must be done in a topological sorting of the dependency graph
+# (dependent module first).
+if(SECP256K1_ENABLE_MODULE_ELLSWIFT)
+  add_compile_definitions(ENABLE_MODULE_ELLSWIFT=1)
+endif()
+
 if(SECP256K1_ENABLE_MODULE_SCHNORRSIG)
+  if(DEFINED SECP256K1_ENABLE_MODULE_EXTRAKEYS AND NOT SECP256K1_ENABLE_MODULE_EXTRAKEYS)
+    message(FATAL_ERROR "Module dependency error: You have disabled the extrakeys module explicitly, but it is required by the schnorrsig module.")
+  endif()
   set(SECP256K1_ENABLE_MODULE_EXTRAKEYS ON)
   add_compile_definitions(ENABLE_MODULE_SCHNORRSIG=1)
 endif()
+
 if(SECP256K1_ENABLE_MODULE_EXTRAKEYS)
   add_compile_definitions(ENABLE_MODULE_EXTRAKEYS=1)
 endif()
 
-option(SECP256K1_ENABLE_MODULE_ELLSWIFT "Enable ElligatorSwift module." ON)
-if(SECP256K1_ENABLE_MODULE_ELLSWIFT)
-  add_compile_definitions(ENABLE_MODULE_ELLSWIFT=1)
+if(SECP256K1_ENABLE_MODULE_RECOVERY)
+  add_compile_definitions(ENABLE_MODULE_RECOVERY=1)
+endif()
+
+if(SECP256K1_ENABLE_MODULE_ECDH)
+  add_compile_definitions(ENABLE_MODULE_ECDH=1)
 endif()
 
 option(SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS "Enable external default callback functions." OFF)
@@ -254,9 +265,14 @@ if(SECP256K1_BUILD_BENCHMARK OR SECP256K1_BUILD_TESTS OR SECP256K1_BUILD_EXHAUST
   enable_testing()
 endif()
 
+set(SECP256K1_LATE_CFLAGS "" CACHE STRING "Compiler flags that are added to the command line after all other flags added by the build system.")
+include(AllTargetsCompileOptions)
+
 add_subdirectory(src)
+all_targets_compile_options(src "${SECP256K1_LATE_CFLAGS}")
 if(SECP256K1_BUILD_EXAMPLES)
   add_subdirectory(examples)
+  all_targets_compile_options(examples "${SECP256K1_LATE_CFLAGS}")
 endif()
 
 message("\n")
@@ -329,6 +345,9 @@ else()
   message(" - CFLAGS ............................. ${CMAKE_C_FLAGS_DEBUG}")
   message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
   message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_DEBUG}")
+endif()
+if(SECP256K1_LATE_CFLAGS)
+  message("SECP256K1_LATE_CFLAGS ................. ${SECP256K1_LATE_CFLAGS}")
 endif()
 message("\n")
 if(SECP256K1_EXPERIMENTAL)

--- a/src/secp256k1/README.md
+++ b/src/secp256k1/README.md
@@ -80,9 +80,9 @@ To maintain a pristine source tree, CMake encourages to perform an out-of-source
 
     $ mkdir build && cd build
     $ cmake ..
-    $ make
-    $ make check  # run the test suite
-    $ sudo make install  # optional
+    $ cmake --build .
+    $ ctest  # run the test suite
+    $ sudo cmake --build . --target install  # optional
 
 To compile optional modules (such as Schnorr signatures), you need to run `cmake` with additional flags (such as `-DSECP256K1_ENABLE_MODULE_SCHNORRSIG=ON`). Run `cmake .. -LH` to see the full list of available flags.
 

--- a/src/secp256k1/ci/cirrus.sh
+++ b/src/secp256k1/ci/cirrus.sh
@@ -16,7 +16,8 @@ print_environment() {
             SECP256K1_TEST_ITERS BENCH SECP256K1_BENCH_ITERS CTIMETESTS\
             EXAMPLES \
             HOST WRAPPER_CMD \
-            CC CFLAGS CPPFLAGS AR NM
+            CC CFLAGS CPPFLAGS AR NM \
+            UBSAN_OPTIONS ASAN_OPTIONS LSAN_OPTIONS
     do
         eval "isset=\${$var+x}"
         if [ -n "$isset" ]; then

--- a/src/secp256k1/cmake/AllTargetsCompileOptions.cmake
+++ b/src/secp256k1/cmake/AllTargetsCompileOptions.cmake
@@ -1,0 +1,12 @@
+# Add compile options to all targets added in the subdirectory.
+function(all_targets_compile_options dir options)
+  get_directory_property(targets DIRECTORY ${dir} BUILDSYSTEM_TARGETS)
+  separate_arguments(options)
+  set(compiled_target_types STATIC_LIBRARY SHARED_LIBRARY OBJECT_LIBRARY EXECUTABLE)
+  foreach(target ${targets})
+    get_target_property(type ${target} TYPE)
+    if(type IN_LIST compiled_target_types)
+      target_compile_options(${target} PRIVATE ${options})
+    endif()
+  endforeach()
+endfunction()

--- a/src/secp256k1/configure.ac
+++ b/src/secp256k1/configure.ac
@@ -393,8 +393,22 @@ SECP_CFLAGS="$SECP_CFLAGS $WERROR_CFLAGS"
 ### Handle module options
 ###
 
-if test x"$enable_module_ecdh" = x"yes"; then
-  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_ECDH=1"
+# Processing must be done in a reverse topological sorting of the dependency graph
+# (dependent module first).
+if test x"$enable_module_ellswift" = x"yes"; then
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_ELLSWIFT=1"
+fi
+
+if test x"$enable_module_schnorrsig" = x"yes"; then
+  if test x"$enable_module_extrakeys" = x"no"; then
+    AC_MSG_ERROR([Module dependency error: You have disabled the extrakeys module explicitly, but it is required by the schnorrsig module.])
+  fi
+  enable_module_extrakeys=yes
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_SCHNORRSIG=1"
+fi
+
+if test x"$enable_module_extrakeys" = x"yes"; then
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_EXTRAKEYS=1"
 fi
 
 if test x"$enable_module_recovery" = x"yes"; then
@@ -414,6 +428,10 @@ fi
 # module to set enable_module_extrakeys=yes
 if test x"$enable_module_extrakeys" = x"yes"; then
   SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_EXTRAKEYS=1"
+fi
+
+if test x"$enable_module_ecdh" = x"yes"; then
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_ECDH=1"
 fi
 
 if test x"$enable_external_default_callbacks" = x"yes"; then

--- a/src/secp256k1/contrib/lax_der_parsing.h
+++ b/src/secp256k1/contrib/lax_der_parsing.h
@@ -67,8 +67,8 @@ extern "C" {
  *
  *  Returns: 1 when the signature could be parsed, 0 otherwise.
  *  Args: ctx:      a secp256k1 context object
- *  Out:  sig:      a pointer to a signature object
- *  In:   input:    a pointer to the signature to be parsed
+ *  Out:  sig:      pointer to a signature object
+ *  In:   input:    pointer to the signature to be parsed
  *        inputlen: the length of the array pointed to be input
  *
  *  This function will accept any valid DER encoded signature, even if the

--- a/src/secp256k1/doc/release-process.md
+++ b/src/secp256k1/doc/release-process.md
@@ -1,4 +1,4 @@
-# Release Process
+# Release process
 
 This document outlines the process for releasing versions of the form `$MAJOR.$MINOR.$PATCH`.
 
@@ -14,26 +14,30 @@ This process also assumes that there will be no minor releases for old major rel
 
 We aim to cut a regular release every 3-4 months, approximately twice as frequent as major Bitcoin Core releases. Every second release should be published one month before the feature freeze of the next major Bitcoin Core release, allowing sufficient time to update the library in Core.
 
-## Sanity Checks
-Perform these checks before creating a release:
+## Sanity checks
+Perform these checks when reviewing the release PR (see below):
 
 1. Ensure `make distcheck` doesn't fail.
-```shell
-./autogen.sh && ./configure --enable-dev-mode && make distcheck
-```
+   ```shell
+   ./autogen.sh && ./configure --enable-dev-mode && make distcheck
+   ```
 2. Check installation with autotools:
-```shell
-dir=$(mktemp -d)
-./autogen.sh && ./configure --prefix=$dir && make clean && make install && ls -l $dir/include $dir/lib
-gcc -o ecdsa examples/ecdsa.c $(PKG_CONFIG_PATH=$dir/lib/pkgconfig pkg-config --cflags --libs libsecp256k1) -Wl,-rpath,"$dir/lib" && ./ecdsa
-```
+   ```shell
+   dir=$(mktemp -d)
+   ./autogen.sh && ./configure --prefix=$dir && make clean && make install && ls -RlAh $dir
+   gcc -o ecdsa examples/ecdsa.c $(PKG_CONFIG_PATH=$dir/lib/pkgconfig pkg-config --cflags --libs libsecp256k1) -Wl,-rpath,"$dir/lib" && ./ecdsa
+   ```
 3. Check installation with CMake:
-```shell
-dir=$(mktemp -d)
-build=$(mktemp -d)
-cmake -B $build -DCMAKE_INSTALL_PREFIX=$dir && cmake --build $build --target install && ls -l $dir/include $dir/lib*
-gcc -o ecdsa examples/ecdsa.c -I $dir/include -L $dir/lib*/ -l secp256k1 -Wl,-rpath,"$dir/lib",-rpath,"$dir/lib64" && ./ecdsa
-```
+   ```shell
+   dir=$(mktemp -d)
+   build=$(mktemp -d)
+   cmake -B $build -DCMAKE_INSTALL_PREFIX=$dir && cmake --build $build --target install && ls -RlAh $dir
+   gcc -o ecdsa examples/ecdsa.c -I $dir/include -L $dir/lib*/ -l secp256k1 -Wl,-rpath,"$dir/lib",-rpath,"$dir/lib64" && ./ecdsa
+   ```
+4. Use the [`check-abi.sh`](/tools/check-abi.sh) tool to verify that there are no unexpected ABI incompatibilities and that the version number and the release notes accurately reflect all potential ABI changes. To run this tool, the `abi-dumper` and `abi-compliance-checker` packages are required.
+   ```shell
+   tools/check-abi.sh
+   ```
 
 ## Regular release
 
@@ -41,28 +45,30 @@ gcc -o ecdsa examples/ecdsa.c -I $dir/include -L $dir/lib*/ -l secp256k1 -Wl,-rp
    * finalizes the release notes in [CHANGELOG.md](../CHANGELOG.md) by
        * adding a section for the release (make sure that the version number is a link to a diff between the previous and new version),
        * removing the `[Unreleased]` section header, and
-       * including an entry for `### ABI Compatibility` if it doesn't exist that mentions the library soname of the release,
-   * sets `_PKG_VERSION_IS_RELEASE` to `true` in `configure.ac`, and
-   * if this is not a patch release
-       * updates `_PKG_VERSION_*` and `_LIB_VERSION_*`  in `configure.ac` and
+       * including an entry for `### ABI Compatibility` if it doesn't exist,
+   * sets `_PKG_VERSION_IS_RELEASE` to `true` in `configure.ac`, and,
+   * if this is not a patch release,
+       * updates `_PKG_VERSION_*` and `_LIB_VERSION_*`  in `configure.ac`, and
        * updates `project(libsecp256k1 VERSION ...)` and `${PROJECT_NAME}_LIB_VERSION_*` in `CMakeLists.txt`.
-2. After the PR is merged, tag the commit and push it:
+2. Perform the [sanity checks](#sanity-checks) on the PR branch.
+3. After the PR is merged, tag the commit, and push the tag:
    ```
    RELEASE_COMMIT=<merge commit of step 1>
    git tag -s v$MAJOR.$MINOR.$PATCH -m "libsecp256k1 $MAJOR.$MINOR.$PATCH" $RELEASE_COMMIT
    git push git@github.com:bitcoin-core/secp256k1.git v$MAJOR.$MINOR.$PATCH
    ```
-3. Open a PR to the master branch with a commit (using message `"release cleanup: bump version after $MAJOR.$MINOR.$PATCH"`, for example) that
+4. Open a PR to the master branch with a commit (using message `"release cleanup: bump version after $MAJOR.$MINOR.$PATCH"`, for example) that
    * sets `_PKG_VERSION_IS_RELEASE` to `false` and increments `_PKG_VERSION_PATCH` and `_LIB_VERSION_REVISION` in `configure.ac`,
    * increments the `$PATCH` component of `project(libsecp256k1 VERSION ...)` and `${PROJECT_NAME}_LIB_VERSION_REVISION` in `CMakeLists.txt`, and
    * adds an `[Unreleased]` section header to the [CHANGELOG.md](../CHANGELOG.md).
 
    If other maintainers are not present to approve the PR, it can be merged without ACKs.
-4. Create a new GitHub release with a link to the corresponding entry in [CHANGELOG.md](../CHANGELOG.md).
+5. Create a new GitHub release with a link to the corresponding entry in [CHANGELOG.md](../CHANGELOG.md).
+6. Send an announcement email to the bitcoin-dev mailing list.
 
 ## Maintenance release
 
-Note that bugfixes only need to be backported to releases for which no compatible release without the bug exists.
+Note that bug fixes need to be backported only to releases for which no compatible release without the bug exists.
 
 1. If there's no maintenance branch `$MAJOR.$MINOR`, create one:
    ```
@@ -70,19 +76,18 @@ Note that bugfixes only need to be backported to releases for which no compatibl
    git push git@github.com:bitcoin-core/secp256k1.git $MAJOR.$MINOR
    ```
 2. Open a pull request to the `$MAJOR.$MINOR` branch that
-   * includes the bugfixes,
+   * includes the bug fixes,
    * finalizes the release notes similar to a regular release,
    * increments `_PKG_VERSION_PATCH` and `_LIB_VERSION_REVISION` in `configure.ac`
      and the `$PATCH` component of `project(libsecp256k1 VERSION ...)` and `${PROJECT_NAME}_LIB_VERSION_REVISION` in `CMakeLists.txt`
      (with commit message `"release: bump versions for $MAJOR.$MINOR.$PATCH"`, for example).
-3. After the PRs are merged, update the release branch and tag the commit:
+3. Perform the [sanity checks](#sanity-checks) on the PR branch.
+4. After the PRs are merged, update the release branch, tag the commit, and push the tag:
    ```
    git checkout $MAJOR.$MINOR && git pull
    git tag -s v$MAJOR.$MINOR.$PATCH -m "libsecp256k1 $MAJOR.$MINOR.$PATCH"
-   ```
-4. Push tag:
-   ```
    git push git@github.com:bitcoin-core/secp256k1.git v$MAJOR.$MINOR.$PATCH
    ```
-5. Create a new GitHub release with a link to the corresponding entry in [CHANGELOG.md](../CHANGELOG.md).
-6. Open PR to the master branch that includes a commit (with commit message `"release notes: add $MAJOR.$MINOR.$PATCH"`, for example) that adds release notes to [CHANGELOG.md](../CHANGELOG.md).
+6. Create a new GitHub release with a link to the corresponding entry in [CHANGELOG.md](../CHANGELOG.md).
+7. Send an announcement email to the bitcoin-dev mailing list.
+8. Open PR to the master branch that includes a commit (with commit message `"release notes: add $MAJOR.$MINOR.$PATCH"`, for example) that adds release notes to [CHANGELOG.md](../CHANGELOG.md).

--- a/src/secp256k1/include/secp256k1.h
+++ b/src/secp256k1/include/secp256k1.h
@@ -258,7 +258,7 @@ SECP256K1_API void secp256k1_selftest(void);
  *  memory allocation entirely, see secp256k1_context_static and the functions in
  *  secp256k1_preallocated.h.
  *
- *  Returns: a newly created context object.
+ *  Returns: pointer to a newly created context object.
  *  In:      flags: Always set to SECP256K1_CONTEXT_NONE (see below).
  *
  *  The only valid non-deprecated flag in recent library versions is
@@ -289,8 +289,8 @@ SECP256K1_API secp256k1_context *secp256k1_context_create(
  *  Cloning secp256k1_context_static is not possible, and should not be emulated by
  *  the caller (e.g., using memcpy). Create a new context instead.
  *
- *  Returns: a newly created context object.
- *  Args:    ctx: an existing context to copy (not secp256k1_context_static)
+ *  Returns: pointer to a newly created context object.
+ *  Args:    ctx: pointer to a context to copy (not secp256k1_context_static).
  */
 SECP256K1_API secp256k1_context *secp256k1_context_clone(
     const secp256k1_context *ctx
@@ -306,7 +306,7 @@ SECP256K1_API secp256k1_context *secp256k1_context_clone(
  *  behaviour is undefined. In that case, secp256k1_context_preallocated_destroy must
  *  be used instead.
  *
- *  Args:   ctx: an existing context to destroy, constructed using
+ *  Args:   ctx: pointer to a context to destroy, constructed using
  *               secp256k1_context_create or secp256k1_context_clone
  *               (i.e., not secp256k1_context_static).
  */
@@ -343,8 +343,8 @@ SECP256K1_API void secp256k1_context_destroy(
  *  fails. In this case, the corresponding default handler will be called with
  *  the data pointer argument set to NULL.
  *
- *  Args: ctx:  an existing context object.
- *  In:   fun:  a pointer to a function to call when an illegal argument is
+ *  Args: ctx:  pointer to a context object.
+ *  In:   fun:  pointer to a function to call when an illegal argument is
  *              passed to the API, taking a message and an opaque pointer.
  *              (NULL restores the default handler.)
  *        data: the opaque pointer to pass to fun above, must be NULL for the default handler.
@@ -370,8 +370,8 @@ SECP256K1_API void secp256k1_context_set_illegal_callback(
  *  for that). After this callback returns, anything may happen, including
  *  crashing.
  *
- *  Args: ctx:  an existing context object.
- *  In:   fun:  a pointer to a function to call when an internal error occurs,
+ *  Args: ctx:  pointer to a context object.
+ *  In:   fun:  pointer to a function to call when an internal error occurs,
  *              taking a message and an opaque pointer (NULL restores the
  *              default handler, see secp256k1_context_set_illegal_callback
  *              for details).
@@ -388,7 +388,7 @@ SECP256K1_API void secp256k1_context_set_error_callback(
 /** Create a secp256k1 scratch space object.
  *
  *  Returns: a newly created scratch space.
- *  Args: ctx:  an existing context object.
+ *  Args: ctx:  pointer to a context object.
  *  In:   size: amount of memory to be available as scratch space. Some extra
  *              (<100 bytes) will be allocated for extra accounting.
  */
@@ -400,7 +400,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT secp256k1_scratch_space *secp256k1_sc
 /** Destroy a secp256k1 scratch space.
  *
  *  The pointer may not be used afterwards.
- *  Args:       ctx: a secp256k1 context object.
+ *  Args:       ctx: pointer to a context object.
  *          scratch: space to destroy
  */
 SECP256K1_API void secp256k1_scratch_space_destroy(
@@ -412,7 +412,7 @@ SECP256K1_API void secp256k1_scratch_space_destroy(
  *
  *  Returns: 1 if the public key was fully valid.
  *           0 if the public key could not be parsed or is invalid.
- *  Args: ctx:      a secp256k1 context object.
+ *  Args: ctx:      pointer to a context object.
  *  Out:  pubkey:   pointer to a pubkey object. If 1 is returned, it is set to a
  *                  parsed version of input. If not, its value is undefined.
  *  In:   input:    pointer to a serialized public key
@@ -432,14 +432,14 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
 /** Serialize a pubkey object into a serialized byte sequence.
  *
  *  Returns: 1 always.
- *  Args:   ctx:        a secp256k1 context object.
- *  Out:    output:     a pointer to a 65-byte (if compressed==0) or 33-byte (if
+ *  Args:   ctx:        pointer to a context object.
+ *  Out:    output:     pointer to a 65-byte (if compressed==0) or 33-byte (if
  *                      compressed==1) byte array to place the serialized key
  *                      in.
- *  In/Out: outputlen:  a pointer to an integer which is initially set to the
+ *  In/Out: outputlen:  pointer to an integer which is initially set to the
  *                      size of output, and is overwritten with the written
  *                      size.
- *  In:     pubkey:     a pointer to a secp256k1_pubkey containing an
+ *  In:     pubkey:     pointer to a secp256k1_pubkey containing an
  *                      initialized public key.
  *          flags:      SECP256K1_EC_COMPRESSED if serialization should be in
  *                      compressed format, otherwise SECP256K1_EC_UNCOMPRESSED.
@@ -457,7 +457,7 @@ SECP256K1_API int secp256k1_ec_pubkey_serialize(
  *  Returns: <0 if the first public key is less than the second
  *           >0 if the first public key is greater than the second
  *           0 if the two public keys are equal
- *  Args: ctx:      a secp256k1 context object.
+ *  Args: ctx:      pointer to a context object
  *  In:   pubkey1:  first public key to compare
  *        pubkey2:  second public key to compare
  */
@@ -470,9 +470,9 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_cmp(
 /** Parse an ECDSA signature in compact (64 bytes) format.
  *
  *  Returns: 1 when the signature could be parsed, 0 otherwise.
- *  Args: ctx:      a secp256k1 context object
- *  Out:  sig:      a pointer to a signature object
- *  In:   input64:  a pointer to the 64-byte array to parse
+ *  Args: ctx:      pointer to a context object
+ *  Out:  sig:      pointer to a signature object
+ *  In:   input64:  pointer to the 64-byte array to parse
  *
  *  The signature must consist of a 32-byte big endian R value, followed by a
  *  32-byte big endian S value. If R or S fall outside of [0..order-1], the
@@ -491,9 +491,9 @@ SECP256K1_API int secp256k1_ecdsa_signature_parse_compact(
 /** Parse a DER ECDSA signature.
  *
  *  Returns: 1 when the signature could be parsed, 0 otherwise.
- *  Args: ctx:      a secp256k1 context object
- *  Out:  sig:      a pointer to a signature object
- *  In:   input:    a pointer to the signature to be parsed
+ *  Args: ctx:      pointer to a context object
+ *  Out:  sig:      pointer to a signature object
+ *  In:   input:    pointer to the signature to be parsed
  *        inputlen: the length of the array pointed to be input
  *
  *  This function will accept any valid DER encoded signature, even if the
@@ -513,13 +513,13 @@ SECP256K1_API int secp256k1_ecdsa_signature_parse_der(
 /** Serialize an ECDSA signature in DER format.
  *
  *  Returns: 1 if enough space was available to serialize, 0 otherwise
- *  Args:   ctx:       a secp256k1 context object
- *  Out:    output:    a pointer to an array to store the DER serialization
- *  In/Out: outputlen: a pointer to a length integer. Initially, this integer
+ *  Args:   ctx:       pointer to a context object
+ *  Out:    output:    pointer to an array to store the DER serialization
+ *  In/Out: outputlen: pointer to a length integer. Initially, this integer
  *                     should be set to the length of output. After the call
  *                     it will be set to the length of the serialization (even
  *                     if 0 was returned).
- *  In:     sig:       a pointer to an initialized signature object
+ *  In:     sig:       pointer to an initialized signature object
  */
 SECP256K1_API int secp256k1_ecdsa_signature_serialize_der(
     const secp256k1_context *ctx,
@@ -531,9 +531,9 @@ SECP256K1_API int secp256k1_ecdsa_signature_serialize_der(
 /** Serialize an ECDSA signature in compact (64 byte) format.
  *
  *  Returns: 1
- *  Args:   ctx:       a secp256k1 context object
- *  Out:    output64:  a pointer to a 64-byte array to store the compact serialization
- *  In:     sig:       a pointer to an initialized signature object
+ *  Args:   ctx:       pointer to a context object
+ *  Out:    output64:  pointer to a 64-byte array to store the compact serialization
+ *  In:     sig:       pointer to an initialized signature object
  *
  *  See secp256k1_ecdsa_signature_parse_compact for details about the encoding.
  */
@@ -547,7 +547,7 @@ SECP256K1_API int secp256k1_ecdsa_signature_serialize_compact(
  *
  *  Returns: 1: correct signature
  *           0: incorrect or unparseable signature
- *  Args:    ctx:       a secp256k1 context object.
+ *  Args:    ctx:       pointer to a context object
  *  In:      sig:       the signature being verified.
  *           msghash32: the 32-byte message hash being verified.
  *                      The verifier must make sure to apply a cryptographic
@@ -578,12 +578,12 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
 /** Convert a signature to a normalized lower-S form.
  *
  *  Returns: 1 if sigin was not normalized, 0 if it already was.
- *  Args: ctx:    a secp256k1 context object
- *  Out:  sigout: a pointer to a signature to fill with the normalized form,
+ *  Args: ctx:    pointer to a context object
+ *  Out:  sigout: pointer to a signature to fill with the normalized form,
  *                or copy if the input was already normalized. (can be NULL if
  *                you're only interested in whether the input was already
  *                normalized).
- *  In:   sigin:  a pointer to a signature to check/normalize (can be identical to sigout)
+ *  In:   sigin:  pointer to a signature to check/normalize (can be identical to sigout)
  *
  *  With ECDSA a third-party can forge a second distinct signature of the same
  *  message, given a single initial signature, but without knowing the key. This

--- a/src/secp256k1/include/secp256k1_ecdh.h
+++ b/src/secp256k1/include/secp256k1_ecdh.h
@@ -39,7 +39,7 @@ SECP256K1_API_VAR const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_functio
  *           0: scalar was invalid (zero or overflow) or hashfp returned 0
  *  Args:    ctx:        pointer to a context object.
  *  Out:     output:     pointer to an array to be filled by hashfp.
- *  In:      pubkey:     a pointer to a secp256k1_pubkey containing an initialized public key.
+ *  In:      pubkey:     pointer to a secp256k1_pubkey containing an initialized public key.
  *           seckey:     a 32-byte scalar with which to multiply the point.
  *           hashfp:     pointer to a hash function. If NULL,
  *                       secp256k1_ecdh_hash_function_sha256 is used

--- a/src/secp256k1/include/secp256k1_ellswift.h
+++ b/src/secp256k1/include/secp256k1_ellswift.h
@@ -85,7 +85,7 @@ SECP256K1_API_VAR const secp256k1_ellswift_xdh_hash_function secp256k1_ellswift_
  *  Returns: 1 always.
  *  Args:    ctx:        pointer to a context object
  *  Out:     ell64:      pointer to a 64-byte array to be filled
- *  In:      pubkey:     a pointer to a secp256k1_pubkey containing an
+ *  In:      pubkey:     pointer to a secp256k1_pubkey containing an
  *                       initialized public key
  *           rnd32:      pointer to 32 bytes of randomness
  *
@@ -167,7 +167,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ellswift_create(
  *                      (will not be NULL)
  *           ell_b64:   pointer to the 64-byte encoded public key of party B
  *                      (will not be NULL)
- *           seckey32:  a pointer to our 32-byte secret key
+ *           seckey32:  pointer to our 32-byte secret key
  *           party:     boolean indicating which party we are: zero if we are
  *                      party A, non-zero if we are party B. seckey32 must be
  *                      the private key corresponding to that party's ell_?64.

--- a/src/secp256k1/include/secp256k1_extrakeys.h
+++ b/src/secp256k1/include/secp256k1_extrakeys.h
@@ -39,7 +39,7 @@ typedef struct {
  *  Returns: 1 if the public key was fully valid.
  *           0 if the public key could not be parsed or is invalid.
  *
- *  Args:   ctx: a secp256k1 context object.
+ *  Args:   ctx: pointer to a context object.
  *  Out: pubkey: pointer to a pubkey object. If 1 is returned, it is set to a
  *               parsed version of input. If not, it's set to an invalid value.
  *  In: input32: pointer to a serialized xonly_pubkey.
@@ -54,9 +54,9 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_xonly_pubkey_parse(
  *
  *  Returns: 1 always.
  *
- *  Args:     ctx: a secp256k1 context object.
- *  Out: output32: a pointer to a 32-byte array to place the serialized key in.
- *  In:    pubkey: a pointer to a secp256k1_xonly_pubkey containing an initialized public key.
+ *  Args:     ctx: pointer to a context object.
+ *  Out: output32: pointer to a 32-byte array to place the serialized key in.
+ *  In:    pubkey: pointer to a secp256k1_xonly_pubkey containing an initialized public key.
  */
 SECP256K1_API int secp256k1_xonly_pubkey_serialize(
     const secp256k1_context *ctx,
@@ -69,7 +69,7 @@ SECP256K1_API int secp256k1_xonly_pubkey_serialize(
  *  Returns: <0 if the first public key is less than the second
  *           >0 if the first public key is greater than the second
  *           0 if the two public keys are equal
- *  Args: ctx:      a secp256k1 context object.
+ *  Args: ctx:      pointer to a context object.
  *  In:   pubkey1:  first public key to compare
  *        pubkey2:  second public key to compare
  */

--- a/src/secp256k1/include/secp256k1_preallocated.h
+++ b/src/secp256k1/include/secp256k1_preallocated.h
@@ -52,8 +52,8 @@ SECP256K1_API size_t secp256k1_context_preallocated_size(
  *  in the memory. In simpler words, the prealloc pointer (or any pointer derived
  *  from it) should not be used during the lifetime of the context object.
  *
- *  Returns: a newly created context object.
- *  In:      prealloc: a pointer to a rewritable contiguous block of memory of
+ *  Returns: pointer to newly created context object.
+ *  In:      prealloc: pointer to a rewritable contiguous block of memory of
  *                     size at least secp256k1_context_preallocated_size(flags)
  *                     bytes, as detailed above.
  *           flags:    which parts of the context to initialize.
@@ -72,7 +72,7 @@ SECP256K1_API secp256k1_context *secp256k1_context_preallocated_create(
  *  caller-provided memory.
  *
  *  Returns: the required size of the caller-provided memory block.
- *  In:      ctx: an existing context to copy.
+ *  In:      ctx: pointer to a context to copy.
  */
 SECP256K1_API size_t secp256k1_context_preallocated_clone_size(
     const secp256k1_context *ctx
@@ -91,9 +91,9 @@ SECP256K1_API size_t secp256k1_context_preallocated_clone_size(
  *  Cloning secp256k1_context_static is not possible, and should not be emulated by
  *  the caller (e.g., using memcpy). Create a new context instead.
  *
- *  Returns: a newly created context object.
- *  Args:    ctx:      an existing context to copy (not secp256k1_context_static).
- *  In:      prealloc: a pointer to a rewritable contiguous block of memory of
+ *  Returns: pointer to a newly created context object.
+ *  Args:    ctx:      pointer to a context to copy (not secp256k1_context_static).
+ *  In:      prealloc: pointer to a rewritable contiguous block of memory of
  *                     size at least secp256k1_context_preallocated_size(flags)
  *                     bytes, as detailed above.
  */
@@ -118,7 +118,7 @@ SECP256K1_API secp256k1_context *secp256k1_context_preallocated_clone(
  *  preallocated pointer given to secp256k1_context_preallocated_create or
  *  secp256k1_context_preallocated_clone.
  *
- *  Args:   ctx: an existing context to destroy, constructed using
+ *  Args:   ctx: pointer to a context to destroy, constructed using
  *               secp256k1_context_preallocated_create or
  *               secp256k1_context_preallocated_clone
  *               (i.e., not secp256k1_context_static).

--- a/src/secp256k1/include/secp256k1_recovery.h
+++ b/src/secp256k1/include/secp256k1_recovery.h
@@ -28,9 +28,9 @@ typedef struct {
 /** Parse a compact ECDSA signature (64 bytes + recovery id).
  *
  *  Returns: 1 when the signature could be parsed, 0 otherwise
- *  Args: ctx:     a secp256k1 context object
- *  Out:  sig:     a pointer to a signature object
- *  In:   input64: a pointer to a 64-byte compact signature
+ *  Args: ctx:     pointer to a context object
+ *  Out:  sig:     pointer to a signature object
+ *  In:   input64: pointer to a 64-byte compact signature
  *        recid:   the recovery id (0, 1, 2 or 3)
  */
 SECP256K1_API int secp256k1_ecdsa_recoverable_signature_parse_compact(
@@ -43,9 +43,9 @@ SECP256K1_API int secp256k1_ecdsa_recoverable_signature_parse_compact(
 /** Convert a recoverable signature into a normal signature.
  *
  *  Returns: 1
- *  Args: ctx:    a secp256k1 context object.
- *  Out:  sig:    a pointer to a normal signature.
- *  In:   sigin:  a pointer to a recoverable signature.
+ *  Args: ctx:    pointer to a context object.
+ *  Out:  sig:    pointer to a normal signature.
+ *  In:   sigin:  pointer to a recoverable signature.
  */
 SECP256K1_API int secp256k1_ecdsa_recoverable_signature_convert(
     const secp256k1_context *ctx,
@@ -56,10 +56,10 @@ SECP256K1_API int secp256k1_ecdsa_recoverable_signature_convert(
 /** Serialize an ECDSA signature in compact format (64 bytes + recovery id).
  *
  *  Returns: 1
- *  Args: ctx:      a secp256k1 context object.
- *  Out:  output64: a pointer to a 64-byte array of the compact signature.
- *        recid:    a pointer to an integer to hold the recovery id.
- *  In:   sig:      a pointer to an initialized signature object.
+ *  Args: ctx:      pointer to a context object.
+ *  Out:  output64: pointer to a 64-byte array of the compact signature.
+ *        recid:    pointer to an integer to hold the recovery id.
+ *  In:   sig:      pointer to an initialized signature object.
  */
 SECP256K1_API int secp256k1_ecdsa_recoverable_signature_serialize_compact(
     const secp256k1_context *ctx,

--- a/src/secp256k1/include/secp256k1_schnorrsig.h
+++ b/src/secp256k1/include/secp256k1_schnorrsig.h
@@ -169,11 +169,11 @@ SECP256K1_API int secp256k1_schnorrsig_sign_custom(
  *
  *  Returns: 1: correct signature
  *           0: incorrect signature
- *  Args:    ctx: a secp256k1 context object.
+ *  Args:    ctx: pointer to a context object.
  *  In:    sig64: pointer to the 64-byte signature to verify.
  *           msg: the message being verified. Can only be NULL if msglen is 0.
  *        msglen: length of the message
- *        pubkey: pointer to an x-only public key to verify with (cannot be NULL)
+ *        pubkey: pointer to an x-only public key to verify with
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorrsig_verify(
     const secp256k1_context *ctx,

--- a/src/secp256k1/src/assumptions.h
+++ b/src/secp256k1/src/assumptions.h
@@ -19,65 +19,69 @@
    reduce the odds of experiencing an unwelcome surprise.
 */
 
-struct secp256k1_assumption_checker {
-    /* This uses a trick to implement a static assertion in C89: a type with an array of negative size is not
-       allowed. */
-    int dummy_array[(
-        /* Bytes are 8 bits. */
-        (CHAR_BIT == 8) &&
+#if defined(__has_attribute)
+# if __has_attribute(__unavailable__)
+__attribute__((__unavailable__("Don't call this function. It only exists because STATIC_ASSERT cannot be used outside a function.")))
+# endif
+#endif
+static void secp256k1_assumption_checker(void) {
+    /* Bytes are 8 bits. */
+    STATIC_ASSERT(CHAR_BIT == 8);
 
-        /* No integer promotion for uint32_t. This ensures that we can multiply uintXX_t values where XX >= 32
-           without signed overflow, which would be undefined behaviour. */
-        (UINT_MAX <= UINT32_MAX) &&
+    /* No integer promotion for uint32_t. This ensures that we can multiply uintXX_t values where XX >= 32
+       without signed overflow, which would be undefined behaviour. */
+    STATIC_ASSERT(UINT_MAX <= UINT32_MAX);
 
-        /* Conversions from unsigned to signed outside of the bounds of the signed type are
-           implementation-defined. Verify that they function as reinterpreting the lower
-           bits of the input in two's complement notation. Do this for conversions:
-           - from uint(N)_t to int(N)_t with negative result
-           - from uint(2N)_t to int(N)_t with negative result
-           - from int(2N)_t to int(N)_t with negative result
-           - from int(2N)_t to int(N)_t with positive result */
+    /* Conversions from unsigned to signed outside of the bounds of the signed type are
+       implementation-defined. Verify that they function as reinterpreting the lower
+       bits of the input in two's complement notation. Do this for conversions:
+       - from uint(N)_t to int(N)_t with negative result
+       - from uint(2N)_t to int(N)_t with negative result
+       - from int(2N)_t to int(N)_t with negative result
+       - from int(2N)_t to int(N)_t with positive result */
 
-        /* To int8_t. */
-        ((int8_t)(uint8_t)0xAB == (int8_t)-(int8_t)0x55) &&
-        ((int8_t)(uint16_t)0xABCD == (int8_t)-(int8_t)0x33) &&
-        ((int8_t)(int16_t)(uint16_t)0xCDEF == (int8_t)(uint8_t)0xEF) &&
-        ((int8_t)(int16_t)(uint16_t)0x9234 == (int8_t)(uint8_t)0x34) &&
+    /* To int8_t. */
+    STATIC_ASSERT(((int8_t)(uint8_t)0xAB == (int8_t)-(int8_t)0x55));
+    STATIC_ASSERT((int8_t)(uint16_t)0xABCD == (int8_t)-(int8_t)0x33);
+    STATIC_ASSERT((int8_t)(int16_t)(uint16_t)0xCDEF == (int8_t)(uint8_t)0xEF);
+    STATIC_ASSERT((int8_t)(int16_t)(uint16_t)0x9234 == (int8_t)(uint8_t)0x34);
 
-        /* To int16_t. */
-        ((int16_t)(uint16_t)0xBCDE == (int16_t)-(int16_t)0x4322) &&
-        ((int16_t)(uint32_t)0xA1B2C3D4 == (int16_t)-(int16_t)0x3C2C) &&
-        ((int16_t)(int32_t)(uint32_t)0xC1D2E3F4 == (int16_t)(uint16_t)0xE3F4) &&
-        ((int16_t)(int32_t)(uint32_t)0x92345678 == (int16_t)(uint16_t)0x5678) &&
+    /* To int16_t. */
+    STATIC_ASSERT((int16_t)(uint16_t)0xBCDE == (int16_t)-(int16_t)0x4322);
+    STATIC_ASSERT((int16_t)(uint32_t)0xA1B2C3D4 == (int16_t)-(int16_t)0x3C2C);
+    STATIC_ASSERT((int16_t)(int32_t)(uint32_t)0xC1D2E3F4 == (int16_t)(uint16_t)0xE3F4);
+    STATIC_ASSERT((int16_t)(int32_t)(uint32_t)0x92345678 == (int16_t)(uint16_t)0x5678);
 
-        /* To int32_t. */
-        ((int32_t)(uint32_t)0xB2C3D4E5 == (int32_t)-(int32_t)0x4D3C2B1B) &&
-        ((int32_t)(uint64_t)0xA123B456C789D012ULL == (int32_t)-(int32_t)0x38762FEE) &&
-        ((int32_t)(int64_t)(uint64_t)0xC1D2E3F4A5B6C7D8ULL == (int32_t)(uint32_t)0xA5B6C7D8) &&
-        ((int32_t)(int64_t)(uint64_t)0xABCDEF0123456789ULL == (int32_t)(uint32_t)0x23456789) &&
+    /* To int32_t. */
+    STATIC_ASSERT((int32_t)(uint32_t)0xB2C3D4E5 == (int32_t)-(int32_t)0x4D3C2B1B);
+    STATIC_ASSERT((int32_t)(uint64_t)0xA123B456C789D012ULL == (int32_t)-(int32_t)0x38762FEE);
+    STATIC_ASSERT((int32_t)(int64_t)(uint64_t)0xC1D2E3F4A5B6C7D8ULL == (int32_t)(uint32_t)0xA5B6C7D8);
+    STATIC_ASSERT((int32_t)(int64_t)(uint64_t)0xABCDEF0123456789ULL == (int32_t)(uint32_t)0x23456789);
 
-        /* To int64_t. */
-        ((int64_t)(uint64_t)0xB123C456D789E012ULL == (int64_t)-(int64_t)0x4EDC3BA928761FEEULL) &&
+    /* To int64_t. */
+    STATIC_ASSERT((int64_t)(uint64_t)0xB123C456D789E012ULL == (int64_t)-(int64_t)0x4EDC3BA928761FEEULL);
 #if defined(SECP256K1_INT128_NATIVE)
-        ((int64_t)(((uint128_t)0xA1234567B8901234ULL << 64) + 0xC5678901D2345678ULL) == (int64_t)-(int64_t)0x3A9876FE2DCBA988ULL) &&
-        (((int64_t)(int128_t)(((uint128_t)0xB1C2D3E4F5A6B7C8ULL << 64) + 0xD9E0F1A2B3C4D5E6ULL)) == (int64_t)(uint64_t)0xD9E0F1A2B3C4D5E6ULL) &&
-        (((int64_t)(int128_t)(((uint128_t)0xABCDEF0123456789ULL << 64) + 0x0123456789ABCDEFULL)) == (int64_t)(uint64_t)0x0123456789ABCDEFULL) &&
+    STATIC_ASSERT((int64_t)(((uint128_t)0xA1234567B8901234ULL << 64) + 0xC5678901D2345678ULL) == (int64_t)-(int64_t)0x3A9876FE2DCBA988ULL);
+    STATIC_ASSERT(((int64_t)(int128_t)(((uint128_t)0xB1C2D3E4F5A6B7C8ULL << 64) + 0xD9E0F1A2B3C4D5E6ULL)) == (int64_t)(uint64_t)0xD9E0F1A2B3C4D5E6ULL);
+    STATIC_ASSERT(((int64_t)(int128_t)(((uint128_t)0xABCDEF0123456789ULL << 64) + 0x0123456789ABCDEFULL)) == (int64_t)(uint64_t)0x0123456789ABCDEFULL);
 
-        /* To int128_t. */
-        ((int128_t)(((uint128_t)0xB1234567C8901234ULL << 64) + 0xD5678901E2345678ULL) == (int128_t)(-(int128_t)0x8E1648B3F50E80DCULL * 0x8E1648B3F50E80DDULL + 0x5EA688D5482F9464ULL)) &&
+    /* To int128_t. */
+    STATIC_ASSERT((int128_t)(((uint128_t)0xB1234567C8901234ULL << 64) + 0xD5678901E2345678ULL) == (int128_t)(-(int128_t)0x8E1648B3F50E80DCULL * 0x8E1648B3F50E80DDULL + 0x5EA688D5482F9464ULL));
 #endif
 
-        /* Right shift on negative signed values is implementation defined. Verify that it
-           acts as a right shift in two's complement with sign extension (i.e duplicating
-           the top bit into newly added bits). */
-        ((((int8_t)0xE8) >> 2) == (int8_t)(uint8_t)0xFA) &&
-        ((((int16_t)0xE9AC) >> 4) == (int16_t)(uint16_t)0xFE9A) &&
-        ((((int32_t)0x937C918A) >> 9) == (int32_t)(uint32_t)0xFFC9BE48) &&
-        ((((int64_t)0xA8B72231DF9CF4B9ULL) >> 19) == (int64_t)(uint64_t)0xFFFFF516E4463BF3ULL) &&
+    /* Right shift on negative signed values is implementation defined. Verify that it
+       acts as a right shift in two's complement with sign extension (i.e duplicating
+       the top bit into newly added bits). */
+    STATIC_ASSERT((((int8_t)0xE8) >> 2) == (int8_t)(uint8_t)0xFA);
+    STATIC_ASSERT((((int16_t)0xE9AC) >> 4) == (int16_t)(uint16_t)0xFE9A);
+    STATIC_ASSERT((((int32_t)0x937C918A) >> 9) == (int32_t)(uint32_t)0xFFC9BE48);
+    STATIC_ASSERT((((int64_t)0xA8B72231DF9CF4B9ULL) >> 19) == (int64_t)(uint64_t)0xFFFFF516E4463BF3ULL);
 #if defined(SECP256K1_INT128_NATIVE)
-        ((((int128_t)(((uint128_t)0xCD833A65684A0DBCULL << 64) + 0xB349312F71EA7637ULL)) >> 39) == (int128_t)(((uint128_t)0xFFFFFFFFFF9B0674ULL << 64) + 0xCAD0941B79669262ULL)) &&
+    STATIC_ASSERT((((int128_t)(((uint128_t)0xCD833A65684A0DBCULL << 64) + 0xB349312F71EA7637ULL)) >> 39) == (int128_t)(((uint128_t)0xFFFFFFFFFF9B0674ULL << 64) + 0xCAD0941B79669262ULL));
 #endif
-    1) * 2 - 1];
-};
+
+    /* This function is not supposed to be called. */
+    VERIFY_CHECK(0);
+}
 
 #endif /* SECP256K1_ASSUMPTIONS_H */

--- a/src/secp256k1/src/checkmem.h
+++ b/src/secp256k1/src/checkmem.h
@@ -30,6 +30,8 @@
  * - SECP256K1_CHECKMEM_DEFINE(p, len):
  *   - marks the len-byte memory pointed to by p as defined data (public data, in the
  *     context of constant-time checking).
+ * - SECP256K1_CHECKMEM_MSAN_DEFINE(p, len):
+ *   - Like SECP256K1_CHECKMEM_DEFINE, but applies only to memory_sanitizer.
  *
  */
 
@@ -48,9 +50,14 @@
 #    define SECP256K1_CHECKMEM_ENABLED 1
 #    define SECP256K1_CHECKMEM_UNDEFINE(p, len) __msan_allocated_memory((p), (len))
 #    define SECP256K1_CHECKMEM_DEFINE(p, len) __msan_unpoison((p), (len))
+#    define SECP256K1_CHECKMEM_MSAN_DEFINE(p, len) __msan_unpoison((p), (len))
 #    define SECP256K1_CHECKMEM_CHECK(p, len) __msan_check_mem_is_initialized((p), (len))
 #    define SECP256K1_CHECKMEM_RUNNING() (1)
 #  endif
+#endif
+
+#if !defined SECP256K1_CHECKMEM_MSAN_DEFINE
+#  define SECP256K1_CHECKMEM_MSAN_DEFINE(p, len) SECP256K1_CHECKMEM_NOOP((p), (len))
 #endif
 
 /* If valgrind integration is desired (through the VALGRIND define), implement the

--- a/src/secp256k1/src/field.h
+++ b/src/secp256k1/src/field.h
@@ -248,8 +248,8 @@ static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_fe *a);
 /** Multiply two field elements.
  *
  * On input, a and b must be valid field elements; r does not need to be initialized.
- * r and a may point to the same object, but neither can be equal to b. The magnitudes
- * of a and b must not exceed 8.
+ * r and a may point to the same object, but neither may point to the object pointed
+ * to by b. The magnitudes of a and b must not exceed 8.
  * Performs {r = a * b}
  * On output, r will have magnitude 1, but won't be normalized.
  */

--- a/src/secp256k1/src/modules/ellswift/tests_impl.h
+++ b/src/secp256k1/src/modules/ellswift/tests_impl.h
@@ -188,9 +188,9 @@ void run_ellswift_tests(void) {
             CHECK(ret == ((testcase->enc_bitmap >> c) & 1));
             if (ret) {
                 secp256k1_fe x2;
-                CHECK(check_fe_equal(&t, &testcase->encs[c]));
+                CHECK(fe_equal(&t, &testcase->encs[c]));
                 secp256k1_ellswift_xswiftec_var(&x2, &testcase->u, &testcase->encs[c]);
-                CHECK(check_fe_equal(&testcase->x, &x2));
+                CHECK(fe_equal(&testcase->x, &x2));
             }
         }
     }
@@ -203,7 +203,7 @@ void run_ellswift_tests(void) {
         CHECK(ret);
         ret = secp256k1_pubkey_load(CTX, &ge, &pubkey);
         CHECK(ret);
-        CHECK(check_fe_equal(&testcase->x, &ge.x));
+        CHECK(fe_equal(&testcase->x, &ge.x));
         CHECK(secp256k1_fe_is_odd(&ge.y) == testcase->odd_y);
     }
     for (i = 0; (unsigned)i < sizeof(ellswift_xdh_tests_bip324) / sizeof(ellswift_xdh_tests_bip324[0]); ++i) {
@@ -290,7 +290,7 @@ void run_ellswift_tests(void) {
         secp256k1_ecmult(&resj, &decj, &sec, NULL);
         secp256k1_ge_set_gej(&res, &resj);
         /* Compare. */
-        CHECK(check_fe_equal(&res.x, &share_x));
+        CHECK(fe_equal(&res.x, &share_x));
     }
     /* Verify the joint behavior of secp256k1_ellswift_xdh */
     for (i = 0; i < 200 * COUNT; i++) {

--- a/src/secp256k1/src/scalar_4x64_impl.h
+++ b/src/secp256k1/src/scalar_4x64_impl.h
@@ -387,6 +387,14 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint64_t *l) 
     : "S"(l), "i"(SECP256K1_N_C_0), "i"(SECP256K1_N_C_1)
     : "rax", "rdx", "r8", "r9", "r10", "r11", "r12", "r13", "r14", "cc");
 
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&m0, sizeof(m0));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&m1, sizeof(m1));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&m2, sizeof(m2));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&m3, sizeof(m3));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&m4, sizeof(m4));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&m5, sizeof(m5));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&m6, sizeof(m6));
+
     /* Reduce 385 bits into 258. */
     __asm__ __volatile__(
     /* Preload */
@@ -466,6 +474,12 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint64_t *l) 
     : "g"(m0), "g"(m1), "g"(m2), "g"(m3), "g"(m4), "g"(m5), "g"(m6), "i"(SECP256K1_N_C_0), "i"(SECP256K1_N_C_1)
     : "rax", "rdx", "r8", "r9", "r10", "r11", "r12", "r13", "cc");
 
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&p0, sizeof(p0));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&p1, sizeof(p1));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&p2, sizeof(p2));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&p3, sizeof(p3));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&p4, sizeof(p4));
+
     /* Reduce 258 bits into 256. */
     __asm__ __volatile__(
     /* Preload */
@@ -511,6 +525,10 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint64_t *l) 
     : "=g"(c)
     : "g"(p0), "g"(p1), "g"(p2), "g"(p3), "g"(p4), "D"(r), "i"(SECP256K1_N_C_0), "i"(SECP256K1_N_C_1)
     : "rax", "rdx", "r8", "r9", "r10", "cc", "memory");
+
+    SECP256K1_CHECKMEM_MSAN_DEFINE(r, sizeof(*r));
+    SECP256K1_CHECKMEM_MSAN_DEFINE(&c, sizeof(c));
+
 #else
     secp256k1_uint128 c128;
     uint64_t c, c0, c1, c2;
@@ -588,7 +606,7 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint64_t *l) 
     secp256k1_scalar_reduce(r, c + secp256k1_scalar_check_overflow(r));
 }
 
-static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, const secp256k1_scalar *b) {
+static void secp256k1_scalar_mul_512(uint64_t *l8, const secp256k1_scalar *a, const secp256k1_scalar *b) {
 #ifdef USE_ASM_X86_64
     const uint64_t *pb = b->d;
     __asm__ __volatile__(
@@ -603,7 +621,7 @@ static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, c
     /* (rax,rdx) = a0 * b0 */
     "movq %%r15, %%rax\n"
     "mulq %%r11\n"
-    /* Extract l0 */
+    /* Extract l8[0] */
     "movq %%rax, 0(%%rsi)\n"
     /* (r8,r9,r10) = (rdx) */
     "movq %%rdx, %%r8\n"
@@ -621,7 +639,7 @@ static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, c
     "addq %%rax, %%r8\n"
     "adcq %%rdx, %%r9\n"
     "adcq $0, %%r10\n"
-    /* Extract l1 */
+    /* Extract l8[1] */
     "movq %%r8, 8(%%rsi)\n"
     "xorq %%r8, %%r8\n"
     /* (r9,r10,r8) += a0 * b2 */
@@ -642,7 +660,7 @@ static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, c
     "addq %%rax, %%r9\n"
     "adcq %%rdx, %%r10\n"
     "adcq $0, %%r8\n"
-    /* Extract l2 */
+    /* Extract l8[2] */
     "movq %%r9, 16(%%rsi)\n"
     "xorq %%r9, %%r9\n"
     /* (r10,r8,r9) += a0 * b3 */
@@ -671,7 +689,7 @@ static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, c
     "addq %%rax, %%r10\n"
     "adcq %%rdx, %%r8\n"
     "adcq $0, %%r9\n"
-    /* Extract l3 */
+    /* Extract l8[3] */
     "movq %%r10, 24(%%rsi)\n"
     "xorq %%r10, %%r10\n"
     /* (r8,r9,r10) += a1 * b3 */
@@ -692,7 +710,7 @@ static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, c
     "addq %%rax, %%r8\n"
     "adcq %%rdx, %%r9\n"
     "adcq $0, %%r10\n"
-    /* Extract l4 */
+    /* Extract l8[4] */
     "movq %%r8, 32(%%rsi)\n"
     "xorq %%r8, %%r8\n"
     /* (r9,r10,r8) += a2 * b3 */
@@ -707,51 +725,54 @@ static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, c
     "addq %%rax, %%r9\n"
     "adcq %%rdx, %%r10\n"
     "adcq $0, %%r8\n"
-    /* Extract l5 */
+    /* Extract l8[5] */
     "movq %%r9, 40(%%rsi)\n"
     /* (r10,r8) += a3 * b3 */
     "movq %%r15, %%rax\n"
     "mulq %%r14\n"
     "addq %%rax, %%r10\n"
     "adcq %%rdx, %%r8\n"
-    /* Extract l6 */
+    /* Extract l8[6] */
     "movq %%r10, 48(%%rsi)\n"
-    /* Extract l7 */
+    /* Extract l8[7] */
     "movq %%r8, 56(%%rsi)\n"
     : "+d"(pb)
-    : "S"(l), "D"(a->d)
+    : "S"(l8), "D"(a->d)
     : "rax", "rbx", "rcx", "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15", "cc", "memory");
+
+    SECP256K1_CHECKMEM_MSAN_DEFINE(l8, sizeof(*l8) * 8);
+
 #else
     /* 160 bit accumulator. */
     uint64_t c0 = 0, c1 = 0;
     uint32_t c2 = 0;
 
-    /* l[0..7] = a[0..3] * b[0..3]. */
+    /* l8[0..7] = a[0..3] * b[0..3]. */
     muladd_fast(a->d[0], b->d[0]);
-    extract_fast(l[0]);
+    extract_fast(l8[0]);
     muladd(a->d[0], b->d[1]);
     muladd(a->d[1], b->d[0]);
-    extract(l[1]);
+    extract(l8[1]);
     muladd(a->d[0], b->d[2]);
     muladd(a->d[1], b->d[1]);
     muladd(a->d[2], b->d[0]);
-    extract(l[2]);
+    extract(l8[2]);
     muladd(a->d[0], b->d[3]);
     muladd(a->d[1], b->d[2]);
     muladd(a->d[2], b->d[1]);
     muladd(a->d[3], b->d[0]);
-    extract(l[3]);
+    extract(l8[3]);
     muladd(a->d[1], b->d[3]);
     muladd(a->d[2], b->d[2]);
     muladd(a->d[3], b->d[1]);
-    extract(l[4]);
+    extract(l8[4]);
     muladd(a->d[2], b->d[3]);
     muladd(a->d[3], b->d[2]);
-    extract(l[5]);
+    extract(l8[5]);
     muladd_fast(a->d[3], b->d[3]);
-    extract_fast(l[6]);
+    extract_fast(l8[6]);
     VERIFY_CHECK(c1 == 0);
-    l[7] = c0;
+    l8[7] = c0;
 #endif
 }
 

--- a/src/secp256k1/src/scalar_impl.h
+++ b/src/secp256k1/src/scalar_impl.h
@@ -212,7 +212,7 @@ static void secp256k1_scalar_split_lambda(secp256k1_scalar * SECP256K1_RESTRICT 
  * <=   {triangle inequality}
  *    a1*|k*b2/n - c1| + a2*|k*(-b1)/n - c2|
  * <    {Lemma 1 and Lemma 2}
- *    a1*(2^-1 + epslion1) + a2*(2^-1 + epsilon2)
+ *    a1*(2^-1 + epsilon1) + a2*(2^-1 + epsilon2)
  * <    {rounding up to an integer}
  *    (a1 + a2 + 1)/2
  * <    {rounding up to a power of 2}
@@ -230,7 +230,7 @@ static void secp256k1_scalar_split_lambda(secp256k1_scalar * SECP256K1_RESTRICT 
  * <=   {triangle inequality}
  *    (-b1)*|k*b2/n - c1| + b2*|k*(-b1)/n - c2|
  * <    {Lemma 1 and Lemma 2}
- *    (-b1)*(2^-1 + epslion1) + b2*(2^-1 + epsilon2)
+ *    (-b1)*(2^-1 + epsilon1) + b2*(2^-1 + epsilon2)
  * <    {rounding up to an integer}
  *    (-b1 + b2)/2 + 1
  * <    {rounding up to a power of 2}

--- a/src/secp256k1/src/secp256k1.c
+++ b/src/secp256k1/src/secp256k1.c
@@ -237,36 +237,25 @@ static SECP256K1_INLINE void secp256k1_declassify(const secp256k1_context* ctx, 
 }
 
 static int secp256k1_pubkey_load(const secp256k1_context* ctx, secp256k1_ge* ge, const secp256k1_pubkey* pubkey) {
-    if (sizeof(secp256k1_ge_storage) == 64) {
-        /* When the secp256k1_ge_storage type is exactly 64 byte, use its
-         * representation inside secp256k1_pubkey, as conversion is very fast.
-         * Note that secp256k1_pubkey_save must use the same representation. */
-        secp256k1_ge_storage s;
-        memcpy(&s, &pubkey->data[0], sizeof(s));
-        secp256k1_ge_from_storage(ge, &s);
-    } else {
-        /* Otherwise, fall back to 32-byte big endian for X and Y. */
-        secp256k1_fe x, y;
-        ARG_CHECK(secp256k1_fe_set_b32_limit(&x, pubkey->data));
-        ARG_CHECK(secp256k1_fe_set_b32_limit(&y, pubkey->data + 32));
-        secp256k1_ge_set_xy(ge, &x, &y);
-    }
+    secp256k1_ge_storage s;
+
+    /* We require that the secp256k1_ge_storage type is exactly 64 bytes.
+     * This is formally not guaranteed by the C standard, but should hold on any
+     * sane compiler in the real world. */
+    STATIC_ASSERT(sizeof(secp256k1_ge_storage) == 64);
+    memcpy(&s, &pubkey->data[0], 64);
+    secp256k1_ge_from_storage(ge, &s);
     ARG_CHECK(!secp256k1_fe_is_zero(&ge->x));
     return 1;
 }
 
 static void secp256k1_pubkey_save(secp256k1_pubkey* pubkey, secp256k1_ge* ge) {
-    if (sizeof(secp256k1_ge_storage) == 64) {
-        secp256k1_ge_storage s;
-        secp256k1_ge_to_storage(&s, ge);
-        memcpy(&pubkey->data[0], &s, sizeof(s));
-    } else {
-        VERIFY_CHECK(!secp256k1_ge_is_infinity(ge));
-        secp256k1_fe_normalize_var(&ge->x);
-        secp256k1_fe_normalize_var(&ge->y);
-        secp256k1_fe_get_b32(pubkey->data, &ge->x);
-        secp256k1_fe_get_b32(pubkey->data + 32, &ge->y);
-    }
+    secp256k1_ge_storage s;
+
+    STATIC_ASSERT(sizeof(secp256k1_ge_storage) == 64);
+    VERIFY_CHECK(!secp256k1_ge_is_infinity(ge));
+    secp256k1_ge_to_storage(&s, ge);
+    memcpy(&pubkey->data[0], &s, 64);
 }
 
 int secp256k1_ec_pubkey_parse(const secp256k1_context* ctx, secp256k1_pubkey* pubkey, const unsigned char *input, size_t inputlen) {

--- a/src/secp256k1/src/tests.c
+++ b/src/secp256k1/src/tests.c
@@ -2954,20 +2954,18 @@ static void run_scalar_tests(void) {
             secp256k1_scalar_set_b32(&r2, res[i][1], &overflow);
             CHECK(!overflow);
             secp256k1_scalar_mul(&z, &x, &y);
-            CHECK(!secp256k1_scalar_check_overflow(&z));
             CHECK(secp256k1_scalar_eq(&r1, &z));
             if (!secp256k1_scalar_is_zero(&y)) {
                 secp256k1_scalar_inverse(&zz, &y);
-                CHECK(!secp256k1_scalar_check_overflow(&zz));
                 secp256k1_scalar_inverse_var(&zzv, &y);
                 CHECK(secp256k1_scalar_eq(&zzv, &zz));
                 secp256k1_scalar_mul(&z, &z, &zz);
-                CHECK(!secp256k1_scalar_check_overflow(&z));
                 CHECK(secp256k1_scalar_eq(&x, &z));
                 secp256k1_scalar_mul(&zz, &zz, &y);
-                CHECK(!secp256k1_scalar_check_overflow(&zz));
                 CHECK(secp256k1_scalar_eq(&secp256k1_scalar_one, &zz));
             }
+            secp256k1_scalar_mul(&z, &x, &x);
+            CHECK(secp256k1_scalar_eq(&r2, &z));
         }
     }
 }
@@ -3015,7 +3013,7 @@ static void random_fe_non_square(secp256k1_fe *ns) {
     }
 }
 
-static int check_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b) {
+static int fe_equal(const secp256k1_fe *a, const secp256k1_fe *b) {
     secp256k1_fe an = *a;
     secp256k1_fe bn = *b;
     secp256k1_fe_normalize_weak(&an);
@@ -3153,7 +3151,7 @@ static void run_field_half(void) {
 #endif
         secp256k1_fe_normalize_weak(&u);
         secp256k1_fe_add(&u, &u);
-        CHECK(check_fe_equal(&t, &u));
+        CHECK(fe_equal(&t, &u));
 
         /* Check worst-case input: ensure the LSB is 1 so that P will be added,
          * which will also cause all carries to be 1, since all limbs that can
@@ -3172,7 +3170,7 @@ static void run_field_half(void) {
 #endif
         secp256k1_fe_normalize_weak(&u);
         secp256k1_fe_add(&u, &u);
-        CHECK(check_fe_equal(&t, &u));
+        CHECK(fe_equal(&t, &u));
     }
 }
 
@@ -3199,7 +3197,7 @@ static void run_field_misc(void) {
         secp256k1_fe_add(&z, &q); /* z = x+v */
         q = x; /* q = x */
         secp256k1_fe_add_int(&q, v); /* q = x+v */
-        CHECK(check_fe_equal(&q, &z));
+        CHECK(fe_equal(&q, &z));
         /* Test the fe equality and comparison operations. */
         CHECK(secp256k1_fe_cmp_var(&x, &x) == 0);
         CHECK(secp256k1_fe_equal_var(&x, &x));
@@ -3259,27 +3257,27 @@ static void run_field_misc(void) {
         secp256k1_fe_add(&y, &x);
         z = x;
         secp256k1_fe_mul_int(&z, 3);
-        CHECK(check_fe_equal(&y, &z));
+        CHECK(fe_equal(&y, &z));
         secp256k1_fe_add(&y, &x);
         secp256k1_fe_add(&z, &x);
-        CHECK(check_fe_equal(&z, &y));
+        CHECK(fe_equal(&z, &y));
         z = x;
         secp256k1_fe_mul_int(&z, 5);
         secp256k1_fe_mul(&q, &x, &fe5);
-        CHECK(check_fe_equal(&z, &q));
+        CHECK(fe_equal(&z, &q));
         secp256k1_fe_negate(&x, &x, 1);
         secp256k1_fe_add(&z, &x);
         secp256k1_fe_add(&q, &x);
-        CHECK(check_fe_equal(&y, &z));
-        CHECK(check_fe_equal(&q, &y));
+        CHECK(fe_equal(&y, &z));
+        CHECK(fe_equal(&q, &y));
         /* Check secp256k1_fe_half. */
         z = x;
         secp256k1_fe_half(&z);
         secp256k1_fe_add(&z, &z);
-        CHECK(check_fe_equal(&x, &z));
+        CHECK(fe_equal(&x, &z));
         secp256k1_fe_add(&z, &z);
         secp256k1_fe_half(&z);
-        CHECK(check_fe_equal(&x, &z));
+        CHECK(fe_equal(&x, &z));
     }
 }
 
@@ -3348,18 +3346,31 @@ static void run_fe_mul(void) {
 }
 
 static void run_sqr(void) {
-    secp256k1_fe x, s;
+    int i;
+    secp256k1_fe x, y, lhs, rhs, tmp;
 
-    {
-        int i;
-        secp256k1_fe_set_int(&x, 1);
-        secp256k1_fe_negate(&x, &x, 1);
+    secp256k1_fe_set_int(&x, 1);
+    secp256k1_fe_negate(&x, &x, 1);
 
-        for (i = 1; i <= 512; ++i) {
-            secp256k1_fe_mul_int(&x, 2);
-            secp256k1_fe_normalize(&x);
-            secp256k1_fe_sqr(&s, &x);
-        }
+    for (i = 1; i <= 512; ++i) {
+        secp256k1_fe_mul_int(&x, 2);
+        secp256k1_fe_normalize(&x);
+
+        /* Check that (x+y)*(x-y) = x^2 - y*2 for some random values y */
+        random_fe_test(&y);
+
+        lhs = x;
+        secp256k1_fe_add(&lhs, &y);         /* lhs = x+y */
+        secp256k1_fe_negate(&tmp, &y, 1);   /* tmp = -y */
+        secp256k1_fe_add(&tmp, &x);         /* tmp = x-y */
+        secp256k1_fe_mul(&lhs, &lhs, &tmp); /* lhs = (x+y)*(x-y) */
+
+        secp256k1_fe_sqr(&rhs, &x);         /* rhs = x^2 */
+        secp256k1_fe_sqr(&tmp, &y);         /* tmp = y^2 */
+        secp256k1_fe_negate(&tmp, &tmp, 1); /* tmp = -y^2 */
+        secp256k1_fe_add(&rhs, &tmp);       /* rhs = x^2 - y^2 */
+
+        CHECK(fe_equal(&lhs, &rhs));
     }
 }
 
@@ -3681,9 +3692,9 @@ static void run_inverse_tests(void)
     for (i = 0; (size_t)i < sizeof(fe_cases)/sizeof(fe_cases[0]); ++i) {
         for (var = 0; var <= 1; ++var) {
             test_inverse_field(&x_fe, &fe_cases[i][0], var);
-            check_fe_equal(&x_fe, &fe_cases[i][1]);
+            CHECK(fe_equal(&x_fe, &fe_cases[i][1]));
             test_inverse_field(&x_fe, &fe_cases[i][1], var);
-            check_fe_equal(&x_fe, &fe_cases[i][0]);
+            CHECK(fe_equal(&x_fe, &fe_cases[i][0]));
         }
     }
     for (i = 0; (size_t)i < sizeof(scalar_cases)/sizeof(scalar_cases[0]); ++i) {
@@ -4606,7 +4617,7 @@ static void ecmult_const_mult_xonly(void) {
         /* Check that resj's X coordinate corresponds with resx. */
         secp256k1_fe_sqr(&v, &resj.z);
         secp256k1_fe_mul(&v, &v, &resx);
-        CHECK(check_fe_equal(&v, &resj.x));
+        CHECK(fe_equal(&v, &resj.x));
     }
 
     /* Test that secp256k1_ecmult_const_xonly correctly rejects X coordinates not on curve. */

--- a/src/secp256k1/src/util.h
+++ b/src/secp256k1/src/util.h
@@ -51,6 +51,32 @@ static void print_buf_plain(const unsigned char *buf, size_t len) {
 #  define SECP256K1_INLINE inline
 # endif
 
+/** Assert statically that expr is true.
+ *
+ * This is a statement-like macro and can only be used inside functions.
+ */
+#define STATIC_ASSERT(expr) do { \
+    switch(0) { \
+        case 0: \
+        /* If expr evaluates to 0, we have two case labels "0", which is illegal. */ \
+        case /* ERROR: static assertion failed */ (expr): \
+        ; \
+    } \
+} while(0)
+
+/** Assert statically that expr is an integer constant expression, and run stmt.
+ *
+ * Useful for example to enforce that magnitude arguments are constant.
+ */
+#define ASSERT_INT_CONST_AND_DO(expr, stmt) do { \
+    switch(42) { \
+        /* C allows only integer constant expressions as case labels. */ \
+        case /* ERROR: integer argument is not constant */ (expr): \
+            break; \
+        default: ; \
+    } \
+    stmt; \
+} while(0)
 typedef struct {
     void (*fn)(const char *text, void* data);
     const void* data;


### PR DESCRIPTION
Backports bitcoin/bitcoin#29803

Original commit: b5d21182e5a66110ce2796c2c99da39c8ebf0d72

Backported from Bitcoin Core v0.28

This PR updates the libsecp256k1 subtree to include the latest changes from upstream. The update includes various improvements and bug fixes to the secp256k1 library, including:
- New static assert macros for compile-time checks
- Updates to build system files (CMake and autotools)
- Documentation improvements
- Performance optimizations in scalar operations
- Test improvements

Note: Some files that were deleted in Dash but modified in Bitcoin were not included (e.g., GitHub actions, CONTRIBUTING.md, check-abi.sh tool).