### PR TITLE
Merge bitcoin/bitcoin#27883: ci: Bump macOS cross task to ubuntu:jammy

### DIFF
--- a/ci/test/00_setup_env_mac.sh
+++ b/ci/test/00_setup_env_mac.sh
@@ -7,6 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_macos_cross
+export CI_IMAGE_NAME_TAG=ubuntu:22.04
 export HOST=x86_64-apple-darwin
 export PACKAGES="clang cmake lld llvm  zip"
 export XCODE_VERSION=15.0


### PR DESCRIPTION
Backports bitcoin/bitcoin#27883

Original commit: ff17b28b02

Backported from Bitcoin Core v0.26

Note: This backport only includes the change to `ci/test/00_setup_env_mac.sh` as `.cirrus.yml` has been removed in Dash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new environment variable to the setup script for improved configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->