### PR TITLE
Merge bitcoin/bitcoin#28070: test: Drop 22.x node from TxindexCompatibilityTest

### DIFF
--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -11,8 +11,6 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_datadir_path
-import os
 
 
 class AbortNodeTest(BitcoinTestFramework):
@@ -27,10 +25,9 @@ class AbortNodeTest(BitcoinTestFramework):
 
     def run_test(self):
         self.generate(self.nodes[0], 3, sync_fun=self.no_op)
-        datadir = get_datadir_path(self.options.tmpdir, 0)
 
         # Deleting the undo file will result in reorg failure
-        os.unlink(os.path.join(datadir, self.chain, 'blocks', 'rev00000.dat'))
+        (self.nodes[0].blocks_path / "rev00000.dat").unlink()
 
         # Connecting to a node with a more work chain will trigger a reorg
         # attempt.

--- a/test/functional/feature_dirsymlinks.py
+++ b/test/functional/feature_dirsymlinks.py
@@ -26,7 +26,7 @@ class SymlinkTest(BitcoinTestFramework):
         self.stop_node(0)
 
         rename_and_link(
-            from_name=self.nodes[0].chain_path / "blocks",
+            from_name=self.nodes[0].blocks_path,
             to_name=dir_new_blocks,
         )
         rename_and_link(

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -37,7 +37,7 @@ class LoadblockTest(BitcoinTestFramework):
         cfg_file = os.path.join(data_dir, "linearize.cfg")
         bootstrap_file = os.path.join(self.options.tmpdir, "bootstrap.dat")
         genesis_block = self.nodes[0].getblockhash(0)
-        blocks_dir = os.path.join(data_dir, self.chain, "blocks")
+        blocks_dir = self.nodes[0].blocks_path
         hash_list = tempfile.NamedTemporaryFile(dir=data_dir,
                                                 mode='w',
                                                 delete=False,

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -39,7 +39,7 @@ class ReindexTest(BitcoinTestFramework):
         # In this test environment, blocks will always be in order (since
         # we're generating them rather than getting them from peers), so to
         # test out-of-order handling, swap blocks 1 and 2 on disk.
-        blk0 = os.path.join(self.nodes[0].datadir, self.nodes[0].chain, 'blocks', 'blk00000.dat')
+        blk0 = self.nodes[0].blocks_path / "blk00000.dat"
         with open(blk0, 'r+b') as bf:
             # Read at least the first few blocks (including genesis)
             b = bf.read(2000)

--- a/test/functional/feature_txindex_compatibility.py
+++ b/test/functional/feature_txindex_compatibility.py
@@ -11,16 +11,16 @@ import os
 import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
 from test_framework.wallet import MiniWallet
 
 
 class MempoolCompatibilityTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 3
+        self.num_nodes = 2
         self.extra_args = [
             ["-reindex", "-txindex"],
-            ["-txindex=0"],
-            ["-txindex=0"],
+            [],
         ]
 
     def skip_test_if_missing_module(self):
@@ -31,19 +31,12 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
             self.num_nodes,
             self.extra_args,
             versions=[
-                170003,   # Last release with legacy txindex
-                None,     # For MiniWallet, without migration code
-                18020200, # Any release with migration code (0.18.x - 21.x)
-                          # We are using v18.2.2 to avoid MigrateDBIfNeeded(2) routines as
-                          # they don't handle a no-upgrade case correctly
+                160300,  # Last release with legacy txindex
+                None,  # For MiniWallet, without migration code
             ],
         )
-        # Delete v18.2.2 cached datadir to avoid making a legacy version try to
-        # make sense of our current database formats
-        shutil.rmtree(os.path.join(self.nodes[2].datadir, self.chain))
         self.start_nodes()
         self.connect_nodes(0, 1)
-        self.connect_nodes(1, 2)
 
     def run_test(self):
         mini_wallet = MiniWallet(self.nodes[1])
@@ -53,21 +46,11 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         self.generate(self.nodes[1], 1)
 
         self.log.info("Check legacy txindex")
+        assert_raises_rpc_error(-5, "Use -txindex", lambda: self.nodes[1].getrawtransaction(txid=spend_utxo["txid"]))
         self.nodes[0].getrawtransaction(txid=spend_utxo["txid"])  # Requires -txindex
 
         self.stop_nodes()
         legacy_chain_dir = os.path.join(self.nodes[0].datadir, self.chain)
-
-        self.log.info("Migrate legacy txindex")
-        migrate_chain_dir = os.path.join(self.nodes[2].datadir, self.chain)
-        shutil.rmtree(migrate_chain_dir)
-        shutil.copytree(legacy_chain_dir, migrate_chain_dir)
-        with self.nodes[2].assert_debug_log([
-                "Upgrading txindex database...",
-                "txindex is enabled at height 200",
-        ]):
-            self.start_node(2, extra_args=["-txindex"])
-        self.nodes[2].getrawtransaction(txid=spend_utxo["txid"])  # Requires -txindex
 
         self.log.info("Drop legacy txindex")
         drop_index_chain_dir = os.path.join(self.nodes[1].datadir, self.chain)
@@ -79,15 +62,13 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         )
         # Build txindex from scratch and check there is no error this time
         self.start_node(1, extra_args=["-txindex"])
