### PR TITLE
Merge bitcoin/bitcoin#27605: refactor: Replace global find_value function with UniValue::find_value method

### DIFF
--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -381,6 +381,88 @@ RPCHelpMan getmempoolentry()
     };
 }
 
+static RPCHelpMan gettxspendingprevout()
+{
+    return RPCHelpMan{"gettxspendingprevout",
+        "Scans the mempool to find transactions spending any of the given outputs",
+        {
+            {"outputs", RPCArg::Type::ARR, RPCArg::Optional::NO, "The transaction outputs that we want to check, and within each, the txid (string) vout (numeric).",
+                {
+                    {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                        },
+                    },
+                },
+            },
+        },
+        RPCResult{
+            RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::STR_HEX, "txid", "the transaction id of the checked output"},
+                    {RPCResult::Type::NUM, "vout", "the vout value of the checked output"},
+                    {RPCResult::Type::STR_HEX, "spendingtxid", /*optional=*/true, "the transaction id of the mempool transaction spending this output (omitted if unspent)"},
+                }},
+            }
+        },
+        RPCExamples{
+            HelpExampleCli("gettxspendingprevout", "\"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":3}]\"")
+            + HelpExampleRpc("gettxspendingprevout", "\"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":3}]\"")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            const UniValue& output_params = request.params[0].get_array();
+            if (output_params.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, outputs are missing");
+            }
+
+            std::vector<COutPoint> prevouts;
+            prevouts.reserve(output_params.size());
+
+            for (unsigned int idx = 0; idx < output_params.size(); idx++) {
+                const UniValue& o = output_params[idx].get_obj();
+
+                RPCTypeCheckObj(o,
+                                {
+                                    {"txid", UniValueType(UniValue::VSTR)},
+                                    {"vout", UniValueType(UniValue::VNUM)},
+                                }, /*fAllowNull=*/false, /*fStrict=*/true);
+
+                const uint256 txid(ParseHashO(o, "txid"));
+                const int nOutput{o.find_value("vout").getInt<int>()};
+                if (nOutput < 0) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout cannot be negative");
+                }
+
+                prevouts.emplace_back(txid, nOutput);
+            }
+
+            const CTxMemPool& mempool = EnsureAnyMemPool(request.context);
+            LOCK(mempool.cs);
+
+            UniValue result{UniValue::VARR};
+
+            for (const COutPoint& prevout : prevouts) {
+                UniValue o(UniValue::VOBJ);
+                o.pushKV("txid", prevout.hash.ToString());
+                o.pushKV("vout", (uint64_t)prevout.n);
+
+                const CTransaction* spendingTx = mempool.GetConflictTx(prevout);
+                if (spendingTx != nullptr) {
+                    o.pushKV("spendingtxid", spendingTx->GetHash().ToString());
+                }
+
+                result.push_back(o);
+            }
+
+            return result;
+        },
+    };
+}
+
 UniValue MempoolInfoToJSON(const CTxMemPool& pool, const llmq::CInstantSendManager& isman)
 {
     // Make sure this call is atomic in the pool.
@@ -478,6 +560,7 @@ void RegisterMempoolRPCCommands(CRPCTable& t)
         {"blockchain", &getmempoolentry},
         {"blockchain", &getmempoolinfo},
         {"blockchain", &getrawmempool},
+        {"blockchain", &gettxspendingprevout},
         {"blockchain", &savemempool},
     };
     for (const auto& c : commands) {


### PR DESCRIPTION
Backports bitcoin/bitcoin#27605

Original commit: e0a70c5b4f

Backported from Bitcoin Core v0.26

Note: Most of the find_value refactoring was already completed in Dash PR #6775. This backport primarily adds the new `gettxspendingprevout` RPC function that uses the refactored `find_value` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new RPC command that allows users to check if specific transaction outputs are being spent by transactions in the mempool. The command returns details about each queried output, including the spending transaction ID if applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->