### PR TITLE
Merge bitcoin/bitcoin#27389: test: refactor: replace unnecessary `BytesIO` uses

### DIFF
--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -7,9 +7,8 @@
 from decimal import Decimal
 from enum import Enum
 import http.client
-from io import BytesIO
 import json
-from struct import pack, unpack
+import typing
 import urllib.parse
 
 
@@ -151,12 +150,11 @@ class RESTTest (BitcoinTestFramework):
         bin_request = b'\x01\x02'
         for txid, n in [spending, spent]:
             bin_request += bytes.fromhex(txid)
-            bin_request += pack("i", n)
+            bin_request += n.to_bytes(4, 'little')
 
         bin_response = self.test_rest_request("/getutxos", http_method='POST', req_type=ReqType.BIN, body=bin_request, ret_type=RetType.BYTES)
-        output = BytesIO(bin_response)
-        chain_height, = unpack("<i", output.read(4))
-        response_hash = output.read(32)[::-1].hex()
+        chain_height = int.from_bytes(bin_response[0:4], 'little')
+        response_hash = bin_response[4:36][::-1].hex()
 
         assert_equal(bb_hash, response_hash)  # check if getutxo's chaintip during calculation was fine
         assert_equal(chain_height, 201)  # chain height must be 201 (pre-mined chain [200] + generated block [1])

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -13,7 +13,6 @@ from test_framework.blocktools import create_block, create_coinbase
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import (
     dashhash,
-    hash256,
     tx_from_hex,
 )
 from test_framework.util import (
@@ -31,9 +30,6 @@ try:
     import zmq
 except ImportError:
     pass
-
-def hash256_reversed(byte_str):
-    return hash256(byte_str)[::-1]
 
 def dashhash_reversed(byte_str):
     return dashhash(byte_str)[::-1]
@@ -240,8 +236,9 @@ class ZMQTest (BitcoinTestFramework):
             #       islocked txes
 
             # Should receive the broadcasted raw transaction.
-            hex = rawtx.receive()
-            assert_equal(payment_txid, hash256_reversed(hex).hex())
+            tx = tx_from_hex(rawtx.receive().hex())
+            tx.calc_sha256()
+            assert_equal(payment_txid, tx.hash)
 
             # Mining the block with this tx should result in second notification
             # after coinbase tx notification

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -6,6 +6,7 @@
 import os
 import struct
 import tempfile
+from time import sleep
 
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE, ADDRESS_BCRT1_P2SH_OP_TRUE
 from test_framework.blocktools import create_block, create_coinbase
@@ -20,8 +21,10 @@ from test_framework.util import (
     assert_raises_rpc_error,
     p2p_port,
 )
+from test_framework.wallet import (
+    MiniWallet,
+)
 from test_framework.netutil import test_ipv6_local, test_unix_socket
-from time import sleep
 
 # Test may be skipped and not have zmq installed
 try:
@@ -209,8 +212,9 @@ class ZMQTest (BitcoinTestFramework):
             txid = hashtx.receive()
 
             # Should receive the coinbase raw transaction.
-            hex = rawtx.receive()
-            assert_equal(hash256_reversed(hex), txid)
+            tx = tx_from_hex(rawtx.receive().hex())
+            tx.calc_sha256()
+            assert_equal(tx.hash, txid.hex())
 
             # Should receive the generated raw block.
             block = rawblock.receive()


### PR DESCRIPTION
Backports bitcoin/bitcoin#27389

Original commit: 49b87bfe7e2799d25ce709123ecafa872b36e87a

Backported from Bitcoin Core v0.25