### PR TITLE
Merge bitcoin/bitcoin#27949: http: update libevent workaround to correct version

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -217,8 +217,10 @@ std::string RequestMethodString(HTTPRequest::RequestMethod m)
 /** HTTP request callback */
 static void http_request_cb(struct evhttp_request* req, void* arg)
 {
-    // Disable reading to work around a libevent bug, fixed in 2.2.0.
-    if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001) {
+    // Disable reading to work around a libevent bug, fixed in 2.1.9
+    // See https://github.com/libevent/libevent/commit/5ff8eb26371c4dc56f384b2de35bea2d87814779
+    // and https://github.com/bitcoin/bitcoin/pull/11593.
+    if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02010900) {
         evhttp_connection* conn = evhttp_request_get_connection(req);
         if (conn) {
             bufferevent* bev = evhttp_connection_get_bufferevent(conn);
@@ -614,7 +616,7 @@ void HTTPRequest::WriteReply(int nStatus, const std::string& strReply)
         evhttp_send_reply(req_copy, nStatus, nullptr, nullptr);
         // Re-enable reading from the socket. This is the second part of the libevent
         // workaround above.
-        if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001) {
+        if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02010900) {
             evhttp_connection* conn = evhttp_request_get_connection(req_copy);
             if (conn) {
                 bufferevent* bev = evhttp_connection_get_bufferevent(conn);

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -13,7 +13,7 @@ import os
 import random
 import unittest
 
-from test_framework.crypto import secp256k1
+from test_framework import secp256k1
 from test_framework.util import random_bitflip
 
 # Order of the secp256k1 curve

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -13,7 +13,7 @@ import os
 import random
 import unittest
 
-from test_framework import secp256k1
+from test_framework.crypto import secp256k1
 from test_framework.util import random_bitflip
 
 # Order of the secp256k1 curve


### PR DESCRIPTION
Backports bitcoin/bitcoin#27949

Original commit: a15388c606

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the version range for a workaround related to HTTP request handling to apply only to specific affected versions of libevent.
  * Improved accuracy of comments regarding the affected libevent versions and the bug fix reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->