### PR TITLE
Merge bitcoin/bitcoin#28565: rpc: getaddrmaninfo followups

### DIFF
--- a/doc/release-notes/release-notes-28565.md
+++ b/doc/release-notes/release-notes-28565.md
@@ -1,0 +1,6 @@
+New RPCs
+--------
+
+- A new RPC `getaddrmaninfo` has been added to view the distribution of addresses in the new and tried table of the
+  node's address manager across different networks(ipv4, ipv6, onion, i2p, cjdns). The RPC returns count of addresses
+  in new and tried table as well as their sum for all networks. (#27511)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1002,11 +1002,7 @@ static RPCHelpMan addpeeraddress()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    if (!node.addrman) {
-        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Address manager functionality missing or disabled");
-    }
+    AddrMan& addrman = EnsureAnyAddrman(request.context);
 
     const std::string& addr_string{request.params[0].get_str()};
     const auto port{request.params[1].getInt<uint16_t>()};
@@ -1022,11 +1018,11 @@ static RPCHelpMan addpeeraddress()
         address.nTime = Now<NodeSeconds>();
         // The source address is set equal to the address. This is equivalent to the peer
         // announcing itself.
-        if (node.addrman->Add({address}, address)) {
+        if (addrman.Add({address}, address)) {
             success = true;
             if (tried) {
                 // Attempt to move the address to the tried addresses table.
-                node.addrman->Good(address);
+                addrman.Good(address);
             }
         }
     }
@@ -1110,6 +1106,111 @@ static RPCHelpMan setmnthreadactive()
     };
 }
 
