### PR TITLE
Merge bitcoin/bitcoin#28186: kernel: Prune leveldb headers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,7 @@ BACKTRACE_LIB = -lbacktrace
 endif
 endif #ENABLE_STACKTRACES
 
-BITCOIN_INCLUDES=-I$(builddir) -I$(srcdir)/$(MINISKETCH_INCLUDE_DIR_INT) -I$(srcdir)/secp256k1/include -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT) $(LEVELDB_CPPFLAGS)
+BITCOIN_INCLUDES=-I$(builddir) -I$(srcdir)/$(MINISKETCH_INCLUDE_DIR_INT) -I$(srcdir)/secp256k1/include -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT)
 BITCOIN_INCLUDES+=-isystem$(srcdir)/dashbls/include -isystem$(srcdir)/dashbls/depends/relic/include -isystem$(srcdir)/dashbls/depends/minialloc/include
 BITCOIN_INCLUDES+=-isystem$(srcdir)/immer
 
@@ -438,12 +438,13 @@ obj/build.h: FORCE
 	  "$(abs_top_srcdir)"
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
+<<<<<<< HEAD
 
 # server: shared between dashd and dash-qt
 # Contains code accessing mempool and chain state that is meant to be separated
 # from wallet and gui code (see node/README.md). Shared code should go in
 # libbitcoin_common or libbitcoin_util libraries, instead.
