### PR TITLE
Merge bitcoin/bitcoin#27647: fuzz: wallet, add target for `fees`

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -223,7 +223,9 @@ endif
 
 FUZZ_WALLET_SRC = \
  wallet/test/fuzz/coincontrol.cpp \
- wallet/test/fuzz/coinselection.cpp
+ wallet/test/fuzz/coinselection.cpp \
+ wallet/test/fuzz/fees.cpp \
+ wallet/test/fuzz/parse_iso8601.cpp
 
 if USE_SQLITE
 FUZZ_WALLET_SRC += \

--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <wallet/coincontrol.h>
+#include <wallet/fees.h>
+#include <wallet/wallet.h>
+#include <wallet/test/util.h>
+#include <validation.h>
+
+namespace wallet {
+namespace {
+const TestingSetup* g_setup;
+static std::unique_ptr<CWallet> g_wallet_ptr;
+
+void initialize_setup()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+    const auto& node{g_setup->m_node};
+    g_wallet_ptr = std::make_unique<CWallet>(node.chain.get(), "", CreateMockableWalletDatabase());
+}
+
+FUZZ_TARGET_INIT(wallet_fees, initialize_setup)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const auto& node{g_setup->m_node};
+    Chainstate* chainstate = &node.chainman->ActiveChainstate();
+    CWallet& wallet = *g_wallet_ptr;
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetLastBlockProcessed(chainstate->m_chain.Height(), chainstate->m_chain.Tip()->GetBlockHash());
+    }
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        wallet.m_discard_rate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+    (void)GetDiscardRate(wallet);
+
+    const auto tx_bytes{fuzzed_data_provider.ConsumeIntegral<unsigned int>()};
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        wallet.m_pay_tx_fee = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+        wallet.m_min_fee = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+
+    (void)GetRequiredFee(wallet, tx_bytes);
+    (void)GetRequiredFeeRate(wallet);
+
+    CCoinControl coin_control;
+    if (fuzzed_data_provider.ConsumeBool()) {
+        coin_control.m_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        coin_control.m_confirm_target = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    }
+
+    FeeCalculation fee_calculation;
+    FeeCalculation* maybe_fee_calculation{fuzzed_data_provider.ConsumeBool() ? nullptr : &fee_calculation};
+    (void)GetMinimumFeeRate(wallet, coin_control, maybe_fee_calculation);
+    (void)GetMinimumFee(wallet, tx_bytes, coin_control, maybe_fee_calculation);
+}
+} // namespace
+} // namespace wallet

--- a/src/wallet/test/fuzz/parse_iso8601.cpp
+++ b/src/wallet/test/fuzz/parse_iso8601.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <util/time.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+FUZZ_TARGET(parse_iso8601)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const int64_t random_time = fuzzed_data_provider.ConsumeIntegral<int32_t>();
+    const std::string random_string = fuzzed_data_provider.ConsumeRemainingBytesAsString();
+
+    const std::string iso8601_datetime = FormatISO8601DateTime(random_time);
+    (void)FormatISO8601Date(random_time);
+    const int64_t parsed_time_1 = ParseISO8601DateTime(iso8601_datetime);
+    if (random_time >= 0) {
+        assert(parsed_time_1 >= 0);
+        if (iso8601_datetime.length() == 20) {
+            assert(parsed_time_1 == random_time);
+        }
+    }
+
+    const int64_t parsed_time_2 = ParseISO8601DateTime(random_string);
+    assert(parsed_time_2 >= 0);
+}


### PR DESCRIPTION
Backports bitcoin/bitcoin#27647

Original commit: 7a59865793cd710d7d6650a6106ca4e790ced5d3

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the wallet fuzz test suite with new cases covering fee calculation logic and ISO8601 date/time formatting and parsing.
  * Increases robustness by exercising diverse edge cases, improving coverage without altering runtime behavior.
  * No user-facing changes; these enhancements strengthen reliability and help catch regressions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->