### PR TITLE
Merge bitcoin/bitcoin#27890: refactor: Make m_count_with_* in CTxMemPoolEntry int64_t, drop UBSAN supp

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -416,8 +416,8 @@ void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFe
     nSizeWithDescendants += modifySize;
     assert(int64_t(nSizeWithDescendants) > 0);
     nModFeesWithDescendants = SaturatingAdd(nModFeesWithDescendants, modifyFee);
-    nCountWithDescendants += modifyCount;
-    assert(int64_t(nCountWithDescendants) > 0);
+    m_count_with_descendants += modifyCount;
+    assert(m_count_with_descendants > 0);
 }
 
 void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
@@ -425,8 +425,8 @@ void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee,
     nSizeWithAncestors += modifySize;
     assert(int64_t(nSizeWithAncestors) > 0);
     nModFeesWithAncestors = SaturatingAdd(nModFeesWithAncestors, modifyFee);
-    nCountWithAncestors += modifyCount;
-    assert(int64_t(nCountWithAncestors) > 0);
+    m_count_with_ancestors += modifyCount;
+    assert(m_count_with_ancestors > 0);
     nSigOpCountWithAncestors += modifySigOps;
     assert(int(nSigOpCountWithAncestors) >= 0);
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -90,7 +90,7 @@ struct CompareIteratorByHash {
  * ("descendant" transactions).
  *
  * When a new entry is added to the mempool, we update the descendant state
- * (nCountWithDescendants, nSizeWithDescendants, and nModFeesWithDescendants) for
+ * (m_count_with_descendants, nSizeWithDescendants, and nModFeesWithDescendants) for
  * all ancestors of the newly added transaction.
  *
  */
@@ -120,12 +120,12 @@ private:
     // Information about descendants of this transaction that are in the
     // mempool; if we remove this transaction we must remove all of these
     // descendants as well.
-    uint64_t nCountWithDescendants{1}; //!< number of descendant transactions
+    int64_t m_count_with_descendants{1}; //!< number of descendant transactions
     uint64_t nSizeWithDescendants;   //!< ... and size
     CAmount nModFeesWithDescendants; //!< ... and total fees (all including us)
 
     // Analogous statistics for ancestor transactions
-    uint64_t nCountWithAncestors{1};
+    int64_t m_count_with_ancestors{1};
     uint64_t nSizeWithAncestors;
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCountWithAncestors;
@@ -156,13 +156,13 @@ public:
     // Update the LockPoints after a reorg
     void UpdateLockPoints(const LockPoints& lp);
 
-    uint64_t GetCountWithDescendants() const { return nCountWithDescendants; }
+    uint64_t GetCountWithDescendants() const { return m_count_with_descendants; }
     uint64_t GetSizeWithDescendants() const { return nSizeWithDescendants; }
     CAmount GetModFeesWithDescendants() const { return nModFeesWithDescendants; }
 
     bool GetSpendsCoinbase() const { return spendsCoinbase; }
 
-    uint64_t GetCountWithAncestors() const { return nCountWithAncestors; }
+    uint64_t GetCountWithAncestors() const { return m_count_with_ancestors; }
     uint64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
     CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }
     int64_t GetSigOpCountWithAncestors() const { return nSigOpCountWithAncestors; }

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -52,7 +52,6 @@ unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
-unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h
 implicit-integer-sign-change:addrman.h


### PR DESCRIPTION
Backports bitcoin/bitcoin#27890

Original commit: d1ae96755a0f9d7e12c3f6741c030d8ea6d0416f

Backported from Bitcoin Core v0.26

## Summary
This is a refactor that changes the type of `m_count_with_descendants` and `m_count_with_ancestors` from `uint64_t` to `int64_t` in CTxMemPoolEntry. This avoids unsigned integer overflow and allows removing the UBSAN suppression for txmempool.cpp.

## Dash Adaptations
- In Dash, CTxMemPoolEntry is defined in `src/txmempool.h` instead of `src/kernel/mempool_entry.h`
- Applied the same type changes and variable renames to the Dash codebase
- The publicly returned type remains `uint64_t` for API compatibility

## Technical Details
- Changed `nCountWithDescendants` → `m_count_with_descendants` (type: `uint64_t` → `int64_t`)
- Changed `nCountWithAncestors` → `m_count_with_ancestors` (type: `uint64_t` → `int64_t`)
- Updated usage in `txmempool.cpp` to use the new names
- Removed UBSAN suppression for `unsigned-integer-overflow:txmempool.cpp`

The main benefit is dropping the file-wide ubsan suppression while maintaining the same functionality.