### PR TITLE
Merge bitcoin/bitcoin#27707: ci, iwyu: Double maximum line length for includes

### DIFF
--- a/ci/dash/lint-tidy.sh
+++ b/ci/dash/lint-tidy.sh
@@ -34,6 +34,7 @@ iwyu_tool.py \
   "src/util/url.cpp" \
   -p . "${MAKEJOBS}" \
   -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
+  -Xiwyu --max_line_length=160 \
   2>&1 | tee "/tmp/iwyu_ci.out"
 
 cd "${BASE_ROOT_DIR}/build-ci/dashcore-${BUILD_TARGET}/src"


### PR DESCRIPTION
Backports bitcoin/bitcoin#27707

Original commit: 9a8318f30b

This PR makes the IWYU output in the CI 'tidy' task more useful by avoiding most cases where a comment ends with an ellipsis like that:
```
#include "primitives/transaction.h"  // for CTxIn, CMutableTransaction, CTra...
```

**Note**: In Dash, the IWYU configuration is located in `ci/dash/lint-tidy.sh` instead of `ci/test/06_script_b.sh`. The same `--max_line_length=160` parameter has been added to achieve the same effect.

Backported from Bitcoin Core v0.26