### PR TITLE
Merge bitcoin/bitcoin#27733: test: refactor: introduce `generate_keypair` helper with WIF support

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -35,7 +35,6 @@ from test_framework.blocktools import (
     create_block,
     create_coinbase,
 )
-from test_framework.key import ECKey
 from test_framework.messages import (
     CBlockHeader,
     COutPoint,
@@ -46,9 +45,13 @@ from test_framework.messages import (
     msg_headers,
 )
 from test_framework.p2p import P2PInterface
-from test_framework.script import (CScript, OP_TRUE)
+from test_framework.script import (
+    CScript,
+    OP_TRUE,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (assert_equal, set_node_times)
+from test_framework.wallet_util import generate_keypair
 
 
 class BaseNode(P2PInterface):
@@ -98,9 +101,7 @@ class AssumeValidTest(BitcoinTestFramework):
         self.blocks = []
 
         # Get a pubkey for the coinbase TXO
-        coinbase_key = ECKey()
-        coinbase_key.generate()
-        coinbase_pubkey = coinbase_key.get_pubkey().get_bytes()
+        _, coinbase_pubkey = generate_keypair()
 
         # Create the first block with a coinbase output to our key
         height = 1

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -13,7 +13,6 @@ from test_framework.blocktools import (
     create_tx_with_script,
     get_legacy_sigopcount_block,
 )
-from test_framework.key import ECKey
 from test_framework.messages import (
     CBlock,
     COIN,
@@ -53,6 +52,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
 )
+from test_framework.wallet_util import generate_keypair
 from data import invalid_txs
 
 # This functional test assumes DIP0001 is disabled
@@ -108,9 +108,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.bootstrap_p2p()  # Add one p2p connection to the node
 
         self.block_heights = {}
-        self.coinbase_key = ECKey()
-        self.coinbase_key.generate()
-        self.coinbase_pubkey = self.coinbase_key.get_pubkey().get_bytes()
+        self.coinbase_key, self.coinbase_pubkey = generate_keypair()
         self.tip = None
         self.blocks = {}
         self.genesis_hash = int(self.nodes[0].getbestblockhash(), 16)

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -29,6 +29,11 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
+<<<<<<< HEAD
+=======
+from test_framework.wallet import getnewdestination
+from test_framework.wallet_util import generate_keypair
+>>>>>>> 7d65e3372f (Merge bitcoin/bitcoin#27733: test: refactor: introduce `generate_keypair` helper with WIF support)
 
 NULLDUMMY_ERROR = "non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
 
@@ -57,6 +62,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
+<<<<<<< HEAD
         self.nodes[0].createwallet(wallet_name='wmulti', disable_private_keys=True)
         wmulti = self.nodes[0].get_wallet_rpc('wmulti')
         w0 = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
@@ -66,6 +72,15 @@ class NULLDUMMYTest(BitcoinTestFramework):
         if not self.options.descriptors:
             # Legacy wallets need to import these so that they are watched by the wallet. This is unnecessary (and does not need to be tested) for descriptor wallets
             wmulti.importaddress(self.ms_address)
+=======
+        self.privkey, self.pubkey = generate_keypair(wif=True)
+        cms = self.nodes[0].createmultisig(1, [self.pubkey.hex()])
+        wms = self.nodes[0].createmultisig(1, [self.pubkey.hex()], 'p2sh-segwit')
+        self.ms_address = cms["address"]
+        ms_unlock_details = {"scriptPubKey": address_to_scriptpubkey(self.ms_address).hex(),
+                             "redeemScript": cms["redeemScript"]}
+        self.wit_ms_address = wms['address']
+>>>>>>> 7d65e3372f (Merge bitcoin/bitcoin#27733: test: refactor: introduce `generate_keypair` helper with WIF support)
 
         self.coinbase_blocks = self.generate(self.nodes[0], 2)  # block height = 2
         coinbase_txid = []

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -29,11 +29,8 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
-<<<<<<< HEAD
-=======
 from test_framework.wallet import getnewdestination
 from test_framework.wallet_util import generate_keypair
->>>>>>> 7d65e3372f (Merge bitcoin/bitcoin#27733: test: refactor: introduce `generate_keypair` helper with WIF support)
 
 NULLDUMMY_ERROR = "non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
 
@@ -62,7 +59,6 @@ class NULLDUMMYTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-<<<<<<< HEAD
         self.nodes[0].createwallet(wallet_name='wmulti', disable_private_keys=True)
         wmulti = self.nodes[0].get_wallet_rpc('wmulti')
         w0 = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
@@ -72,15 +68,6 @@ class NULLDUMMYTest(BitcoinTestFramework):
         if not self.options.descriptors:
             # Legacy wallets need to import these so that they are watched by the wallet. This is unnecessary (and does not need to be tested) for descriptor wallets
             wmulti.importaddress(self.ms_address)
-=======
-        self.privkey, self.pubkey = generate_keypair(wif=True)
-        cms = self.nodes[0].createmultisig(1, [self.pubkey.hex()])
-        wms = self.nodes[0].createmultisig(1, [self.pubkey.hex()], 'p2sh-segwit')
-        self.ms_address = cms["address"]
-        ms_unlock_details = {"scriptPubKey": address_to_scriptpubkey(self.ms_address).hex(),
-                             "redeemScript": cms["redeemScript"]}
-        self.wit_ms_address = wms['address']
->>>>>>> 7d65e3372f (Merge bitcoin/bitcoin#27733: test: refactor: introduce `generate_keypair` helper with WIF support)
 
         self.coinbase_blocks = self.generate(self.nodes[0], 2)  # block height = 2
         coinbase_txid = []

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 import math
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.key import ECKey
 from test_framework.messages import (
     BIP125_SEQUENCE_NUMBER,
     COIN,
@@ -36,6 +35,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import MiniWallet
+from test_framework.wallet_util import generate_keypair
 
 
 class MempoolAcceptanceTest(BitcoinTestFramework):
@@ -270,9 +270,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
-        key = ECKey()
-        key.generate()
-        pubkey = key.get_pubkey().get_bytes()
+        _, pubkey = generate_keypair()
         tx.vout[0].scriptPubKey = keys_to_multisig_script([pubkey] * 3, k=2)  # Some bare multisig script (2-of-3)
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bare-multisig'}],

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -10,13 +10,13 @@ import os
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create, drop_origins
-from test_framework.key import ECPubKey, ECKey
+from test_framework.key import ECPubKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 from test_framework.wallet import (
     MiniWallet,
     getnewdestination,
@@ -35,10 +35,9 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         self.priv = []
         node0, node1, node2 = self.nodes
         for _ in range(self.nkeys):
-            k = ECKey()
-            k.generate()
-            self.pub.append(k.get_pubkey().get_bytes().hex())
-            self.priv.append(bytes_to_wif(k.get_bytes(), k.is_compressed))
+            privkey, pubkey = generate_keypair(wif=True)
+            self.pub.append(pubkey.hex())
+            self.priv.append(privkey)
         if self.is_bdb_compiled():
             self.final = node2.getnewaddress()
         else:

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -8,7 +8,9 @@ from decimal import Decimal
 from itertools import product
 
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
+from test_framework.messages import (
+    COIN,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
@@ -21,7 +23,7 @@ from test_framework.util import (
     find_vout_for_address,
     satoshi_round,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 
 def get_unspent(listunspent, amount):
@@ -943,11 +945,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
     def test_external_inputs(self):
         self.log.info("Test funding with external inputs")
-
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
-
+        privkey, _ = generate_keypair(wif=True)
         self.nodes[2].createwallet("extfund")
         wallet = self.nodes[2].get_wallet_rpc("extfund")
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 from itertools import product
 
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
@@ -17,7 +16,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     find_output
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import bytes_to_wif, generate_keypair
 
 import json
 import os
@@ -465,9 +464,7 @@ class PSBTTest(BitcoinTestFramework):
         assert_raises_rpc_error(-25, 'Inputs missing or spent', self.nodes[0].walletprocesspsbt, 'cHNidP8BAJoCAAAAAkvEW8NnDtdNtDpsmze+Ht2LH35IJcKv00jKAlUs21RrAwAAAAD/////S8Rbw2cO1020OmybN74e3Ysffkglwq/TSMoCVSzbVGsBAAAAAP7///8CwLYClQAAAAAWABSNJKzjaUb3uOxixsvh1GGE3fW7zQD5ApUAAAAAFgAUKNw0x8HRctAgmvoevm4u1SbN7XIAAAAAAAEAnQIAAAACczMa321tVHuN4GKWKRncycI22aX3uXgwSFUKM2orjRsBAAAAAP7///9zMxrfbW1Ue43gYpYpGdzJwjbZpfe5eDBIVQozaiuNGwAAAAAA/v///wIA+QKVAAAAABl2qRT9zXUVA8Ls5iVqynLHe5/vSe1XyYisQM0ClQAAAAAWABRmWQUcjSjghQ8/uH4Bn/zkakwLtAAAAAAAAQEfQM0ClQAAAAAWABRmWQUcjSjghQ8/uH4Bn/zkakwLtAAAAA==')
 
         # Test that we can fund psbts with external inputs specified
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
+        privkey, _ = generate_keypair(wif=True)
 
         # Make a weird but signable script. sh(pkh()) descriptor accomplishes this
         desc = descsum_create("sh(pkh({}))".format(privkey))

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -18,6 +18,7 @@ from test_framework.address import (
     key_to_p2pkh,
     ADDRESS_BCRT1_P2SH_OP_TRUE,
 )
+from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.descriptors import descsum_create
 from test_framework.key import ECKey
 from test_framework.messages import (
@@ -45,7 +46,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
 )
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.wallet_util import generate_keypair
 
 DEFAULT_FEE = Decimal("0.0001")
 
@@ -317,12 +318,19 @@ class MiniWallet:
 def getnewdestination(address_type='legacy'):
     """Generate a random destination of the specified type and return the
        corresponding public key, scriptPubKey and address. Supported types are
+<<<<<<< HEAD
        'legacy'. Can be used when a random destination is needed, but no
        compiled wallet is available (e.g. as replacement to the
        getnewaddress/getaddressinfo RPCs)."""
     key = ECKey()
     key.generate()
     pubkey = key.get_pubkey().get_bytes()
+=======
+       'legacy', 'p2sh-segwit', 'bech32' and 'bech32m'. Can be used when a random
+       destination is needed, but no compiled wallet is available (e.g. as
+       replacement to the getnewaddress/getaddressinfo RPCs)."""
+    key, pubkey = generate_keypair()
+>>>>>>> 7d65e3372f (Merge bitcoin/bitcoin#27733: test: refactor: introduce `generate_keypair` helper with WIF support)
     if address_type == 'legacy':
         scriptpubkey = key_to_p2pkh_script(pubkey)
         address = key_to_p2pkh(pubkey)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -318,19 +318,10 @@ class MiniWallet:
 def getnewdestination(address_type='legacy'):
     """Generate a random destination of the specified type and return the
        corresponding public key, scriptPubKey and address. Supported types are
-<<<<<<< HEAD
        'legacy'. Can be used when a random destination is needed, but no
        compiled wallet is available (e.g. as replacement to the
        getnewaddress/getaddressinfo RPCs)."""
-    key = ECKey()
-    key.generate()
-    pubkey = key.get_pubkey().get_bytes()
-=======
-       'legacy', 'p2sh-segwit', 'bech32' and 'bech32m'. Can be used when a random
-       destination is needed, but no compiled wallet is available (e.g. as
-       replacement to the getnewaddress/getaddressinfo RPCs)."""
     key, pubkey = generate_keypair()
->>>>>>> 7d65e3372f (Merge bitcoin/bitcoin#27733: test: refactor: introduce `generate_keypair` helper with WIF support)
     if address_type == 'legacy':
         scriptpubkey = key_to_p2pkh_script(pubkey)
         address = key_to_p2pkh(pubkey)

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -43,12 +43,9 @@ def get_generate_key():
     """Generate a fresh key
 
     Returns a named tuple of privkey, pubkey and all address and scripts."""
-    eckey = ECKey()
-    eckey.generate()
-    privkey = bytes_to_wif(eckey.get_bytes())
-    pubkey = eckey.get_pubkey().get_bytes().hex()
+    privkey, pubkey = generate_keypair(wif=True)
     return Key(privkey=privkey,
-               pubkey=pubkey,
+               pubkey=pubkey.hex(),
                p2pkh_script=key_to_p2pkh_script(pubkey).hex(),
                p2pkh_addr=key_to_p2pkh(pubkey))
 
@@ -84,8 +81,14 @@ def bytes_to_wif(b, compressed=True):
         b += b'\x01'
     return byte_to_base58(b, 239)
 
-def generate_wif_key():
-    # Makes a WIF privkey for imports
-    k = ECKey()
-    k.generate()
-    return bytes_to_wif(k.get_bytes(), k.is_compressed)
+def generate_keypair(compressed=True, wif=False):
+    """Generate a new random keypair and return the corresponding ECKey /
+    bytes objects. The private key can also be provided as WIF (wallet
+    import format) string instead, which is often useful for wallet RPC
+    interaction."""
+    privkey = ECKey()
+    privkey.generate(compressed)
+    pubkey = privkey.get_pubkey().get_bytes()
+    if wif:
+        privkey = bytes_to_wif(privkey.get_bytes(), compressed)
+    return privkey, pubkey

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -7,13 +7,13 @@
 
 from test_framework.address import key_to_p2pkh
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import bytes_to_wif, generate_wif_key
+from test_framework.wallet_util import generate_keypair
+
 
 class CreateWalletTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -43,14 +43,12 @@ class CreateWalletTest(BitcoinTestFramework):
         w1.importpubkey(w0.getaddressinfo(address1)['pubkey'])
 
         self.log.info('Test that private keys cannot be imported')
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
+        privkey, pubkey = generate_keypair(wif=True)
         assert_raises_rpc_error(-4, 'Cannot import private keys to a wallet with private keys disabled', w1.importprivkey, privkey)
         if self.options.descriptors:
             result = w1.importdescriptors([{'desc': descsum_create('pkh(' + privkey + ')'), 'timestamp': 'now'}])
         else:
-            result = w1.importmulti([{'scriptPubKey': {'address': key_to_p2pkh(eckey.get_pubkey().get_bytes())}, 'timestamp': 'now', 'keys': [privkey]}])
+            result = w1.importmulti([{'scriptPubKey': {'address': key_to_p2pkh(pubkey)}, 'timestamp': 'now', 'keys': [privkey]}])
         assert not result[0]['success']
         assert 'warning' not in result[0]
         assert_equal(result[0]['error']['code'], -4)
@@ -70,7 +68,7 @@ class CreateWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w3.getnewaddress)
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w3.getrawchangeaddress)
         # Import private key
-        w3.importprivkey(generate_wif_key())
+        w3.importprivkey(generate_keypair(wif=True)[0])
         # Imported private keys are currently ignored by the keypool
         assert_equal(w3.getwalletinfo()['keypoolsize'], 0)
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w3.getnewaddress)

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -7,13 +7,16 @@ from decimal import Decimal
 
 from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.key import ECKey
+from test_framework.messages import (
+    CMerkleBlock,
+    from_hex,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 class ImportPrunedFundsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -32,10 +35,8 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         # pubkey
         address2 = self.nodes[0].getnewaddress()
         # privkey
-        eckey = ECKey()
-        eckey.generate()
-        address3_privkey = bytes_to_wif(eckey.get_bytes())
-        address3 = key_to_p2pkh(eckey.get_pubkey().get_bytes())
+        address3_privkey, address3_pubkey = generate_keypair(wif=True)
+        address3 = key_to_p2pkh(address3_pubkey)
         self.nodes[0].importprivkey(address3_privkey)
 
         # Check only one address

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -6,7 +6,7 @@
 
 from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.key import ECKey
+from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import BIP125_SEQUENCE_NUMBER
 from test_framework.util import (
@@ -14,7 +14,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 from decimal import Decimal
 
@@ -182,10 +182,8 @@ class ListSinceBlockTest(BitcoinTestFramework):
         self.sync_all()
 
         # share utxo between nodes[1] and nodes[2]
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
-        address = key_to_p2pkh(eckey.get_pubkey().get_bytes())
+        privkey, pubkey = generate_keypair(wif=True)
+        address = key_to_p2pkh(pubkey)
         self.nodes[2].sendtoaddress(address, 10)
         self.generate(self.nodes[2], 6)
         self.nodes[2].importprivkey(privkey)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -9,7 +9,10 @@ from itertools import product
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
+from test_framework.messages import (
+    ser_compact_size,
+    WITNESS_SCALE_FACTOR,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -17,7 +20,8 @@ from test_framework.util import (
     assert_greater_than,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
+
 
 class WalletSendTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -463,9 +467,7 @@ class WalletSendTest(BitcoinTestFramework):
         assert res["complete"]
 
         self.log.info("External outputs")
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
+        privkey, _ = generate_keypair(wif=True)
 
         self.nodes[1].createwallet("extsend")
         ext_wallet = self.nodes[1].get_wallet_rpc("extsend")


### PR DESCRIPTION
Backports bitcoin/bitcoin#27733

Original commit: 7d65e3372fc7e08fccd7babb3aa66351e0e9442d

Backported from Bitcoin Core v0.26

## Notes
This commit introduces a `generate_keypair` helper function to simplify keypair generation in functional tests. Several Bitcoin-specific test files were skipped as they test features not present in Dash (Taproot, Segwit, etc.):
- test/functional/feature_taproot.py
- test/functional/mempool_dust.py 
- test/functional/p2p_segwit.py
- test/functional/rpc_signrawtransactionwithkey.py
- test/functional/wallet_blank.py

The changes were adapted to use Dash's p2pkh addresses instead of Bitcoin's p2wpkh addresses where applicable.