### PR TITLE
Merge bitcoin/bitcoin#27177: test: fix intermittent issue in `feature_bip68_sequence`

### DIFF
--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -50,12 +50,12 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         # unbroadcasted_tx won't pass old_node's `MemPoolAccept::PreChecks`.
         self.connect_nodes(0, 1)
         self.sync_blocks()
-        self.stop_node(1)
 
         self.log.info("Add a transaction to mempool on old node and shutdown")
         old_tx_hash = new_wallet.send_self_transfer(from_node=old_node)["txid"]
         assert old_tx_hash in old_node.getrawmempool()
         self.stop_node(0)
+        self.stop_node(1)
 
         self.log.info("Move mempool.dat from old to new node")
         old_node_mempool = os.path.join(old_node.datadir, self.chain, 'mempool.dat')

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -171,6 +171,7 @@ class MempoolPersistTest(BitcoinTestFramework):
     def test_persist_unbroadcast(self):
         node0 = self.nodes[0]
         self.start_node(0)
+        self.start_node(2)
 
         # clear out mempool
         self.generate(node0, 1, sync_fun=self.no_op)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -186,10 +186,12 @@ class MiniWallet:
         txid: get the first utxo we find from a specific transaction
         """
         self._utxos = sorted(self._utxos, key=lambda k: (k['value'], -k['height']))  # Put the largest utxo last
+        blocks_height = self._test_node.getblockchaininfo()['blocks']
+        mature_coins = list(filter(lambda utxo: not utxo['coinbase'] or COINBASE_MATURITY - 1 <= blocks_height - utxo['height'], self._utxos))
         if txid:
             utxo_filter: Any = filter(lambda utxo: txid == utxo['txid'], self._utxos)
         else:
-            utxo_filter = reversed(self._utxos)  # By default the largest utxo
+            utxo_filter = reversed(mature_coins)  # By default the largest utxo
         if vout is not None:
             utxo_filter = filter(lambda utxo: vout == utxo['vout'], utxo_filter)
         index = self._utxos.index(next(utxo_filter))
@@ -201,7 +203,8 @@ class MiniWallet:
     def get_utxos(self, *, include_immature_coinbase=False, mark_as_spent=True):
         """Returns the list of all utxos and optionally mark them as spent"""
         if not include_immature_coinbase:
-            utxo_filter = filter(lambda utxo: not utxo['coinbase'] or COINBASE_MATURITY <= utxo['confirmations'], self._utxos)
+            blocks_height = self._test_node.getblockchaininfo()['blocks']
+            utxo_filter = filter(lambda utxo: not utxo['coinbase'] or COINBASE_MATURITY - 1 <= blocks_height - utxo['height'], self._utxos)
         else:
             utxo_filter = self._utxos
         utxos = deepcopy(list(utxo_filter))


### PR DESCRIPTION
Backports bitcoin/bitcoin#27177

Original commit: 3132ec64d9e0f7af88e61ac35807f44315a5ca96

Backported from Bitcoin Core v0.26

This PR fixes intermittent test issues related to premature spending of coinbase transactions by improving the logic in MiniWallet's `get_utxo` and `get_utxos` functions to properly check for mature coinbase UTXOs.

Note: The following files were not backported as they don't exist or use different implementations in Dash:
- `test/functional/interface_usdt_mempool.py` (Bitcoin-specific USDT tracing)
- `test/functional/mempool_package_limits.py` (Dash doesn't use MiniWallet yet)