### PR TITLE
Merge bitcoin/bitcoin#27889: test: Kill `BOOST_ASSERT` and update the linter

### DIFF
--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -478,7 +478,7 @@ void FuncDIP3Protx(TestChainSetup& setup)
     // check MN reward payments
     for (size_t i = 0; i < 20; i++) {
         auto dmnExpectedPayee = dmnman.GetListAtChainTip().GetMNPayee(chainman.ActiveChain().Tip());
-        BOOST_ASSERT(dmnExpectedPayee);
+        BOOST_REQUIRE(dmnExpectedPayee);
 
         CBlock block = setup.CreateAndProcessBlock({}, setup.coinbaseKey);
         dmnman.UpdatedBlockTip(chainman.ActiveChain().Tip());
@@ -587,7 +587,7 @@ void FuncDIP3Protx(TestChainSetup& setup)
     bool foundRevived = false;
     for (size_t i = 0; i < 20; i++) {
         auto dmnExpectedPayee = dmnman.GetListAtChainTip().GetMNPayee(chainman.ActiveChain().Tip());
-        BOOST_ASSERT(dmnExpectedPayee);
+        BOOST_REQUIRE(dmnExpectedPayee);
         if (dmnExpectedPayee->proTxHash == dmnHashes[0]) {
             foundRevived = true;
         }

--- a/test/lint/lint-assertions.py
+++ b/test/lint/lint-assertions.py
@@ -35,6 +35,16 @@ def main():
         ":(exclude)src/rpc/server.cpp",
     ], "CHECK_NONFATAL(condition) or NONFATAL_UNREACHABLE should be used instead of assert for RPC code.")
 
+    # The `BOOST_ASSERT` macro requires to `#include boost/assert.hpp`,
+    # which is an unnecessary Boost dependency.
+    exit_code |= git_grep([
+        "-E",
+        r"BOOST_ASSERT *\(.*\);",
+        "--",
+        "*.cpp",
+        "*.h",
+    ], "BOOST_ASSERT must be replaced with Assert, BOOST_REQUIRE, or BOOST_CHECK.")
+
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27889

Original commit: 2880bb588a

Backported from Bitcoin Core v0.26

## Changes made:
- Added BOOST_ASSERT check to lint-assertions.py linter
- Replaced existing BOOST_ASSERT occurrences in Dash code with BOOST_REQUIRE in test files

Note: The Bitcoin PR included changes to `src/wallet/test/db_tests.cpp` which doesn't have the same test structure in Dash yet, so those specific changes were not applied. Instead, we fixed the BOOST_ASSERT usage that exists in Dash's `src/test/evo_deterministicmns_tests.cpp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test reliability by replacing certain assertions to ensure immediate failure when conditions are not met.
* **Chores**
  * Added a lint check to detect and discourage the use of a specific assertion macro, promoting consistency and reducing unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->