### PR TITLE
Merge bitcoin-core/gui#764: Remove legacy wallet creation

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -111,12 +111,18 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
 #ifdef ENABLE_WALLET
     if(enableWallet)
     {
+<<<<<<< HEAD
         /** Create wallet frame*/
         walletFrame = new WalletFrame(this);
         connect(walletFrame, &WalletFrame::createWalletButtonClicked, [this] {
             auto activity = new CreateWalletActivity(getWalletController(), this);
             activity->create();
         });
+=======
+        /** Create wallet frame and make it the central widget */
+        walletFrame = new WalletFrame(_platformStyle, this);
+        connect(walletFrame, &WalletFrame::createWalletButtonClicked, this, &BitcoinGUI::createWallet);
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
         connect(walletFrame, &WalletFrame::message, [this](const QString& title, const QString& message, unsigned int style) {
             this->message(title, message, style);
         });
@@ -574,12 +580,7 @@ void BitcoinGUI::createActions()
         connect(m_close_wallet_action, &QAction::triggered, [this] {
             m_wallet_controller->closeWallet(walletFrame->currentWalletModel(), this);
         });
-        connect(m_create_wallet_action, &QAction::triggered, [this] {
-            auto activity = new CreateWalletActivity(m_wallet_controller, this);
-            connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
-            connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
-            activity->create();
-        });
+        connect(m_create_wallet_action, &QAction::triggered, this, &BitcoinGUI::createWallet);
         connect(m_close_all_wallets_action, &QAction::triggered, [this] {
             m_wallet_controller->closeAllWallets(this);
         });
@@ -1600,6 +1601,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
     progressBar->setToolTip(tooltip);
 }
 
