### PR TITLE
Merge bitcoin/bitcoin#27477: test: add regression tests for #27468 (invalid URI segfaults)

### DIFF
--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -271,6 +271,11 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(len(json_obj), 1)  # ensure that there is one header in the json response
         assert_equal(json_obj[0]['hash'], bb_hash)  # request/response hash should be the same
 
+        # Check invalid uri (% symbol at the end of the request)
+        for invalid_uri in [f"/headers/{bb_hash}%", f"/blockfilterheaders/basic/{bb_hash}%", "/mempool/contents.json?%"]:
+            resp = self.test_rest_request(invalid_uri, ret_type=RetType.OBJ, status=400)
+            assert_equal(resp.read().decode('utf-8').rstrip(), "URI parsing failed, it likely contained RFC 3986 invalid characters")
+
         # Compare with normal RPC block response
         rpc_block_json = self.nodes[0].getblock(bb_hash)
         for key in ['hash', 'confirmations', 'height', 'version', 'merkleroot', 'time', 'nonce', 'bits', 'difficulty', 'chainwork', 'previousblockhash']:


### PR DESCRIPTION
Backports bitcoin/bitcoin#27477

Original commit: 467fa8943801911c233cb96d45282b1de10bfa90

Backported from Bitcoin Core v0.25

---

This PR adds regression tests for invalid URI parsing that could cause segfaults in the REST interface. The tests verify that malformed URIs with RFC 3986 invalid characters (like % at the end) are properly rejected with appropriate error messages.

The backport was clean with only minor context conflicts that were resolved.