### PR TITLE
Merge bitcoin/bitcoin#28149: net processing: clamp PeerManager::Options user input

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -44,6 +44,7 @@
 #include <chrono>
 #include <future>
 #include <list>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -1047,7 +1048,7 @@ private:
      *  these are kept in a ring buffer */
     std::vector<std::pair<uint256, CTransactionRef>> vExtraTxnForCompact GUARDED_BY(g_cs_orphans);
     /** Offset into vExtraTxnForCompact to insert the next tx */
-    size_t vExtraTxnForCompactIt GUARDED_BY(g_cs_orphans) = 0;
+    uint32_t vExtraTxnForCompactIt GUARDED_BY(g_cs_orphans) = 0;
 };
 
 // Keeps track of the time (in microseconds) when transactions were requested last time
@@ -1770,7 +1771,8 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
 
 void PeerManagerImpl::AddToCompactExtraTransactions(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans)
 {
-    size_t max_extra_txn = gArgs.GetIntArg("-blockreconstructionextratxn", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN);
+    auto value = gArgs.GetIntArg("-blockreconstructionextratxn", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN);
+    uint32_t max_extra_txn = uint32_t(std::clamp<int64_t>(value, 0, std::numeric_limits<uint32_t>::max()));
     if (max_extra_txn <= 0)
         return;
     if (!vExtraTxnForCompact.size())

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -30,7 +30,8 @@ struct LLMQContext;
 
 /** Default for -maxorphantxsize, maximum size in megabytes the orphan map can grow before entries are removed */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE = 10; // this allows around 100 TXs of max size (and many more of normal size)
-/** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
+/** Default number of non-mempool transactions to keep around for block reconstruction. Includes
+    orphan, replaced, and rejected transactions. */
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_PEERBLOCKFILTERS = false;


### PR DESCRIPTION
Backports bitcoin/bitcoin#28149

Original commit: 0d9a13ddd8

This backport applies the security fix from Bitcoin that clamps the `-blockreconstructionextratxn` parameter to prevent integer overflow. 

Since Dash doesn't have the `PeerManager::Options` struct or the `peerman_args.cpp` file, the changes were applied directly where the parameter is used in `net_processing.cpp`.

Changes:
- Added clamping for `-blockreconstructionextratxn` to `uint32_t` bounds
- Changed `vExtraTxnForCompactIt` from `size_t` to `uint32_t` for consistency
- Updated documentation comment for `DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN`
- Added `<limits>` include for `std::numeric_limits`

Note: The `-maxorphantx` parameter doesn't exist in Dash (Dash uses `-maxorphantxsize` in megabytes instead), so that part of the Bitcoin change was not applicable.

Backported from Bitcoin Core v0.26