### PR TITLE
Merge bitcoin/bitcoin#25634: wallet, tests: Expand and test when the blank wallet flag should be un/set

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -192,6 +192,7 @@ static RPCHelpMan getwalletinfo()
                                      {RPCResult::Type::NUM, "progress", "scanning progress percentage [0.0, 1.0]"},
                                 }},
                             {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for scriptPubKey management"},
+                            {RPCResult::Type::BOOL, "blank", "Whether this wallet intentionally does not contain any keys, scripts, or descriptors"},
                         },
                 },
                 RPCExamples{
@@ -269,6 +270,7 @@ static RPCHelpMan getwalletinfo()
         obj.pushKV("scanning", false);
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+    obj.pushKV("blank", pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET));
     return obj;
 },
     };

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -866,12 +866,12 @@ bool LegacyScriptPubKeyMan::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& s
         RemoveWatchOnly(script);
     }
 
+    m_storage.UnsetBlankWalletFlag(batch);
     if (!m_storage.HasEncryptionKeys()) {
         return batch.WriteKey(pubkey,
                                  secret.GetPrivKey(),
                                  mapKeyMetadata[pubkey.GetID()]);
     }
-    m_storage.UnsetBlankWalletFlag(batch);
     return true;
 }
 

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -47,9 +47,17 @@ enum WalletFlags : uint64_t {
     //! Flag set when a wallet contains no HD seed and no private keys, scripts,
     //! addresses, and other watch only things, and is therefore "blank."
     //!
-    //! The only function this flag serves is to distinguish a blank wallet from
+    //! The main function this flag serves is to distinguish a blank wallet from
     //! a newly created wallet when the wallet database is loaded, to avoid
     //! initialization that should only happen on first run.
+    //!
+    //! A secondary function of this flag, which applies to descriptor wallets
+    //! only, is to serve as an ongoing indication that descriptors in the
+    //! wallet should be created manually, and that the wallet should not
+    //! generate automatically generate new descriptors if it is later
+    //! encrypted. To support this behavior, descriptor wallets unlike legacy
+    //! wallets do not automatically unset the BLANK flag when things are
+    //! imported.
     //!
     //! This flag is also a mandatory flag to prevent previous versions of
     //! bitcoin from opening the wallet, thinking it was newly created, and

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -159,6 +159,8 @@ BASE_SCRIPTS = [
     'feature_abortnode.py',
     # vv Tests less than 30s vv
     'rpc_quorum.py',
+    'wallet_blank.py --legacy-wallet',
+    'wallet_blank.py --descriptors',
     'wallet_keypool_topup.py --legacy-wallet',
     'wallet_keypool_topup.py --descriptors',
     'feature_fee_estimation.py',

--- a/test/functional/wallet_blank.py
+++ b/test/functional/wallet_blank.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.address import (
+    ADDRESS_BCRT1_UNSPENDABLE,
+    ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR,
+)
+from test_framework.key import ECKey
+from test_framework.util import (
+    assert_equal,
+)
+from test_framework.wallet_util import bytes_to_wif
+
+
+class WalletBlankTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def add_options(self, options):
+        self.add_wallet_options(options)
+
+    def test_importaddress(self):
+        if self.options.descriptors:
+            return
+        self.log.info("Test that importaddress unsets the blank flag")
+        self.nodes[0].createwallet(wallet_name="iaddr", disable_private_keys=True, blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("iaddr")
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["blank"], True)
+        wallet.importaddress(ADDRESS_BCRT1_UNSPENDABLE)
+        assert_equal(wallet.getwalletinfo()["blank"], False)
+
+    def test_importpubkey(self):
+        if self.options.descriptors:
+            return
+        self.log.info("Test that importpubkey unsets the blank flag")
+        for i, comp in enumerate([True, False]):
+            self.nodes[0].createwallet(wallet_name=f"ipub{i}", disable_private_keys=True, blank=True)
+            wallet = self.nodes[0].get_wallet_rpc(f"ipub{i}")
+            info = wallet.getwalletinfo()
+            assert_equal(info["descriptors"], False)
+            assert_equal(info["blank"], True)
+
+            eckey = ECKey()
+            eckey.generate(compressed=comp)
+
+            wallet.importpubkey(eckey.get_pubkey().get_bytes().hex())
+            assert_equal(wallet.getwalletinfo()["blank"], False)
+
+    def test_importprivkey(self):
+        if self.options.descriptors:
+            return
+        self.log.info("Test that importprivkey unsets the blank flag")
+        for i, comp in enumerate([True, False]):
+            self.nodes[0].createwallet(wallet_name=f"ipriv{i}", blank=True)
+            wallet = self.nodes[0].get_wallet_rpc(f"ipriv{i}")
+            info = wallet.getwalletinfo()
+            assert_equal(info["descriptors"], False)
+            assert_equal(info["blank"], True)
+
+            eckey = ECKey()
+            eckey.generate(compressed=comp)
+            wif = bytes_to_wif(eckey.get_bytes(), eckey.is_compressed)
+
+            wallet.importprivkey(wif)
+            assert_equal(wallet.getwalletinfo()["blank"], False)
+
+    def test_importmulti(self):
+        if self.options.descriptors:
+            return
+        self.log.info("Test that importmulti unsets the blank flag")
+        self.nodes[0].createwallet(wallet_name="imulti", disable_private_keys=True, blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("imulti")
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["blank"], True)
+        wallet.importmulti([{
+            "desc": ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR,
+            "timestamp": "now",
+        }])
+        assert_equal(wallet.getwalletinfo()["blank"], False)
+
+    def test_importdescriptors(self):
+        if not self.options.descriptors:
+            return
+        self.log.info("Test that importdescriptors preserves the blank flag")
+        self.nodes[0].createwallet(wallet_name="idesc", disable_private_keys=True, blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("idesc")
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["blank"], True)
+        wallet.importdescriptors([{
+            "desc": ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR,
+            "timestamp": "now",
+        }])
+        assert_equal(wallet.getwalletinfo()["blank"], True)
+
+    def test_importwallet(self):
+        if self.options.descriptors:
+            return
+        self.log.info("Test that importwallet unsets the blank flag")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        self.nodes[0].createwallet(wallet_name="iwallet", blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("iwallet")
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["blank"], True)
+
+        wallet_dump_path = os.path.join(self.nodes[0].datadir, "wallet.dump")
+        def_wallet.dumpwallet(wallet_dump_path)
+
+        wallet.importwallet(wallet_dump_path)
+        assert_equal(wallet.getwalletinfo()["blank"], False)
+
+    def test_encrypt_legacy(self):
+        if self.options.descriptors:
+            return
+        self.log.info("Test that encrypting a blank legacy wallet preserves the blank flag and does not generate a seed")
+        self.nodes[0].createwallet(wallet_name="encblanklegacy", blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("encblanklegacy")
+
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["blank"], True)
+        assert "hdseedid" not in info
+
+        wallet.encryptwallet("pass")
+        info = wallet.getwalletinfo()
+        assert_equal(info["blank"], True)
+        assert "hdseedid" not in info
+
+    def test_encrypt_descriptors(self):
+        if not self.options.descriptors:
+            return
+        self.log.info("Test that encrypting a blank descriptor wallet preserves the blank flag and descriptors remain the same")
+        self.nodes[0].createwallet(wallet_name="encblankdesc", blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("encblankdesc")
+
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["blank"], True)
+        descs = wallet.listdescriptors()
+
+        wallet.encryptwallet("pass")
+        assert_equal(wallet.getwalletinfo()["blank"], True)
+        assert_equal(descs, wallet.listdescriptors())
+
+    def run_test(self):
+        self.test_importaddress()
+        self.test_importpubkey()
+        self.test_importprivkey()
+        self.test_importmulti()
+        self.test_importdescriptors()
+        self.test_importwallet()
+        self.test_encrypt_legacy()
+        self.test_encrypt_descriptors()
+
+
+if __name__ == '__main__':
+    WalletBlankTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#25634

Original commit: 6663c802fee07692283d55a785896d8712d11d9c

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The wallet information command now includes a new indicator showing whether a wallet was created as a blank wallet.
* **Bug Fixes**
  * Improved handling of the blank wallet status when importing keys or descriptors, ensuring accurate flag updates for both legacy and descriptor wallets.
* **Documentation**
  * Updated help text and internal comments to clarify the meaning and behavior of blank wallets.
* **Tests**
  * Added new automated tests to verify correct blank wallet behavior for both legacy and descriptor wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->