### PR TITLE
Merge bitcoin/bitcoin#27976: ci: Start with clean env

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -27,10 +27,11 @@ To run the default test stage,
 ./ci/test_run_all.sh
 ```
 
-To run the test stage with a specific configuration,
+It is recommended to run the ci system in a clean env. To run the test stage
+with a specific configuration,
 
 ```
-FILE_ENV="./ci/test/00_setup_env_arm.sh" ./ci/test_run_all.sh
+env -i HOME="$HOME" PATH="$PATH" USER="$USER" bash -c 'FILE_ENV="./ci/test/00_setup_env_arm.sh" ./ci/test_run_all.sh'
 ```
 
 ### Configurations
@@ -45,14 +46,11 @@ the system package manager to install build dependencies. This guarantees that
 the tester is using the same versions as the release builds, which also use
 `./depends`.
 
-If no `FILE_ENV` has been specified or values are left out, `00_setup_env.sh`
-is used as the default configuration with fallback values.
-
 It is also possible to force a specific configuration without modifying the
 file. For example,
 
 ```
-MAKEJOBS="-j1" FILE_ENV="./ci/test/00_setup_env_arm.sh" ./ci/test_run_all.sh
+env -i HOME="$HOME" PATH="$PATH" USER="$USER" bash -c 'MAKEJOBS="-j1" FILE_ENV="./ci/test/00_setup_env_arm.sh" ./ci/test_run_all.sh'
 ```
 
 The files starting with `0n` (`n` greater than 0) are the scripts that are run

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -67,10 +67,12 @@ export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}
 # Folder where the build result is put (bin and lib).
 export BASE_OUTDIR=${BASE_OUTDIR:-$BASE_SCRATCH_DIR/out/$HOST}
 # Folder where the build is done (dist and out-of-tree build).
-export BASE_BUILD_DIR=${BASE_BUILD_DIR:-$BASE_SCRATCH_DIR/build-ci}
-export PREVIOUS_RELEASES_DIR=${PREVIOUS_RELEASES_DIR:-$BASE_ROOT_DIR/releases/$HOST}
+export BASE_BUILD_DIR=${BASE_BUILD_DIR:-$BASE_SCRATCH_DIR/build}
+# The folder for previous release binaries.
+# This folder exists only on the ci guest, and on the ci host as a volume.
+export PREVIOUS_RELEASES_DIR=${PREVIOUS_RELEASES_DIR:-$BASE_ROOT_DIR/prev_releases}
 export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
-export DOCKER_PACKAGES=${DOCKER_PACKAGES:-build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps}
+export CI_BASE_PACKAGES=${CI_BASE_PACKAGES:-build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps bison}
 export GOAL=${GOAL:-install}
 export DIR_QA_ASSETS=${DIR_QA_ASSETS:-${BASE_SCRATCH_DIR}/qa-assets}
 export PATH=${BASE_ROOT_DIR}/ci/retry:$PATH

--- a/ci/test/00_setup_env_mac.sh
+++ b/ci/test/00_setup_env_mac.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
+export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
+
 export CONTAINER_NAME=ci_macos_cross
 export HOST=x86_64-apple-darwin
 export PACKAGES="clang cmake lld llvm  zip"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -31,7 +31,6 @@ fi
 
 export P_CI_DIR="$PWD"
 export BINS_SCRATCH_DIR="${BASE_SCRATCH_DIR}/bins/"
-
 if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Creating $DOCKER_NAME_TAG container to run in"
   LOCAL_UID=$(id -u)
@@ -82,10 +81,10 @@ fi
 
 if [[ $DOCKER_NAME_TAG == *centos* ]]; then
   CI_EXEC_ROOT yum -y install epel-release
-  CI_EXEC_ROOT yum -y install "$DOCKER_PACKAGES" "$PACKAGES"
+  CI_EXEC_ROOT yum -y install "$CI_BASE_PACKAGES" "$PACKAGES"
 elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
   ${CI_RETRY_EXE} CI_EXEC_ROOT apt-get update
-  ${CI_RETRY_EXE} CI_EXEC_ROOT apt-get install --no-install-recommends --no-upgrade -y "$PACKAGES" "$DOCKER_PACKAGES"
+  ${CI_RETRY_EXE} CI_EXEC_ROOT apt-get install --no-install-recommends --no-upgrade -y "$PACKAGES" "$CI_BASE_PACKAGES"
   if [ -n "$PIP_PACKAGES" ]; then
     # shellcheck disable=SC2086
     ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES


### PR DESCRIPTION
Backports bitcoin/bitcoin#27976

Original commit: cd5d2f5f0938ad4f8737caf4e7c501101818fd36

Backported from Bitcoin Core v0.26

## Changes summary:
- Updates CI environment variable handling to start with a clean environment
- Changes `BASE_BUILD_DIR` from `build-ci` to `build`
- Changes `PREVIOUS_RELEASES_DIR` path structure
- Renames `DOCKER_PACKAGES` to `CI_BASE_PACKAGES` and adds `bison` package
- Adds `SDK_URL` export to mac setup
- Removes documentation about default configuration fallback

Note: Bitcoin moved sanitizer exports to a new 06_script_b.sh file, but since Dash doesn't have this file structure, we kept the sanitizer exports in 04_install.sh.