-        self.nodes[2].getrawtransaction(txid=spend_utxo["txid"])  # Requires -txindex
+        self.wait_until(lambda: self.nodes[1].getindexinfo()["txindex"]["synced"] == True)
+        self.nodes[1].getrawtransaction(txid=spend_utxo["txid"])  # Requires -txindex
 
         self.stop_nodes()
 
         self.log.info("Check migrated txindex cannot be read by legacy node")
         err_msg = f": You need to rebuild the database using -reindex to change -txindex.{os.linesep}Please restart with -reindex or -reindex-chainstate to recover."
-        shutil.rmtree(legacy_chain_dir)
-        shutil.copytree(migrate_chain_dir, legacy_chain_dir)
-        self.nodes[0].assert_start_raises_init_error(extra_args=["-txindex"], expected_msg=err_msg)
         shutil.rmtree(legacy_chain_dir)
         shutil.copytree(drop_index_chain_dir, legacy_chain_dir)
         self.nodes[0].assert_start_raises_init_error(extra_args=["-txindex"], expected_msg=err_msg)

--- a/test/functional/feature_unsupported_utxo_db.py
+++ b/test/functional/feature_unsupported_utxo_db.py
@@ -42,9 +42,9 @@ class UnsupportedUtxoDbTest(BitcoinTestFramework):
 
         self.log.info("Check init error")
         legacy_utxos_dir = self.nodes[0].chain_path / "chainstate"
-        legacy_blocks_dir = self.nodes[0].chain_path / "blocks"
+        legacy_blocks_dir = self.nodes[0].blocks_path
         recent_utxos_dir = self.nodes[1].chain_path / "chainstate"
-        recent_blocks_dir = self.nodes[1].chain_path / "blocks"
+        recent_blocks_dir = self.nodes[1].blocks_path
         shutil.copytree(legacy_utxos_dir, recent_utxos_dir)
         shutil.copytree(legacy_blocks_dir, recent_blocks_dir)
         self.nodes[1].assert_start_raises_init_error(

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -13,6 +13,7 @@ The previous release v0.15.0.0 is required by this test, see test/README.md.
 import os
 import shutil
 
+from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.wallet import MiniWallet
 
@@ -20,6 +21,7 @@ from test_framework.wallet import MiniWallet
 class MempoolCompatibilityTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.setup_clean_chain = True
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_previous_releases()
@@ -58,9 +60,9 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         self.stop_node(0)
 
         self.log.info("Move mempool.dat from old to new node")
-        old_node_mempool = os.path.join(old_node.datadir, self.chain, 'mempool.dat')
-        new_node_mempool = os.path.join(new_node.datadir, self.chain, 'mempool.dat')
-        os.rename(old_node_mempool, new_node_mempool)
+        old_node_mempool = old_node.chain_path / "mempool.dat"
+        new_node_mempool = new_node.chain_path / "mempool.dat"
+        old_node_mempool.rename(new_node_mempool)
 
         self.log.info("Start new node and verify mempool contains the tx")
         self.start_node(1)
@@ -73,7 +75,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         self.stop_node(1)
 
         self.log.info("Move mempool.dat from new to old node")
-        os.rename(new_node_mempool, old_node_mempool)
+        new_node_mempool.rename(old_node_mempool)
 
         self.log.info("Start old node again and verify mempool contains both txs")
         self.start_node(0, ['-nowallet'])

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -23,7 +23,6 @@ Tests correspond to code in rpc/blockchain.cpp.
 
 from decimal import Decimal
 import http.client
-import os
 import subprocess
 
 from test_framework.blocktools import (
@@ -48,7 +47,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     assert_is_hex_string,
     assert_is_hash_string,
-    get_datadir_path,
 )
 from test_framework.wallet import MiniWallet
 
@@ -540,15 +538,14 @@ class BlockchainTest(BitcoinTestFramework):
         assert_vin_contains_prevout(3)
 
         self.log.info("Test that getblock with verbosity 2 and 3 still works with pruned Undo data")
-        datadir = get_datadir_path(self.options.tmpdir, 0)
 
         self.log.info("Test that getblock with invalid verbosity type returns proper error message")
         assert_raises_rpc_error(-1, "JSON value is not an integer as expected", node.getblock, blockhash, "2")
 
         def move_block_file(old, new):
-            old_path = os.path.join(datadir, self.chain, 'blocks', old)
-            new_path = os.path.join(datadir, self.chain, 'blocks', new)
-            os.rename(old_path, new_path)
+            old_path = self.nodes[0].blocks_path / old
+            new_path = self.nodes[0].blocks_path / new
+            old_path.rename(new_path)
 
         # Move instead of deleting so we can restore chain state afterwards
         move_block_file('rev00000.dat', 'rev_wrong')

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -432,6 +432,14 @@ class TestNode():
     def debug_log_path(self) -> Path:
         return self.chain_path / 'debug.log'
 
+    @property
+    def blocks_path(self) -> Path:
+        return self.chain_path / "blocks"
+
+    @property
+    def wallets_path(self) -> Path:
+        return self.chain_path / "wallets"
+
     def debug_log_bytes(self) -> int:
         with open(self.debug_log_path, encoding='utf-8') as dl:
             dl.seek(0, 2)


### PR DESCRIPTION
Backports bitcoin/bitcoin#28070

Original commit: 8535802f1d

This PR drops the 22.x node from TxindexCompatibilityTest and makes several test improvements including:
- Using the new blocks_path property in TestNode
- Simplifying test setup by removing unnecessary nodes
- Using pathlib-style path operations instead of os.path.join

Note: The file `test/functional/feature_remove_pruned_files_on_startup.py` was already removed in Dash, so changes to that file were skipped.

Backported from Bitcoin Core v0.26