### PR TITLE
Merge bitcoin/bitcoin#27884: test: Use TestNode datadir_path or chain_path where possible

### DIFF
--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -9,10 +9,7 @@
 - Mine a fork that requires disconnecting the tip.
 - Verify that dashd AbortNode's.
 """
-
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_datadir_path
-import os
 
 
 class AbortNodeTest(BitcoinTestFramework):
@@ -27,10 +24,9 @@ class AbortNodeTest(BitcoinTestFramework):
 
     def run_test(self):
         self.generate(self.nodes[0], 3, sync_fun=self.no_op)
-        datadir = get_datadir_path(self.options.tmpdir, 0)
 
         # Deleting the undo file will result in reorg failure
-        os.unlink(os.path.join(datadir, self.chain, 'blocks', 'rev00000.dat'))
+        (self.nodes[0].chain_path / "blocks" / "rev00000.dat").unlink()
 
         # Connecting to a node with a more work chain will trigger a reorg
         # attempt.

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -52,7 +52,7 @@ class AddrmanTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def run_test(self):
-        peers_dat = os.path.join(self.nodes[0].datadir, self.chain, "peers.dat")
+        peers_dat = os.path.join(self.nodes[0].chain_path, "peers.dat")
         init_error = lambda reason: (
             f"Error: Invalid or corrupt peers.dat \\({reason}\\). If you believe this "
             f"is a bug, please report it to {self.config['environment']['PACKAGE_BUGREPORT']}. "

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -22,9 +22,7 @@ class AnchorsTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def run_test(self):
-        node_anchors_path = os.path.join(
-            self.nodes[0].datadir, "regtest", "anchors.dat"
-        )
+        node_anchors_path = self.nodes[0].chain_path / "anchors.dat"
 
         self.log.info("When node starts, check if anchors.dat doesn't exist")
         assert not os.path.exists(node_anchors_path)

--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -113,7 +113,7 @@ class AsmapTest(BitcoinTestFramework):
 
     def run_test(self):
         self.node = self.nodes[0]
-        self.datadir = os.path.join(self.node.datadir, self.chain)
+        self.datadir = self.node.chain_path
         self.default_asmap = os.path.join(self.datadir, DEFAULT_ASMAP_FILENAME)
         self.asmap_raw = os.path.join(os.path.dirname(os.path.realpath(__file__)), ASMAP)
 

--- a/test/functional/feature_blocksdir.py
+++ b/test/functional/feature_blocksdir.py
@@ -18,7 +18,7 @@ class BlocksdirTest(BitcoinTestFramework):
 
     def run_test(self):
         self.stop_node(0)
-        assert os.path.isdir(os.path.join(self.nodes[0].datadir, self.chain, "blocks"))
+        assert os.path.isdir(os.path.join(self.nodes[0].chain_path, "blocks"))
         assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "blocks"))
         shutil.rmtree(self.nodes[0].datadir)
         initialize_datadir(self.options.tmpdir, 0, self.chain)
@@ -31,7 +31,7 @@ class BlocksdirTest(BitcoinTestFramework):
         self.log.info("mining blocks..")
         self.generatetoaddress(self.nodes[0], 10, self.nodes[0].get_deterministic_priv_key().address)
         assert os.path.isfile(os.path.join(blocksdir_path, self.chain, "blocks", "blk00000.dat"))
-        assert os.path.isdir(os.path.join(self.nodes[0].datadir, self.chain, "blocks", "index"))
+        assert os.path.isdir(os.path.join(self.nodes[0].chain_path, "blocks", "index"))
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -23,7 +23,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.stop_node(0)
 
         # Check that startup fails if conf= is set in bitcoin.conf or in an included conf file
-        bad_conf_file_path = os.path.join(self.options.tmpdir, 'node0', 'bitcoin_bad.conf')
+        bad_conf_file_path = self.nodes[0].datadir_path / "bitcoin_bad.conf"
         util.write_config(bad_conf_file_path, n=0, chain='', extra_config=f'conf=some.conf\n')
         conf_in_config_file_err = 'Error: Error reading configuration file: conf cannot be set in the configuration file; use includeconf= if you want to include additional config files'
         self.nodes[0].assert_start_raises_init_error(
@@ -66,7 +66,7 @@ class ConfArgsTest(BitcoinTestFramework):
                 conf.write("wallet=foo\n")
             self.nodes[0].assert_start_raises_init_error(expected_msg=f'Error: Config setting for -wallet only applied on {self.chain} network when in [{self.chain}] section.')
 
-        main_conf_file_path = os.path.join(self.options.tmpdir, 'node0', 'dash_main.conf')
+        main_conf_file_path = self.nodes[0].datadir_path / "dash_main.conf"
         util.write_config(main_conf_file_path, n=0, chain='', extra_config=f'includeconf={inc_conf_file_path}\n')
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('acceptnonstdtxn=1\n')

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -3,7 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Check that it's not possible to start a second bitcoind instance using the same datadir or wallet."""
-import os
 import random
 import string
 
@@ -21,7 +20,7 @@ class FilelockTest(BitcoinTestFramework):
         self.nodes[0].wait_for_rpc_connection()
 
     def run_test(self):
-        datadir = os.path.join(self.nodes[0].datadir, self.chain)
+        datadir = self.nodes[0].chain_path
         self.log.info(f"Using datadir {datadir}")
 
         self.log.info("Check that we can't start a second dashd instance using the same datadir")
@@ -32,7 +31,7 @@ class FilelockTest(BitcoinTestFramework):
             def check_wallet_filelock(descriptors):
                 wallet_name = ''.join([random.choice(string.ascii_lowercase) for _ in range(6)])
                 self.nodes[0].createwallet(wallet_name=wallet_name, descriptors=descriptors)
