### PR TITLE
Merge bitcoin/bitcoin#27996: ci: filter all subtrees from tidy output

### DIFF
--- a/src/.bear-tidy-config
+++ b/src/.bear-tidy-config
@@ -5,14 +5,16 @@
       "paths_to_include": [],
       "paths_to_exclude": [
         "src/crc32",
+        "src/crc32c",
+        "src/crypto/ctaes",
         "src/crypto/x11",
         "src/dashbls",
         "src/gsl",
         "src/immer",
         "src/leveldb",
         "src/minisketch",
-        "src/univalue",
-        "src/secp256k1"
+        "src/secp256k1",
+        "src/univalue"
       ]
     },
     "format": {


### PR DESCRIPTION
Backports bitcoin/bitcoin#27996

Original commit: c6287faae4

Backported from Bitcoin Core v0.26

Note: The ci/test/06_script_b.sh file was modified in Bitcoin but does not exist in Dash's current branch structure. Only the bear-tidy-config changes were applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude additional directories from processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->