### PR TITLE
Merge bitcoin/bitcoin#28320: test: Support riscv64 in get_previous_releases.py

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Copyright (c) 2018-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -274,6 +274,7 @@ def check_host(args) -> int:
     if args.download_binary:
         platforms = {
             'aarch64-*-linux*': 'aarch64-linux-gnu',
+            'riscv64-*-linux*': 'riscv64-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',
             'aarch64-apple-darwin*': 'arm64-apple-darwin',


### PR DESCRIPTION
Backports bitcoin/bitcoin#28320

Original commit: 38db2bd4e1

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RISC-V 64-bit Linux platform detection when downloading binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->