### PR TITLE
Merge bitcoin/bitcoin#27683: ci: remove `RUN_SECURITY_TESTS`

### DIFF
--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -72,6 +72,3 @@ if [ "${RUN_TIDY}" = "true" ] && [ "${GITHUB_ACTIONS}" != "true" ]; then
   "${BASE_ROOT_DIR}/ci/dash/lint-tidy.sh"
 fi
 
-if [ "$RUN_SECURITY_TESTS" = "true" ]; then
-  make test-security-check
-fi

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -39,7 +39,6 @@ export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
 export RUN_UNIT_TESTS=${RUN_UNIT_TESTS:-true}
 export RUN_FUNCTIONAL_TESTS=${RUN_FUNCTIONAL_TESTS:-true}
 export RUN_TIDY=${RUN_TIDY:-false}
-export RUN_SECURITY_TESTS=${RUN_SECURITY_TESTS:-false}
 # By how much to scale the test_runner timeouts (option --timeout-factor).
 # This is needed because some ci machines have slow CPU or disk, so sanitizers
 # might be slow or a reindex might be waiting on disk IO.

--- a/ci/test/00_setup_env_mac_native_x86_64.sh
+++ b/ci/test/00_setup_env_mac_native_x86_64.sh
@@ -16,4 +16,3 @@ export NO_DEPENDS=1
 export OSX_SDK=""
 export CCACHE_SIZE=300M
 
-export RUN_SECURITY_TESTS="true"

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -11,7 +11,6 @@ export HOST=x86_64-w64-mingw32
 export DPKG_ADD_ARCH="i386"
 export PACKAGES="python3 nsis g++-mingw-w64-x86-64-posix wine-binfmt wine64 wine32 file"
 export RUN_FUNCTIONAL_TESTS=false
-export RUN_SECURITY_TESTS="false"
 export GOAL="deploy"
 # Prior to 11.0.0, the mingw-w64 headers were missing noreturn attributes, causing warnings when
 # cross-compiling for Windows. https://sourceforge.net/p/mingw-w64/bugs/306/


### PR DESCRIPTION
Backports bitcoin/bitcoin#27683

Original commit: f998eb7662

Backported from Bitcoin Core v0.26

Note: The file `ci/test/06_script_b.sh` that Bitcoin modifies has already been deleted in Dash, so only the changes to `ci/test/00_setup_env.sh` were applied.