### PR TITLE
Merge bitcoin/bitcoin#27892: refactor: Avoid copy of bilingual_str when formatting, Fix ADL violation

### DIFF
--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -51,7 +51,15 @@ namespace tinyformat {
 template <typename... Args>
 bilingual_str format(const bilingual_str& fmt, const Args&... args)
 {
-    return bilingual_str{format(fmt.original, args...), format(fmt.translated, args...)};
+    const auto translate_arg{[](const auto& arg, bool translated) -> const auto& {
+        if constexpr (std::is_same_v<decltype(arg), const bilingual_str&>) {
+            return translated ? arg.translated : arg.original;
+        } else {
+            return arg;
+        }
+    }};
+    return bilingual_str{tfm::format(fmt.original, translate_arg(args, false)...),
+                         tfm::format(fmt.translated, translate_arg(args, true)...)};
 }
 } // namespace tinyformat
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27892

Original commit: 5b8e07725d

Backported from Bitcoin Core v0.26

## Summary
This refactoring change updates the `tinyformat::format` function for `bilingual_str` to:
- Add a lambda `translate_arg` that handles bilingual_str arguments specially
- Use `tfm::format` instead of just `format` to avoid ADL (Argument-Dependent Lookup) issues
- Properly handle translation of bilingual_str arguments

The change prevents potential compile errors and improves the code structure.

## Notes
- The backport was smaller than the Bitcoin commit (45.5% size ratio) because Dash's codebase doesn't have the `TranslateArg` functions that Bitcoin removed in this commit
- This is expected as Dash's translation.h is at a different state than Bitcoin's
- The important improvement (lambda-based approach) was successfully applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for bilingual strings to ensure that embedded bilingual arguments are correctly displayed in both original and translated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->