### PR TITLE
Merge bitcoin-core/gui#771: Avoid error-prone leading whitespace in translatable strings

### DIFF
--- a/ci/dash/lint-tidy.sh
+++ b/ci/dash/lint-tidy.sh
@@ -23,6 +23,7 @@ iwyu_tool.py \
   "src/test/fuzz/txorphan.cpp" \
   "src/util/bip32.cpp" \
   "src/util/bytevectorhash.cpp" \
+  "src/util/check.cpp" \
   "src/util/error.cpp" \
   "src/util/getuniquepath.cpp" \
   "src/util/hasher.cpp" \

--- a/ci/dash/lint-tidy.sh
+++ b/ci/dash/lint-tidy.sh
@@ -20,6 +20,7 @@ iwyu_tool.py \
   "src/init" \
   "src/rpc/fees.cpp" \
   "src/rpc/signmessage.cpp" \
+  "src/test/fuzz/txorphan.cpp" \
   "src/util/bip32.cpp" \
   "src/util/bytevectorhash.cpp" \
   "src/util/error.cpp" \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -363,6 +363,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/tx_in.cpp \
  test/fuzz/tx_out.cpp \
  test/fuzz/tx_pool.cpp \
+ test/fuzz/txorphan.cpp \
  test/fuzz/utxo_snapshot.cpp \
  test/fuzz/validation_load_mempool.cpp \
  test/fuzz/versionbits.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,7 +62,6 @@
 #include <torcontrol.h>
 #include <txdb.h>
 #include <txmempool.h>
-#include <txorphanage.h>
 #include <util/asmap.h>
 #include <util/error.h>
 #include <util/moneystr.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4550,10 +4550,7 @@ void PeerManagerImpl::ProcessMessage(
 
                 // DoS prevention: do not allow m_orphans to grow unbounded (see CVE-2012-3789)
                 unsigned int nMaxOrphanTxSize = (unsigned int)std::max((int64_t)0, gArgs.GetIntArg("-maxorphantxsize", DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE)) * 1000000;