+static RPCHelpMan getaddrmaninfo()
+{
+    return RPCHelpMan{
+        "getaddrmaninfo",
+        "\nProvides information about the node's address manager by returning the number of "
+        "addresses in the `new` and `tried` tables and their sum for all networks.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::OBJ_DYN, "", "json object with network type as keys", {
+                {RPCResult::Type::OBJ, "network", "the network (" + Join(GetNetworkNames(), ", ") + ", all_networks)", {
+                {RPCResult::Type::NUM, "new", "number of addresses in the new table, which represent potential peers the node has discovered but hasn't yet successfully connected to."},
+                {RPCResult::Type::NUM, "tried", "number of addresses in the tried table, which represent peers the node has successfully connected to in the past."},
+                {RPCResult::Type::NUM, "total", "total number of addresses in both new/tried tables"},
+            }},
+        }},
+        RPCExamples{HelpExampleCli("getaddrmaninfo", "") + HelpExampleRpc("getaddrmaninfo", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            AddrMan& addrman = EnsureAnyAddrman(request.context);
+
+            UniValue ret(UniValue::VOBJ);
+            for (int n = 0; n < NET_MAX; ++n) {
+                enum Network network = static_cast<enum Network>(n);
+                if (network == NET_UNROUTABLE || network == NET_INTERNAL) continue;
+                UniValue obj(UniValue::VOBJ);
+                obj.pushKV("new", addrman.Size(network, true));
+                obj.pushKV("tried", addrman.Size(network, false));
+                obj.pushKV("total", addrman.Size(network));
+                ret.pushKV(GetNetworkName(network), obj);
+            }
+            UniValue obj(UniValue::VOBJ);
+            obj.pushKV("new", addrman.Size(std::nullopt, true));
+            obj.pushKV("tried", addrman.Size(std::nullopt, false));
+            obj.pushKV("total", addrman.Size());
+            ret.pushKV("all_networks", obj);
+            return ret;
+        },
+    };
+}
+
+UniValue AddrmanEntryToJSON(const AddrInfo& info)
+{
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("address", info.ToStringAddr());
+    obj.pushKV("port", info.GetPort());
+    obj.pushKV("services", (uint64_t)info.nServices);
+    obj.pushKV("time", int64_t{TicksSinceEpoch<std::chrono::seconds>(info.nTime)});
+    obj.pushKV("network", GetNetworkName(info.GetNetClass()));
+    obj.pushKV("source", info.source.ToStringAddr());
+    obj.pushKV("source_network", GetNetworkName(info.source.GetNetClass()));
+    return obj;
+}
+
+UniValue AddrmanTableToJSON(const std::vector<std::pair<AddrInfo, AddressPosition>>& tableInfos)
+{
+    UniValue table(UniValue::VOBJ);
+    for (const auto& e : tableInfos) {
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("address", e.first.ToStringAddr());
+        obj.pushKV("port", e.first.GetPort());
+        obj.pushKV("services", (uint64_t)e.first.nServices);
+        obj.pushKV("time", int64_t{TicksSinceEpoch<std::chrono::seconds>(e.first.nTime)});
+        obj.pushKV("network", GetNetworkName(e.first.GetNetClass()));
+        obj.pushKV("source", e.first.source.ToStringAddr());
+        obj.pushKV("source_network", GetNetworkName(e.first.source.GetNetClass()));
+        table.pushKV(ToString(e.second), obj);
+    }
+    return table;
+}
+
+static RPCHelpMan getrawaddrman()
+{
+    return RPCHelpMan{"getrawaddrman",
+        "EXPERIMENTAL warning: this call may be changed in future releases.\n"
+        "\nReturns information on all address manager entries for the new and tried tables.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::OBJ_DYN, "", "", {
+                {RPCResult::Type::OBJ_DYN, "table", "buckets with addresses in the address manager table ( new, tried )", {
+                    {RPCResult::Type::OBJ, "bucket/position", "the location in the address manager table (<bucket>/<position>)", {
+                        {RPCResult::Type::STR, "address", "The address of the node"},
+                        {RPCResult::Type::NUM, "port", "The port number of the node"},
+                        {RPCResult::Type::STR, "network", "The network (" + Join(GetNetworkNames(), ", ") + ") of the address"},
+                        {RPCResult::Type::NUM, "services", "The services offered by the node"},
+                        {RPCResult::Type::NUM_TIME, "time", "The " + UNIX_EPOCH_TIME + " when the node was last seen"},
+                        {RPCResult::Type::STR, "source", "The address that relayed the address to us"},
+                        {RPCResult::Type::STR, "source_network", "The network (" + Join(GetNetworkNames(), ", ") + ") of the source address"},
+                    }}
+                }}
+            }
+        },
+        RPCExamples{
+            HelpExampleCli("getrawaddrman", "")
+            + HelpExampleRpc("getrawaddrman", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            AddrMan& addrman = EnsureAnyAddrman(request.context);
+
+            UniValue ret(UniValue::VOBJ);
+            ret.pushKV("new", AddrmanTableToJSON(addrman.GetEntries(false)));
+            ret.pushKV("tried", AddrmanTableToJSON(addrman.GetEntries(true)));
+            return ret;
+        },
+    };
+}
+
 void RegisterNetRPCCommands(CRPCTable &t)
 {
 // clang-format off
@@ -1129,12 +1230,14 @@ static const CRPCCommand commands[] =
     { "network",             &clearbanned,             },
     { "network",             &setnetworkactive,        },
     { "network",             &getnodeaddresses,        },
+    { "network",             &getaddrmaninfo,          },
 
     { "hidden",              &cleardiscouraged,        },
     { "hidden",              &addconnection,           },
     { "hidden",              &addpeeraddress,          },
     { "hidden",              &sendmsgtopeer            },
     { "hidden",              &setmnthreadactive        },
+    { "hidden",              &getrawaddrman            },
 };
 // clang-format on
     for (const auto& c : commands) {

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -138,3 +138,16 @@ PeerManager& EnsurePeerman(const NodeContext& node)
     }
     return *node.peerman;
 }
+
+AddrMan& EnsureAddrman(const NodeContext& node)
+{
+    if (!node.addrman) {
+        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Address manager functionality missing or disabled");
+    }
+    return *node.addrman;
+}
+
+AddrMan& EnsureAnyAddrman(const std::any& context)
+{
+    return EnsureAddrman(EnsureAnyNodeContext(context));
+}

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -7,6 +7,7 @@
 
 #include <context.h>
 
