### PR TITLE
Merge bitcoin/bitcoin#28144: test: fix intermittent failure in p2p_getaddr_caching.py

### DIFF
--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -4,8 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test addr response caching"""
 
-import time
-
 from test_framework.p2p import (
     P2PInterface,
     p2p_lock
@@ -67,7 +65,7 @@ class AddrTest(BitcoinTestFramework):
         last_response_on_onion_bind2 = None
         self.log.info('Send many addr requests within short time to receive same response')
         N = 5
-        cur_mock_time = int(time.time())
+        cur_mock_time = self.mocktime
         for i in range(N):
             addr_receiver_local = self.nodes[0].add_p2p_connection(AddrReceiver())
             addr_receiver_onion1 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port1)

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -4,7 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test addr response caching"""
 
-from test_framework.messages import msg_getaddr
+import time
+
 from test_framework.p2p import (
     P2PInterface,
     p2p_lock
@@ -18,6 +19,7 @@ from test_framework.util import (
 # As defined in net_processing.
 MAX_ADDR_TO_SEND = 1000
 MAX_PCT_ADDR_TO_SEND = 23
+
 
 class AddrReceiver(P2PInterface):
 
@@ -65,14 +67,11 @@ class AddrTest(BitcoinTestFramework):
         last_response_on_onion_bind2 = None
         self.log.info('Send many addr requests within short time to receive same response')
         N = 5
-        cur_mock_time = self.mocktime
+        cur_mock_time = int(time.time())
         for i in range(N):
             addr_receiver_local = self.nodes[0].add_p2p_connection(AddrReceiver())
-            addr_receiver_local.send_and_ping(msg_getaddr())
             addr_receiver_onion1 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port1)
-            addr_receiver_onion1.send_and_ping(msg_getaddr())
             addr_receiver_onion2 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port2)
-            addr_receiver_onion2.send_and_ping(msg_getaddr())
 
             # Trigger response
             cur_mock_time += 5 * 60
@@ -103,11 +102,8 @@ class AddrTest(BitcoinTestFramework):
 
         self.log.info('After time passed, see a new response to addr request')
         addr_receiver_local = self.nodes[0].add_p2p_connection(AddrReceiver())
-        addr_receiver_local.send_and_ping(msg_getaddr())
         addr_receiver_onion1 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port1)
-        addr_receiver_onion1.send_and_ping(msg_getaddr())
         addr_receiver_onion2 = self.nodes[0].add_p2p_connection(AddrReceiver(), dstport=self.onion_port2)
-        addr_receiver_onion2.send_and_ping(msg_getaddr())
 
         # Trigger response
         cur_mock_time += 5 * 60
@@ -117,9 +113,10 @@ class AddrTest(BitcoinTestFramework):
         addr_receiver_onion2.wait_until(addr_receiver_onion2.addr_received)
 
         # new response is different
-        assert(set(last_response_on_local_bind) != set(addr_receiver_local.get_received_addrs()))
-        assert(set(last_response_on_onion_bind1) != set(addr_receiver_onion1.get_received_addrs()))
-        assert(set(last_response_on_onion_bind2) != set(addr_receiver_onion2.get_received_addrs()))
+        assert set(last_response_on_local_bind) != set(addr_receiver_local.get_received_addrs())
+        assert set(last_response_on_onion_bind1) != set(addr_receiver_onion1.get_received_addrs())
+        assert set(last_response_on_onion_bind2) != set(addr_receiver_onion2.get_received_addrs())
+
 
 if __name__ == '__main__':
     AddrTest().main()

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -695,10 +695,11 @@ class TestNode():
             p2p_conn.sync_with_ping()
 
             # Consistency check that the node received our user agent string.
-            # Find our connection in getpeerinfo by our address:port, as it is unique.
+            # Find our connection in getpeerinfo by our address:port and theirs, as this combination is unique.
             sockname = p2p_conn._transport.get_extra_info("socket").getsockname()
             our_addr_and_port = f"{sockname[0]}:{sockname[1]}"
-            info = [peer for peer in self.getpeerinfo() if peer["addr"] == our_addr_and_port]
+            dst_addr_and_port = f"{p2p_conn.dstaddr}:{p2p_conn.dstport}"
+            info = [peer for peer in self.getpeerinfo() if peer["addr"] == our_addr_and_port and peer["addrbind"] == dst_addr_and_port]
             assert_equal(len(info), 1)
             assert_equal(info[0]["subver"], p2p_conn.strSubVer)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -701,7 +701,7 @@ class TestNode():
             dst_addr_and_port = f"{p2p_conn.dstaddr}:{p2p_conn.dstport}"
             info = [peer for peer in self.getpeerinfo() if peer["addr"] == our_addr_and_port and peer["addrbind"] == dst_addr_and_port]
             assert_equal(len(info), 1)
-            assert_equal(info[0]["subver"], p2p_conn.strSubVer)
+            assert_equal(info[0]["subver"], P2P_SUBVERSION)
 
         return p2p_conn
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28144

Original commit: 1b5cbf71df

This PR fixes an intermittent test failure in p2p_getaddr_caching.py by:
1. Fixing the consistency check in test_node.py to use both source and destination address:port combination as unique identifiers
2. Removing duplicate getaddr messages that were being ignored anyway
3. Adding the time import needed for int(time.time())

The changes ensure proper test stability and remove unnecessary duplicate messages.

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by refining how P2P connections are identified and verified.
  * Updated address response checks to rely on connection behavior rather than explicit message sending.
  * Simplified assertion formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->