-                unsigned int nEvicted = m_orphanage.LimitOrphans(nMaxOrphanTxSize);
-                if (nEvicted > 0) {
-                    LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
-                }
+                m_orphanage.LimitOrphans(nMaxOrphanTxSize);
             } else {
                 LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s\n",tx.GetHash().ToString());
                 // We will continue to reject this tx since it has rejected

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -168,19 +168,20 @@ void PSBTOperationsDialog::saveTransaction() {
 }
 
 void PSBTOperationsDialog::updateTransactionDisplay() {
-    m_ui->transactionDescription->setText(QString::fromStdString(renderTransaction(m_transaction_data)));
+    m_ui->transactionDescription->setText(renderTransaction(m_transaction_data));
     showTransactionStatus(m_transaction_data);
 }
 
-std::string PSBTOperationsDialog::renderTransaction(const PartiallySignedTransaction &psbtx)
+QString PSBTOperationsDialog::renderTransaction(const PartiallySignedTransaction &psbtx)
 {
-    QString tx_description = "";
+    QString tx_description;
+    QLatin1String bullet_point(" * ");
     CAmount totalAmount = 0;
     for (const CTxOut& out : psbtx.tx->vout) {
         CTxDestination address;
         ExtractDestination(out.scriptPubKey, address);
         totalAmount += out.nValue;
-        tx_description.append(tr(" * Sends %1 to %2")
+        tx_description.append(bullet_point).append(tr("Sends %1 to %2")
             .arg(BitcoinUnits::formatWithUnit(BitcoinUnit::DASH, out.nValue))
             .arg(QString::fromStdString(EncodeDestination(address))));
         // Check if the address is one of ours
@@ -189,7 +190,7 @@ std::string PSBTOperationsDialog::renderTransaction(const PartiallySignedTransac
     }
 
     PSBTAnalysis analysis = AnalyzePSBT(psbtx);
-    tx_description.append(" * ");
+    tx_description.append(bullet_point);
     if (!*analysis.fee) {
         // This happens if the transaction is missing input UTXO information.
         tx_description.append(tr("Unable to calculate transaction fee or total transaction amount."));
@@ -218,7 +219,7 @@ std::string PSBTOperationsDialog::renderTransaction(const PartiallySignedTransac
         tx_description.append(tr("Transaction has %1 unsigned inputs.").arg(QString::number(num_unsigned)));
     }
 
-    return tx_description.toStdString();
+    return tx_description;
 }
 
 void PSBTOperationsDialog::showStatus(const QString &msg, StatusLevel level) {

--- a/src/qt/psbtoperationsdialog.h
+++ b/src/qt/psbtoperationsdialog.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_PSBTOPERATIONSDIALOG_H
 
 #include <QDialog>
+#include <QString>
 
 #include <psbt.h>
 #include <qt/clientmodel.h>
@@ -46,7 +47,7 @@ private:
 
     size_t couldSignInputs(const PartiallySignedTransaction &psbtx);
     void updateTransactionDisplay();
-    std::string renderTransaction(const PartiallySignedTransaction &psbtx);
+    QString renderTransaction(const PartiallySignedTransaction &psbtx);
     void showStatus(const QString &msg, StatusLevel level);
     void showTransactionStatus(const PartiallySignedTransaction &psbtx);
 };

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -342,7 +342,7 @@ bool SendCoinsDialog::send(const QList<SendCoinsRecipient>& recipients, QString&
         // generate amount string with wallet name in case of multiwallet
         QString amount = BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
         if (model->isMultiwallet()) {
-            amount.append(tr(" from wallet '%1'").arg(model->getWalletName()));
+            amount = tr("%1 from wallet '%2'").arg(amount, GUIUtil::HtmlEscape(model->getWalletName()));
         }
 
         // generate address string

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -999,7 +999,7 @@ static RPCHelpMan addpeeraddress()
     }
 
     const std::string& addr_string{request.params[0].get_str()};
-    const uint16_t port = request.params[1].getInt<int>();
+    const auto port{request.params[1].getInt<uint16_t>()};
     const bool tried{request.params[2].isTrue()};
 
     UniValue obj(UniValue::VOBJ);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -196,6 +196,14 @@ static RPCHelpMan getpeerinfo()
         UniValue obj(UniValue::VOBJ);
         CNodeStateStats statestats;
         bool fStateStats = peerman.GetNodeStateStats(stats.nodeid, statestats);
+        // GetNodeStateStats() requires the existence of a CNodeState and a Peer object
+        // to succeed for this peer. These are created at connection initialisation and
+        // exist for the duration of the connection - except if there is a race where the
+        // peer got disconnected in between the GetNodeStats() and the GetNodeStateStats()
+        // calls. In this case, the peer doesn't need to be reported here.
+        if (!fStateStats) {
+            continue;
+        }
         obj.pushKV("id", stats.nodeid);
         obj.pushKV("addr", stats.m_addr_name);
         if (stats.addrBind.IsValid()) {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -782,6 +782,10 @@ static RPCHelpMan setban()
         if (request.params[3].isTrue())
             absolute = true;
 
+        if (absolute && banTime < GetTime()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: Absolute timestamp is in the past");
+        }
+
         if (isSubnet) {
             banman.Ban(subNet, banTime, absolute);
             if (node.connman) {

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -19,7 +19,6 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
-#include <txorphanage.h>
 #include <validationinterface.h>
 #include <version.h>
 

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -13,7 +13,6 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
-#include <txorphanage.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -3,8 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
-#include <net.h>
+#include <consensus/validation.h>
 #include <net_processing.h>
+#include <node/eviction.h>
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <sync.h>
@@ -102,16 +104,20 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                 [&] {
                     bool have_tx = orphanage.HaveTx(tx->GetHash());
                     // AddTx should return false if tx is too big or already have it
+                    // tx size is unknown, we only check when tx is already in orphanage
                     {
                         LOCK(g_cs_orphans);
-                        Assert(have_tx != orphanage.AddTx(tx, peer_id));
+                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        // have_tx == true -> add_tx == false
+                        Assert(!have_tx || !add_tx);
                     }
                     have_tx = orphanage.HaveTx(tx->GetHash());
-                    // tx should already be added since it will not be too big in the test
-                    // have_tx should be true and AddTx should fail
                     {
                         LOCK(g_cs_orphans);
-                        Assert(have_tx && !orphanage.AddTx(tx, peer_id));
+                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        // if have_tx is still false, it must be too big
+                        Assert(!have_tx == ::GetSerializeSize(*tx, PROTOCOL_VERSION) > MAX_STANDARD_TX_SIZE);
+                        Assert(!have_tx || !add_tx);
                     }
                 },
                 [&] {

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/amount.h>
+#include <net.h>
+#include <net_processing.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <txorphanage.h>
+#include <uint256.h>
+#include <util/check.h>
+#include <util/time.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+//! Default maximum number of maximum size orphan transactions that can be kept in memory
+static const uint32_t DEFAULT_MAX_ORPHAN_TRANSACTIONS{(DEFAULT_MAX_ORPHAN_TRANSACTIONS_SIZE * 1000000) / MAX_STANDARD_TX_SIZE};
+
+void initialize_orphanage()
+{
+    static const auto testing_setup = MakeNoLogFileContext();
+}
+
+FUZZ_TARGET(txorphan, .init = initialize_orphanage)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    SetMockTime(ConsumeTime(fuzzed_data_provider));
+
+    TxOrphanage orphanage;
+    std::set<uint256> orphan_work_set;
+    std::vector<COutPoint> outpoints;
+    // initial outpoints used to construct transactions later
+    for (uint8_t i = 0; i < 4; i++) {
+        outpoints.emplace_back(uint256{i}, 0);
+    }
+    // if true, allow duplicate input when constructing tx
+    const bool duplicate_input = fuzzed_data_provider.ConsumeBool();
+
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
+    {
+        // construct transaction
+        const CTransactionRef tx = [&] {
+            CMutableTransaction tx_mut;
+            const auto num_in = fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(1, outpoints.size());
+            const auto num_out = fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(1, outpoints.size());
+            // pick unique outpoints from outpoints as input
+            for (uint32_t i = 0; i < num_in; i++) {
+                auto& prevout = PickValue(fuzzed_data_provider, outpoints);
+                tx_mut.vin.emplace_back(prevout);
+                // pop the picked outpoint if duplicate input is not allowed
+                if (!duplicate_input) {
+                    std::swap(prevout, outpoints.back());
+                    outpoints.pop_back();
+                }
+            }
+            // output amount will not affect txorphanage
+            for (uint32_t i = 0; i < num_out; i++) {
+                tx_mut.vout.emplace_back(CAmount{0}, CScript{});
+            }
+            // restore previously poped outpoints
+            for (auto& in : tx_mut.vin) {
+                outpoints.push_back(in.prevout);
+            }
+            const auto new_tx = MakeTransactionRef(tx_mut);
+            // add newly constructed transaction to outpoints
+            for (uint32_t i = 0; i < num_out; i++) {
+                outpoints.emplace_back(new_tx->GetHash(), i);
+            }
+            return new_tx;
+        }();
+
+        // trigger orphanage functions
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
+        {
+            NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
+
+            CallOneOf(
+                fuzzed_data_provider,
+                [&] {
+                    LOCK(g_cs_orphans);
+                    orphanage.AddChildrenToWorkSet(*tx, orphan_work_set);
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(tx->GetHash());
+                    {
+                        LOCK(g_cs_orphans);
+                        bool get_tx = orphanage.GetTx(tx->GetHash()).first != nullptr;
+                        Assert(have_tx == get_tx);
+                    }
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(tx->GetHash());
+                    // AddTx should return false if tx is too big or already have it
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(have_tx != orphanage.AddTx(tx, peer_id));
+                    }
+                    have_tx = orphanage.HaveTx(tx->GetHash());
+                    // tx should already be added since it will not be too big in the test
+                    // have_tx should be true and AddTx should fail
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(have_tx && !orphanage.AddTx(tx, peer_id));
+                    }
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(tx->GetHash());
+                    // EraseTx should return 0 if m_orphans doesn't have the tx
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(have_tx == orphanage.EraseTx(tx->GetHash()));
+                    }
+                    have_tx = orphanage.HaveTx(tx->GetHash());
+                    // have_tx should be false and EraseTx should fail
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(!have_tx && !orphanage.EraseTx(tx->GetHash()));
+                    }
+                },
+                [&] {
+                    LOCK(g_cs_orphans);
+                    orphanage.EraseForPeer(peer_id);
+                },
+                [&] {
+                    // test mocktime and expiry
+                    SetMockTime(ConsumeTime(fuzzed_data_provider));
+                    auto size_before = orphanage.Size();
+                    auto limit = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+                    auto n_evicted = WITH_LOCK(g_cs_orphans, return orphanage.LimitOrphans(limit));
+                    Assert(size_before - n_evicted <= limit);
+                    Assert(orphanage.Size() <= limit);
+                });
+        }
+    }
+}

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -141,10 +141,8 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                 [&] {
                     // test mocktime and expiry
                     SetMockTime(ConsumeTime(fuzzed_data_provider));
-                    auto size_before = orphanage.Size();
                     auto limit = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
-                    auto n_evicted = WITH_LOCK(g_cs_orphans, return orphanage.LimitOrphans(limit));
-                    Assert(size_before - n_evicted <= limit);
+                    WITH_LOCK(g_cs_orphans, orphanage.LimitOrphans(limit));
                     Assert(orphanage.Size() <= limit);
                 });
         }

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -116,7 +116,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                         LOCK(g_cs_orphans);
                         bool add_tx = orphanage.AddTx(tx, peer_id);
                         // if have_tx is still false, it must be too big
-                        Assert(!have_tx == ::GetSerializeSize(*tx, PROTOCOL_VERSION) > MAX_STANDARD_TX_SIZE);
+                        Assert(!have_tx == (::GetSerializeSize(*tx, PROTOCOL_VERSION) > MAX_STANDARD_TX_SIZE));
                         Assert(!have_tx || !add_tx);
                     }
                 },

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -49,7 +49,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
     // if true, allow duplicate input when constructing tx
     const bool duplicate_input = fuzzed_data_provider.ConsumeBool();
 
