### PR TITLE
Merge bitcoin/bitcoin#27453: test: added coverage to rpc_scantxoutset.py

### DIFF
--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -126,5 +126,8 @@ class ScantxoutsetTest(BitcoinTestFramework):
         # Check that second arg is needed for start
         assert_raises_rpc_error(-1, "scanobjects argument is required for the start action", self.nodes[0].scantxoutset, "start")
 
+        # Check that invalid command give error
+        assert_raises_rpc_error(-8, "Invalid action 'invalid_command'", self.nodes[0].scantxoutset, "invalid_command")
+
 if __name__ == '__main__':
     ScantxoutsetTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#27453

Original commit: d654c762c8

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the `scantxoutset` feature by adding checks for invalid commands, ensuring appropriate error messages are returned for unrecognized actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->