### PR TITLE
Merge bitcoin/bitcoin#28540: tests: Fix wallet_resendwallettransactions.py intermittent failure by using manual bumps instead of bumpfee

### DIFF
--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -4,14 +4,20 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test that the wallet resends transactions periodically."""
 
+from decimal import Decimal
+
 from test_framework.blocktools import (
     create_block,
     create_coinbase,
 )
 from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
-
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    get_fee,
+    try_rpc,
+)
 
 class ResendWalletTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -75,6 +81,76 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.setmocktime(self.mocktime + 36 * 60 * 60 + 600)
         peer_second.wait_for_broadcast([txid])
 
+<<<<<<< HEAD
+=======
+        self.log.info("Chain of unconfirmed not-in-mempool txs are rebroadcast")
+        # This tests that the node broadcasts the parent transaction before the child transaction.
+        # To test that scenario, we need a method to reliably get a child transaction placed
+        # in mapWallet positioned before the parent. We cannot predict the position in mapWallet,
+        # but we can observe it using listreceivedbyaddress and other related RPCs.
+        #
+        # So we will create the child transaction, use listreceivedbyaddress to see what the
+        # ordering of mapWallet is, if the child is not before the parent, we will create a new
+        # child (via bumpfee) and remove the old child (via removeprunedfunds) until we get the
+        # ordering of child before parent.
+        child_inputs = [{"txid": txid, "vout": 0}]
+        child_txid = node.sendall(recipients=[addr], inputs=child_inputs)["txid"]
+        # Get the child tx's info for manual bumping
+        child_tx_info = node.gettransaction(txid=child_txid, verbose=True)
+        child_output_value = child_tx_info["decoded"]["vout"][0]["value"]
+        # Include an additional 1 vbyte buffer to handle when we have a smaller signature
+        additional_child_fee = get_fee(child_tx_info["decoded"]["vsize"] + 1, Decimal(0.00001100))
+        while True:
+            txids = node.listreceivedbyaddress(minconf=0, address_filter=addr)[0]["txids"]
+            if txids == [child_txid, txid]:
+                break
+            # Manually bump the tx
+            # The inputs and the output address stay the same, just changing the amount for the new fee
+            child_output_value -= additional_child_fee
+            bumped_raw = node.createrawtransaction(inputs=child_inputs, outputs=[{addr: child_output_value}])
+            bumped = node.signrawtransactionwithwallet(bumped_raw)
+            bumped_txid = node.decoderawtransaction(bumped["hex"])["txid"]
+            # Sometimes we will get a signature that is a little bit shorter than we expect which causes the
+            # feerate to be a bit higher, then the followup to be a bit lower. This results in a replacement
+            # that can't be broadcast. We can just skip that and keep grinding.
+            if try_rpc(-26, "insufficient fee, rejecting replacement", node.sendrawtransaction, bumped["hex"]):
+                continue
+            # The scheduler queue creates a copy of the added tx after
+            # send/bumpfee and re-adds it to the wallet (undoing the next
+            # removeprunedfunds). So empty the scheduler queue:
+            node.syncwithvalidationinterfacequeue()
+            node.removeprunedfunds(child_txid)
+            child_txid = bumped_txid
+        entry_time = node.getmempoolentry(child_txid)["time"]
+
+        block_time = entry_time + 6 * 60
+        node.setmocktime(block_time)
+        block = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount() + 1), block_time)
+        block.solve()
+        node.submitblock(block.serialize().hex())
+        # Set correct m_best_block_time, which is used in ResubmitWalletTransactions
+        node.syncwithvalidationinterfacequeue()
+
+        evict_time = block_time + 60 * 60 * DEFAULT_MEMPOOL_EXPIRY_HOURS + 5
+        # Flush out currently scheduled resubmit attempt now so that there can't be one right between eviction and check.
+        with node.assert_debug_log(['resubmit 2 unconfirmed transactions']):
+            node.setmocktime(evict_time)
+            node.mockscheduler(60)
+
+        # Evict these txs from the mempool
+        indep_send = node.send(outputs=[{node.getnewaddress(): 1}], inputs=[indep_utxo])
+        node.getmempoolentry(indep_send["txid"])
+        assert_raises_rpc_error(-5, "Transaction not in mempool", node.getmempoolentry, txid)
+        assert_raises_rpc_error(-5, "Transaction not in mempool", node.getmempoolentry, child_txid)
+
+        # Rebroadcast and check that parent and child are both in the mempool
+        with node.assert_debug_log(['resubmit 2 unconfirmed transactions']):
+            node.setmocktime(evict_time + 36 * 60 * 60) # 36 hrs is the upper limit of the resend timer
+            node.mockscheduler(60)
+        node.getmempoolentry(txid)
+        node.getmempoolentry(child_txid)
+
+>>>>>>> 9d5150ac47 (Merge bitcoin/bitcoin#28540: tests: Fix wallet_resendwallettransactions.py intermittent failure by using manual bumps instead of bumpfee)
 
 if __name__ == '__main__':
     ResendWalletTransactionsTest().main()

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -19,6 +19,8 @@ from test_framework.util import (
     try_rpc,
 )
 
+DEFAULT_MEMPOOL_EXPIRY_HOURS = 336
+
 class ResendWalletTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -32,7 +34,9 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         peer_first = node.add_p2p_connection(P2PTxInvStore())
 
         self.log.info("Create a new transaction and wait until it's broadcast")
-        txid = node.sendtoaddress(node.getnewaddress(), 1)
+        parent_utxo, indep_utxo = node.listunspent()[:2]
+        addr = node.getnewaddress()
+        txid = node.send(outputs=[{addr: 1}], inputs=[parent_utxo])["txid"]
 
         # Wallet rebroadcast is first scheduled 1 min sec after startup (see
         # nNextResend in ResendWalletTransactions()). Tell scheduler to call
@@ -41,10 +45,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.mockscheduler(60)
 
         # Can take a few seconds due to transaction trickling
-        def wait_p2p():
-            self.bump_mocktime(1)
-            return peer_first.tx_invs_received[int(txid, 16)] >= 1
-        self.wait_until(wait_p2p)
+        peer_first.wait_for_broadcast([txid])
 
         # Add a second peer since txs aren't rebroadcast to the same peer (see m_tx_inventory_known_filter)
         peer_second = node.add_p2p_connection(P2PTxInvStore())
@@ -81,8 +82,6 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.setmocktime(self.mocktime + 36 * 60 * 60 + 600)
         peer_second.wait_for_broadcast([txid])
 
-<<<<<<< HEAD
-=======
         self.log.info("Chain of unconfirmed not-in-mempool txs are rebroadcast")
         # This tests that the node broadcasts the parent transaction before the child transaction.
         # To test that scenario, we need a method to reliably get a child transaction placed
@@ -150,7 +149,6 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.getmempoolentry(txid)
         node.getmempoolentry(child_txid)
 
->>>>>>> 9d5150ac47 (Merge bitcoin/bitcoin#28540: tests: Fix wallet_resendwallettransactions.py intermittent failure by using manual bumps instead of bumpfee)
 
 if __name__ == '__main__':
     ResendWalletTransactionsTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#28540

Original commit: 9d5150ac47a2e8db0f23a2f04211fec3516afbe1

Backported from Bitcoin Core v0.26

Note: This backport adds more lines than the original Bitcoin change because the Dash version was missing the entire second test case ("Chain of unconfirmed not-in-mempool txs are rebroadcast") that Bitcoin already had. The backport includes both the missing test case and the fix to use manual bumps instead of bumpfee.