-                wallet_dir = os.path.join(datadir, 'wallets')
+                wallet_dir = self.nodes[0].wallets_path
                 self.log.info("Check that we can't start a second dashd instance using the same wallet")
                 if descriptors:
                     expected_msg = f"Error: SQLiteDatabase: Unable to obtain an exclusive lock on the database, is it being used by another instance of {self.config['environment']['PACKAGE_NAME']}?"

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -14,27 +14,25 @@ Verify that:
 4. multiple includeconf arguments can be specified in the main config
    file.
 """
-import os
-
 from test_framework.test_framework import BitcoinTestFramework
+
 
 class IncludeConfTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
 
-    def setup_chain(self):
-        super().setup_chain()
+    def run_test(self):
         # Create additional config files
         # - tmpdir/node0/relative.conf
-        with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "w", encoding="utf8") as f:
+        with open(self.nodes[0].datadir_path / "relative.conf", "w", encoding="utf8") as f:
             f.write("uacomment=relative\n")
         # - tmpdir/node0/relative2.conf
-        with open(os.path.join(self.options.tmpdir, "node0", "relative2.conf"), "w", encoding="utf8") as f:
+        with open(self.nodes[0].datadir_path / "relative2.conf", "w", encoding="utf8") as f:
             f.write("uacomment=relative2\n")
-        with open(os.path.join(self.options.tmpdir, "node0", "dash.conf"), "a", encoding='utf8') as f:
+        with open(self.nodes[0].datadir_path / "dash.conf", "a", encoding="utf8") as f:
             f.write("uacomment=main\nincludeconf=relative.conf\n")
+        self.restart_node(0)
 
-    def run_test(self):
         self.log.info("-includeconf works from config file. subversion should end with 'main; relative)/'")
 
         subversion = self.nodes[0].getnetworkinfo()["subversion"]
@@ -52,7 +50,7 @@ class IncludeConfTest(BitcoinTestFramework):
         )
 
         self.log.info("-includeconf cannot be used recursively. subversion should end with 'main; relative)/'")
-        with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "a", encoding="utf8") as f:
+        with open(self.nodes[0].datadir_path / "relative.conf", "a", encoding="utf8") as f:
             f.write("includeconf=relative2.conf\n")
         self.start_node(0)
 
@@ -63,20 +61,20 @@ class IncludeConfTest(BitcoinTestFramework):
         self.log.info("-includeconf cannot contain invalid arg")
 
         # Commented out as long as we ignore invalid arguments in configuration files
-        #with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "w", encoding="utf8") as f:
+        #with open(self.nodes[0].datadir_path / "relative.conf", "w", encoding="utf8") as f:
         #    f.write("foo=bar\n")
         #self.nodes[0].assert_start_raises_init_error(expected_msg="Error: Error reading configuration file: Invalid configuration value foo")
 
         self.log.info("-includeconf cannot be invalid path")
-        os.remove(os.path.join(self.options.tmpdir, "node0", "relative.conf"))
+        (self.nodes[0].datadir_path / "relative.conf").unlink()
         self.nodes[0].assert_start_raises_init_error(expected_msg="Error: Error reading configuration file: Failed to include configuration file relative.conf")
 
         self.log.info("multiple -includeconf args can be used from the base config file. subversion should end with 'main; relative; relative2)/'")
-        with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "w", encoding="utf8") as f:
+        with open(self.nodes[0].datadir_path / "relative.conf", "w", encoding="utf8") as f:
             # Restore initial file contents
             f.write("uacomment=relative\n")
 
-        with open(os.path.join(self.options.tmpdir, "node0", "dash.conf"), "a", encoding='utf8') as f:
+        with open(self.nodes[0].datadir_path / "dash.conf", "a", encoding="utf8") as f:
             f.write("includeconf=relative2.conf\n")
 
         self.start_node(0)

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -37,7 +37,7 @@ class LoadblockTest(BitcoinTestFramework):
         cfg_file = os.path.join(data_dir, "linearize.cfg")
         bootstrap_file = os.path.join(self.options.tmpdir, "bootstrap.dat")
         genesis_block = self.nodes[0].getblockhash(0)
-        blocks_dir = os.path.join(data_dir, self.chain, "blocks")
+        blocks_dir = self.nodes[0].chain_path / "blocks"
         hash_list = tempfile.NamedTemporaryFile(dir=data_dir,
                                                 mode='w',
                                                 delete=False,

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -16,7 +16,7 @@ class LoggingTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def relative_log_path(self, name):
-        return os.path.join(self.nodes[0].datadir, self.chain, name)
+        return os.path.join(self.nodes[0].chain_path, name)
 
     def run_test(self):
         # test default log file name

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -111,7 +111,7 @@ class PruneTest(BitcoinTestFramework):
     def setup_network(self):
         self.setup_nodes()
 
-        self.prunedir = os.path.join(self.nodes[2].datadir, self.chain, 'blocks', '')
+        self.prunedir = os.path.join(self.nodes[2].chain_path, 'blocks', '')
 
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 2)
@@ -316,7 +316,7 @@ class PruneTest(BitcoinTestFramework):
             assert_equal(ret, node.getblockchaininfo()['pruneheight'])
 
         def has_block(index):
-            return os.path.isfile(os.path.join(self.nodes[node_number].datadir, self.chain, "blocks", f"blk{index:05}.dat"))
+            return os.path.isfile(os.path.join(self.nodes[node_number].chain_path, "blocks", f"blk{index:05}.dat"))
 
         # should not prune because chain tip of node 3 (995) < PruneAfterHeight (1000)
         assert_raises_rpc_error(-1, "Blockchain is too short for pruning", node.pruneblockchain, height(500))

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -10,7 +10,6 @@
 - Verify that out-of-order blocks are correctly processed, see LoadExternalBlockFile()
 """
 
-import os
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import MAGIC_BYTES
 from test_framework.util import assert_equal
@@ -39,7 +38,7 @@ class ReindexTest(BitcoinTestFramework):
         # In this test environment, blocks will always be in order (since
         # we're generating them rather than getting them from peers), so to
         # test out-of-order handling, swap blocks 1 and 2 on disk.
