### PR TITLE
Merge bitcoin/bitcoin#28014: ci: re-enable gui tests for s390x

### DIFF
--- a/ci/test/00_setup_env_s390x.sh
+++ b/ci/test/00_setup_env_s390x.sh
@@ -22,4 +22,4 @@ export RUN_UNIT_TESTS=true
 export TEST_RUNNER_EXTRA="--exclude rpc_bind,feature_bind_extra"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export RUN_FUNCTIONAL_TESTS=true
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests --with-boost-process"  # GUI tests disabled for now, see https://github.com/bitcoin/bitcoin/issues/23730
+export BITCOIN_CONFIG="--enable-reduce-exports --with-boost-process"


### PR DESCRIPTION
Backports bitcoin/bitcoin#28014

Original commit: f8a71f3fc0

Backported from Bitcoin Core v0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to allow GUI tests on the s390x platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->