### PR TITLE
Merge bitcoin/bitcoin#27662: build: Bump minimum supported GCC to g++-9

### DIFF
--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -8,11 +8,13 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_qt5
 export HOST=x86_64-pc-linux-gnu
-export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
-export DEP_OPTS=""
+# Use minimum supported gcc-9, see doc/dependencies.md
+export PACKAGES="gcc-9 g++-9 python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
+export DEP_OPTS="CC=gcc-9 CXX=g++-9"
 export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_pruning,feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"
+export NO_WERROR=1  # -Werror=maybe-uninitialized
 export PREVIOUS_RELEASES_TO_DOWNLOAD="v0.12.1.5 v0.15.0.0 v0.16.1.1 v0.17.0.3 v18.2.2 v19.3.0 v20.0.1"
 export BITCOIN_CONFIG="--enable-zmq --with-libs=no --enable-reduce-exports --disable-fuzz-binary LDFLAGS=-static-libstdc++ --with-boost-process"


### PR DESCRIPTION
Backports bitcoin/bitcoin#27662

Original commit: edd6d8395f

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment setup to use GCC 9 for native Qt5 testing.
  * Disabled treating warnings as errors during testing to improve build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->