-        blk0 = os.path.join(self.nodes[0].datadir, self.nodes[0].chain, 'blocks', 'blk00000.dat')
+        blk0 = self.nodes[0].chain_path / "blocks" / "blk00000.dat"
         with open(blk0, 'r+b') as bf:
             # Read at least the first few blocks (including genesis)
             b = bf.read(2000)

--- a/test/functional/feature_settings.py
+++ b/test/functional/feature_settings.py
@@ -21,7 +21,7 @@ class SettingsTest(BitcoinTestFramework):
 
     def run_test(self):
         node, = self.nodes
-        settings = Path(node.datadir, self.chain, "settings.json")
+        settings = Path(node.chain_path, "settings.json")
         conf = Path(node.datadir, "dash.conf")
 
         # Assert empty settings file was created

--- a/test/functional/feature_startupnotify.py
+++ b/test/functional/feature_startupnotify.py
@@ -3,9 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test -startupnotify."""
-
-import os
-
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -21,12 +18,12 @@ class StartupNotifyTest(BitcoinTestFramework):
         self.disable_syscall_sandbox = True
 
     def run_test(self):
-        tmpdir_file = os.path.join(self.options.tmpdir, NODE_DIR, FILE_NAME)
-        assert not os.path.exists(tmpdir_file)
+        tmpdir_file = self.nodes[0].datadir_path / FILE_NAME
+        assert not tmpdir_file.exists()
 
         self.log.info("Test -startupnotify command is run when node starts")
         self.restart_node(0, extra_args=[f"-startupnotify=echo '{FILE_NAME}' >> {NODE_DIR}/{FILE_NAME}"])
-        self.wait_until(lambda: os.path.exists(tmpdir_file))
+        self.wait_until(lambda: tmpdir_file.exists())
 
         self.log.info("Test -startupnotify is executed once")
 

--- a/test/functional/feature_txindex_compatibility.py
+++ b/test/functional/feature_txindex_compatibility.py
@@ -40,7 +40,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         )
         # Delete v18.2.2 cached datadir to avoid making a legacy version try to
         # make sense of our current database formats
-        shutil.rmtree(os.path.join(self.nodes[2].datadir, self.chain))
+        shutil.rmtree(os.path.join(self.nodes[2].chain_path))
         self.start_nodes()
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 2)

--- a/test/functional/feature_txindex_compatibility.py
+++ b/test/functional/feature_txindex_compatibility.py
@@ -56,10 +56,10 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         self.nodes[0].getrawtransaction(txid=spend_utxo["txid"])  # Requires -txindex
 
         self.stop_nodes()
-        legacy_chain_dir = os.path.join(self.nodes[0].datadir, self.chain)
+        legacy_chain_dir = self.nodes[0].chain_path
 
         self.log.info("Migrate legacy txindex")
-        migrate_chain_dir = os.path.join(self.nodes[2].datadir, self.chain)
+        migrate_chain_dir = self.nodes[2].chain_path
         shutil.rmtree(migrate_chain_dir)
         shutil.copytree(legacy_chain_dir, migrate_chain_dir)
         with self.nodes[2].assert_debug_log([
@@ -70,7 +70,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         self.nodes[2].getrawtransaction(txid=spend_utxo["txid"])  # Requires -txindex
 
         self.log.info("Drop legacy txindex")
-        drop_index_chain_dir = os.path.join(self.nodes[1].datadir, self.chain)
+        drop_index_chain_dir = self.nodes[1].chain_path
         shutil.rmtree(drop_index_chain_dir)
         shutil.copytree(legacy_chain_dir, drop_index_chain_dir)
         self.nodes[1].assert_start_raises_init_error(

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -46,7 +46,7 @@ class RPCInterfaceTest(BitcoinTestFramework):
         command = info['active_commands'][0]
         assert_equal(command['method'], 'getrpcinfo')
         assert_greater_than_or_equal(command['duration'], 0)
-        assert_equal(info['logpath'], os.path.join(self.nodes[0].datadir, self.chain, 'debug.log'))
+        assert_equal(info['logpath'], str(self.nodes[0].debug_log_path))
 
     def test_batch_request(self):
         self.log.info("Testing basic JSON-RPC batch request...")

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -35,7 +35,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         ]
         # Delete v18.2.2 cached datadir to avoid making a legacy version try to
         # make sense of our current database formats
-        shutil.rmtree(os.path.join(self.nodes[0].datadir, self.chain))
+        shutil.rmtree(os.path.join(self.nodes[0].chain_path))
         self.start_nodes()
 
     def run_test(self):
@@ -58,8 +58,8 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         self.stop_node(0)
 
         self.log.info("Move mempool.dat from old to new node")
-        old_node_mempool = os.path.join(old_node.datadir, self.chain, 'mempool.dat')
-        new_node_mempool = os.path.join(new_node.datadir, self.chain, 'mempool.dat')
+        old_node_mempool = os.path.join(old_node.chain_path, 'mempool.dat')
+        new_node_mempool = os.path.join(new_node.chain_path, 'mempool.dat')
         os.rename(old_node_mempool, new_node_mempool)
 
         self.log.info("Start new node and verify mempool contains the tx")

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -143,8 +143,8 @@ class MempoolPersistTest(BitcoinTestFramework):
         assert self.nodes[0].getmempoolinfo()["loaded"]
         assert_equal(len(self.nodes[0].getrawmempool()), 6)
 
-        mempooldat0 = os.path.join(self.nodes[0].datadir, self.chain, 'mempool.dat')
-        mempooldat1 = os.path.join(self.nodes[1].datadir, self.chain, 'mempool.dat')
+        mempooldat0 = os.path.join(self.nodes[0].chain_path, 'mempool.dat')
+        mempooldat1 = os.path.join(self.nodes[1].chain_path, 'mempool.dat')
         self.log.debug("Remove the mempool.dat file. Verify that savemempool to disk via RPC re-creates it")
         os.remove(mempooldat0)
         result0 = self.nodes[0].savemempool()

--- a/test/functional/p2p_message_capture.py
+++ b/test/functional/p2p_message_capture.py
@@ -58,7 +58,7 @@ class MessageCaptureTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        capturedir = os.path.join(self.nodes[0].datadir, "regtest/message_capture")
+        capturedir = self.nodes[0].chain_path / "message_capture"
         # Connect a node so that the handshake occurs
         self.nodes[0].add_p2p_connection(P2PDataStore())
         self.nodes[0].disconnect_p2ps()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -48,7 +48,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     assert_is_hex_string,
     assert_is_hash_string,
-    get_datadir_path,
 )
 from test_framework.wallet import MiniWallet
 
@@ -539,16 +538,15 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("Test that getblock with verbosity 3 includes prevout")
         assert_vin_contains_prevout(3)
 
-        self.log.info("Test that getblock with verbosity 2 and 3 still works with pruned Undo data")
-        datadir = get_datadir_path(self.options.tmpdir, 0)
-
         self.log.info("Test that getblock with invalid verbosity type returns proper error message")
         assert_raises_rpc_error(-1, "JSON value is not an integer as expected", node.getblock, blockhash, "2")
 
+        self.log.info("Test that getblock with verbosity 2 and 3 still works with pruned Undo data")
+
         def move_block_file(old, new):
-            old_path = os.path.join(datadir, self.chain, 'blocks', old)
-            new_path = os.path.join(datadir, self.chain, 'blocks', new)
-            os.rename(old_path, new_path)
+            old_path = self.nodes[0].chain_path / "blocks" / old
+            new_path = self.nodes[0].chain_path / "blocks" / new
+            old_path.rename(new_path)
 
         # Move instead of deleting so we can restore chain state afterwards
         move_block_file('rev00000.dat', 'rev_wrong')

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -130,7 +130,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
                 try:
                     node1.loadwallet('wmulti')
                 except JSONRPCException as e:
-                    path = os.path.join(self.options.tmpdir, "node1", "regtest", "wallets", "wmulti")
+                    path = self.nodes[1].wallets_path / "wmulti"
                     if e.error['code'] == -18 and "Wallet file verification failed. Failed to load database path '{}'. Path does not exist.".format(path) in e.error['message']:
                         node1.createwallet(wallet_name='wmulti', disable_private_keys=True)
                     else:

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -27,7 +27,7 @@ class DumptxoutsetTest(BitcoinTestFramework):
 
         FILENAME = 'txoutset.dat'
         out = node.dumptxoutset(FILENAME)
-        expected_path = Path(node.datadir) / self.chain / FILENAME
+        expected_path = node.chain_path / FILENAME
 
         assert expected_path.is_file()
 

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -7,11 +7,9 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    get_datadir_path,
     str_to_b64str,
 )
 
-import os
 import http.client
 import urllib.parse
 import subprocess
@@ -37,8 +35,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.supports_cli = False
 
-    def setup_chain(self):
-        super().setup_chain()
+    def conf_setup(self):
         #Append rpcauth to dash.conf before initialization
         self.rtpassword = "cA773lm788buwYe4g4WT+05pKyNruVKjQ25x3n0DQcM="
         rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
@@ -63,13 +60,15 @@ class HTTPBasicsTest(BitcoinTestFramework):
         rpcauth3 = lines[1]
         self.password = lines[3]
 
-        with open(os.path.join(get_datadir_path(self.options.tmpdir, 0), "dash.conf"), 'a', encoding='utf8') as f:
+        with open(self.nodes[0].datadir_path / "dash.conf", "a", encoding="utf8") as f:
             f.write(rpcauth + "\n")
             f.write(rpcauth2 + "\n")
             f.write(rpcauth3 + "\n")
-        with open(os.path.join(get_datadir_path(self.options.tmpdir, 1), "dash.conf"), 'a', encoding='utf8') as f:
+        with open(self.nodes[1].datadir_path / "dash.conf", "a", encoding="utf8") as f:
             f.write("rpcuser={}\n".format(self.rpcuser))
             f.write("rpcpassword={}\n".format(self.rpcpassword))
+        self.restart_node(0)
+        self.restart_node(1)
 
     def test_auth(self, node, user, password):
         self.log.info('Correct...')
@@ -85,6 +84,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
         assert_equal(401, call_with_auth(node, user+'wrong', password+'wrong').status)
 
     def run_test(self):
+        self.conf_setup()
         self.log.info('Check correctness of the rpcauth config option')
         url = urllib.parse.urlparse(self.nodes[0].url)
 
@@ -108,8 +108,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo:bar'])
 
         self.log.info('Check that failure to write cookie file will abort the node gracefully')
-        cookie_file = os.path.join(get_datadir_path(self.options.tmpdir, 0), self.chain, '.cookie.tmp')
-        os.mkdir(cookie_file)
+        (self.nodes[0].chain_path / ".cookie.tmp").mkdir()
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error)
 
 

--- a/test/functional/rpc_whitelist.py
+++ b/test/functional/rpc_whitelist.py
@@ -6,11 +6,9 @@
 A test for RPC users with restricted permissions
 """
 from test_framework.test_framework import BitcoinTestFramework
