### PR TITLE
Merge bitcoin/bitcoin#28575: ci: Print Linux kernel info

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -98,6 +98,7 @@ if [ "$CI_OS_NAME" == "macos" ]; then
 else
   CI_EXEC free -m -h
   CI_EXEC echo "Number of CPUs (nproc): $(nproc)"
+  CI_EXEC echo "System info: $(uname --kernel-name --kernel-release)"
   CI_EXEC echo "$(lscpu | grep Endian)"
 fi
 CI_EXEC echo "Free disk space:"


### PR DESCRIPTION
Backports bitcoin/bitcoin#28575

Original commit: 97f756b12c8d8a9d3b621f296725dd7bf36bc8a9

Backported from Bitcoin Core v0.26

Note: The original change targeted `ci/test/06_script_b.sh` which was deleted in Dash. The equivalent change has been applied to `ci/test/04_install.sh` where similar system information is printed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system information output in CI by including kernel name and release details during test setup (non-macOS environments).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->