### PR TITLE
Merge bitcoin/bitcoin#29821: fuzz: Some `test/fuzz/test_runner.py` improvements

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -99,9 +99,11 @@ def main():
         logging.error("Must have fuzz targets built")
         sys.exit(1)
 
+    fuzz_bin=os.getenv("DASHFUZZ", default=os.path.join(config["environment"]["BUILDDIR"], 'src', 'test', 'fuzz', 'fuzz'))
+
     # Build list of tests
     test_list_all = parse_test_list(
-        fuzz_bin=os.path.join(config["environment"]["BUILDDIR"], 'src', 'test', 'fuzz', 'fuzz'),
+        fuzz_bin=fuzz_bin,
         source_dir=config['environment']['SRCDIR'],
     )
 
@@ -146,7 +148,7 @@ def main():
     try:
         help_output = subprocess.run(
             args=[
-                os.path.join(config["environment"]["BUILDDIR"], 'src', 'test', 'fuzz', 'fuzz'),
+                fuzz_bin,
                 '-help=1',
             ],
             env=get_fuzz_env(target=test_list_selection[0], source_dir=config['environment']['SRCDIR']),
@@ -167,7 +169,7 @@ def main():
             return generate_corpus(
                 fuzz_pool=fuzz_pool,
                 src_dir=config['environment']['SRCDIR'],
-                build_dir=config["environment"]["BUILDDIR"],
+                fuzz_bin=fuzz_bin,
                 corpus_dir=args.corpus_dir,
                 targets=test_list_selection,
             )
@@ -178,7 +180,7 @@ def main():
                 corpus=args.corpus_dir,
                 test_list=test_list_selection,
                 src_dir=config['environment']['SRCDIR'],
-                build_dir=config["environment"]["BUILDDIR"],
+                fuzz_bin=fuzz_bin,
                 merge_dir=args.m_dir,
             )
             return
@@ -188,13 +190,13 @@ def main():
             corpus=args.corpus_dir,
             test_list=test_list_selection,
             src_dir=config['environment']['SRCDIR'],
-            build_dir=config["environment"]["BUILDDIR"],
+            fuzz_bin=fuzz_bin,
             use_valgrind=args.valgrind,
             empty_min_time=args.empty_min_time,
         )
 
 
-def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
+def generate_corpus(*, fuzz_pool, src_dir, fuzz_bin, corpus_dir, targets):
     """Generates new corpus.
 
     Run {targets} without input, and outputs the generated corpus to
@@ -220,7 +222,7 @@ def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
         os.makedirs(target_corpus_dir, exist_ok=True)
         use_value_profile = int(random.random() < .3)
         command = [
-            os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
+            fuzz_bin,
             "-rss_limit_mb=8000",
             "-max_total_time=6000",
             "-reload=0",
@@ -233,12 +235,12 @@ def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
         future.result()
 
 
-def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, build_dir, merge_dir):
+def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, merge_dir):
     logging.info("Merge the inputs from the passed dir into the corpus_dir. Passed dir {}".format(merge_dir))
     jobs = []
     for t in test_list:
         args = [
-            os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
+            fuzz_bin,
             '-rss_limit_mb=8000',
             '-set_cover_merge=1',
             # set_cover_merge is used instead of -merge=1 to reduce the overall
@@ -271,13 +273,13 @@ def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, build_dir, merge_dir)
         future.result()
 
 
-def run_once(*, fuzz_pool, corpus, test_list, src_dir, build_dir, use_valgrind, empty_min_time):
+def run_once(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, use_valgrind, empty_min_time):
     jobs = []
     for t in test_list:
         corpus_path = corpus / t
         os.makedirs(corpus_path, exist_ok=True)
         args = [
-            os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
+            fuzz_bin,
         ]
         empty_dir = not any(corpus_path.iterdir())
         if empty_min_time and empty_dir:


### PR DESCRIPTION
Backports bitcoin/bitcoin#29821

Original commit: f348ec7c2a9bec428a0b7a62592a5662c0087750

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined how the fuzz binary path is managed by introducing a single variable that can be set via an environment variable or defaults to a standard location.
  * Updated several internal functions to use this new approach for specifying the fuzz binary path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->