-import os
 from test_framework.util import (
-    get_datadir_path,
     assert_equal,
-    str_to_b64str
+    str_to_b64str,
 )
 import json
 import http.client
@@ -43,8 +41,7 @@ class RPCWhitelistTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.supports_cli = False
 
-    def setup_chain(self):
-        super().setup_chain()
+    def run_test(self):
         # 0 => Username
         # 1 => Password (Hashed)
         # 2 => Permissions
@@ -69,7 +66,7 @@ class RPCWhitelistTest(BitcoinTestFramework):
         ]
         # These commands shouldn't be allowed for any user to test failures
         self.never_allowed = ["getnetworkinfo", "quorum sign"]
-        with open(os.path.join(get_datadir_path(self.options.tmpdir, 0), "dash.conf"), 'a', encoding='utf8') as f:
+        with open(self.nodes[0].datadir_path / "dash.conf", "a", encoding="utf8") as f:
             f.write("\nrpcwhitelistdefault=0\n")
             for user in self.users:
                 f.write("rpcauth=" + user[0] + ":" + user[1] + "\n")
@@ -78,9 +75,8 @@ class RPCWhitelistTest(BitcoinTestFramework):
             for strangedude in self.strange_users:
                 f.write("rpcauth=" + strangedude[0] + ":" + strangedude[1] + "\n")
                 f.write("rpcwhitelist=" + strangedude[0] + strangedude[2] + "\n")
