### PR TITLE
Merge bitcoin/bitcoin#27556: wallet: fix deadlock in bdb read write operation

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -672,7 +672,9 @@ bool BerkeleyBatch::StartCursor()
     assert(!m_cursor);
     if (!pdb)
         return false;
-    int ret = pdb->cursor(nullptr, &m_cursor, 0);
+    // Transaction argument to cursor is needed when using the cursor to
+    // write to the database. Pass the active transaction to avoid deadlocks.
+    int ret = pdb->cursor(activeTxn, &m_cursor, 0);
     return ret == 0;
 }
 

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_TEST_UTIL_H
 
 #include <memory>
+#include <wallet/db.h>
 
 class ArgsManager;
 class CChain;
@@ -19,6 +20,16 @@ class Loader;
 
 namespace wallet {
 class CWallet;
+class WalletDatabase;
+
+static const DatabaseFormat DATABASE_FORMATS[] = {
+#ifdef USE_SQLITE
+       DatabaseFormat::SQLITE,
+#endif
+#ifdef USE_BDB
+       DatabaseFormat::BERKELEY,
+#endif
+};
 
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, interfaces::CoinJoin::Loader& coinjoin_loader, CChain& cchain, ArgsManager& args, const CKey& key);
 } // namespace wallet

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -6,6 +6,8 @@
 #include <clientversion.h>
 #include <streams.h>
 #include <uint256.h>
+#include <wallet/test/util.h>
+#include <wallet/wallet.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -25,6 +27,32 @@ BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
     CDataStream ssValue(SER_DISK, CLIENT_VERSION);
     uint256 dummy;
     BOOST_CHECK_THROW(ssValue >> dummy, std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(walletdb_read_write_deadlock)
+{
+    // Exercises a db read write operation that shouldn't deadlock.
+    for (const DatabaseFormat& db_format : DATABASE_FORMATS) {
+        // Context setup
+        DatabaseOptions options;
+        options.require_format = db_format;
+        DatabaseStatus status;
+        bilingual_str error_string;
+        std::unique_ptr<WalletDatabase> db = MakeDatabase(m_path_root / strprintf("wallet_%d_.dat", db_format).c_str(), options, status, error_string);
+        BOOST_ASSERT(status == DatabaseStatus::SUCCESS);
+
+        std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(db)));
+        wallet->m_keypool_size = 4;
+
+        // Create legacy spkm
+        LOCK(wallet->cs_wallet);
+        auto legacy_spkm = wallet->GetOrCreateLegacyScriptPubKeyMan();
+        BOOST_CHECK(legacy_spkm->SetupGeneration(true));
+        wallet->Flush();
+
+        // Now delete all records, which performs a read write operation.
+        BOOST_CHECK(wallet->GetLegacyScriptPubKeyMan()->DeleteRecords());
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1126,6 +1126,51 @@ bool WalletBatch::WriteWalletFlags(const uint64_t flags)
     return WriteIC(DBKeys::FLAGS, flags);
 }
 
+bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)
+{
+    // Begin db txn
+    if (!m_batch->TxnBegin()) return false;
+
+    // Get cursor
+    if (!m_batch->StartCursor())
+    {
+        m_batch->TxnAbort();
+        return false;
+    }
+
+    // Iterate the DB and look for any records that have the type prefixes
+    while (true) {
+        // Read next record
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
+        bool complete;
+        bool ret = m_batch->ReadAtCursor(ssKey, ssValue, complete);
+        if (complete) {
+            break;
+        } else if (!ret) {
+            m_batch->CloseCursor();
+            m_batch->TxnAbort(); // abort db txn
+            return false;
+        }
+
+        // Make a copy of key to avoid data being deleted by the following read of the type
+        CDataStream ssKeyCopy(ssKey);
+
+        std::string type;
+        ssKey >> type;
+
+        if (types.count(type) > 0) {
+            if (!m_batch->Erase(ssKeyCopy)) {
+                m_batch->CloseCursor();
+                m_batch->TxnAbort();
+                return false; // erase failed
+            }
+        }
+    }
+    // Finish db txn
+    m_batch->CloseCursor();
+    return m_batch->TxnCommit();
+}
 bool WalletBatch::TxnBegin()
 {
     return m_batch->TxnBegin();


### PR DESCRIPTION
Backports bitcoin/bitcoin#27556

Original commit: 6cc136bbd3

## Summary
This PR fixes a deadlock issue in Berkeley DB wallet operations where the cursor was not using the active transaction context. The fix passes the transaction pointer to the cursor to avoid deadlocks when making write operations while traversing the database.

### Changes:
- Modified `BerkeleyBatch::StartCursor()` to pass `activeTxn` instead of `nullptr` when creating a cursor
- Added `EraseRecords()` function to perform batch record deletion under a single transaction
- Added test coverage for the deadlock issue

### Notes:
The backport adapts Bitcoin's fix to Dash's cursor API. While Bitcoin uses a new `DatabaseCursor` class-based API, Dash uses the older `StartCursor`/`ReadAtCursor`/`CloseCursor` API. The core fix (passing the transaction to the cursor) was successfully applied.

Backported from Bitcoin Core v0.26

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method to erase multiple database records by type in the wallet.
  * Introduced a new test to ensure wallet database operations do not cause deadlocks.
* **Tests**
  * Added comprehensive tests covering read-write concurrency in the wallet database.
* **Chores**
  * Updated internal test utilities to support multiple database formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->