### PR TITLE
Merge bitcoin/bitcoin#28597: wallet: No BDB creation, unless -deprecatedrpc=create_bdb

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -566,7 +566,9 @@ static RPCHelpMan createwallet()
             {"blank", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a blank wallet. A blank wallet has no keys or HD seed. One can be set using upgradetohd (by mnemonic) or sethdseed (WIF private key)."},
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Encrypt the wallet with this passphrase."},
             {"avoid_reuse", RPCArg::Type::BOOL, RPCArg::Default{false}, "Keep track of coin reuse, and treat dirty and clean coins differently with privacy considerations in mind."},
-            {"descriptors", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation. This feature is well-tested but still considered experimental."},
+            {"descriptors", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation. This feature is well-tested but still considered experimental."
+                                                                       " Setting to \"false\" will create a legacy wallet; This is only possible with the -deprecatedrpc=create_bdb setting because, the legacy wallet type is being deprecated and"
+                                                                       " support for creating and opening legacy wallets will be removed in the future."},
             {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
         },
         RPCResult{
@@ -616,6 +618,11 @@ static RPCHelpMan createwallet()
         }
         flags |= WALLET_FLAG_DESCRIPTORS;
         warnings.emplace_back(Untranslated("Wallet is an experimental descriptor wallet"));
+    } else {
+        if (!context.chain->rpcEnableDeprecated("create_bdb")) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "BDB wallet creation is deprecated and will be removed in a future release."
+                                                 " In this release it can be re-enabled temporarily with the -deprecatedrpc=create_bdb setting.");
+        }
     }
 
 #ifndef USE_BDB

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -412,6 +412,7 @@ def write_config(config_path, *, n, chain, extra_config=""):
         f.write("upnp=0\n")
         f.write("natpmp=0\n")
         f.write("shrinkdebugfile=0\n")
+        f.write("deprecatedrpc=create_bdb\n")  # Required to run the tests
         # To improve SQLite wallet performance so that the tests don't timeout, use -unsafesqlitesync
         f.write("unsafesqlitesync=1\n")
         f.write(extra_config)


### PR DESCRIPTION
Backports bitcoin/bitcoin#28597

Original commit: cf553e3ab7b3827c9c1b91fcc50082856f761913

Backported from Bitcoin Core v0.26

This PR adds a deprecation check for BDB wallet creation. Users must now specify `-deprecatedrpc=create_bdb` to create legacy BDB wallets, as the legacy wallet type is being deprecated and support will be removed in the future.

Changes:
- Updated help text for the `descriptors` parameter in `createwallet` RPC to mention the deprecation requirement
- Added check in `createwallet` to throw an error if attempting to create BDB wallet without the deprecation flag
- Added `deprecatedrpc=create_bdb` to test framework configuration to allow tests to continue using BDB wallets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and messaging when attempting to create a legacy wallet, making it clear that legacy wallet creation is deprecated and now requires a specific setting to be enabled.
* **Documentation**
  * Clarified help text for wallet creation to indicate the deprecation of legacy wallets and the need for a special flag to enable their creation.
* **Chores**
  * Updated test configuration to ensure compatibility with the new legacy wallet creation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->