+        self.restart_node(0)
 
-
-    def run_test(self):
         for user in self.users:
             permissions = user[2].replace(" ", "").split(",")
             # Pop all empty items

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -39,6 +39,7 @@ from http import HTTPStatus
 import http.client
 import json
 import logging
+import pathlib
 import socket
 import time
 import urllib.parse
@@ -61,6 +62,8 @@ class JSONRPCException(Exception):
 
 def EncodeDecimal(o):
     if isinstance(o, decimal.Decimal):
+        return str(o)
+    if isinstance(o, pathlib.Path):
         return str(o)
     raise TypeError(repr(o) + " is not JSON serializable")
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -22,7 +22,10 @@ import sys
 import collections
 from pathlib import Path
 
-from .authproxy import JSONRPCException
+from .authproxy import (
+    JSONRPCException,
+    EncodeDecimal,
+)
 from .descriptors import descsum_create
 from .messages import NODE_P2P_V2
 from .p2p import P2P_SERVICES, P2P_SUBVERSION
@@ -37,7 +40,6 @@ from .util import (
     wait_until_helper,
     p2p_port,
     get_chain_folder,
-    EncodeDecimal,
 )
 
 BITCOIND_PROC_WAIT_TIMEOUT = 60
@@ -425,12 +427,20 @@ class TestNode():
         wait_until_helper(self.is_node_stopped, timeout=timeout, timeout_factor=self.timeout_factor)
 
     @property
+    def datadir_path(self) -> Path:
+        return Path(self.datadir)
+
+    @property
     def chain_path(self) -> Path:
-        return Path(self.datadir) / get_chain_folder(self.datadir, self.chain)
+        return self.datadir_path / get_chain_folder(self.datadir, self.chain)
 
     @property
     def debug_log_path(self) -> Path:
         return self.chain_path / 'debug.log'
+
+    @property
+    def wallets_path(self) -> Path:
+        return self.chain_path / "wallets"
 
     def debug_log_bytes(self) -> int:
         with open(self.debug_log_path, encoding='utf-8') as dl:

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -228,11 +228,6 @@ def check_json_precision():
         raise RuntimeError("JSON encode/decode loses precision")
 
 
-def EncodeDecimal(o):
-    if isinstance(o, Decimal):
-        return str(o)
-    raise TypeError(repr(o) + " is not JSON serializable")
-
 
 def count_bytes(hex_string):
     return len(bytearray.fromhex(hex_string))

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -169,12 +169,12 @@ class ToolWalletTest(BitcoinTestFramework):
         if file_format is not None and file_format != dump_data["format"]:
             load_output += "Warning: Dumpfile wallet format \"{}\" does not match command line specified format \"{}\".\n".format(dump_data["format"], file_format)
         self.assert_tool_output(load_output, *args)
-        assert os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", wallet_name))
+        assert (self.nodes[0].wallets_path / wallet_name).is_dir()
 
         self.assert_tool_output("The dumpfile may contain private keys. To ensure the safety of your Bitcoin, do not share the dumpfile.\n", '-wallet={}'.format(wallet_name), '-dumpfile={}'.format(rt_dumppath), 'dump')
 
         rt_dump_data = self.read_dump(rt_dumppath)
-        wallet_dat = os.path.join(self.nodes[0].datadir, "regtest/wallets/", wallet_name, "wallet.dat")
+        wallet_dat = self.nodes[0].wallets_path / wallet_name / "wallet.dat"
         if rt_dump_data["format"] == "bdb":
             self.assert_is_bdb(wallet_dat)
         else:
@@ -189,7 +189,7 @@ class ToolWalletTest(BitcoinTestFramework):
         self.assert_raises_tool_error('Error parsing command line arguments: Invalid parameter -foo', '-foo')
         self.assert_raises_tool_error('No method provided. Run `dash-wallet -help` for valid methods.')
         self.assert_raises_tool_error('Wallet name must be provided when creating a new wallet.', 'create')
-        locked_dir = os.path.join(self.options.tmpdir, "node0", self.chain, "wallets")
+        locked_dir = self.nodes[0].wallets_path
         error = 'Error initializing wallet database environment "{}"!'.format(locked_dir)
         if self.options.descriptors:
             error = f"SQLiteDatabase: Unable to obtain an exclusive lock on the database, is it being used by another instance of {self.config['environment']['PACKAGE_NAME']}?"
@@ -198,7 +198,7 @@ class ToolWalletTest(BitcoinTestFramework):
             '-wallet=' + self.default_wallet_name,
             'info',
         )
-        path = os.path.join(self.options.tmpdir, "node0", self.chain, "wallets", "nonexistent.dat")
+        path = self.nodes[0].wallets_path / "nonexistent.dat"
         self.assert_raises_tool_error("Failed to load database path '{}'. Path does not exist.".format(path), '-wallet=nonexistent.dat', 'info')
 
     def test_tool_wallet_info(self):
