### PR TITLE
Merge bitcoin/bitcoin#27831: test: handle failed `assert_equal()` assertions in bcc callback functions

### DIFF
--- a/test/functional/interface_usdt_validation.py
+++ b/test/functional/interface_usdt_validation.py
@@ -101,16 +101,7 @@ class ValidationTracepointTest(BitcoinTestFramework):
             nonlocal events, blocks_checked
             event = ctypes.cast(data, ctypes.POINTER(Block)).contents
             self.log.info(f"handle_blockconnected(): {event}")
-            block_hash = bytes(event.hash[::-1]).hex()
-            block = expected_blocks[block_hash]
-            assert_equal(block["hash"], block_hash)
-            assert_equal(block["height"], event.height)
-            assert_equal(len(block["tx"]), event.transactions)
-            assert_equal(len([tx["vin"] for tx in block["tx"]]), event.inputs)
-            assert_equal(0, event.sigops)  # no sigops in coinbase tx
-            # only plausibility checks
-            assert(event.duration > 0)
-            del expected_blocks[block_hash]
+            events.append(event)
             blocks_checked += 1
 
         bpf["block_connected"].open_perf_buffer(


### PR DESCRIPTION
Backports bitcoin/bitcoin#27831

Original commit: a7261da479c2dffb89694b17c4f446ea0b302f34

Backported from Bitcoin Core v0.26

Note: This is a partial backport. The following files from the Bitcoin commit were not backported because they don't exist in Dash:
- test/functional/interface_usdt_mempool.py
- test/functional/interface_usdt_net.py  
- test/functional/interface_usdt_utxocache.py

Only the changes to test/functional/interface_usdt_validation.py were applied.