### PR TITLE
Merge bitcoin/bitcoin#27574: doc: Add post branch-off note about fuzz input pruning

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -28,6 +28,8 @@ Before every major release:
 * [ ] Update [`src/chainparams.cpp`](/src/chainparams.cpp) `m_assumed_blockchain_size` and `m_assumed_chain_state_size` with the current size plus some overhead (see [this](#how-to-calculate-assumed-blockchain-and-chain-state-size) for information on how to calculate them).
 * [ ] Update [`src/chainparams.cpp`](/src/chainparams.cpp) `chainTxData` with statistics about the transaction count and rate. Use the output of the `getchaintxstats` RPC, see
   [this pull request](https://github.com/dashpay/dash/pull/5692) for an example. Reviewers can verify the results by running `getchaintxstats <window_block_count> <window_last_block_hash>` with the `window_block_count` and `window_last_block_hash` from your output.
+* [ ] Prune inputs from the qa-assets repo (See [pruning
+  inputs](https://github.com/bitcoin-core/qa-assets#pruning-inputs)).
 
 ### First time / New builders
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27574

Original commit: 5d1014d5a1196ff97c1f88b6052c8bef1ebeb43e

Backported from Bitcoin Core v0.26