### PR TITLE
Merge bitcoin/bitcoin#27838: ci: Invalidate Cirrus CI docker cache

### DIFF
--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2021 The Bitcoin Core developers
+# Copyright (c) 2019-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27838

Original commit: a36134fcc7

Backported from Bitcoin Core v0.26

This commit updates copyright years in CI configuration files. Dash doesn't have the msan and tidy CI configurations, so only the tsan file was updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year range in header comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->