### PR TITLE
Merge bitcoin/bitcoin#28644: test: Fuzz merge with -use_value_profile=0 for now

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Copyright (c) 2019-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Run fuzz test targets.

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -239,7 +239,11 @@ def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, build_dir, merge_dir)
             # [0] https://github.com/bitcoin-core/qa-assets/issues/130#issuecomment-1761760866
             '-shuffle=0',
             '-prefer_small=1',
-            '-use_value_profile=1',  # Also done by oss-fuzz https://github.com/google/oss-fuzz/issues/1406#issuecomment-387790487
+            '-use_value_profile=0',
+            # use_value_profile is enabled by oss-fuzz [0], but disabled for
+            # now to avoid bloating the qa-assets git repository [1].
+            # [0] https://github.com/google/oss-fuzz/issues/1406#issuecomment-387790487
+            # [1] https://github.com/bitcoin-core/qa-assets/issues/130#issuecomment-1749075891
             os.path.join(corpus, t),
             os.path.join(merge_dir, t),
         ]


### PR DESCRIPTION
Backports bitcoin/bitcoin#28644

Original commit: 151a2b189c3561dda2bb7de809306c1cfeb40e23

Backported from Bitcoin Core v0.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comments explaining the disabling of value profiling during input merging, with references to related GitHub issues.

* **Chores**
  * Updated configuration to disable value profiling when merging inputs to prevent repository bloat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->