### PR TITLE
Merge bitcoin/bitcoin#28643: ci: Add missing CI_RETRY_EXE before git clone

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -17,7 +17,7 @@ if [ -z "${SKIP_PYTHON_INSTALL}" ]; then
     PYTHON_PATH=/tmp/python
     if [ ! -d "${PYTHON_PATH}/bin" ]; then
       (
-        git clone https://github.com/pyenv/pyenv.git
+        ${CI_RETRY_EXE} git clone https://github.com/pyenv/pyenv.git
         cd pyenv/plugins/python-build || exit 1
         ./install.sh
       )

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -106,7 +106,7 @@ CI_EXEC df -h
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
   if [ ! -d "$DIR_FUZZ_IN" ]; then
-    CI_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
+    CI_EXEC ${CI_RETRY_EXE} git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
   fi
   (
     CI_EXEC cd "${DIR_QA_ASSETS}"


### PR DESCRIPTION
Backports bitcoin/bitcoin#28643

Original commit: fc1073bb45

Backported from Bitcoin Core v0.26

This PR adds CI_RETRY_EXE before git clone commands in CI scripts to improve reliability. The change was partially applicable to Dash as we have a different CI structure - only the change to ci/lint/04_install.sh was relevant and applied.