### PR TITLE
Merge bitcoin/bitcoin#28002: refactor: remove in-code warning suppression

### DIFF
--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -21,14 +21,7 @@
 
 struct bilingual_str;
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsuggest-override"
-#endif
 #include <db_cxx.h>
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 namespace wallet {
 struct WalletDatabaseFileId {


### PR DESCRIPTION
Backports bitcoin/bitcoin#28002

Original commit: b5ebeb376d

Backported from Bitcoin Core v0.26

Note: This backport only affects `src/wallet/bdb.h` as:
- `src/common/run_command.cpp` doesn't exist in Dash
- `src/test/system_tests.cpp` already didn't have the warning suppression pragmas

The change removes GCC warning suppression pragmas that were needed for older Boost versions.