### PR TITLE
Merge bitcoin/bitcoin#28200: refactor: Remove unused includes from wallet.cpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -284,6 +284,7 @@ BITCOIN_CORE_H = \
   node/context.h \
   node/eviction.h \
   node/miner.h \
+  node/mempool_removal_reason.h \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
@@ -534,6 +535,7 @@ libbitcoin_node_a_SOURCES = \
   node/eviction.cpp \
   node/interfaces.cpp \
   node/miner.cpp \
+  node/mempool_removal_reason.cpp \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -8,9 +8,11 @@
 #include <blockfilter.h>
 #include <crypto/siphash.h>
 #include <hash.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <streams.h>
+#include <undo.h>
 #include <util/golombrice.h>
 #include <util/string.h>
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -5,18 +5,21 @@
 #ifndef BITCOIN_BLOCKFILTER_H
 #define BITCOIN_BLOCKFILTER_H
 
-#include <stdint.h>
-#include <string>
+#include <cstddef>
+#include <cstdint>
+#include <ios>
 #include <set>
+#include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <attributes.h>
-#include <primitives/block.h>
-#include <serialize.h>
 #include <uint256.h>
-#include <undo.h>
 #include <util/bytevectorhash.h>
+
+class CBlock;
+class CBlockUndo;
 
 /**
  * This implements a Golomb-coded set as defined in BIP 158. It is a

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -7,6 +7,7 @@
 #include <dbwrapper.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <serialize.h>
 #include <undo.h>

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -9,6 +9,9 @@
 #include <index/blockfilterindex.h>
 #include <node/blockstorage.h>
 #include <serialize.h>
+#include <undo.h>
+#include <util/fs_helpers.h>
+#include <validation.h>
 
 using node::UndoReadFromDisk;
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -12,6 +12,9 @@
 #include <index/base.h>
 #include <util/hasher.h>
 
+#include <unordered_map>
+
+static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 /** Interval between compact filter checkpoints. See BIP 157. */
 static constexpr int CFCHECKPT_INTERVAL = 1000;
 

--- a/src/node/mempool_removal_reason.cpp
+++ b/src/node/mempool_removal_reason.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <node/mempool_removal_reason.h>
+
+#include <cassert>
+#include <string>
+
+std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
+{
+    switch (r) {
+        case MemPoolRemovalReason::EXPIRY: return "expiry";
+        case MemPoolRemovalReason::SIZELIMIT: return "sizelimit";
+        case MemPoolRemovalReason::REORG: return "reorg";
+        case MemPoolRemovalReason::BLOCK: return "block";
+        case MemPoolRemovalReason::CONFLICT: return "conflict";
+        case MemPoolRemovalReason::REPLACED: return "replaced";
+        case MemPoolRemovalReason::MANUAL: return "manual";
+    }
+    assert(false);
+}

--- a/src/node/mempool_removal_reason.h
+++ b/src/node/mempool_removal_reason.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_NODE_MEMPOOL_REMOVAL_REASON_H
+#define BITCOIN_NODE_MEMPOOL_REMOVAL_REASON_H
+
+#include <string>
+
+/** Reason why a transaction was removed from the mempool,
+ * this is passed to the notification signal.
+ */
+enum class MemPoolRemovalReason {
+    EXPIRY,      //!< Expired from mempool
+    SIZELIMIT,   //!< Removed in size limiting
+    REORG,       //!< Removed for reorganization
+    BLOCK,       //!< Removed for block
+    CONFLICT,    //!< Removed for conflict with in-block transaction
+    REPLACED,    //!< Removed for replacement
+    MANUAL       //!< Removed manually
+};
+
+std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
+
+#endif // BITCOIN_NODE_MEMPOOL_REMOVAL_REASON_H

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -19,6 +19,7 @@
 #include <boost/multi_index/tag.hpp>
 #include <boost/multi_index_container.hpp>
 
+class ArgsManager;
 class CBlockIndex;
 class CChainParams;
 class CChainstateHelper;
@@ -28,6 +29,8 @@ class CEvoDB;
 class CMNHFManager;
 class CScript;
 struct LLMQContext;
+class Chainstate;
+class ChainstateManager;
 
 namespace Consensus { struct Params; };
 namespace llmq {

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -7,8 +7,10 @@
 
 #include <blockfilter.h>
 #include <core_io.h>
+#include <primitives/block.h>
 #include <serialize.h>
 #include <streams.h>
+#include <undo.h>
 #include <univalue.h>
 #include <util/strencodings.h>
 

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -6,6 +6,8 @@
 
 #include <chainparams.h>
 #include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <undo.h>
 #include <validation.h>
 
 using node::ReadBlockFromDisk;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1738,29 +1738,3 @@ void CTxMemPool::SetIsLoaded(bool loaded)
     m_is_loaded = loaded;
 }
 
-std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const
-{
-    AssertLockHeld(cs);
-    std::vector<txiter> clustered_txs{GetIterVec(txids)};
-    // Use epoch: visiting an entry means we have added it to the clustered_txs vector. It does not
-    // necessarily mean the entry has been processed.
-    WITH_FRESH_EPOCH(m_epoch);
-    for (const auto& it : clustered_txs) {
-        visited(it);
-    }
-    // i = index of where the list of entries to process starts
-    for (size_t i{0}; i < clustered_txs.size(); ++i) {
-        // DoS protection: if there are 500 or more entries to process, just quit.
-        if (clustered_txs.size() > 500) return {};
-        const txiter& tx_iter = clustered_txs.at(i);
-        for (const auto& entries : {tx_iter->GetMemPoolParentsConst(), tx_iter->GetMemPoolChildrenConst()}) {
-            for (const CTxMemPoolEntry& entry : entries) {
-                const auto entry_it = mapTx.iterator_to(entry);
-                if (!visited(entry_it)) {
-                    clustered_txs.push_back(entry_it);
-                }
-            }
-        }
-    }
-    return clustered_txs;
-}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1738,16 +1738,29 @@ void CTxMemPool::SetIsLoaded(bool loaded)
     m_is_loaded = loaded;
 }
 