-    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
+    LIMITED_WHILE(outpoints.size() < 200'000 && fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
     {
         // construct transaction
         const CTransactionRef tx = [&] {

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -16,11 +16,10 @@ static constexpr int64_t ORPHAN_TX_EXPIRE_TIME = 20 * 60;
 /** Minimum time between orphan transactions expire time checks in seconds */
 static constexpr int64_t ORPHAN_TX_EXPIRE_INTERVAL = 5 * 60;
 
-RecursiveMutex g_cs_orphans;
 
 bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 {
-    AssertLockHeld(g_cs_orphans);
+    LOCK(m_mutex);
 
     const uint256& hash = tx->GetHash();
     if (m_orphans.count(hash))
@@ -59,7 +58,13 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 
 int TxOrphanage::EraseTx(const uint256& txid)
 {
-    AssertLockHeld(g_cs_orphans);
+    LOCK(m_mutex);
+    return _EraseTx(txid);
+}
+
+int TxOrphanage::_EraseTx(const uint256& txid)
+{
+    AssertLockHeld(m_mutex);
     std::map<uint256, OrphanTx>::iterator it = m_orphans.find(txid);
     if (it == m_orphans.end())
         return 0;
@@ -94,7 +99,9 @@ int TxOrphanage::EraseTx(const uint256& txid)
 
 void TxOrphanage::EraseForPeer(NodeId peer)
 {
-    AssertLockHeld(g_cs_orphans);
+    LOCK(m_mutex);
+
+    m_peer_work_set.erase(peer);
 
     int nErased = 0;
     std::map<uint256, OrphanTx>::iterator iter = m_orphans.begin();
@@ -103,7 +110,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
         std::map<uint256, OrphanTx>::iterator maybeErase = iter++; // increment to avoid iterator becoming invalid
         if (maybeErase->second.fromPeer == peer)
         {
-            nErased += EraseTx(maybeErase->second.tx->GetHash());
+            nErased += _EraseTx(maybeErase->second.tx->GetHash());
         }
     }
     if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx from peer=%d\n", nErased, peer);
@@ -111,7 +118,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
 
 void TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
 {
-    AssertLockHeld(g_cs_orphans);
+    LOCK(m_mutex);
 
     unsigned int nEvicted = 0;
     static int64_t nNextSweep;
@@ -125,7 +132,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
         {
             std::map<uint256, OrphanTx>::iterator maybeErase = iter++;
             if (maybeErase->second.nTimeExpire <= nNow) {
-                nErased += EraseTx(maybeErase->second.tx->GetHash());
+                nErased += _EraseTx(maybeErase->second.tx->GetHash());
             } else {
                 nMinExpTime = std::min(maybeErase->second.nTimeExpire, nMinExpTime);
             }
@@ -139,15 +146,19 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
     {
         // Evict a random orphan:
         size_t randompos = rng.randrange(m_orphan_list.size());
-        EraseTx(m_orphan_list[randompos]->first);
+        _EraseTx(m_orphan_list[randompos]->first);
         ++nEvicted;
     }
     if (nEvicted > 0) LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
 }
 
-void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>& orphan_work_set) const
+void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx, NodeId peer)
 {
-    AssertLockHeld(g_cs_orphans);
+    LOCK(m_mutex);
+
+    // Get this peer's work set, emplacing an empty set it didn't exist
+    std::set<uint256>& orphan_work_set = m_peer_work_set.try_emplace(peer).first->second;
+
     for (unsigned int i = 0; i < tx.vout.size(); i++) {
         const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(tx.GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
@@ -160,22 +171,36 @@ void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>
 
 bool TxOrphanage::HaveTx(const uint256& txid) const
 {
-    LOCK(g_cs_orphans);
+    LOCK(m_mutex);
     return m_orphans.count(txid);
 }
 
-std::pair<CTransactionRef, NodeId> TxOrphanage::GetTx(const uint256& txid) const
+CTransactionRef TxOrphanage::GetTxToReconsider(NodeId peer, NodeId& originator, bool& more)
 {
-    AssertLockHeld(g_cs_orphans);
+    LOCK(m_mutex);
 
-    const auto it = m_orphans.find(txid);
-    if (it == m_orphans.end()) return {nullptr, -1};
-    return {it->second.tx, it->second.fromPeer};
+    auto work_set_it = m_peer_work_set.find(peer);
+    if (work_set_it != m_peer_work_set.end()) {
+        auto& work_set = work_set_it->second;
+        while (!work_set.empty()) {
+            uint256 txid = *work_set.begin();
+            work_set.erase(work_set.begin());
+
+            const auto orphan_it = m_orphans.find(txid);
+            if (orphan_it != m_orphans.end()) {
+                more = !work_set.empty();
+                originator = orphan_it->second.fromPeer;
+                return orphan_it->second.tx;
+            }
+        }
+    }
+    more = false;
+    return nullptr;
 }
 
 std::set<uint256> TxOrphanage::GetCandidatesForBlock(const CBlock& block)
 {
-    AssertLockHeld(g_cs_orphans);
+    LOCK(m_mutex);
 
     std::set<uint256> orphan_work_set;
     for (const auto& ptx : block.vtx) {
@@ -186,7 +211,7 @@ std::set<uint256> TxOrphanage::GetCandidatesForBlock(const CBlock& block)
 
 void TxOrphanage::EraseForBlock(const CBlock& block)
 {
-    LOCK(g_cs_orphans);
+    LOCK(m_mutex);
 
     std::vector<uint256> vOrphanErase;
 
@@ -209,7 +234,7 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
     if (vOrphanErase.size()) {
         int nErased = 0;
         for (const uint256& orphanHash : vOrphanErase) {
-            nErased += EraseTx(orphanHash);
+            nErased += _EraseTx(orphanHash);
         }
         LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -109,7 +109,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx from peer=%d\n", nErased, peer);
 }
 
-unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
+void TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
 {
     AssertLockHeld(g_cs_orphans);
 
@@ -142,7 +142,7 @@ unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans_size)
         EraseTx(m_orphan_list[randompos]->first);
         ++nEvicted;
     }
-    return nEvicted;
+    if (nEvicted > 0) LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
 }
 
 void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>& orphan_work_set) const

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -177,22 +177,11 @@ std::set<uint256> TxOrphanage::GetCandidatesForBlock(const CBlock& block)
 {
     AssertLockHeld(g_cs_orphans);
 
-    std::set<uint256> orphanWorkSet;
-
-    for (const CTransactionRef& ptx : block.vtx) {
-        const CTransaction& tx = *ptx;
-
-        // Which orphan pool entries we should reprocess and potentially try to accept into mempool again?
-        for (size_t i = 0; i < tx.vin.size(); i++) {
-            auto itByPrev = m_outpoint_to_orphan_it.find(COutPoint(tx.GetHash(), (uint32_t)i));
-            if (itByPrev == m_outpoint_to_orphan_it.end()) continue;
-            for (const auto& elem : itByPrev->second) {
-                orphanWorkSet.insert(elem->first);
-            }
-        }
+    std::set<uint256> orphan_work_set;
+    for (const auto& ptx : block.vtx) {
+        AddChildrenToWorkSet(*ptx, orphan_work_set);
     }
-
-    return orphanWorkSet;
+    return orphan_work_set;
 }
 
 void TxOrphanage::EraseForBlock(const CBlock& block)

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -35,8 +35,8 @@ public:
      */
     CTransactionRef GetTxToReconsider(NodeId peer, NodeId& originator, bool& more) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Get a set of orphan transactions that can be candidates for reconsideration into the mempool */
-    std::set<uint256> GetCandidatesForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Determine orphan transactions that can be candidates for reconsideration into the mempool based on block */
+    void SetCandidatesByBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase an orphan by txid */
     int EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -46,6 +46,9 @@ public:
 
     /** Erase all orphans included in or invalidated by a new block */
     void EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Check if there are more orphans reported by a peer to work on */
+    bool HaveMoreWork(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Limit the orphanage to the given maximum */
     void LimitOrphans(unsigned int max_orphans_size) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -89,7 +89,7 @@ protected:
     std::vector<OrphanMap::iterator> m_orphan_list GUARDED_BY(g_cs_orphans);
 
     /** Cumulative size of all transactions in the orphan map */
-    size_t m_orphan_tx_size{0};
+    size_t m_orphan_tx_size GUARDED_BY(g_cs_orphans){0};
 };
 
 #endif // BITCOIN_TXORPHANAGE_H

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -10,8 +10,8 @@
 #include <primitives/transaction.h>
 #include <sync.h>
 
-/** Guards orphan transactions and extra txs for compact blocks */
-extern RecursiveMutex g_cs_orphans;
+#include <map>
+#include <set>
 
 /** A class to track orphan transactions (failed on TX_MISSING_INPUTS)
  * Since we cannot distinguish orphans from bad transactions with
@@ -21,43 +21,49 @@ extern RecursiveMutex g_cs_orphans;
 class TxOrphanage {
 public:
     /** Add a new orphan transaction */
-    bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Check if we already have an orphan transaction */
-    bool HaveTx(const uint256& txid) const LOCKS_EXCLUDED(::g_cs_orphans);
+    bool HaveTx(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Get an orphan transaction and its orginating peer
-     * (Transaction ref will be nullptr if not found)
+    /** Extract a transaction from a peer's work set
+     *  Returns nullptr and sets more to false if there are no transactions
+     *  to work on. Otherwise returns the transaction reference, removes
+     *  the transaction from the work set, and populates its arguments with
+     *  the originating peer, and whether there are more orphans for this peer
+     *  to work on after this tx.
      */
-    std::pair<CTransactionRef, NodeId> GetTx(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    CTransactionRef GetTxToReconsider(NodeId peer, NodeId& originator, bool& more) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Get a set of orphan transactions that can be candidates for reconsideration into the mempool */
-    std::set<uint256> GetCandidatesForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    std::set<uint256> GetCandidatesForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase an orphan by txid */
-    int EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    int EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
-    void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase all orphans included in or invalidated by a new block */
-    void EraseForBlock(const CBlock& block) LOCKS_EXCLUDED(::g_cs_orphans);
+    void EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Limit the orphanage to the given maximum */
-    void LimitOrphans(unsigned int max_orphans_size) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    void LimitOrphans(unsigned int max_orphans_size) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Add any orphans that list a particular tx as a parent into a peer's work set
-     * (ie orphans that may have found their final missing parent, and so should be reconsidered for the mempool) */
-    void AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>& orphan_work_set) const EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    /** Add any orphans that list a particular tx as a parent into a peer's work set */
+    void AddChildrenToWorkSet(const CTransaction& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Return how many entries exist in the orphange */
-    size_t Size() LOCKS_EXCLUDED(::g_cs_orphans)
+    size_t Size() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
-        LOCK(::g_cs_orphans);
+        LOCK(m_mutex);
         return m_orphans.size();
     }
 
 protected:
+    /** Guards orphan transactions */
+    mutable Mutex m_mutex;
+
     struct OrphanTx {
         CTransactionRef tx;
         NodeId fromPeer;
@@ -68,7 +74,10 @@ protected:
 
     /** Map from txid to orphan transaction record. Limited by
      *  -maxorphantx/DEFAULT_MAX_ORPHAN_TRANSACTIONS */
-    std::map<uint256, OrphanTx> m_orphans GUARDED_BY(g_cs_orphans);
+    std::map<uint256, OrphanTx> m_orphans GUARDED_BY(m_mutex);
+
+    /** Which peer provided a parent tx of orphans that need to be reconsidered */
+    std::map<NodeId, std::set<uint256>> m_peer_work_set GUARDED_BY(m_mutex);
 
     using OrphanMap = decltype(m_orphans);
 
@@ -83,13 +92,16 @@ protected:
 
     /** Index from the parents' COutPoint into the m_orphans. Used
      *  to remove orphan transactions from the m_orphans */
-    std::map<COutPoint, std::set<OrphanMap::iterator, IteratorComparator>> m_outpoint_to_orphan_it GUARDED_BY(g_cs_orphans);
+    std::map<COutPoint, std::set<OrphanMap::iterator, IteratorComparator>> m_outpoint_to_orphan_it GUARDED_BY(m_mutex);
 
     /** Orphan transactions in vector for quick random eviction */
-    std::vector<OrphanMap::iterator> m_orphan_list GUARDED_BY(g_cs_orphans);
+    std::vector<OrphanMap::iterator> m_orphan_list GUARDED_BY(m_mutex);
 
     /** Cumulative size of all transactions in the orphan map */
-    size_t m_orphan_tx_size GUARDED_BY(g_cs_orphans){0};
+    size_t m_orphan_tx_size GUARDED_BY(m_mutex){0};
+
+    /** Erase an orphan by txid */
+    int _EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
 };
 
 #endif // BITCOIN_TXORPHANAGE_H

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -44,7 +44,7 @@ public:
     void EraseForBlock(const CBlock& block) LOCKS_EXCLUDED(::g_cs_orphans);
 
     /** Limit the orphanage to the given maximum */
-    unsigned int LimitOrphans(unsigned int max_orphans_size) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+    void LimitOrphans(unsigned int max_orphans_size) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
 
     /** Add any orphans that list a particular tx as a parent into a peer's work set
      * (ie orphans that may have found their final missing parent, and so should be reconsidered for the mempool) */

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -4,7 +4,26 @@
 
 #include <util/check.h>
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <clientversion.h>
 #include <tinyformat.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+
+NonFatalCheckError::NonFatalCheckError(const char* msg, const char* file, int line, const char* func)
+    : std::runtime_error{
+          strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\n"
+                    "%s %s\n"
+                    "Please report this issue here: %s\n",
+                    msg, file, line, func, PACKAGE_NAME, FormatFullVersion(), PACKAGE_BUGREPORT)}
+{
+}
 
 void assertion_fail(const char* file, int line, const char* func, const char* assertion)
 {

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -5,34 +5,23 @@
 #ifndef BITCOIN_UTIL_CHECK_H
 #define BITCOIN_UTIL_CHECK_H
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
-
 #include <attributes.h>
-#include <clientversion.h>
-#include <tinyformat.h>
 
 #include <stdexcept>
+#include <utility>
 
 class NonFatalCheckError : public std::runtime_error
 {
-    using std::runtime_error::runtime_error;
+public:
+    NonFatalCheckError(const char* msg, const char* file, int line, const char* func);
 };
-
-#define format_internal_error(msg, file, line, func, report)                                    \
-    strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\n"                                     \
-              "%s %s\n"                                                                           \
-              "Please report this issue here: %s\n",                                             \
-              msg, file, line, func, PACKAGE_NAME, FormatFullVersion(), report)
 
 /** Helper for CHECK_NONFATAL() */
 template <typename T>
 T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, const char* func, const char* assertion)
 {
-    if (!(val)) {
-        throw NonFatalCheckError(
-            format_internal_error(assertion, file, line, func, PACKAGE_BUGREPORT));
+    if (!val) {
+        throw NonFatalCheckError{assertion, file, line, func};
     }
     return std::forward<T>(val);
 }
@@ -91,11 +80,9 @@ T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* f
 
 /**
  * NONFATAL_UNREACHABLE() is a macro that is used to mark unreachable code. It throws a NonFatalCheckError.
- * This is used to mark code that is not yet implemented or is not yet reachable.
  */
 #define NONFATAL_UNREACHABLE()                                        \
     throw NonFatalCheckError(                                         \
-        format_internal_error("Unreachable code reached (non-fatal)", \
-                              __FILE__, __LINE__, __func__, PACKAGE_BUGREPORT))
+        "Unreachable code reached (non-fatal)", __FILE__, __LINE__, __func__)
 
 #endif // BITCOIN_UTIL_CHECK_H

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -307,7 +307,6 @@ protected:
      * Get data directory path
      *
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
-     * @post Returned directory path is created unless it is empty
      */
     fs::path GetDataDirBase() const { return GetDataDir(false); }
 
@@ -315,7 +314,6 @@ protected:
      * Get data directory path with appended network identifier
      *
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
-     * @post Returned directory path is created unless it is empty
      */
     fs::path GetDataDirNet() const { return GetDataDir(true); }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2652,8 +2652,6 @@ bool CChainState::FlushStateToDisk(
 {
     LOCK(cs_main);
     assert(this->CanFlushToDisk());
-    static std::chrono::microseconds nLastWrite{0};
-    static std::chrono::microseconds nLastFlush{0};
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
 
@@ -2707,11 +2705,11 @@ bool CChainState::FlushStateToDisk(
         }
         const auto nNow = GetTime<std::chrono::microseconds>();
         // Avoid writing/flushing immediately after startup.
-        if (nLastWrite.count() == 0) {
-            nLastWrite = nNow;
+        if (m_last_write.count() == 0) {
+            m_last_write = nNow;
         }
-        if (nLastFlush.count() == 0) {
-            nLastFlush = nNow;
+        if (m_last_flush.count() == 0) {
+            m_last_flush = nNow;
         }
         // The cache is large and we're within 10% and 10 MiB of the limit, but we have time now (not in the middle of a block processing).
         bool fCacheLarge = mode == FlushStateMode::PERIODIC && cache_state >= CoinsCacheSizeState::LARGE;
@@ -2720,9 +2718,9 @@ bool CChainState::FlushStateToDisk(
         // The evodb cache is too large
         bool fEvoDbCacheCritical = mode == FlushStateMode::IF_NEEDED && m_evoDb.GetMemoryUsage() >= (64 << 20);
         // It's been a while since we wrote the block index to disk. Do this frequently, so we don't need to redownload after a crash.
-        bool fPeriodicWrite = mode == FlushStateMode::PERIODIC && nNow > nLastWrite + DATABASE_WRITE_INTERVAL;
+        bool fPeriodicWrite = mode == FlushStateMode::PERIODIC && nNow > m_last_write + DATABASE_WRITE_INTERVAL;
         // It's been very long since we flushed the cache. Do this infrequently, to optimize cache usage.
-        bool fPeriodicFlush = mode == FlushStateMode::PERIODIC && nNow > nLastFlush + DATABASE_FLUSH_INTERVAL;
+        bool fPeriodicFlush = mode == FlushStateMode::PERIODIC && nNow > m_last_flush + DATABASE_FLUSH_INTERVAL;
         // Combine all conditions that result in a full cache flush.
         fDoFullFlush = (mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fEvoDbCacheCritical || fPeriodicFlush || fFlushForPrune;
         // Write blocks and block index to disk.
@@ -2753,7 +2751,7 @@ bool CChainState::FlushStateToDisk(
 
                 UnlinkPrunedFiles(setFilesToPrune);
             }
-            nLastWrite = nNow;
+            m_last_write = nNow;
         }
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
         if (fDoFullFlush && !CoinsTip().GetBestBlock().IsNull()) {
@@ -2779,7 +2777,7 @@ bool CChainState::FlushStateToDisk(
                     return AbortNode(state, "Failed to commit EvoDB");
                 }
             }
-            nLastFlush = nNow;
+            m_last_flush = nNow;
             full_flush_completed = true;
             TRACE5(utxocache, flush,
                    (int64_t)(GetTimeMicros() - nNow.count()), // in microseconds (µs)

--- a/src/validation.h
+++ b/src/validation.h
@@ -31,6 +31,7 @@
 #include <util/translation.h>
 
 #include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <optional>
@@ -796,6 +797,9 @@ private:
     /** Check warning conditions and do some notifications on new chain tip set. */
     void UpdateTip(const CBlockIndex* pindexNew)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    std::chrono::microseconds m_last_write{0};
+    std::chrono::microseconds m_last_flush{0};
 
     friend ChainstateManager;
 };

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -90,13 +90,15 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
     std::vector<size_t> best_selection;
     CAmount best_waste = MAX_MONEY;
 
+    bool is_feerate_high = utxo_pool.at(0).fee > utxo_pool.at(0).long_term_fee;
+
     // Depth First search loop for choosing the UTXOs
     for (size_t curr_try = 0, utxo_pool_index = 0; curr_try < TOTAL_TRIES; ++curr_try, ++utxo_pool_index) {
         // Conditions for starting a backtrack
         bool backtrack = false;
         if (curr_value + curr_available_value < selection_target || // Cannot possibly reach target with the amount remaining in the curr_available_value.
             curr_value > selection_target + cost_of_change || // Selected value is out of range, go back and try other branch
-            (curr_waste > best_waste && (utxo_pool.at(0).fee - utxo_pool.at(0).long_term_fee) > 0)) { // Don't select things which we know will be more wasteful if the waste is increasing
+            (curr_waste > best_waste && is_feerate_high)) { // Don't select things which we know will be more wasteful if the waste is increasing
             backtrack = true;
         } else if (curr_value >= selection_target) {       // Selected value is within range
             curr_waste += (curr_value - selection_target); // This is the excess value which is added to the waste for the below comparison

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -420,8 +420,6 @@ static RPCHelpMan upgradetohd()
         pwallet->WalletLogPrintf("Upgrading wallet to HD\n");
         pwallet->SetMinVersion(FEATURE_HD);
 
-        bool is_locked = pwallet->IsLocked();
-
         if (pwallet->IsCrypted()) {
             if (secureWalletPassphrase.empty()) {
                 throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: Wallet encrypted but supplied empty wallet passphrase");
@@ -455,12 +453,11 @@ static RPCHelpMan upgradetohd()
             }
         }
 
-        if (is_locked) {
-            // Relock the wallet
+        if (pwallet->IsCrypted()) {
+            // Relock encrypted wallet
             pwallet->Lock();
-        }
-
-        if (!secureWalletPassphrase.empty() && !pwallet->IsCrypted()) {
+        } else if (!secureWalletPassphrase.empty()) {
+            // Encrypt non-encrypted wallet
             if (!pwallet->EncryptWallet(secureWalletPassphrase)) {
                 throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Failed to encrypt HD wallet");
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1112,7 +1112,13 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             // Block disconnection override an abandoned tx as unconfirmed
             // which means user may have to call abandontransaction again
             TxState tx_state = std::visit([](auto&& s) -> TxState { return s; }, state);
-            return AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, /*fFlushOnClose=*/false, rescanning_old_block);
+            CWalletTx* wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, /*fFlushOnClose=*/false, rescanning_old_block);
+            if (!wtx) {
+                // Can only be nullptr if there was a db write error (missing db, read-only db or a db engine internal writing error).
+                // As we only store arriving transaction in this process, and we don't want an inconsistent state, let's throw an error.
+                throw std::runtime_error("DB error adding transaction to wallet, write failed");
+            }
+            return true;
         }
     }
     return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -353,11 +353,17 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
                 // TODO: drop this condition after removing option to create non-HD wallets
                 // related backport bitcoin#11250
                 if (wallet->GetVersion() >= FEATURE_HD) {
-                    if (!wallet->GenerateNewHDChain(/*secureMnemonic=*/"", /*secureMnemonicPassphrase=*/"", passphrase)) {
-                       error = Untranslated("Error: Failed to generate encrypted HD wallet");
-                       status = DatabaseStatus::FAILED_CREATE;
-                       return nullptr;
+                    auto spk_man = wallet->GetLegacyScriptPubKeyMan();
+                    if (!spk_man) {
+                        error = Untranslated("Error: Legacy ScriptPubKeyMan is not available");
+                        status = DatabaseStatus::FAILED_ENCRYPT;
+                        return nullptr;
                     }
+
+                    wallet->WithEncryptionKey([&](const CKeyingMaterial& encryption_key) {
+                            spk_man->GenerateNewHDChain(/*secureMnemonic=*/"", /*secureMnemonicPassphrase=*/"", encryption_key);
+                            return true;
+                        });
                 }
             }
 
@@ -3203,52 +3209,6 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
     return true;
 }
 
-bool CWallet::UpgradeToHD(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, const SecureString& secureWalletPassphrase, bilingual_str& error)
-{
-    LOCK(cs_wallet);
-
-    // Do not do anything to HD wallets
-    if (IsHDEnabled()) {
-        error = Untranslated("Cannot upgrade a wallet to HD if it is already upgraded to HD.");
-        return false;
-    }
-
-    if (IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        error = Untranslated("Private keys are disabled for this wallet");
-        return false;
-    }
-
-    WalletLogPrintf("Upgrading wallet to HD\n");
-    SetMinVersion(FEATURE_HD);
-
-    if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
-        if (IsCrypted()) {
-            if (secureWalletPassphrase.empty()) {
-                error = Untranslated("Error: Wallet encrypted but supplied empty wallet passphrase");
-                return false;
-            }
-
-            // Unlock the wallet
-            if (!Unlock(secureWalletPassphrase)) {
-                error = Untranslated("Error: The wallet passphrase entered was incorrect");
-                return false;
-            }
-        }
-        SetupDescriptorScriptPubKeyMans(secureMnemonic, secureMnemonicPassphrase);
-
-        if (IsCrypted()) {
-            // Relock the wallet
-            Lock();
-        }
-    } else {
-        if (!GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase, secureWalletPassphrase)) {
-            error = Untranslated("Failed to generate HD wallet");
-            return false;
-        }
-    }
-    return true;
-}
-
 const CAddressBookData* CWallet::FindAddressBookEntry(const CTxDestination& dest, bool allow_change) const
 {
     const auto& address_book_it = m_address_book.find(dest);
@@ -3777,64 +3737,6 @@ void CWallet::ConnectScriptPubKeyManNotifiers()
         spk_man->NotifyWatchonlyChanged.connect(NotifyWatchonlyChanged);
         spk_man->NotifyCanGetAddressesChanged.connect(NotifyCanGetAddressesChanged);
     }
-}
-
-bool CWallet::GenerateNewHDChain(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, const SecureString& secureWalletPassphrase)
-{
-    auto spk_man = GetLegacyScriptPubKeyMan();
-    if (!spk_man) {
-        throw std::runtime_error(strprintf("%s: spk_man is not available", __func__));
-    }
-
-    if (IsCrypted()) {
-        if (secureWalletPassphrase.empty()) {
-            throw std::runtime_error(strprintf("%s: encrypted but supplied empty wallet passphrase", __func__));
-        }
-
-        bool is_locked = IsLocked();
-
-        CCrypter crypter;
-        CKeyingMaterial vMasterKey;
-
-        // We are intentionally re-locking the wallet so we can validate vMasterKey
-        // by verifying if it can unlock the wallet
-        Lock();
-
-        LOCK(cs_wallet);
-        for (const auto& [_, master_key] : mapMasterKeys) {
-            CKeyingMaterial _vMasterKey;
-            if (!crypter.SetKeyFromPassphrase(secureWalletPassphrase, master_key.vchSalt, master_key.nDeriveIterations, master_key.nDerivationMethod)) {
-                return false;
-            }
-            // Try another key if it cannot be decrypted or the key is incapable of encrypting
-            if (!crypter.Decrypt(master_key.vchCryptedKey, _vMasterKey) || _vMasterKey.size() != WALLET_CRYPTO_KEY_SIZE) {
-                continue;
-            }
-            // The likelihood of the plaintext being gibberish but also of the expected size is low but not zero.
-            // If it can unlock the wallet, it's a good key.
-            if (Unlock(_vMasterKey)) {
-                vMasterKey = _vMasterKey;
-                break;
-            }
-        }
-
-        // We got a gibberish key...
-        if (vMasterKey.empty()) {
-            // Mimicking the error message of RPC_WALLET_PASSPHRASE_INCORRECT as it's possible
-            // that the user may see this error when interacting with the upgradetohd RPC
-            throw std::runtime_error("Error: The wallet passphrase entered was incorrect");
-        }
-
-        spk_man->GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase, vMasterKey);
-
-        if (is_locked) {
-            Lock();
-        }
-    } else {
-        spk_man->GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase);
-    }
-
-    return true;
 }
 
 void CWallet::UpdateProgress(const std::string& title, int nProgress)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -915,10 +915,6 @@ public:
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const;
 
-    // TODO: move it to scriptpubkeyman
-    /* Generates a new HD chain */
-    bool GenerateNewHDChain(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, const SecureString& secureWalletPassphrase = "");
-
     /* Returns true if the wallet can give out new addresses. This means it has keys in the keypool or can generate new keys */
     bool CanGetAddresses(bool internal = false) const;
 
@@ -974,9 +970,6 @@ public:
 
     /** Upgrade the wallet */
     bool UpgradeWallet(int version, bilingual_str& error);
-
-    /** Upgrade non-HD wallet to HD wallet */
-    bool UpgradeToHD(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, const SecureString& secureWalletPassphrase, bilingual_str& error);
 
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers
     std::set<ScriptPubKeyMan*> GetActiveScriptPubKeyMans() const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -617,6 +617,10 @@ public:
     //! @return true if wtx is changed and needs to be saved to disk, otherwise false
     using UpdateWalletTxFn = std::function<bool(CWalletTx& wtx, bool new_tx)>;
 
+    /**
+     * Add the transaction to the wallet, wrapping it up inside a CWalletTx
+     * @return the recently added wtx pointer or nullptr if there was a db write error.
+     */
     CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool fFlushOnClose=true, bool rescanning_old_block = false);
     bool LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime, uint64_t mempool_sequence) override;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -974,7 +974,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     return result;
 }
 
-DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWalletTx>& vWtx)
+DBErrors WalletBatch::FindWalletTxHashes(std::vector<uint256>& tx_hashes)
 {
     DBErrors result = DBErrors::LOAD_OK;
 
@@ -1012,9 +1012,7 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWal
             if (strType == DBKeys::TX) {
                 uint256 hash;
                 ssKey >> hash;
-                vTxHash.push_back(hash);
-                vWtx.emplace_back(/*tx=*/nullptr, TxStateInactive{});
-                ssValue >> vWtx.back();
+                tx_hashes.push_back(hash);
             }
         }
     } catch (...) {
@@ -1027,10 +1025,9 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWal
 
 DBErrors WalletBatch::ZapSelectTx(std::vector<uint256>& vTxHashIn, std::vector<uint256>& vTxHashOut)
 {
-    // build list of wallet TXs and hashes
+    // build list of wallet TX hashes
     std::vector<uint256> vTxHash;
-    std::list<CWalletTx> vWtx;
-    DBErrors err = FindWalletTx(vTxHash, vWtx);
+    DBErrors err = FindWalletTxHashes(vTxHash);
     if (err != DBErrors::LOAD_OK) {
         return err;
     }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -233,7 +233,7 @@ public:
     bool EraseActiveScriptPubKeyMan(bool internal);
 
     DBErrors LoadWallet(CWallet* pwallet);
-    DBErrors FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWalletTx>& vWtx);
+    DBErrors FindWalletTxHashes(std::vector<uint256>& tx_hashes);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut);
     /* Function to determine if a certain KV/key-type is a key (cryptographical key) type */
     static bool IsKeyType(const std::string& strType);

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -57,6 +57,9 @@ class DisconnectBanTest(BitcoinTestFramework):
         assert_raises_rpc_error(-30, "Error: Invalid IP/Subnet", self.nodes[1].setban, "127.0.0.1/42", "add")
         assert_equal(len(self.nodes[1].listbanned()), 1)  # still only one banned ip because 127.0.0.1 is within the range of 127.0.0.0/24
 
+        self.log.info("setban: fail to ban with past absolute timestamp")
+        assert_raises_rpc_error(-8, "Error: Absolute timestamp is in the past", self.nodes[1].setban, "127.27.0.1", "add", 123, True)
+
         self.log.info("setban remove: fail to unban a non-banned subnet")
         assert_raises_rpc_error(-30, "Error: Unban failed", self.nodes[1].setban, "127.0.0.1", "remove")
         assert_equal(len(self.nodes[1].listbanned()), 1)
@@ -74,9 +77,13 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19", "add", 1000)  # ban for 1000 seconds
         listBeforeShutdown = self.nodes[1].listbanned()
         assert_equal("192.168.0.1/32", listBeforeShutdown[2]['address'])
+
+        self.log.info("setban: test banning with absolute timestamp")
+        self.nodes[1].setban("192.168.0.2", "add", self.mocktime + 120, True)
+
         # Move time forward by 3 seconds so the third ban has expired
         self.bump_mocktime(3)
-        self.wait_until(lambda: len(self.nodes[1].listbanned()) == 3, timeout=10)
+        self.wait_until(lambda: len(self.nodes[1].listbanned()) == 4, timeout=10)
 
         self.log.info("Test ban_duration and time_remaining")
         for ban in self.nodes[1].listbanned():
@@ -86,13 +93,17 @@ class DisconnectBanTest(BitcoinTestFramework):
             elif ban["address"] == "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19":
                 assert_equal(ban["ban_duration"], 1000)
                 assert_equal(ban["time_remaining"], 997)
+            elif ban["address"] == "192.168.0.2/32":
+                assert_equal(ban["ban_duration"], 120)
+                assert_equal(ban["time_remaining"], 117)
 
         self.restart_node(1)
 
         listAfterShutdown = self.nodes[1].listbanned()
         assert_equal("127.0.0.0/24", listAfterShutdown[0]['address'])
         assert_equal("127.0.0.0/32", listAfterShutdown[1]['address'])
-        assert_equal("/19" in listAfterShutdown[2]['address'], True)
+        assert_equal("192.168.0.2/32", listAfterShutdown[2]['address'])
+        assert_equal("/19" in listAfterShutdown[3]['address'], True)
 
         # Clear ban lists
         self.nodes[1].clearbanned()

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -74,14 +74,15 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19", "add", 1000)  # ban for 1000 seconds
         listBeforeShutdown = self.nodes[1].listbanned()
         assert_equal("192.168.0.1/32", listBeforeShutdown[2]['address'])
-        self.bump_mocktime(2)
+        # Move time forward by 3 seconds so the third ban has expired
+        self.bump_mocktime(3)
         self.wait_until(lambda: len(self.nodes[1].listbanned()) == 3, timeout=10)
 
         self.log.info("Test ban_duration and time_remaining")
         for ban in self.nodes[1].listbanned():
             if ban["address"] in ["127.0.0.0/32", "127.0.0.0/24"]:
                 assert_equal(ban["ban_duration"], 86400)
-                assert_equal(ban["time_remaining"], 86398)
+                assert_equal(ban["time_remaining"], 86397)
             elif ban["address"] == "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19":
                 assert_equal(ban["ban_duration"], 1000)
                 assert_equal(ban["time_remaining"], 997)

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -341,6 +341,10 @@ class NetTest(DashTestFramework):
         assert_equal(node.addpeeraddress(address="", port=8333), {"success": False})
         assert_equal(node.getnodeaddresses(count=0), [])
 
+        self.log.debug("Test that adding an address with invalid port fails")
+        assert_raises_rpc_error(-1, "JSON integer out of range", self.nodes[0].addpeeraddress, address="1.2.3.4", port=-1)
+        assert_raises_rpc_error(-1, "JSON integer out of range", self.nodes[0].addpeeraddress,address="1.2.3.4", port=65536)
+
         self.log.debug("Test that adding a valid address to the tried table succeeds")
         assert_equal(node.addpeeraddress(address="1.2.3.4", tried=True, port=8333), {"success": True})
         with node.assert_debug_log(expected_msgs=["CheckAddrman: new 0, tried 1, total 1 started"]):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -106,6 +106,7 @@ class TestNode():
             "-debug",
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
+            "-debugexclude=rand",
             "-uacomment=testnode%d" % i,  # required for subversion uniqueness across peers
         ]
         if self.mocktime != 0:

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -552,39 +552,6 @@ def find_output(node, txid, amount, *, blockhash=None):
     raise RuntimeError("find_output txid %s : %s not found" % (txid, str(amount)))
 
 
-# Helper to create at least "count" utxos
-# Pass in a fee that is sufficient for relay and mining new transactions.
-def create_confirmed_utxos(test_framework, fee, node, count, **kwargs):
-    to_generate = int(0.5 * count) + 101
-    while to_generate > 0:
-        test_framework.generate(node, min(25, to_generate), **kwargs)
-        to_generate -= 25
-    utxos = node.listunspent()
-    iterations = count - len(utxos)
-    addr1 = node.getnewaddress()
-    addr2 = node.getnewaddress()
-    if iterations <= 0:
-        return utxos
-    for _ in range(iterations):
-        t = utxos.pop()
-        inputs = []
-        inputs.append({"txid": t["txid"], "vout": t["vout"]})
-        outputs = {}
-        send_value = t['amount'] - fee
-        outputs[addr1] = satoshi_round(send_value / 2)
-        outputs[addr2] = satoshi_round(send_value / 2)
-        raw_tx = node.createrawtransaction(inputs, outputs)
-        signed_tx = node.signrawtransactionwithwallet(raw_tx)["hex"]
-        node.sendrawtransaction(signed_tx)
-
-    while (node.getmempoolinfo()['size'] > 0):
-        test_framework.generate(node, 1, **kwargs)
-
-    utxos = node.listunspent()
-    assert len(utxos) >= count
-    return utxos
-
-
 def chain_transaction(node, parent_txids, vouts, value, fee, num_outputs):
     """Build and send a transaction that spends the given inputs (specified
     by lists of parent_txid:vout each), with the desired total value and fee,

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -203,10 +203,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         node.wait_until_stopped()
         self.start_node(0, extra_args=['-rescan'])
         assert_raises_rpc_error(-13, "Error: Wallet encrypted but passphrase not supplied to RPC.", node.upgradetohd, mnemonic)
-        if not self.options.descriptors:
-            assert_raises_rpc_error(-1,  "Error: The wallet passphrase entered was incorrect", node.upgradetohd, mnemonic, "", "wrongpass")
-        else:
-            assert_raises_rpc_error(-4,  "Error: The wallet passphrase entered was incorrect", node.upgradetohd, mnemonic, "", "wrongpass")
+        assert_raises_rpc_error(-14, "Error: The wallet passphrase entered was incorrect", node.upgradetohd, mnemonic, "", "wrongpass")
         assert node.upgradetohd(mnemonic, "", walletpass)
         if not self.options.descriptors:
             assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.", node.dumphdinfo)

--- a/test/lint/lint-qt-translation.py
+++ b/test/lint/lint-qt-translation.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+#
+# Check for leading whitespaces in the translatable strings.
+
+import subprocess
+import sys
+
+
+def main():
+    tr_strings = subprocess.run(['git', 'grep', '-e', 'tr("[[:space:]]', '--', 'src/qt'], stdout=subprocess.PIPE, text=True).stdout
+
+    if tr_strings.strip():
+        print("Avoid leading whitespaces in:")
+        print(tr_strings)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#771

Original commit: 64879f4c03

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new fuzz test for orphan transaction handling.
  * Introduced a script to lint Qt translatable strings for leading whitespace.

* **Bug Fixes**
  * Improved error handling and validation in wallet upgrade and RPC commands.
  * Enhanced wallet transaction addition to prevent inconsistent state on database write failures.
  * Updated tests to ensure correct error codes and messages for wallet passphrase errors and invalid port values in RPC calls.

* **Refactor**
  * Centralized orphan transaction synchronization and processing, replacing global locks with internal mutexes and per-peer work sets.
  * Simplified and clarified HD wallet upgrade logic.
  * Updated coin selection and transaction rendering for better code clarity and consistency.

* **Tests**
  * Added and updated test cases for orphan transaction handling, wallet upgrades, database write failures, and RPC validation.
  * Removed a utility function for generating confirmed UTXOs in test framework.

* **Documentation**
  * Improved and clarified method documentation in wallet and system modules.

* **Chores**
  * Updated build scripts and CI to include new test targets and linting steps.
  * Adjusted debug logging configuration for test nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->