### PR TITLE
Merge bitcoin/bitcoin#28458: refactor: Remove unused GetType() from CBufferedFile and CAutoFile

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -56,16 +56,16 @@ private:
     const CDBWrapper &parent;
     leveldb::WriteBatch batch;
 
-    CDataStream ssKey;
-    CDataStream ssValue;
+    DataStream ssKey{};
+    DataStream ssValue{};
 
-    size_t size_estimate;
+    size_t size_estimate{0};
 
 public:
     /**
      * @param[in] _parent    CDBWrapper that this batch is to be submitted to
      */
-    explicit CDBBatch(const CDBWrapper &_parent) : parent(_parent), ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION), size_estimate(0) { };
+    explicit CDBBatch(const CDBWrapper &_parent) : parent(_parent) { };
 
     void Clear()
     {
@@ -83,7 +83,7 @@ public:
     }
 
     template <typename V>
-    void Write(const CDataStream& _ssKey, const V& value)
+    void Write(const DataStream& _ssKey, const V& value)
     {
         leveldb::Slice slKey(CharCast(_ssKey.data()), _ssKey.size());
 
@@ -111,7 +111,7 @@ public:
         ssKey.clear();
     }
 
-    void Erase(const CDataStream& _ssKey) {
+    void Erase(const DataStream& _ssKey) {
         leveldb::Slice slKey(CharCast(_ssKey.data()), _ssKey.size());
 
         batch.Delete(slKey);

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -80,7 +80,7 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
         return false;
     }
 
-    CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile file(OpenBlockFile(postx, true), CLIENT_VERSION);
     if (file.IsNull()) {
         return error("%s: OpenBlockFile failed", __func__);
     }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -693,7 +693,7 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
 static bool WriteBlockToDisk(const CBlock& block, FlatFilePos& pos, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
-    CAutoFile fileout(OpenBlockFile(pos), SER_DISK, CLIENT_VERSION);
+    CAutoFile fileout{OpenBlockFile(pos), CLIENT_VERSION};
     if (fileout.IsNull()) {
         return error("WriteBlockToDisk: OpenBlockFile failed");
     }
@@ -748,7 +748,7 @@ bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::P
     block.SetNull();
 
     // Open history file to read
-    CAutoFile filein(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile filein{OpenBlockFile(pos, true), CLIENT_VERSION};
     if (filein.IsNull()) {
         return error("ReadBlockFromDisk: OpenBlockFile failed for %s", pos.ToString());
     }

--- a/src/streams.h
+++ b/src/streams.h
@@ -494,13 +494,12 @@ public:
 class CAutoFile
 {
 private:
-    const int nType;
     const int nVersion;
 
     FILE* file;
 
 public:
-    CAutoFile(FILE* filenew, int nTypeIn, int nVersionIn) : nType(nTypeIn), nVersion(nVersionIn)
+    CAutoFile(FILE* filenew, int nVersionIn) : nVersion(nVersionIn)
     {
         file = filenew;
     }
@@ -541,7 +540,6 @@ public:
     //
     // Stream subset
     //
-    int GetType() const          { return nType; }
     int GetVersion() const       { return nVersion; }
 
     void read(Span<std::byte> dst)
@@ -605,7 +603,6 @@ public:
 class CBufferedFile
 {
 private:
-    const int nType;
     const int nVersion;
 
     FILE *src;            //!< source file
@@ -655,8 +652,8 @@ private:
     }
 
 public:
-    CBufferedFile(FILE* fileIn, uint64_t nBufSize, uint64_t nRewindIn, int nTypeIn, int nVersionIn)
-        : nType(nTypeIn), nVersion(nVersionIn), nSrcPos(0), m_read_pos(0), nReadLimit(std::numeric_limits<uint64_t>::max()), nRewind(nRewindIn), vchBuf(nBufSize, std::byte{0})
+    CBufferedFile(FILE* fileIn, uint64_t nBufSize, uint64_t nRewindIn, int nVersionIn)
+        : nVersion(nVersionIn), nSrcPos(0), m_read_pos(0), nReadLimit(std::numeric_limits<uint64_t>::max()), nRewind(nRewindIn), vchBuf(nBufSize, std::byte{0})
     {
         if (nRewindIn >= nBufSize)
             throw std::ios_base::failure("Rewind limit must be less than buffer size");
@@ -673,7 +670,6 @@ public:
     CBufferedFile& operator=(const CBufferedFile&) = delete;
 
     int GetVersion() const { return nVersion; }
-    int GetType() const { return nType; }
 
     void fclose()
     {

--- a/src/streams.h
+++ b/src/streams.h
@@ -600,7 +600,7 @@ public:
  *  Will automatically close the file when it goes out of scope if not null.
  *  If you need to close the file early, use file.fclose() instead of fclose(file).
  */
-class CBufferedFile
+class BufferedFile
 {
 private:
     const int nVersion;
@@ -623,7 +623,7 @@ private:
             return false;
         size_t nBytes = fread((void*)&vchBuf[pos], 1, readNow, src);
         if (nBytes == 0) {
-            throw std::ios_base::failure(feof(src) ? "CBufferedFile::Fill: end of file" : "CBufferedFile::Fill: fread failed");
+            throw std::ios_base::failure(feof(src) ? "BufferedFile::Fill: end of file" : "BufferedFile::Fill: fread failed");
         }
         nSrcPos += nBytes;
         return true;
@@ -652,7 +652,7 @@ private:
     }
 
 public:
-    CBufferedFile(FILE* fileIn, uint64_t nBufSize, uint64_t nRewindIn, int nVersionIn)
+    BufferedFile(FILE* fileIn, uint64_t nBufSize, uint64_t nRewindIn, int nVersionIn)
         : nVersion(nVersionIn), nSrcPos(0), m_read_pos(0), nReadLimit(std::numeric_limits<uint64_t>::max()), nRewind(nRewindIn), vchBuf(nBufSize, std::byte{0})
     {
         if (nRewindIn >= nBufSize)
@@ -660,14 +660,14 @@ public:
         src = fileIn;
     }
 
-    ~CBufferedFile()
+    ~BufferedFile()
     {
         fclose();
     }
 
     // Disallow copies
-    CBufferedFile(const CBufferedFile&) = delete;
-    CBufferedFile& operator=(const CBufferedFile&) = delete;
+    BufferedFile(const BufferedFile&) = delete;
+    BufferedFile& operator=(const BufferedFile&) = delete;
 
     int GetVersion() const { return nVersion; }
 
@@ -734,7 +734,7 @@ public:
     }
 
     template<typename T>
-    CBufferedFile& operator>>(T&& obj) {
+    BufferedFile& operator>>(T&& obj) {
         // Unserialize from this stream
         ::Unserialize(*this, obj);
         return (*this);

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -18,7 +18,7 @@ FUZZ_TARGET(buffered_file)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     FuzzedFileProvider fuzzed_file_provider = ConsumeFile(fuzzed_data_provider);
-    std::optional<CBufferedFile> opt_buffered_file;
+    std::optional<BufferedFile> opt_buffered_file;
     FILE* fuzzed_file = fuzzed_file_provider.open();
     try {
         opt_buffered_file.emplace(fuzzed_file, fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegral<int>());

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -21,7 +21,7 @@ FUZZ_TARGET(buffered_file)
     std::optional<CBufferedFile> opt_buffered_file;
     FILE* fuzzed_file = fuzzed_file_provider.open();
     try {
-        opt_buffered_file.emplace(fuzzed_file, fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegral<int>(), fuzzed_data_provider.ConsumeIntegral<int>());
+        opt_buffered_file.emplace(fuzzed_file, fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegral<int>());
     } catch (const std::ios_base::failure&) {
         if (fuzzed_file != nullptr) {
             fclose(fuzzed_file);
@@ -62,7 +62,6 @@ FUZZ_TARGET(buffered_file)
                 });
         }
         opt_buffered_file->GetPos();
-        opt_buffered_file->GetType();
         opt_buffered_file->GetVersion();
     }
 }

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     // The buffer size (second arg) must be greater than the rewind
     // amount (third arg).
     try {
-        CBufferedFile bfbad{file, 25, 25, 333};
+        BufferedFile bfbad{file, 25, 25, 333};
         BOOST_CHECK(false);
     } catch (const std::exception& e) {
         BOOST_CHECK(strstr(e.what(),
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     }
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
-    CBufferedFile bf{file, 25, 10, 333};
+    BufferedFile bf{file, 25, 10, 333};
     BOOST_CHECK(!bf.eof());
 
     // This member has no functional effect.
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
         BOOST_CHECK(false);
     } catch (const std::exception& e) {
         BOOST_CHECK(strstr(e.what(),
-                        "CBufferedFile::Fill: end of file") != nullptr);
+                        "BufferedFile::Fill: end of file") != nullptr);
     }
     // Attempting to read beyond the end sets the EOF indicator.
     BOOST_CHECK(bf.eof());
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_skip)
     rewind(file);
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
-    CBufferedFile bf{file, 25, 10, 333};
+    BufferedFile bf{file, 25, 10, 333};
 
     uint8_t i;
     // This is like bf >> (7-byte-variable), in that it will cause data
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
 
         size_t bufSize = InsecureRandRange(300) + 1;
         size_t rewindSize = InsecureRandRange(bufSize);
-        CBufferedFile bf{file, bufSize, rewindSize, 333};
+        BufferedFile bf{file, bufSize, rewindSize, 333};
         size_t currentPos = 0;
         size_t maxPos = 0;
         for (int step = 0; step < 100; ++step) {

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     // The buffer size (second arg) must be greater than the rewind
     // amount (third arg).
     try {
-        CBufferedFile bfbad(file, 25, 25, 222, 333);
+        CBufferedFile bfbad{file, 25, 25, 333};
         BOOST_CHECK(false);
     } catch (const std::exception& e) {
         BOOST_CHECK(strstr(e.what(),
@@ -217,11 +217,10 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     }
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
-    CBufferedFile bf(file, 25, 10, 222, 333);
+    CBufferedFile bf{file, 25, 10, 333};
     BOOST_CHECK(!bf.eof());
 
-    // These two members have no functional effect.
-    BOOST_CHECK_EQUAL(bf.GetType(), 222);
+    // This member has no functional effect.
     BOOST_CHECK_EQUAL(bf.GetVersion(), 333);
 
     uint8_t i;
@@ -341,7 +340,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_skip)
     rewind(file);
 
     // The buffer is 25 bytes, allow rewinding 10 bytes.
-    CBufferedFile bf(file, 25, 10, 222, 333);
+    CBufferedFile bf{file, 25, 10, 333};
 
     uint8_t i;
     // This is like bf >> (7-byte-variable), in that it will cause data
@@ -395,7 +394,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
 
         size_t bufSize = InsecureRandRange(300) + 1;
         size_t rewindSize = InsecureRandRange(bufSize);
-        CBufferedFile bf(file, bufSize, rewindSize, 222, 333);
+        CBufferedFile bf{file, bufSize, rewindSize, 333};
         size_t currentPos = 0;
         size_t maxPos = 0;
         for (int step = 0; step < 100; ++step) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4955,7 +4955,7 @@ void CChainState::LoadExternalBlockFile(
     try {
         unsigned int nMaxBlockSize = MaxBlockSize();
         // This takes over fileIn and calls fclose() on it in the CBufferedFile destructor
-        CBufferedFile blkdat(fileIn, 2*nMaxBlockSize, nMaxBlockSize+8, SER_DISK, CLIENT_VERSION);
+        CBufferedFile blkdat(fileIn, 2*nMaxBlockSize, nMaxBlockSize+8, CLIENT_VERSION);
         // nRewind indicates where to resume scanning in case something goes wrong,
         // such as a block fails to deserialize.
         uint64_t nRewind = blkdat.GetPos();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4954,8 +4954,8 @@ void CChainState::LoadExternalBlockFile(
     int nLoaded = 0;
     try {
         unsigned int nMaxBlockSize = MaxBlockSize();
-        // This takes over fileIn and calls fclose() on it in the CBufferedFile destructor
-        CBufferedFile blkdat(fileIn, 2*nMaxBlockSize, nMaxBlockSize+8, CLIENT_VERSION);
+        // This takes over fileIn and calls fclose() on it in the BufferedFile destructor
+        BufferedFile blkdat(fileIn, 2*nMaxBlockSize, nMaxBlockSize+8, CLIENT_VERSION);
         // nRewind indicates where to resume scanning in case something goes wrong,
         // such as a block fails to deserialize.
         uint64_t nRewind = blkdat.GetPos();


### PR DESCRIPTION
Backports bitcoin/bitcoin#28458

Original commit: 8209e86eeb

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed `CBufferedFile` to `BufferedFile` and updated related usage across the application.
  * Updated constructors and removed the serialization type parameter from file handling classes.
  * Removed unused or redundant member variables and methods related to serialization type.
* **Tests**
  * Updated test cases to use the new `BufferedFile` class and adjusted constructor arguments and exception checks accordingly.
* **Chores**
  * Updated comments to reflect class renaming and changes in file handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->