+class AddrMan;
 class ArgsManager;
 class CBlockPolicyEstimator;
 class CConnman;
@@ -34,5 +35,7 @@ LLMQContext& EnsureLLMQContext(const node::NodeContext& node);
 LLMQContext& EnsureAnyLLMQContext(const CoreContext& context);
 CConnman& EnsureConnman(const node::NodeContext& node);
 PeerManager& EnsurePeerman(const node::NodeContext& node);
+AddrMan& EnsureAddrman(const node::NodeContext& node);
+AddrMan& EnsureAnyAddrman(const std::any& context);
 
 #endif // BITCOIN_RPC_SERVER_UTIL_H

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -15,6 +15,7 @@ from test_framework.messages import (
 )
 
 from itertools import product
+import time
 
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
@@ -25,6 +26,10 @@ from test_framework.util import (
     p2p_port,
 )
 from test_framework.wallet import MiniWallet
+
+# Addrman implementation-specific constants
+ADDRMAN_NEW_BUCKET_COUNT = 1024
+ADDRMAN_BUCKET_SIZE = 64
 
 
 def assert_net_servicesnames(servicesflag, servicenames):
@@ -68,6 +73,8 @@ class NetTest(DashTestFramework):
         self.test_getnodeaddresses()
         self.test_addpeeraddress()
         self.test_sendmsgtopeer()
+        self.test_getaddrmaninfo()
+        self.test_getrawaddrman()
 
     def test_connection_count(self):
         self.log.info("Test getconnectioncount")
@@ -397,6 +404,132 @@ class NetTest(DashTestFramework):
         zero_byte_string = b'\x00' * int(MAX_PROTOCOL_MESSAGE_LENGTH + 1)
         node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=zero_byte_string.hex())
         self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