@@ -353,7 +353,7 @@ class ToolWalletTest(BitcoinTestFramework):
         non_exist_dump = os.path.join(self.nodes[0].datadir, "wallet.nodump")
         self.assert_raises_tool_error('Unknown wallet file format "notaformat" provided. Please provide one of "bdb" or "sqlite".', '-wallet=todump', '-format=notaformat', '-dumpfile={}'.format(wallet_dump), 'createfromdump')
         self.assert_raises_tool_error('Dump file {} does not exist.'.format(non_exist_dump), '-wallet=todump', '-dumpfile={}'.format(non_exist_dump), 'createfromdump')
-        wallet_path = os.path.join(self.nodes[0].datadir, 'regtest/wallets/todump2')
+        wallet_path = self.nodes[0].wallets_path / "todump2"
         self.assert_raises_tool_error('Failed to create database path \'{}\'. Database already exists.'.format(wallet_path), '-wallet=todump2', '-dumpfile={}'.format(wallet_dump), 'createfromdump')
         self.assert_raises_tool_error("The -descriptors option can only be used with the 'create' command.", '-descriptors', '-wallet=todump2', '-dumpfile={}'.format(wallet_dump), 'createfromdump')
 
@@ -369,18 +369,18 @@ class ToolWalletTest(BitcoinTestFramework):
         dump_data["BITCOIN_CORE_WALLET_DUMP"] = "0"
         self.write_dump(dump_data, bad_ver_wallet_dump)
         self.assert_raises_tool_error('Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version 0', '-wallet=badload', '-dumpfile={}'.format(bad_ver_wallet_dump), 'createfromdump')
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        assert not (self.nodes[0].wallets_path / "badload").is_dir()
         bad_ver_wallet_dump = os.path.join(self.nodes[0].datadir, "wallet-bad_ver2.dump")
         dump_data["BITCOIN_CORE_WALLET_DUMP"] = "2"
         self.write_dump(dump_data, bad_ver_wallet_dump)
         self.assert_raises_tool_error('Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version 2', '-wallet=badload', '-dumpfile={}'.format(bad_ver_wallet_dump), 'createfromdump')
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        assert not (self.nodes[0].wallets_path / "badload").is_dir()
         bad_magic_wallet_dump = os.path.join(self.nodes[0].datadir, "wallet-bad_magic.dump")
         del dump_data["BITCOIN_CORE_WALLET_DUMP"]
         dump_data["not_the_right_magic"] = "1"
         self.write_dump(dump_data, bad_magic_wallet_dump, "not_the_right_magic")
         self.assert_raises_tool_error('Error: Dumpfile identifier record is incorrect. Got "not_the_right_magic", expected "BITCOIN_CORE_WALLET_DUMP".', '-wallet=badload', '-dumpfile={}'.format(bad_magic_wallet_dump), 'createfromdump')
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        assert not (self.nodes[0].wallets_path / "badload").is_dir()
 
         self.log.info('Checking createfromdump handling of checksums')
         bad_sum_wallet_dump = os.path.join(self.nodes[0].datadir, "wallet-bad_sum1.dump")
@@ -389,21 +389,21 @@ class ToolWalletTest(BitcoinTestFramework):
         dump_data["checksum"] = "1" * 64
         self.write_dump(dump_data, bad_sum_wallet_dump)
         self.assert_raises_tool_error('Error: Dumpfile checksum does not match. Computed {}, expected {}'.format(checksum, "1" * 64), '-wallet=bad', '-dumpfile={}'.format(bad_sum_wallet_dump), 'createfromdump')
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        assert not (self.nodes[0].wallets_path / "badload").is_dir()
         bad_sum_wallet_dump = os.path.join(self.nodes[0].datadir, "wallet-bad_sum2.dump")
         del dump_data["checksum"]
         self.write_dump(dump_data, bad_sum_wallet_dump, skip_checksum=True)
         self.assert_raises_tool_error('Error: Missing checksum', '-wallet=badload', '-dumpfile={}'.format(bad_sum_wallet_dump), 'createfromdump')
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        assert not (self.nodes[0].wallets_path / "badload").is_dir()
         bad_sum_wallet_dump = os.path.join(self.nodes[0].datadir, "wallet-bad_sum3.dump")
         dump_data["checksum"] = "2" * 10
         self.write_dump(dump_data, bad_sum_wallet_dump)
         self.assert_raises_tool_error('Error: Checksum is not the correct size', '-wallet=badload', '-dumpfile={}'.format(bad_sum_wallet_dump), 'createfromdump')
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        assert not (self.nodes[0].wallets_path / "badload").is_dir()
         dump_data["checksum"] = "3" * 66
         self.write_dump(dump_data, bad_sum_wallet_dump)
         self.assert_raises_tool_error('Error: Checksum is not the correct size', '-wallet=badload', '-dumpfile={}'.format(bad_sum_wallet_dump), 'createfromdump')
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        assert not (self.nodes[0].wallets_path / "badload").is_dir()
 
 
     def test_nonhd(self):

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -102,16 +102,16 @@ class WalletBackupTest(BitcoinTestFramework):
         self.stop_node(2)
 
     def erase_three(self):
-        os.remove(os.path.join(self.nodes[0].datadir, self.chain, 'wallets', self.default_wallet_name, self.wallet_data_filename))
-        os.remove(os.path.join(self.nodes[1].datadir, self.chain, 'wallets', self.default_wallet_name, self.wallet_data_filename))
-        os.remove(os.path.join(self.nodes[2].datadir, self.chain, 'wallets', self.default_wallet_name, self.wallet_data_filename))
+        os.remove(os.path.join(self.nodes[0].wallets_path, self.default_wallet_name, self.wallet_data_filename))
+        os.remove(os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename))
+        os.remove(os.path.join(self.nodes[2].wallets_path, self.default_wallet_name, self.wallet_data_filename))
 
     def restore_invalid_wallet(self):
         node = self.nodes[3]
         invalid_wallet_file = os.path.join(self.nodes[0].datadir, 'invalid_wallet_file.bak')
         open(invalid_wallet_file, 'a', encoding="utf8").write('invald wallet')
         wallet_name = "res0"
