### PR TITLE
Merge bitcoin/bitcoin#28352: test: Support powerpc64le in get_previous_releases.py

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -274,6 +274,7 @@ def check_host(args) -> int:
     if args.download_binary:
         platforms = {
             'aarch64-*-linux*': 'aarch64-linux-gnu',
+            'powerpc64le-*-linux-*': 'powerpc64le-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',
             'aarch64-apple-darwin*': 'arm64-apple-darwin',


### PR DESCRIPTION
Backports bitcoin/bitcoin#28352

Original commit: 1348454d82

Backported from Bitcoin Core v0.26