-libbitcoin_node_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS) $(MINIUPNPC_CPPFLAGS) $(NATPMP_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
+libbitcoin_node_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(LEVELDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(MINIUPNPC_CPPFLAGS) $(NATPMP_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
 libbitcoin_node_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_node_a_SOURCES = \
   addrdb.cpp \

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -8,6 +8,7 @@
 #include <chainparams.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
+#include <logging.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,16 +4,47 @@
 
 #include <dbwrapper.h>
 
-#include <memory>
+#include <clientversion.h>
+#include <logging.h>
 #include <random.h>
+#include <serialize.h>
+#include <span.h>
+#include <streams.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
+#include <util/strencodings.h>
 
 #include <leveldb/cache.h>
 #include <leveldb/env.h>
 #include <leveldb/filter_policy.h>
 #include <leveldb/helpers/memenv/memenv.h>
-#include <stdint.h>
-#include <algorithm>
+#include <leveldb/iterator.h>
+#include <leveldb/options.h>
+#include <leveldb/slice.h>
+#include <leveldb/status.h>
+#include <leveldb/write_batch.h>
+#include <memory>
 #include <optional>
+#include <utility>
+
+static auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
+
+bool DestroyDB(const std::string& path_str)
+{
+    return leveldb::DestroyDB(path_str, {}).ok();
+}
+
+/** Handle database error by throwing dbwrapper_error exception.
+ */
+static void HandleError(const leveldb::Status& status)
+{
+    if (status.ok())
+        return;
+    const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
+    LogPrintf("%s\n", errmsg);
+    LogPrintf("You can use -debug=leveldb to get more complete diagnostic messages\n");
+    throw dbwrapper_error(errmsg);
+}
 
 class CBitcoinLevelDBLogger : public leveldb::Logger {
 public:
@@ -115,40 +146,109 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     return options;
 }
 
-CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
-    : m_name{fs::PathToString(path.stem())}
+struct CDBBatch::WriteBatchImpl {
+    leveldb::WriteBatch batch;
+};
+
+CDBBatch::CDBBatch(const CDBWrapper& _parent) : parent(_parent),
+                                                m_impl_batch{std::make_unique<CDBBatch::WriteBatchImpl>()},
+                                                ssKey(SER_DISK, CLIENT_VERSION),
+                                                ssValue(SER_DISK, CLIENT_VERSION),
+                                                size_estimate(0) {};
+
+CDBBatch::~CDBBatch() = default;
+
+void CDBBatch::Clear()
 {
-    penv = nullptr;
-    readoptions.verify_checksums = true;
-    iteroptions.verify_checksums = true;
-    iteroptions.fill_cache = false;
-    syncoptions.sync = true;
-    options = GetOptions(nCacheSize);
-    options.create_if_missing = true;
-    if (fMemory) {
-        penv = leveldb::NewMemEnv(leveldb::Env::Default());
-        options.env = penv;
+    m_impl_batch->batch.Clear();
+    size_estimate = 0;
+}
+
+void CDBBatch::WriteImpl(Span<const std::byte> key, CDataStream& ssValue)
+{
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
+    ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
+    leveldb::Slice slValue(CharCast(ssValue.data()), ssValue.size());
+    m_impl_batch->batch.Put(slKey, slValue);
+    // LevelDB serializes writes as:
+    // - byte: header
+    // - varint: key length (1 byte up to 127B, 2 bytes up to 16383B, ...)
+    // - byte[]: key
+    // - varint: value length
+    // - byte[]: value
+    // The formula below assumes the key and value are both less than 16k.
+    size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
+}
+
+void CDBBatch::EraseImpl(Span<const std::byte> key)
+{
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
+    m_impl_batch->batch.Delete(slKey);
+    // LevelDB serializes erases as:
+    // - byte: header
+    // - varint: key length
+    // - byte[]: key
+    // The formula below assumes the key is less than 16kB.
+    size_estimate += 2 + (slKey.size() > 127) + slKey.size();
+}
+
+struct LevelDBContext {
+    //! custom environment this database is using (may be nullptr in case of default environment)
+    leveldb::Env* penv;
+
+    //! database options used
+    leveldb::Options options;
+
+    //! options used when reading from the database
+    leveldb::ReadOptions readoptions;
+
+    //! options used when iterating over values of the database
+    leveldb::ReadOptions iteroptions;
+
+    //! options used when writing to the database
+    leveldb::WriteOptions writeoptions;
+
+    //! options used when sync writing to the database
+    leveldb::WriteOptions syncoptions;
+
+    //! the database itself
+    leveldb::DB* pdb;
+};
+
+CDBWrapper::CDBWrapper(const DBParams& params)
+    : m_db_context{std::make_unique<LevelDBContext>()}, m_name{fs::PathToString(params.path.stem())}, m_path{params.path}, m_is_memory{params.memory_only}
+{
+    DBContext().penv = nullptr;
+    DBContext().readoptions.verify_checksums = true;
+    DBContext().iteroptions.verify_checksums = true;
+    DBContext().iteroptions.fill_cache = false;
+    DBContext().syncoptions.sync = true;
+    DBContext().options = GetOptions(params.cache_bytes);
+    DBContext().options.create_if_missing = true;
+    if (params.memory_only) {
+        DBContext().penv = leveldb::NewMemEnv(leveldb::Env::Default());
+        DBContext().options.env = DBContext().penv;
     } else {
-        if (fWipe) {
-            LogPrintf("Wiping LevelDB in %s\n", fs::PathToString(path));
-            leveldb::Status result = leveldb::DestroyDB(fs::PathToString(path), options);
-            dbwrapper_private::HandleError(result);
+        if (params.wipe_data) {
+            LogPrintf("Wiping LevelDB in %s\n", fs::PathToString(params.path));
+            leveldb::Status result = leveldb::DestroyDB(fs::PathToString(params.path), DBContext().options);
+            HandleError(result);
         }
-        TryCreateDirectories(path);
-        LogPrintf("Opening LevelDB in %s\n", fs::PathToString(path));
+        TryCreateDirectories(params.path);
+        LogPrintf("Opening LevelDB in %s\n", fs::PathToString(params.path));
     }
     // PathToString() return value is safe to pass to leveldb open function,
     // because on POSIX leveldb passes the byte string directly to ::open(), and
     // on Windows it converts from UTF-8 to UTF-16 before calling ::CreateFileW
     // (see env_posix.cc and env_windows.cc).
-    leveldb::Status status = leveldb::DB::Open(options, fs::PathToString(path), &pdb);
-    dbwrapper_private::HandleError(status);
+    leveldb::Status status = leveldb::DB::Open(DBContext().options, fs::PathToString(params.path), &DBContext().pdb);
+    HandleError(status);
     LogPrintf("Opened LevelDB successfully\n");
 
-    if (gArgs.GetBoolArg("-forcecompactdb", false)) {
-        LogPrintf("Starting database compaction of %s\n", fs::PathToString(path));
-        pdb->CompactRange(nullptr, nullptr);
-        LogPrintf("Finished database compaction of %s\n", fs::PathToString(path));
+    if (params.options.force_compact) {
+        LogPrintf("Starting database compaction of %s\n", fs::PathToString(params.path));
+        DBContext().pdb->CompactRange(nullptr, nullptr);
+        LogPrintf("Finished database compaction of %s\n", fs::PathToString(params.path));
     }
 
     // The base-case obfuscation key, which is a noop.
@@ -156,7 +256,7 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
 
     bool key_exists = Read(OBFUSCATE_KEY_KEY, obfuscate_key);
 
-    if (!key_exists && obfuscate && IsEmpty()) {
+    if (!key_exists && params.obfuscate && IsEmpty()) {
         // Initialize non-degenerate obfuscation if it won't upset
         // existing, non-obfuscated data.
         std::vector<unsigned char> new_key = CreateObfuscateKey();
@@ -165,24 +265,24 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
         Write(OBFUSCATE_KEY_KEY, new_key);
         obfuscate_key = new_key;
 
-        LogPrintf("Wrote new obfuscate key for %s: %s\n", fs::PathToString(path), HexStr(obfuscate_key));
+        LogPrintf("Wrote new obfuscate key for %s: %s\n", fs::PathToString(params.path), HexStr(obfuscate_key));
     }
 
-    LogPrintf("Using obfuscation key for %s: %s\n", fs::PathToString(path), HexStr(obfuscate_key));
+    LogPrintf("Using obfuscation key for %s: %s\n", fs::PathToString(params.path), HexStr(obfuscate_key));
 }
 
 CDBWrapper::~CDBWrapper()
 {
-    delete pdb;
-    pdb = nullptr;
-    delete options.filter_policy;
-    options.filter_policy = nullptr;
-    delete options.info_log;
-    options.info_log = nullptr;
-    delete options.block_cache;
-    options.block_cache = nullptr;
-    delete penv;
-    options.env = nullptr;
+    delete DBContext().pdb;
+    DBContext().pdb = nullptr;
+    delete DBContext().options.filter_policy;
+    DBContext().options.filter_policy = nullptr;
+    delete DBContext().options.info_log;
+    DBContext().options.info_log = nullptr;
+    delete DBContext().options.block_cache;
+    DBContext().options.block_cache = nullptr;
+    delete DBContext().penv;
+    DBContext().options.env = nullptr;
 }
 
 bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
@@ -192,8 +292,8 @@ bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
     if (log_memory) {
         mem_before = DynamicMemoryUsage() / 1024.0 / 1024;
     }
-    leveldb::Status status = pdb->Write(fSync ? syncoptions : writeoptions, &batch.batch);
-    dbwrapper_private::HandleError(status);
+    leveldb::Status status = DBContext().pdb->Write(fSync ? DBContext().syncoptions : DBContext().writeoptions, &batch.m_impl_batch->batch);
+    HandleError(status);
     if (log_memory) {
         double mem_after = DynamicMemoryUsage() / 1024.0 / 1024;
         LogPrint(BCLog::LEVELDB, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
@@ -206,7 +306,7 @@ size_t CDBWrapper::DynamicMemoryUsage() const
 {
     std::string memory;
     std::optional<size_t> parsed;
-    if (!pdb->GetProperty("leveldb.approximate-memory-usage", &memory) || !(parsed = ToIntegral<size_t>(memory))) {
+    if (!DBContext().pdb->GetProperty("leveldb.approximate-memory-usage", &memory) || !(parsed = ToIntegral<size_t>(memory))) {
         LogPrint(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
         return 0;
     }
@@ -232,6 +332,45 @@ std::vector<unsigned char> CDBWrapper::CreateObfuscateKey() const
     return ret;
 }
 
+std::optional<std::string> CDBWrapper::ReadImpl(Span<const std::byte> key) const
+{
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
+    std::string strValue;
+    leveldb::Status status = DBContext().pdb->Get(DBContext().readoptions, slKey, &strValue);
+    if (!status.ok()) {
+        if (status.IsNotFound())
+            return std::nullopt;
+        LogPrintf("LevelDB read failure: %s\n", status.ToString());
+        HandleError(status);
+    }
+    return strValue;
+}
+
+bool CDBWrapper::ExistsImpl(Span<const std::byte> key) const
+{
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
+
+    std::string strValue;
+    leveldb::Status status = DBContext().pdb->Get(DBContext().readoptions, slKey, &strValue);
+    if (!status.ok()) {
+        if (status.IsNotFound())
+            return false;
+        LogPrintf("LevelDB read failure: %s\n", status.ToString());
+        HandleError(status);
+    }
+    return true;
+}
+
+size_t CDBWrapper::EstimateSizeImpl(Span<const std::byte> key1, Span<const std::byte> key2) const
+{
+    leveldb::Slice slKey1(CharCast(key1.data()), key1.size());
+    leveldb::Slice slKey2(CharCast(key2.data()), key2.size());
+    uint64_t size = 0;
+    leveldb::Range range(slKey1, slKey2);
+    DBContext().pdb->GetApproximateSizes(&range, 1, &size);
+    return size;
+}
+
 bool CDBWrapper::IsEmpty()
 {
     std::unique_ptr<CDBIterator> it(NewIterator());
@@ -239,22 +378,47 @@ bool CDBWrapper::IsEmpty()
     return !(it->Valid());
 }
 
-CDBIterator::~CDBIterator() { delete piter; }
-bool CDBIterator::Valid() const { return piter->Valid(); }
-void CDBIterator::SeekToFirst() { piter->SeekToFirst(); }
-void CDBIterator::Next() { piter->Next(); }
+void CDBWrapper::CompactFull() const
+{
+    DBContext().pdb->CompactRange(nullptr, nullptr);
+}
+
+struct CDBIterator::IteratorImpl {
+    const std::unique_ptr<leveldb::Iterator> iter;
+
+    explicit IteratorImpl(leveldb::Iterator* _iter) : iter{_iter} {}
+};
+
+CDBIterator::CDBIterator(const CDBWrapper& _parent, std::unique_ptr<IteratorImpl> _piter) : parent(_parent),
+                                                                                            m_impl_iter(std::move(_piter)) {}
+
+CDBIterator* CDBWrapper::NewIterator()
+{
+    return new CDBIterator{*this, std::make_unique<CDBIterator::IteratorImpl>(DBContext().pdb->NewIterator(DBContext().iteroptions))};
+}
+
+void CDBIterator::SeekImpl(Span<const std::byte> key)
+{
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
+    m_impl_iter->iter->Seek(slKey);
+}
+
+Span<const std::byte> CDBIterator::GetKeyImpl() const
+{
+    return MakeByteSpan(m_impl_iter->iter->key());
+}
+
+Span<const std::byte> CDBIterator::GetValueImpl() const
+{
+    return MakeByteSpan(m_impl_iter->iter->value());
+}
+
+CDBIterator::~CDBIterator() = default;
+bool CDBIterator::Valid() const { return m_impl_iter->iter->Valid(); }
+void CDBIterator::SeekToFirst() { m_impl_iter->iter->SeekToFirst(); }
+void CDBIterator::Next() { m_impl_iter->iter->Next(); }
 
 namespace dbwrapper_private {
-
-void HandleError(const leveldb::Status& status)
-{
-    if (status.ok())
-        return;
-    const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
-    LogPrintf("%s\n", errmsg);
-    LogPrintf("You can use -debug=leveldb to get more complete diagnostic messages\n");
-    throw dbwrapper_error(errmsg);
-}
 
 const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w)
 {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -5,23 +5,47 @@
 #ifndef BITCOIN_DBWRAPPER_H
 #define BITCOIN_DBWRAPPER_H
 
+#include <attributes.h>
 #include <clientversion.h>
-#include <fs.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
-#include <util/strencodings.h>
-#include <util/system.h>
+#include <util/check.h>
+#include <util/fs.h>
 
-#include <typeindex>
-
-#include <leveldb/db.h>
-#include <leveldb/write_batch.h>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
 static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;
 
-inline auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
+//! User-controlled performance and debug options.
+struct DBOptions {
+    //! Compact database on startup.
+    bool force_compact = false;
+};
+
+//! Application-specific storage settings.
+struct DBParams {
+    //! Location in the filesystem where leveldb data will be stored.
+    fs::path path;
+    //! Configures various leveldb cache settings.
+    size_t cache_bytes;
+    //! If true, use leveldb's memory environment.
+    bool memory_only = false;
+    //! If true, remove all existing data.
+    bool wipe_data = false;
+    //! If true, store data obfuscated via simple XOR. If false, XOR with a
+    //! zero'd byte array.
+    bool obfuscate = false;
+    //! Passed-through options.
+    DBOptions options{};
+};
 
 class dbwrapper_error : public std::runtime_error
 {
@@ -35,17 +59,15 @@ class CDBWrapper;
  */
 namespace dbwrapper_private {
 
-/** Handle database error by throwing dbwrapper_error exception.
- */
-void HandleError(const leveldb::Status& status);
-
 /** Work around circular dependency, as well as for testing in dbwrapper_tests.
  * Database obfuscation should be considered an implementation detail of the
  * specific database.
  */
 const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w);
 
-};
+}; // namespace dbwrapper_private
+
+bool DestroyDB(const std::string& path_str);
 
 /** Batch of changes queued to be written to a CDBWrapper */
 class CDBBatch
@@ -54,51 +76,35 @@ class CDBBatch
 
 private:
     const CDBWrapper &parent;
-    leveldb::WriteBatch batch;
+
+    struct WriteBatchImpl;
+    const std::unique_ptr<WriteBatchImpl> m_impl_batch;
 
     CDataStream ssKey;
     CDataStream ssValue;
 
     size_t size_estimate;
 
+    void WriteImpl(Span<const std::byte> key, CDataStream& ssValue);
+    void EraseImpl(Span<const std::byte> key);
+
 public:
     /**
      * @param[in] _parent    CDBWrapper that this batch is to be submitted to
      */
-    explicit CDBBatch(const CDBWrapper &_parent) : parent(_parent), ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION), size_estimate(0) { };
-
-    void Clear()
-    {
-        batch.Clear();
-        size_estimate = 0;
-    }
+    explicit CDBBatch(const CDBWrapper& _parent);
+    ~CDBBatch();
+    void Clear();
 
     template <typename K, typename V>
     void Write(const K& key, const V& value)
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        Write(ssKey, value);
-        ssKey.clear();
-    }
-
-    template <typename V>
-    void Write(const CDataStream& _ssKey, const V& value)
-    {
-        leveldb::Slice slKey(CharCast(_ssKey.data()), _ssKey.size());
-
         ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
+        ssKey << key;
         ssValue << value;
-        ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
-        leveldb::Slice slValue(CharCast(ssValue.data()), ssValue.size());
-
-        batch.Put(slKey, slValue);
-        // - varint: key length (1 byte up to 127B, 2 bytes up to 16383B, ...)
-        // - byte[]: key
-        // - varint: value length
-        // - byte[]: value
-        // The formula below assumes the key and value are both less than 16k.
-        size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
+        WriteImpl(ssKey, ssValue);
+        ssKey.clear();
         ssValue.clear();
     }
 
@@ -107,19 +113,8 @@ public:
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        Erase(ssKey);
+        EraseImpl(ssKey);
         ssKey.clear();
-    }
-
-    void Erase(const CDataStream& _ssKey) {
-        leveldb::Slice slKey(CharCast(_ssKey.data()), _ssKey.size());
-
-        batch.Delete(slKey);
-        // - byte: header
-        // - varint: key length
-        // - byte[]: key
-        // The formula below assumes the key is less than 16kB.
-        size_estimate += 2 + (slKey.size() > 127) + slKey.size();
     }
 
     size_t SizeEstimate() const { return size_estimate; }
@@ -127,9 +122,16 @@ public:
 
 class CDBIterator
 {
+public:
+    struct IteratorImpl;
+
 private:
     const CDBWrapper &parent;
-    leveldb::Iterator *piter;
+    const std::unique_ptr<IteratorImpl> m_impl_iter;
+
+    void SeekImpl(Span<const std::byte> key);
+    Span<const std::byte> GetKeyImpl() const;
+    Span<const std::byte> GetValueImpl() const;
 
 public:
 
@@ -137,8 +139,7 @@ public:
      * @param[in] _parent          Parent CDBWrapper instance.
      * @param[in] _piter           The original leveldb iterator.
      */
-    CDBIterator(const CDBWrapper &_parent, leveldb::Iterator *_piter) :
-        parent(_parent), piter(_piter) { };
+    CDBIterator(const CDBWrapper& _parent, std::unique_ptr<IteratorImpl> _piter);
     ~CDBIterator();
 
     bool Valid() const;
@@ -149,19 +150,14 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        Seek(ssKey);
-    }
-
-    void Seek(const CDataStream& ssKey) {
-        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
-        piter->Seek(slKey);
+        SeekImpl(ssKey);
     }
 
     void Next();
 
     template<typename K> bool GetKey(K& key) {
         try {
-            CDataStream ssKey = GetKey();
+            DataStream ssKey{GetKeyImpl()};
             ssKey >> key;
         } catch (const std::exception&) {
             return false;
@@ -170,18 +166,16 @@ public:
     }
 
     CDataStream GetKey() {
-        leveldb::Slice slKey = piter->key();
-        return CDataStream{MakeByteSpan(slKey), SER_DISK, CLIENT_VERSION};
+        return CDataStream{GetKeyImpl(), SER_DISK, CLIENT_VERSION};
     }
 
     unsigned int GetKeySize() {
-        return piter->key().size();
+        return GetKeyImpl().size();
     }
 
     template<typename V> bool GetValue(V& value) {
-        leveldb::Slice slValue = piter->value();
         try {
-            CDataStream ssValue{MakeByteSpan(slValue), SER_DISK, CLIENT_VERSION};
+            CDataStream ssValue{GetValueImpl(), SER_DISK, CLIENT_VERSION};
             ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
             ssValue >> value;
         } catch (const std::exception&) {
@@ -191,30 +185,14 @@ public:
     }
 };
 
+struct LevelDBContext;
+
 class CDBWrapper
 {
     friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
 private:
-    //! custom environment this database is using (may be nullptr in case of default environment)
-    leveldb::Env* penv;
-
-    //! database options used
-    leveldb::Options options;
-
-    //! options used when reading from the database
-    leveldb::ReadOptions readoptions;
-
-    //! options used when iterating over values of the database
-    leveldb::ReadOptions iteroptions;
-
-    //! options used when writing to the database
-    leveldb::WriteOptions writeoptions;
-
-    //! options used when sync writing to the database
-    leveldb::WriteOptions syncoptions;
-
-    //! the database itself
-    leveldb::DB* pdb;
+    //! holds all leveldb-specific fields of this class
+    std::unique_ptr<LevelDBContext> m_db_context;
 
     //! the name of this database
     std::string m_name;
@@ -230,16 +208,22 @@ private:
 
     std::vector<unsigned char> CreateObfuscateKey() const;
 
+    //! path to filesystem storage
+    const fs::path m_path;
+
+    //! whether or not the database resides in memory
+    bool m_is_memory;
+
+    std::optional<std::string> ReadImpl(Span<const std::byte> key) const;
+    bool ExistsImpl(Span<const std::byte> key) const;
+    size_t EstimateSizeImpl(Span<const std::byte> key1, Span<const std::byte> key2) const;
+    auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
+
 public:
     /**
-     * @param[in] path        Location in the filesystem where leveldb data will be stored.
-     * @param[in] nCacheSize  Configures various leveldb cache settings.
-     * @param[in] fMemory     If true, use leveldb's memory environment.
-     * @param[in] fWipe       If true, remove all existing data.
-     * @param[in] obfuscate   If true, store data obfuscated via simple XOR. If false, XOR
-     *                        with a zero'd byte array.
+     * @param[in] params    Parameters for the database.
      */
-    CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
+    CDBWrapper(const DBParams& params);
     ~CDBWrapper();
 
     CDBWrapper(const CDBWrapper&) = delete;
@@ -251,22 +235,11 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        return ReadDataStream(ssKey, ssValue);
-    }
-
-    bool ReadDataStream(const CDataStream& ssKey, CDataStream& ssValue) const
-    {
-        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
-
-        std::string strValue;
-        leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
-        if (!status.ok()) {
-            if (status.IsNotFound())
-                return false;
-            LogPrintf("LevelDB read failure: %s\n", status.ToString());
-            dbwrapper_private::HandleError(status);
+        std::optional<std::string> strValue{ReadImpl(ssKey)};
+        if (!strValue) {
+            return false;
         }
-        CDataStream ssValueTmp{MakeByteSpan(strValue), SER_DISK, CLIENT_VERSION};
+        CDataStream ssValueTmp{MakeByteSpan(*strValue), SER_DISK, CLIENT_VERSION};
         ssValueTmp.Xor(obfuscate_key);
         ssValue = std::move(ssValueTmp);
         return true;
@@ -311,22 +284,7 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        return Exists(ssKey);
-    }
-
-    bool Exists(const CDataStream& key) const
-    {
-        leveldb::Slice slKey(CharCast(key.data()), key.size());
-
-        std::string strValue;
-        leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
-        if (!status.ok()) {
-            if (status.IsNotFound())
-                return false;
-            LogPrintf("LevelDB read failure: %s\n", status.ToString());
-            dbwrapper_private::HandleError(status);
-        }
-        return true;
+        return ExistsImpl(ssKey);
     }
 
     template <typename K>
@@ -342,10 +300,7 @@ public:
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 
-    CDBIterator *NewIterator()
-    {
-        return new CDBIterator(*this, pdb->NewIterator(iteroptions));
-    }
+    CDBIterator* NewIterator();
 
     /**
      * Return true if the database managed by this class contains no entries.
@@ -360,18 +315,10 @@ public:
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
         ssKey2 << key_end;
-        leveldb::Slice slKey1(CharCast(ssKey1.data()), ssKey1.size());
-        leveldb::Slice slKey2(CharCast(ssKey2.data()), ssKey2.size());
-        uint64_t size = 0;
-        leveldb::Range range(slKey1, slKey2);
-        pdb->GetApproximateSizes(&range, 1, &size);
-        return size;
+        return EstimateSizeImpl(ssKey1, ssKey2);
     }
 
-    void CompactFull() const
-    {
-        pdb->CompactRange(nullptr, nullptr);
-    }
+    void CompactFull() const;
 };
 
 template<typename CDBTransaction>

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -7,6 +7,7 @@
 #include <dbwrapper.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <serialize.h>
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -32,6 +32,7 @@
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
+#include <logging.h>
 #include <mapport.h>
 #include <node/miner.h>
 #include <net.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -15,6 +15,8 @@
 #include <hash.h>
 #include <index/blockfilterindex.h>
 #include <validation.h>
+#include <kernel/mempool_entry.h>
+#include <logging.h>
 #include <merkleblock.h>
 #include <netmessagemaker.h>
 #include <netbase.h>

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -23,6 +23,9 @@
 #include <instantsend/instantsend.h>
 #include <llmq/chainlocks.h>
 #include <llmq/context.h>
+#include <kernel/chain.h>
+#include <kernel/mempool_entry.h>
+#include <logging.h>
 #include <mapport.h>
 #include <masternode/sync.h>
 #include <net.h>

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -15,6 +15,7 @@
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
 #include <node/context.h>
+#include <logging.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <pow.h>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -11,11 +11,15 @@
 
 #include <chainparams.h>
 #include <fs.h>
+#include <common/args.h>
+#include <common/init.h>
+#include <common/system.h>
 #include <init.h>
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <net.h>
+#include <logging.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <noui.h>

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <key.h>
+#include <logging.h>
 #include <qt/bitcoin.h>
 #include <qt/bitcoingui.h>
 #include <qt/networkstyle.h>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -19,6 +19,8 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <util/system.h>
+#include <logging.h>
+#include <policy/policy.h>
 #include <validation.h>
 #include <wallet/ismine.h>
 

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -19,6 +19,8 @@
 #include <interfaces/ipc.h>
 #include <key_io.h>
 #include <net.h>
+#include <kernel/cs_main.h>
+#include <logging.h>
 #include <node/context.h>
 #include <rpc/index_util.h>
 #include <rpc/server.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -16,6 +16,8 @@
 #include <index/txindex.h>
 #include <init.h>
 #include <interfaces/chain.h>
+#include <kernel/mempool_entry.h>
+#include <logging.h>
 #include <net.h>
 #include <net_processing.h>
 #include <noui.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5588,6 +5588,45 @@ const AssumeutxoData* ExpectedAssumeutxo(
     return nullptr;
 }
 
+static bool DeleteCoinsDBFromDisk(const fs::path db_path, bool is_snapshot)
+    EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+{
+    AssertLockHeld(::cs_main);
+
+    if (is_snapshot) {
+        fs::path base_blockhash_path = db_path / node::SNAPSHOT_BLOCKHASH_FILENAME;
+
+        try {
+            bool existed = fs::remove(base_blockhash_path);
+            if (!existed) {
+                LogPrintf("[snapshot] snapshot chainstate dir being removed lacks %s file\n",
+                          fs::PathToString(node::SNAPSHOT_BLOCKHASH_FILENAME));
+            }
+        } catch (const fs::filesystem_error& e) {
+            LogPrintf("[snapshot] failed to remove file %s: %s\n",
+                    fs::PathToString(base_blockhash_path), fsbridge::get_filesystem_error_message(e));
+        }
+    }
+
+    std::string path_str = fs::PathToString(db_path);
+    LogPrintf("Removing leveldb dir at %s\n", path_str);
+
+    // We have to destruct before this call leveldb::DB in order to release the db
+    // lock, otherwise `DestroyDB` will fail. See `leveldb::~DBImpl()`.
+    const bool destroyed = DestroyDB(path_str);
+
+    if (!destroyed) {
+        LogPrintf("error: leveldb DestroyDB call failed on %s\n", path_str);
+    }
+
+    // Datadir should be removed from filesystem; otherwise initialization may detect
+    // it on subsequent statups and get confused.
+    //
+    // If the base_blockhash_path removal above fails in the case of snapshot
+    // chainstates, this will return false since leveldb won't remove a non-empty
+    // directory.
+    return destroyed && !fs::exists(db_path);
+}
 bool ChainstateManager::ActivateSnapshot(
         CAutoFile& coins_file,
         const SnapshotMetadata& metadata,


### PR DESCRIPTION
## Summary
- Backports Bitcoin Core PR #28186 which implements the pimpl pattern for leveldb headers in dbwrapper
- Removes leveldb includes from dbwrapper.h to reduce header pollution
- Moves implementation details to dbwrapper.cpp using forward declarations and impl structs

## Test plan
- [ ] Build succeeds
- [ ] All unit tests pass
- [ ] Functional tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)