### PR TITLE
Merge bitcoin/bitcoin#27689: doc: remove mention of glibc 2.10+

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -43,7 +43,7 @@ threads take up 8MiB for the thread stack on a 64-bit system, and 4MiB in a
 
 ## Linux specific
 
-By default, since glibc `2.10`, the C library will create up to two heap arenas per core. This is known to cause excessive memory usage in some scenarios. To avoid this make a script that sets `MALLOC_ARENA_MAX` before starting dashd:
+By default, glibc will create up to two heap arenas per core. This is known to cause excessive memory usage in some scenarios. To avoid this make a script that sets `MALLOC_ARENA_MAX` before starting dashd:
 
 ```bash
 #!/usr/bin/env bash

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -892,7 +892,7 @@ static RPCHelpMan getmemoryinfo()
         {
             {"mode", RPCArg::Type::STR, RPCArg::Default{"stats"}, "determines what kind of information is returned.\n"
     "  - \"stats\" returns general statistics about memory usage in the daemon.\n"
-    "  - \"mallocinfo\" returns an XML string describing low-level heap state (only available if compiled with glibc 2.10+)."},
+    "  - \"mallocinfo\" returns an XML string describing low-level heap state (only available if compiled with glibc)."},
         },
         {
             RPCResult{"mode \"stats\"",


### PR DESCRIPTION
Backports bitcoin/bitcoin#27689

Original commit: 8146f2a035

Backported from Bitcoin Core v0.26