### PR TITLE
Merge bitcoin/bitcoin#27735: test: Move test_chain_listunspent wallet check from mempool_packages to wallet_basic

### DIFF
--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -50,9 +50,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
         txid = utxo[0]['txid']
         vout = utxo[0]['vout']
         value = utxo[0]['amount']
-        assert 'ancestorcount' not in utxo[0]
-        assert 'ancestorsize' not in utxo[0]
-        assert 'ancestorfees' not in utxo[0]
 
         fee = Decimal("0.0001")
         # MAX_ANCESTORS transactions off a confirmed tx should be fine
@@ -64,14 +61,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
             value = sent_value
             chain.append(txid)
 
-            # Check that listunspent ancestor{count, size, fees} yield the correct results
-            wallet_unspent = self.nodes[0].listunspent(minconf=0)
-            this_unspent = next(utxo_info for utxo_info in wallet_unspent if utxo_info['txid'] == txid)
-            assert_equal(this_unspent['ancestorcount'], i + 1)
             ancestor_vsize += self.nodes[0].getrawtransaction(txid=txid, verbose=True)['size']
-            assert_equal(this_unspent['ancestorsize'], ancestor_vsize)
             ancestor_fees -= self.nodes[0].gettransaction(txid=txid)['fee']
-            assert_equal(this_unspent['ancestorfees'], ancestor_fees * COIN)
 
         # Wait until mempool transactions have passed initial broadcast (sent inv and received getdata)
         # Otherwise, getrawmempool may be inconsistent with getmempoolentry if unbroadcast changes in between

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from itertools import product
 
 from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_array_result,
@@ -14,6 +15,7 @@ from test_framework.util import (
     assert_fee_amount,
     assert_greater_than,
     assert_raises_rpc_error,
+    chain_transaction,
     count_bytes,
     find_vout_for_address,
 )
@@ -742,6 +744,49 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].gettransaction(txid_feeReason_three)['txid'], txid_feeReason_three)
         txid_feeReason_four = self.nodes[2].sendmany(dummy='', amounts={address: 5}, verbose=False)
         assert_equal(self.nodes[2].gettransaction(txid_feeReason_four)['txid'], txid_feeReason_four)
+
+        self.test_chain_listunspent()
+
+    def test_chain_listunspent(self):
+        """Test ancestor tracking in listunspent"""
+        self.log.info("Testing chain listunspent...")
+        
+        # Mine some blocks and have them mature.
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
+        
+        # Get a utxo to create a chain
+        utxo = self.nodes[0].listunspent(10)[0]
+        txid = utxo['txid']
+        vout = utxo['vout']
+        value = utxo['amount']
+        
+        # Check that ancestor fields don't exist for confirmed utxos
+        assert 'ancestorcount' not in utxo
+        assert 'ancestorsize' not in utxo
+        assert 'ancestorfees' not in utxo
+        
+        fee = Decimal("0.0001")
+        # Create a chain of 25 transactions
+        chain = []
+        ancestor_vsize = 0
+        ancestor_fees = Decimal(0)
+        
+        # Use MAX_ANCESTORS = 25 as in mempool_packages
+        MAX_ANCESTORS = 25
+        
+        for i in range(MAX_ANCESTORS):
+            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [0], value, fee, 1)
+            value = sent_value
+            chain.append(txid)
+            
+            # Check that listunspent ancestor{count, size, fees} yield the correct results
+            wallet_unspent = self.nodes[0].listunspent(minconf=0)
+            this_unspent = next(utxo_info for utxo_info in wallet_unspent if utxo_info['txid'] == txid)
+            assert_equal(this_unspent['ancestorcount'], i + 1)
+            ancestor_vsize += self.nodes[0].getrawtransaction(txid=txid, verbose=True)['size']
+            assert_equal(this_unspent['ancestorsize'], ancestor_vsize)
+            ancestor_fees -= self.nodes[0].gettransaction(txid=txid)['fee']
+            assert_equal(this_unspent['ancestorfees'], ancestor_fees * COIN)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backports bitcoin/bitcoin#27735

Original commit: 7794d9d93f

This fixes a bug where the wallet checks in mempool_packages.py were incompatible with certain wallet configurations.

The test_chain_listunspent functionality is moved from mempool_packages.py to wallet_basic.py where it belongs, as it tests wallet-specific functionality.

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for ancestor tracking fields in wallet unspent outputs, including a new test that verifies correct ancestor count, size, and fee accumulation in transaction chains.
  * Updated existing tests by removing redundant assertions related to ancestor fields in unspent outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->