-        not_created_wallet_file = os.path.join(node.datadir, self.chain, 'wallets', wallet_name)
+        not_created_wallet_file = os.path.join(node.wallets_path, wallet_name)
         error_message = "Wallet file verification failed. Failed to load database path '{}'. Data is not in recognized format.".format(not_created_wallet_file)
         assert_raises_rpc_error(-18, error_message, node.restorewallet, wallet_name, invalid_wallet_file)
         assert not os.path.exists(not_created_wallet_file)
@@ -121,14 +121,14 @@ class WalletBackupTest(BitcoinTestFramework):
         nonexistent_wallet_file = os.path.join(self.nodes[0].datadir, 'nonexistent_wallet.bak')
         wallet_name = "res0"
         assert_raises_rpc_error(-8, "Backup file does not exist", node.restorewallet, wallet_name, nonexistent_wallet_file)
-        not_created_wallet_file = os.path.join(node.datadir, self.chain, 'wallets', wallet_name)
+        not_created_wallet_file = os.path.join(node.wallets_path, wallet_name)
         assert not os.path.exists(not_created_wallet_file)
 
     def restore_wallet_existent_name(self):
         node = self.nodes[3]
         backup_file = os.path.join(self.nodes[0].datadir, 'wallet.bak')
         wallet_name = "res0"
-        wallet_file = os.path.join(node.datadir, self.chain, 'wallets', wallet_name)
+        wallet_file = os.path.join(node.wallets_path, wallet_name)
         error_message = "Failed to create database path '{}'. Database already exists.".format(wallet_file)
         assert_raises_rpc_error(-36, error_message, node.restorewallet, wallet_name, backup_file)
         assert os.path.exists(wallet_file)
@@ -194,9 +194,9 @@ class WalletBackupTest(BitcoinTestFramework):
         self.nodes[3].restorewallet("res1", backup_file_1)
         self.nodes[3].restorewallet("res2", backup_file_2)
 
-        assert os.path.exists(os.path.join(self.nodes[3].datadir, self.chain, 'wallets', "res0"))
-        assert os.path.exists(os.path.join(self.nodes[3].datadir, self.chain, 'wallets', "res1"))
-        assert os.path.exists(os.path.join(self.nodes[3].datadir, self.chain, 'wallets', "res2"))
+        assert os.path.exists(os.path.join(self.nodes[3].wallets_path, "res0"))
+        assert os.path.exists(os.path.join(self.nodes[3].wallets_path, "res1"))
+        assert os.path.exists(os.path.join(self.nodes[3].wallets_path, "res2"))
 
         res0_rpc = self.nodes[3].get_wallet_rpc("res0")
         res1_rpc = self.nodes[3].get_wallet_rpc("res1")
@@ -214,10 +214,10 @@ class WalletBackupTest(BitcoinTestFramework):
             self.erase_three()
 
             #start node2 with no chain
-            shutil.rmtree(os.path.join(self.nodes[2].datadir, self.chain, 'blocks'))
-            shutil.rmtree(os.path.join(self.nodes[2].datadir, self.chain, 'chainstate'))
-            shutil.rmtree(os.path.join(self.nodes[2].datadir, self.chain, 'evodb'))
-            shutil.rmtree(os.path.join(self.nodes[2].datadir, self.chain, 'llmq'))
+            shutil.rmtree(os.path.join(self.nodes[2].chain_path, 'blocks'))
+            shutil.rmtree(os.path.join(self.nodes[2].chain_path, 'chainstate'))
+            shutil.rmtree(os.path.join(self.nodes[2].chain_path, 'evodb'))
+            shutil.rmtree(os.path.join(self.nodes[2].chain_path, 'llmq'))
 
             self.start_three(["-nowallet"])
             # Create new wallets for the three nodes.
@@ -241,10 +241,10 @@ class WalletBackupTest(BitcoinTestFramework):
 
         # Backup to source wallet file must fail
         sourcePaths = [
-            os.path.join(self.nodes[0].datadir, self.chain, 'wallets', self.default_wallet_name, self.wallet_data_filename),
-            os.path.join(self.nodes[0].datadir, self.chain, '.', 'wallets', self.default_wallet_name, self.wallet_data_filename),
-            os.path.join(self.nodes[0].datadir, self.chain, 'wallets', self.default_wallet_name),
-            os.path.join(self.nodes[0].datadir, self.chain, 'wallets')]
+            os.path.join(self.nodes[0].wallets_path, self.default_wallet_name, self.wallet_data_filename),
+            os.path.join(self.nodes[0].chain_path, '.', 'wallets', self.default_wallet_name, self.wallet_data_filename),
+            os.path.join(self.nodes[0].wallets_path, self.default_wallet_name),
+            self.nodes[0].wallets_path]
 
         for sourcePath in sourcePaths:
             assert_raises_rpc_error(-4, "backup failed", self.nodes[0].backupwallet, sourcePath)

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -89,7 +89,7 @@ class WalletHDTest(BitcoinTestFramework):
         shutil.rmtree(os.path.join(self.nodes[1].datadir, self.chain, "llmq"))
         shutil.copyfile(
             os.path.join(self.nodes[1].datadir, "hd.bak"),
-            os.path.join(self.nodes[1].datadir, self.chain, "wallets", self.default_wallet_name, self.wallet_data_filename),
+            os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename),
         )
         self.start_node(1)
 