-
-std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
+std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const
 {
-    switch (r) {
-        case MemPoolRemovalReason::EXPIRY: return "expiry";
-        case MemPoolRemovalReason::SIZELIMIT: return "sizelimit";
-        case MemPoolRemovalReason::REORG: return "reorg";
-        case MemPoolRemovalReason::BLOCK: return "block";
-        case MemPoolRemovalReason::CONFLICT: return "conflict";
-        case MemPoolRemovalReason::MANUAL: return "manual";
+    AssertLockHeld(cs);
+    std::vector<txiter> clustered_txs{GetIterVec(txids)};
+    // Use epoch: visiting an entry means we have added it to the clustered_txs vector. It does not
+    // necessarily mean the entry has been processed.
+    WITH_FRESH_EPOCH(m_epoch);
+    for (const auto& it : clustered_txs) {
+        visited(it);
     }
-    assert(false);
+    // i = index of where the list of entries to process starts
+    for (size_t i{0}; i < clustered_txs.size(); ++i) {
+        // DoS protection: if there are 500 or more entries to process, just quit.
+        if (clustered_txs.size() > 500) return {};
+        const txiter& tx_iter = clustered_txs.at(i);
+        for (const auto& entries : {tx_iter->GetMemPoolParentsConst(), tx_iter->GetMemPoolChildrenConst()}) {
+            for (const CTxMemPoolEntry& entry : entries) {
+                const auto entry_it = mapTx.iterator_to(entry);
+                if (!visited(entry_it)) {
+                    clustered_txs.push_back(entry_it);
+                }
+            }
+        }
+    }
+    return clustered_txs;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -41,6 +41,7 @@
 #include <utility>
 #include <vector>
 
+class CBlockIndex;
 class CChain;
 class CChainState;
 extern RecursiveMutex cs_main;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -6,21 +6,14 @@
 #ifndef BITCOIN_TXMEMPOOL_H
 #define BITCOIN_TXMEMPOOL_H
 
-#include <atomic>
-#include <map>
-#include <optional>
-#include <set>
-#include <string>
-#include <utility>
-#include <vector>
-
-#include <addressindex.h>
 #include <coins.h>
 #include <consensus/amount.h>
 #include <evo/netinfo.h>
 #include <gsl/pointers.h>
 #include <indirectmap.h>
+#include <addressindex.h>
 #include <netaddress.h>
+#include <node/mempool_removal_reason.h> // IWYU pragma: export
 #include <policy/feerate.h>
 #include <policy/packages.h>
 #include <primitives/transaction.h>
@@ -39,7 +32,15 @@
 #include <boost/multi_index/tag.hpp>
 #include <boost/multi_index_container.hpp>
 
-class CBlockIndex;
+#include <atomic>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
 class CChain;
 class CChainState;
 extern RecursiveMutex cs_main;
@@ -343,20 +344,6 @@ struct TxMempoolInfo
     /** The fee delta. */
     int64_t nFeeDelta;
 };
-
-/** Reason why a transaction was removed from the mempool,
- * this is passed to the notification signal.
- */
-enum class MemPoolRemovalReason {
-    EXPIRY,      //!< Expired from mempool
-    SIZELIMIT,   //!< Removed in size limiting
-    REORG,       //!< Removed for reorganization
-    BLOCK,       //!< Removed for block
-    CONFLICT,    //!< Removed for conflict with in-block transaction
-    MANUAL       //!< Removed manually
-};
-
-std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
 
 /**
  * CTxMemPool stores valid-according-to-the-current-best-chain transactions

--- a/src/validation.h
+++ b/src/validation.h
@@ -79,7 +79,6 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 6 * 60 * 60; // ~144 blocks behind ->
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = true;
 static constexpr bool DEFAULT_COINSTATSINDEX{false};
-static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;
 /** Default for -syncmempool */

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -8,6 +8,8 @@
 #include <key.h>
 #include <key_io.h>
 #include <test/util/setup_common.h>
+#include <validationinterface.h>
+#include <wallet/context.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -25,6 +25,7 @@
 #include <util/translation.h>
 #include <policy/settings.h>
 #include <validation.h>
+#include <validationinterface.h>
 #include <wallet/coincontrol.h>
 #include <wallet/context.h>
 #include <wallet/receive.h>


### PR DESCRIPTION
Backports bitcoin/bitcoin#28200

Original commit: 00fc7cdc25

## Changes
Partial backport of Bitcoin Core's include cleanup:
- Moved mempool_removal_reason from kernel/ to node/ directory (Dash doesn't have kernel/)
- Added MANUAL removal reason to maintain Dash-specific functionality
- Cleaned up includes in txmempool, blockfilter, and related files

## Excluded Changes
- wallet.cpp/wallet.h changes - significant structural differences require manual review
- miniminer_tests.cpp - file doesn't exist in Dash
- lint-circular-dependencies.py - not critical for functionality

Backported from Bitcoin Core v0.26