### PR TITLE
Merge bitcoin/bitcoin#28284: refactor: Remove confusing static_cast in address types

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -7,7 +7,10 @@
 
 #include <pubkey.h>
 #include <script/script.h>
+#include <span.h>
 
+#include <algorithm>
+#include <cassert>
 #include <string>
 
 typedef std::vector<unsigned char> valtype;
@@ -16,17 +19,17 @@ bool fAcceptDatacarrier = DEFAULT_ACCEPT_DATACARRIER;
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
 CScriptID::CScriptID(const CScript& in) : BaseHash(Hash160(in)) {}
-CScriptID::CScriptID(const ScriptHash& in) : BaseHash(static_cast<uint160>(in)) {}
+CScriptID::CScriptID(const ScriptHash& in) : BaseHash{in} {}
 
 ScriptHash::ScriptHash(const CScript& in) : BaseHash(Hash160(in)) {}
-ScriptHash::ScriptHash(const CScriptID& in) : BaseHash(static_cast<uint160>(in)) {}
+ScriptHash::ScriptHash(const CScriptID& in) : BaseHash{in} {}
 
 PKHash::PKHash(const CPubKey& pubkey) : BaseHash(pubkey.GetID()) {}
 PKHash::PKHash(const CKeyID& pubkey_id) : BaseHash(pubkey_id) {}
 
 CKeyID ToKeyID(const PKHash& key_hash)
 {
-    return CKeyID{static_cast<uint160>(key_hash)};
+    return CKeyID{uint160{key_hash}};
 }
 
 std::string GetTxnOutputType(TxoutType t)


### PR DESCRIPTION
Backports bitcoin/bitcoin#28284

Original commit: 03a536f1ed

Backported from Bitcoin Core v0.26

### Notes on adaptation
- Bitcoin modified `src/addresstype.cpp` which doesn't exist in Dash
- The corresponding code exists in `src/script/standard.cpp` in Dash
- Applied the static_cast refactoring changes to the relevant constructors in standard.cpp
- Added missing includes from Bitcoin's changes to maintain consistency