+<<<<<<< HEAD
 void BitcoinGUI::setAdditionalDataSyncProgress(double nSyncProgress)
 {
     if(!clientModel)
@@ -1654,6 +1656,21 @@ void BitcoinGUI::setAdditionalDataSyncProgress(double nSyncProgress)
     labelBlocksIcon->setToolTip(tooltip);
     progressBarLabel->setToolTip(tooltip);
     progressBar->setToolTip(tooltip);
+=======
+void BitcoinGUI::createWallet()
+{
+#ifdef ENABLE_WALLET
+#ifndef USE_SQLITE
+    // Compiled without sqlite support (required for descriptor wallets)
+    message(tr("Error creating wallet"), tr("Cannot create new wallet, the software was compiled without sqlite support (required for descriptor wallets)"), CClientUIInterface::MSG_ERROR);
+    return;
+#endif // USE_SQLITE
+    auto activity = new CreateWalletActivity(getWalletController(), this);
+    connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
+    connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
+    activity->create();
+#endif // ENABLE_WALLET
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
 }
 
 void BitcoinGUI::message(const QString& title, QString message, unsigned int style, bool* ret, const QString& detailed_message)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -272,9 +272,15 @@ public Q_SLOTS:
     /** Get restart command-line parameters and request restart */
     void handleRestart(QStringList args);
     /** Set number of blocks and last block date shown in the UI */
+<<<<<<< HEAD
     void setNumBlocks(int count, const QDateTime& blockDate, const QString& blockHash, double nVerificationProgress, bool headers, SynchronizationState sync_state);
     /** Set additional data sync status shown in the UI */
     void setAdditionalDataSyncProgress(double nSyncProgress);
+=======
+    void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, SyncType synctype, SynchronizationState sync_state);
+    /** Launch the wallet creation modal (no-op if wallet is not compiled) **/
+    void createWallet();
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
 
     /** Notify the user of an event from the core network or transaction handling code.
        @param[in] title             the message box / notification title

--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -36,6 +36,23 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
             ui->disable_privkeys_checkbox->setChecked(false);
         }
     });
+<<<<<<< HEAD
+=======
+
+    connect(ui->external_signer_checkbox, &QCheckBox::toggled, [this](bool checked) {
+        ui->encrypt_wallet_checkbox->setEnabled(!checked);
+        ui->blank_wallet_checkbox->setEnabled(!checked);
+        ui->disable_privkeys_checkbox->setEnabled(!checked);
+
+        // The external signer checkbox is only enabled when a device is detected.
+        // In that case it is checked by default. Toggling it restores the other
+        // options to their default.
+        ui->encrypt_wallet_checkbox->setChecked(false);
+        ui->disable_privkeys_checkbox->setChecked(checked);
+        ui->blank_wallet_checkbox->setChecked(false);
+    });
+
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
     connect(ui->disable_privkeys_checkbox, &QCheckBox::toggled, [this](bool checked) {
         // Disable the encrypt_wallet_checkbox when isDisablePrivateKeysChecked is
         // set to true, enable it when isDisablePrivateKeysChecked is false.
@@ -58,6 +75,7 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
         }
     });
 
+<<<<<<< HEAD
 #ifndef USE_SQLITE
     ui->descriptor_checkbox->setToolTip(tr("Compiled without sqlite support (required for descriptor wallets)"));
     ui->descriptor_checkbox->setEnabled(false);
@@ -67,6 +85,15 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
     ui->descriptor_checkbox->setEnabled(false);
     ui->descriptor_checkbox->setChecked(true);
 #endif
+=======
+#ifndef ENABLE_EXTERNAL_SIGNER
+        //: "External signing" means using devices such as hardware wallets.
+        ui->external_signer_checkbox->setToolTip(tr("Compiled without external signing support (required for external signing)"));
+        ui->external_signer_checkbox->setEnabled(false);
+        ui->external_signer_checkbox->setChecked(false);
+#endif
+
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
 }
 
 CreateWalletDialog::~CreateWalletDialog()
@@ -94,7 +121,13 @@ bool CreateWalletDialog::isMakeBlankWalletChecked() const
     return ui->blank_wallet_checkbox->isChecked();
 }
 
+<<<<<<< HEAD
 bool CreateWalletDialog::isDescriptorWalletChecked() const
 {
     return ui->descriptor_checkbox->isChecked();
+=======
+bool CreateWalletDialog::isExternalSignerChecked() const
+{
+    return ui->external_signer_checkbox->isChecked();
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
 }

--- a/src/qt/createwalletdialog.h
+++ b/src/qt/createwalletdialog.h
@@ -27,7 +27,11 @@ public:
     bool isEncryptWalletChecked() const;
     bool isDisablePrivateKeysChecked() const;
     bool isMakeBlankWalletChecked() const;
+<<<<<<< HEAD
     bool isDescriptorWalletChecked() const;
+=======
+    bool isExternalSignerChecked() const;
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
 
 private:
     Ui::CreateWalletDialog *ui;

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -6,8 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
+<<<<<<< HEAD
     <width>407</width>
     <height>0</height>
+=======
+    <width>371</width>
+    <height>298</height>
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,6 +22,48 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_description">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>You are one step away from creating your new wallet!</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_subdescription">
+     <property name="text">
+      <string>Please provide a name and, if desired, enable any advanced options</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>3</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -75,7 +122,19 @@
      <property name="title">
       <string>Advanced Options</string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_groupbox">
+      <property name="spacing">
+       <number>9</number>
+      </property>
       <item>
        <widget class="QCheckBox" name="disable_privkeys_checkbox">
         <property name="enabled">
@@ -100,12 +159,21 @@
        </widget>
       </item>
       <item>
+<<<<<<< HEAD
        <widget class="QCheckBox" name="descriptor_checkbox">
         <property name="toolTip">
          <string>Use descriptors for scriptPubKey management. This feature is well-tested but still considered experimental and not recommended for use yet.</string>
         </property>
         <property name="text">
          <string>Descriptor Wallet (EXPERIMENTAL)</string>
+=======
+       <widget class="QCheckBox" name="external_signer_checkbox">
+        <property name="toolTip">
+         <string>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</string>
+        </property>
+        <property name="text">
+         <string>External signer</string>
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
         </property>
        </widget>
       </item>
@@ -142,6 +210,10 @@
   <tabstop>encrypt_wallet_checkbox</tabstop>
   <tabstop>disable_privkeys_checkbox</tabstop>
   <tabstop>blank_wallet_checkbox</tabstop>
+<<<<<<< HEAD
+=======
+  <tabstop>external_signer_checkbox</tabstop>
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
  </tabstops>
  <resources/>
  <connections>

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -247,14 +247,21 @@ void CreateWalletActivity::createWallet()
 
     std::string name = m_create_wallet_dialog->walletName().toStdString();
     uint64_t flags = 0;
+    // Enable descriptors by default.
+    flags |= WALLET_FLAG_DESCRIPTORS;
     if (m_create_wallet_dialog->isDisablePrivateKeysChecked()) {
         flags |= WALLET_FLAG_DISABLE_PRIVATE_KEYS;
     }
     if (m_create_wallet_dialog->isMakeBlankWalletChecked()) {
         flags |= WALLET_FLAG_BLANK_WALLET;
     }
+<<<<<<< HEAD
     if (m_create_wallet_dialog->isDescriptorWalletChecked()) {
         flags |= WALLET_FLAG_DESCRIPTORS;
+=======
+    if (m_create_wallet_dialog->isExternalSignerChecked()) {
+        flags |= WALLET_FLAG_EXTERNAL_SIGNER;
+>>>>>>> d2b8c5e123 (Merge bitcoin-core/gui#764: Remove legacy wallet creation)
     }
 
     QTimer::singleShot(500ms, worker(), [this, name, flags] {


### PR DESCRIPTION
Backports bitcoin-core/gui#764

Original commit: d2b8c5e123

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating wallets with external signer devices, including a new option in the wallet creation dialog.
  * Improved user guidance in the wallet creation dialog with clearer instructions and updated layout.

* **Bug Fixes**
  * Wallet creation now checks for necessary support (e.g., SQLite) and displays an error if missing.

* **Refactor**
  * Centralized wallet creation logic for improved maintainability.
  * Updated wallet creation to always use descriptor wallets by default.

* **Style**
  * Enhanced the wallet creation dialog layout and spacing for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->