@@ -116,7 +116,7 @@ class WalletHDTest(BitcoinTestFramework):
         shutil.rmtree(os.path.join(self.nodes[1].datadir, self.chain, "llmq"))
         shutil.copyfile(
             os.path.join(self.nodes[1].datadir, "hd.bak"),
-            os.path.join(self.nodes[1].datadir, self.chain, "wallets", self.default_wallet_name, self.wallet_data_filename),
+            os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename),
         )
         self.start_node(1, extra_args=self.extra_args[1])
         self.connect_nodes(0, 1)

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -30,7 +30,7 @@ class KeypoolRestoreTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        wallet_path = os.path.join(self.nodes[1].datadir, self.chain, "wallets", self.default_wallet_name, self.wallet_data_filename)
+        wallet_path = os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename)
         wallet_backup_path = os.path.join(self.nodes[1].datadir, "wallet.bak")
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -295,7 +295,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(set(self.nodes[0].listwallets()), set(wallet_names))
 
         # Fail to load if wallet doesn't exist
-        path = os.path.join(self.options.tmpdir, "node0", self.chain, "wallets", "wallets")
+        path = wallet_dir("wallets")
         assert_raises_rpc_error(-18, "Wallet file verification failed. Failed to load database path '{}'. Path does not exist.".format(path), self.nodes[0].loadwallet, 'wallets')
 
         # Fail to load duplicate wallets
@@ -307,7 +307,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # Fail to load duplicate wallets by different ways (directory and filepath)
         if not self.options.descriptors:
-            path = os.path.join(self.options.tmpdir, "node0", self.chain, "wallets", self.wallet_data_filename)
+            path = wallet_dir(self.wallet_data_filename)
             assert_raises_rpc_error(-35, "Wallet file verification failed. Refusing to load database. Data file '{}' is already loaded.".format(path), self.nodes[0].loadwallet, self.wallet_data_filename)
 
             # Only BDB doesn't open duplicate wallet files. SQLite does not have this limitation. While this may be desired in the future, it is not necessary
@@ -323,7 +323,7 @@ class MultiWalletTest(BitcoinTestFramework):
         self.log.info("Test dynamic wallet creation.")
 
         # Fail to create a wallet if it already exists.
-        path = os.path.join(self.options.tmpdir, "node0", self.chain, "wallets", "w2")
+        path = wallet_dir("w2")
         assert_raises_rpc_error(-4, "Failed to create database path '{}'. Database already exists.".format(path), self.nodes[0].createwallet, 'w2')
 
         # Successfully create a wallet with a new name
@@ -347,7 +347,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # Fail to load if a directory is specified that doesn't contain a wallet
         os.mkdir(wallet_dir('empty_wallet_dir'))
-        path = os.path.join(self.options.tmpdir, "node0", self.chain, "wallets", "empty_wallet_dir")
+        path = wallet_dir("empty_wallet_dir")
         assert_raises_rpc_error(-18, "Wallet file verification failed. Failed to load database path '{}'. Data is not in recognized format.".format(path), self.nodes[0].loadwallet, 'empty_wallet_dir')
 
         self.log.info("Test dynamic wallet unloading")

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -86,7 +86,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         # Node0 wallet file is loaded on longest sync'ed node1
         self.stop_node(1)
         self.nodes[0].backupwallet(os.path.join(self.nodes[0].datadir, 'wallet.bak'))
-        shutil.copyfile(os.path.join(self.nodes[0].datadir, 'wallet.bak'), os.path.join(self.nodes[1].datadir, self.chain, self.default_wallet_name, self.wallet_data_filename))
+        shutil.copyfile(os.path.join(self.nodes[0].datadir, 'wallet.bak'), os.path.join(self.nodes[1].chain_path, self.default_wallet_name, self.wallet_data_filename))
         self.start_node(1)
         tx_after_reorg = self.nodes[1].gettransaction(txid)
         # Check that normal confirmed tx is confirmed again but with different blockhash

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -113,10 +113,10 @@ class UpgradeWalletTest(BitcoinTestFramework):
 
         self.log.info("Test upgradewallet RPC...")
         # Prepare for copying of the older wallet
-        node_master_wallet_dir = os.path.join(node_master.datadir, "regtest/wallets", self.default_wallet_name)
-        node_master_wallet = os.path.join(node_master_wallet_dir, self.default_wallet_name, self.wallet_data_filename)
-        v18_2_wallet       = os.path.join(v18_2_node.datadir, "regtest/wallets/wallet.dat")
-        v16_1_wallet       = os.path.join(v16_1_node.datadir, "regtest/wallets/wallet.dat")
+        node_master_wallet_dir = node_master.wallets_path / self.default_wallet_name
+        node_master_wallet = node_master_wallet_dir / self.default_wallet_name / self.wallet_data_filename
+        v18_2_wallet = v18_2_node.wallets_path / "wallet.dat"
+        v16_1_wallet = v16_1_node.wallets_path / "wallet.dat"
         self.stop_nodes()
 
         shutil.rmtree(node_master_wallet_dir)


### PR DESCRIPTION
Backports bitcoin/bitcoin#27884

Original commit: e8543629ae

This PR refactors test files to use TestNode properties (`datadir_path`, `chain_path`, `wallets_path`) instead of manually constructing paths using `os.path.join()`. This is a test-only change that improves code consistency and readability.

Changes:
- Replace `os.path.join(self.options.tmpdir, 'node0', ...)` with `self.nodes[0].datadir_path / ...`
- Replace `os.path.join(self.nodes[0].datadir, self.chain)` with `self.nodes[0].chain_path`
- Replace `os.path.join(datadir, 'wallets')` with `self.nodes[0].wallets_path`

Note: Many test files from the Bitcoin commit don't exist in Dash (e.g., wallet migration tests, backwards compatibility tests, etc.), so only the files that exist in Dash were modified.

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized and standardized file and directory path handling across functional tests by replacing manual string-based path construction and `os.path` usage with `pathlib.Path` attributes and operations.
  * Introduced new node attributes for direct access to data, chain, and wallet directories, improving clarity and consistency.
  * Removed unused imports and utility functions related to previous path handling methods.
  * Merged or renamed some setup methods for improved test structure and explicit node restarts after configuration changes.

* **Chores**
  * Improved code readability and maintainability by centralizing path logic and removing redundancy in test scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->