### PR TITLE
Merge bitcoin/bitcoin#28512: doc: Be vague instead of wrong about MALLOC_ARENA_MAX

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -43,7 +43,7 @@ threads take up 8MiB for the thread stack on a 64-bit system, and 4MiB in a
 
 ## Linux specific
 
-By default, since glibc `2.10`, the C library will create up to two heap arenas per core. This is known to cause excessive memory usage in some scenarios. To avoid this make a script that sets `MALLOC_ARENA_MAX` before starting dashd:
+By default, glibc's implementation of `malloc` may use more than one arena. This is known to cause excessive memory usage in some scenarios. To avoid this, make a script that sets `MALLOC_ARENA_MAX` before starting dashd:
 
 ```bash
 #!/usr/bin/env bash


### PR DESCRIPTION
Backports bitcoin/bitcoin#28512

Original commit: dcfbf3c210

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and generalized the explanation of glibc's memory allocation behavior in the "Linux specific" section, improving readability. No changes to example scripts or performance impact explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->