### PR TITLE
Merge bitcoin/bitcoin#27947: MaybePunishNodeForTx: Remove unused message arg and logging

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1876,7 +1876,7 @@ bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationStat
     case TxValidationResult::TX_CONSENSUS:
         {
             LOCK(cs_main);
-            Misbehaving(nodeid, 100, "");
+            Misbehaving(nodeid, 100);
             return true;
         }
     // Conflicting (but not necessarily invalid) data or different policy:

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -700,7 +700,7 @@ private:
      *
      * Changes here may need to be reflected in TxRelayMayResultInDisconnect().
      */
-    bool MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state, const std::string& message = "")
+    bool MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state)
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
 
     /** Maybe disconnect a peer and discourage future connections from its address.
@@ -1868,7 +1868,7 @@ bool PeerManagerImpl::MaybePunishNodeForBlock(NodeId nodeid, const BlockValidati
     return false;
 }
 
-bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state, const std::string& message) {
+bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state) {
     switch (state.GetResult()) {
     case TxValidationResult::TX_RESULT_UNSET:
         break;
@@ -1876,7 +1876,7 @@ bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationStat
     case TxValidationResult::TX_CONSENSUS:
         {
             LOCK(cs_main);
-            Misbehaving(nodeid, 100, message);
+            Misbehaving(nodeid, 100, "");
             return true;
         }
     // Conflicting (but not necessarily invalid) data or different policy:
@@ -1892,9 +1892,6 @@ bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationStat
     case TxValidationResult::TX_BAD_SPECIAL:
     case TxValidationResult::TX_CONFLICT_LOCK:
         break;
-    }
-    if (message != "") {
-        LogPrint(BCLog::NET, "peer=%d: %s\n", nodeid, message);
     }
     return false;
 }


### PR DESCRIPTION
Backports bitcoin/bitcoin#27947

Original commit: 296735f763

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of transaction validation without affecting user-facing functionality. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->