### PR TITLE
Merge bitcoin/bitcoin#27685: doc: Rework build-unix.md

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -15,6 +15,7 @@ For example:
 **Dash Core's `configure` script by default will ignore the depends output.** In
 order for it to pick up libraries, tools, and settings from the depends build,
 you must set the `CONFIG_SITE` environment variable to point to a `config.site` settings file.
+Make sure that `CONFIG_SITE` is an absolute path.
 In the above example, a file named `depends/x86_64-w64-mingw32/share/config.site` will be
 created. To use it during compilation:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -4,18 +4,6 @@ Some notes on how to build Dash Core in Unix.
 
 (For BSD specific instructions, see `build-*bsd.md` in this directory.)
 
-Note
----------------------
-Always use absolute paths to configure and compile Dash Core and the dependencies.
-For example, when specifying the path of the dependency:
-
-```sh
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
-```
-
-Here `BDB_PREFIX` must be an absolute path - it is defined using $(pwd) which ensures
-the usage of the absolute path.
-
 To Build
 ---------------------
 
@@ -26,12 +14,11 @@ make # use "-j N" for N parallel jobs
 make install # optional
 ```
 
-This will build dash-qt as well, if the dependencies are met.
+See below for instructions on how to [install the dependencies on popular Linux
+distributions](#linux-distribution-specific-instructions), or the
+[dependencies](#dependencies) section for a complete overview.
 
-See [dependencies.md](dependencies.md) for a complete overview.
-
-Memory Requirements
---------------------
+## Memory Requirements
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
 memory available when compiling Dash Core. On systems with less, gcc can be
@@ -55,7 +42,7 @@ Build requirements:
 sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils bison python3
 ```
 
-Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
+Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
 
 ```sh
 sudo apt-get install libevent-dev libboost-dev
@@ -67,7 +54,7 @@ SQLite is required for the descriptor wallet:
 sudo apt-get install libsqlite3-dev
 ```
 
-Berkeley DB is required for the legacy wallet. Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages,
+Berkeley DB is only required for the legacy wallet. Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages,
 but these will install Berkeley DB 5.1 or later. This will break binary wallet compatibility with the distributed
 executables, which are based on BerkeleyDB 4.8. If you do not care about wallet compatibility, pass
 `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
@@ -136,7 +123,7 @@ Build requirements:
 sudo dnf install gcc-c++ libtool make autoconf automake python3
 ```
 
-Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
+Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
 
 ```sh
 sudo dnf install libevent-devel boost-devel
@@ -154,7 +141,7 @@ Berkeley DB is required for the legacy wallet:
 sudo dnf install libdb4-devel libdb4-cxx-devel
 ```
 
-Newer Fedora releases, since Fedora 33, have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
+Berkeley DB is only required for the legacy wallet. Newer Fedora releases have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
 Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed executables, which
 are based on Berkeley DB 4.8. If you do not care about wallet compatibility,
 pass `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
@@ -212,28 +199,13 @@ sudo dnf install qrencode-devel
 Once these are installed, they will be found by configure and a dash-qt executable will be
 built by default.
 
-Notes
------
-The release is built with GCC and then "strip dashd" to strip the debug
-symbols, which reduces the executable size by about 90%.
+## Dependencies
 
+See [dependencies.md](dependencies.md) for a complete overview, and
+[depends](/depends/README.md) on how to compile them yourself, if you wish to
+not use the packages of your Linux distribution.
 
-miniupnpc
----------
-
-[miniupnpc](https://miniupnp.tuxfamily.org) may be used for UPnP port mapping.  It can be downloaded from [here](
-https://miniupnp.tuxfamily.org/files/).  UPnP support is compiled in and
-turned off by default.
-
-libnatpmp
----------
-
-[libnatpmp](https://miniupnp.tuxfamily.org/libnatpmp.html) may be used for NAT-PMP port mapping. It can be downloaded
-from [here](https://miniupnp.tuxfamily.org/files/). NAT-PMP support is compiled in and
-turned off by default.
-
-Berkeley DB
------------
+### Berkeley DB
 
 The legacy wallet uses Berkeley DB. To ensure backwards compatibility it is
 recommended to use Berkeley DB 4.8. If you have to build it yourself, you can
@@ -246,9 +218,9 @@ like so:
 
 from the root of the repository.
 
-Otherwise, you can build Dash Core from self-compiled [depends](/depends/README.md).
+**Note**: Make sure that `BDB_PREFIX` is an absolute path.
 
-**Note**: You only need Berkeley DB if the wallet is enabled (see [*Disable-wallet mode*](#disable-wallet-mode)).
+**Note**: You only need Berkeley DB if the legacy wallet is enabled (see [*Disable-wallet mode*](#disable-wallet-mode)).
 
 Security
 --------


### PR DESCRIPTION
Backports bitcoin/bitcoin#27685

Original commit: 5f70cd39974dcb966f2a7913dda216258c2d24c1

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions regarding the use of absolute paths with the CONFIG_SITE environment variable.
  * Consolidated and reorganized dependency-related information for improved clarity.
  * Updated references and cross-links for consistency.
  * Refined wording to specify that Berkeley DB is only required for the legacy wallet.
  * Removed redundant notes and merged related dependency sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->