### PR TITLE
Merge bitcoin/bitcoin#28056: rpc: doc: Added `longpollid` and `data` params to `template_request`

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -563,7 +563,7 @@ static RPCHelpMan getblocktemplate()
                             {"str", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "client side supported softfork deployment"},
                         },
                         },
-                    {"longpollid", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "delay processing request until the result would vary significantly from the \"longpollid\" of a prior template"},
+                        {"longpollid", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "delay processing request until the result would vary significantly from the \"longpollid\" of a prior template"},
                     {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "proposed block data to check, encoded in hexadecimal; valid only for mode=\"proposal\""},
                 },
                 "\"template_request\""},

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -563,6 +563,8 @@ static RPCHelpMan getblocktemplate()
                             {"str", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "client side supported softfork deployment"},
                         },
                         },
+                    {"longpollid", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "delay processing request until the result would vary significantly from the \"longpollid\" of a prior template"},
+                    {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "proposed block data to check, encoded in hexadecimal; valid only for mode=\"proposal\""},
                 },
                 "\"template_request\""},
         },


### PR DESCRIPTION
Backports bitcoin/bitcoin#28056

Original commit: 3648a9b4f714b49a152f2bf0f9d5f4c8e1089add

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * getblocktemplate now accepts two additional optional parameters — "longpollid" (string) and "data" (hex string) — in the request schema. These options are optional, appear in the RPC request input, and do not change existing behavior or control flow of template requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->