### PR TITLE
Merge bitcoin/bitcoin#28741: refactor: Fix bugprone-string-constructor warning

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: '
 -*,
 bugprone-argument-comment,
+bugprone-string-constructor,
 modernize-use-nullptr,
 readability-const-return-type,
 readability-redundant-declaration,

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -129,9 +129,9 @@ bool IsSQLiteFile(const fs::path& path)
 
     file.close();
 
-    // Check the magic, see https://sqlite.org/fileformat2.html
+    // Check the magic, see https://sqlite.org/fileformat.html
     std::string magic_str(magic, 16);
-    if (magic_str != std::string("SQLite format 3", 16)) {
+    if (magic_str != std::string{"SQLite format 3\000", 16}) {
         return false;
     }
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28741

Original commit: 4458ae811a

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code style checks to enhance code quality.

* **Documentation**
  * Corrected a reference link in a comment to the latest SQLite file format documentation.

* **Bug Fixes**
  * Improved validation of the SQLite file magic header for increased accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->