+    def test_getaddrmaninfo(self):
+        self.log.info("Test getaddrmaninfo")
+        node = self.nodes[1]
+
+        # current count of ipv4 addresses in addrman is {'new':1, 'tried':1}
+        self.log.info("Test that count of addresses in addrman match expected values")
+        res = node.getaddrmaninfo()
+        assert_equal(res["ipv4"]["new"], 1)
+        assert_equal(res["ipv4"]["tried"], 1)
+        assert_equal(res["ipv4"]["total"], 2)
+        assert_equal(res["all_networks"]["new"], 1)
+        assert_equal(res["all_networks"]["tried"], 1)
+        assert_equal(res["all_networks"]["total"], 2)
+        for net in ["ipv6", "onion", "i2p", "cjdns"]:
+            assert_equal(res[net]["new"], 0)
+            assert_equal(res[net]["tried"], 0)
+            assert_equal(res[net]["total"], 0)
+
+    def test_getrawaddrman(self):
+        self.log.info("Test getrawaddrman")
+        node = self.nodes[1]
+
+        self.log.debug("Test that getrawaddrman is a hidden RPC")
+        # It is hidden from general help, but its detailed help may be called directly.
+        assert "getrawaddrman" not in node.help()
+        assert "getrawaddrman" in node.help("getrawaddrman")
+
+        def check_addr_information(result, expected):
+            """Utility to compare a getrawaddrman result entry with an expected entry"""
+            assert_equal(result["address"], expected["address"])
+            assert_equal(result["port"], expected["port"])
+            assert_equal(result["services"], expected["services"])
+            assert_equal(result["network"], expected["network"])
+            assert_equal(result["source"], expected["source"])
+            assert_equal(result["source_network"], expected["source_network"])
+            # To avoid failing on slow test runners, use a 10s vspan here.
+            assert_approx(result["time"], time.time(), vspan=10)
+
+        def check_getrawaddrman_entries(expected):
+            """Utility to compare a getrawaddrman result with expected addrman contents"""
+            getrawaddrman = node.getrawaddrman()
+            getaddrmaninfo = node.getaddrmaninfo()
+            for (table_name, table_info) in expected.items():
+                assert_equal(len(getrawaddrman[table_name]), len(table_info["entries"]))
+                assert_equal(len(getrawaddrman[table_name]), getaddrmaninfo["all_networks"][table_name])
+
+                for bucket_position in getrawaddrman[table_name].keys():
+                    bucket = int(bucket_position.split("/")[0])
+                    position = int(bucket_position.split("/")[1])
+
+                    # bucket and position only be sanity checked here as the
+                    # test-addrman isn't deterministic
+                    assert 0 <= int(bucket) < table_info["bucket_count"]
+                    assert 0 <= int(position) < ADDRMAN_BUCKET_SIZE
+
+                    entry = getrawaddrman[table_name][bucket_position]
+                    expected_entry = list(filter(lambda e: e["address"] == entry["address"], table_info["entries"]))[0]
+                    check_addr_information(entry, expected_entry)
+
+        # we expect one addrman new and tried table entry, which were added in a previous test
+        expected = {
+            "new": {
+                "bucket_count": ADDRMAN_NEW_BUCKET_COUNT,
+                "entries": [
+                    {
+                        "address": "2.0.0.0",
+                        "port": 8333,
+                        "services": 9,
+                        "network": "ipv4",
+                        "source": "2.0.0.0",
+                        "source_network": "ipv4",
+                    }
+                ]
+            },
+            "tried": {
+                "bucket_count": ADDRMAN_TRIED_BUCKET_COUNT,
+                "entries": [
+                    {
+                        "address": "1.2.3.4",
+                        "port": 8333,
+                        "services": 9,
+                        "network": "ipv4",
+                        "source": "1.2.3.4",
+                        "source_network": "ipv4",
+                    }
+                ]
+            }
+        }
+
+        self.log.debug("Test that the getrawaddrman contains information about the addresses added in a previous test")
+        check_getrawaddrman_entries(expected)
+
+        self.log.debug("Add one new address to each addrman table")
+        expected["new"]["entries"].append({
+            "address": "2803:0:1234:abcd::1",
+            "services": 9,
+            "network": "ipv6",
+            "source": "2803:0:1234:abcd::1",
+            "source_network": "ipv6",
+            "port": -1,  # set once addpeeraddress is successful
+        })
+        expected["tried"]["entries"].append({
+            "address": "nrfj6inpyf73gpkyool35hcmne5zwfmse3jl3aw23vk7chdemalyaqad.onion",
+            "services": 9,
+            "network": "onion",
+            "source": "nrfj6inpyf73gpkyool35hcmne5zwfmse3jl3aw23vk7chdemalyaqad.onion",
+            "source_network": "onion",
+            "port": -1,  # set once addpeeraddress is successful
+        })
+
+        port = 0
+        for (table_name, table_info) in expected.items():
+            # There's a slight chance that the to-be-added address collides with an already
+            # present table entry. To avoid this, we increment the port until an address has been
+            # added. Incrementing the port changes the position in the new table bucket (bucket
+            # stays the same) and changes both the bucket and the position in the tried table.
+            while True:
+                if node.addpeeraddress(address=table_info["entries"][1]["address"], port=port, tried=table_name == "tried")["success"]:
+                    table_info["entries"][1]["port"] = port
+                    self.log.debug(f"Added {table_info['entries'][1]['address']} to {table_name} table")
+                    break
+                else:
+                    port += 1
+
+        self.log.debug("Test that the newly added addresses appear in getrawaddrman")
+        check_getrawaddrman_entries(expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backports bitcoin/bitcoin#28565

Original commit: 22fa1f4702e9a60e141f545f8d09704deca34b22

Backported from Bitcoin Core v0.26

This PR includes:
- make `getaddrmaninfo` RPC public since it's not for development purposes only
- add missing `all_networks` key to RPC help
- fix clang format spacing
- add and use `EnsureAnyAddrman` in RPC code

Note: Adapted `EnsureAnyAddrman` to use `CoreContext` instead of `std::any` to match Dash's RPC infrastructure.