### PR TITLE
Merge bitcoin/bitcoin#28168: refactor: Remove unused raw-pointer read helper from univalue

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -444,9 +444,10 @@ endif
 
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)
-	@{ \
+	$(AM_V_GEN) { \
+	 echo "#include <string>" && \
 	 echo "namespace json_tests{" && \
-	 echo "static unsigned const char $(*F)[] = {" && \
+	 echo "static const std::string $(*F){" && \
 	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
 	 echo "};};"; \
 	} > "$@.new" && mv -f "$@.new" "$@"

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_SUITE(base58_tests)
 // Goal: test low-level base58 encoding functionality
 BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 {
-    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
+    UniValue tests = read_json(json_tests::base58_encode_decode);
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
         std::string strTest = test.write();
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 // Goal: test low-level base58 decoding functionality
 BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
 {
-    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
+    UniValue tests = read_json(json_tests::base58_encode_decode);
     std::vector<unsigned char> result;
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -128,9 +128,7 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
 BOOST_AUTO_TEST_CASE(blockfilters_json_test)
 {
     UniValue json;
-    std::string json_data(json_tests::blockfilters,
-                          json_tests::blockfilters + sizeof(json_tests::blockfilters));
-    if (!json.read(json_data) || !json.isArray()) {
+    if (!json.read(json_tests::blockfilters) || !json.isArray()) {
         BOOST_ERROR("Parse error.");
         return;
     }

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -22,7 +22,7 @@ BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 // Goal: check that parsed keys match test payload
 BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
+    UniValue tests = read_json(json_tests::key_io_valid);
     CKey privkey;
     CTxDestination destination;
     SelectParams(CBaseChainParams::MAIN);
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 // Goal: check that generated keys match test vectors
 BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
+    UniValue tests = read_json(json_tests::key_io_valid);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 // Goal: check that base58 parsing code is robust against a variety of corrupted data
 BOOST_AUTO_TEST_CASE(key_io_invalid)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_invalid, json_tests::key_io_invalid + sizeof(json_tests::key_io_invalid))); // Negative testcases
+    UniValue tests = read_json(json_tests::key_io_invalid); // Negative testcases
     CKey privkey;
     CTxDestination destination;
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -19,7 +19,7 @@
 static UniValue JSON(std::string_view json)
 {
     UniValue value;
-    BOOST_CHECK(value.read(json.data(), json.size()));
+    BOOST_CHECK(value.read(json));
     return value;
 }
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -841,7 +841,7 @@ BOOST_AUTO_TEST_CASE(script_build)
     std::set<std::string> tests_set;
 
     {
-        UniValue json_tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
+        UniValue json_tests = read_json(json_tests::script_tests);
 
         for (unsigned int idx = 0; idx < json_tests.size(); idx++) {
             const UniValue& tv = json_tests[idx];
@@ -878,7 +878,9 @@ BOOST_AUTO_TEST_CASE(script_json_test)
     // Inner arrays are [ "scriptSig", "scriptPubKey", "flags", "expected_scripterror" ]
     // ... where scriptSig and scriptPubKey are stringified
     // scripts.
-    UniValue tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
+    // If a witness is given, then the last value in the array should be the
+    // amount (nValue) to use in the crediting tx
+    UniValue tests = read_json(json_tests::script_tests);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
 // Goal: check that SignatureHash generates correct hash
 BOOST_AUTO_TEST_CASE(sighash_from_data)
 {
-    UniValue tests = read_json(std::string(json_tests::sighash, json_tests::sighash + sizeof(json_tests::sighash)));
+    UniValue tests = read_json(json_tests::sighash);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -150,7 +150,7 @@ BOOST_FIXTURE_TEST_SUITE(transaction_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(tx_valid)
 {
     // Read tests from test/data/tx_valid.json
-    UniValue tests = read_json(std::string(json_tests::tx_valid, json_tests::tx_valid + sizeof(json_tests::tx_valid)));
+    UniValue tests = read_json(json_tests::tx_valid);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
 BOOST_AUTO_TEST_CASE(tx_invalid)
 {
     // Read tests from test/data/tx_invalid.json
-    UniValue tests = read_json(std::string(json_tests::tx_invalid, json_tests::tx_invalid + sizeof(json_tests::tx_invalid)));
+    UniValue tests = read_json(json_tests::tx_invalid);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -7,13 +7,15 @@
 #define BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H
 
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <map>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 class UniValue {
@@ -90,9 +92,7 @@ public:
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
 
-    bool read(const char *raw, size_t len);
-    bool read(const char *raw) { return read(raw, strlen(raw)); }
-    bool read(std::string_view raw) { return read(raw.data(), raw.size()); }
+    bool read(std::string_view raw);
 
 private:
     UniValue::VType typ;

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -5,10 +5,11 @@
 #include <univalue.h>
 #include <univalue_utffilter.h>
 
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /*
@@ -259,7 +260,7 @@ enum expect_bits : unsigned {
 #define setExpect(bit) (expectMask |= EXP_##bit)
 #define clearExpect(bit) (expectMask &= ~EXP_##bit)
 
-bool UniValue::read(const char *raw, size_t size)
+bool UniValue::read(std::string_view str_in)
 {
     clear();
 
@@ -270,7 +271,8 @@ bool UniValue::read(const char *raw, size_t size)
     unsigned int consumed;
     enum jtokentype tok = JTOK_NONE;
     enum jtokentype last_tok = JTOK_NONE;
-    const char* end = raw + size;
+    const char* raw{str_in.data()};
+    const char* end{raw + str_in.size()};
     do {
         last_tok = tok;
 

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -153,7 +153,7 @@ void no_nul_test()
 {
     char buf[] = "___[1,2,3]___";
     UniValue val;
-    assert(val.read(buf + 3, 7));
+    assert(val.read({buf + 3, 7}));
 }
 
 int main (int argc, char *argv[])


### PR DESCRIPTION
Backports bitcoin/bitcoin#28168

Original commit: 8aa77a77e6

Backported from Bitcoin Core v0.26