### PR TITLE
Merge bitcoin/bitcoin#28729: addrman: log AS only when using asmap

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -614,8 +614,9 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, std::c
             ClearNew(nUBucket, nUBucketPos);
             pinfo->nRefCount++;
             vvNew[nUBucket][nUBucketPos] = nId;
-            LogPrint(BCLog::ADDRMAN, "Added %s mapped to AS%i to new[%i][%i]\n",
-                     addr.ToStringAddrPort(), m_netgroupman.GetMappedAS(addr), nUBucket, nUBucketPos);
+            const auto mapped_as{m_netgroupman.GetMappedAS(addr)};
+            LogPrint(BCLog::ADDRMAN, "Added %s%s to new[%i][%i]\n",
+                     addr.ToStringAddrPort(), (mapped_as ? strprintf(" mapped to AS%i", mapped_as) : ""), nUBucket, nUBucketPos);
         } else {
             if (pinfo->nRefCount == 0) {
                 Delete(nId);
@@ -676,8 +677,9 @@ bool AddrManImpl::Good_(const CService& addr, bool test_before_evict, NodeSecond
         // move nId to the tried tables
         MakeTried(info, nId);
         if (fLogIPs) {
-            LogPrint(BCLog::ADDRMAN, "Moved %s mapped to AS%i to tried[%i][%i]\n",
-                     addr.ToStringAddrPort(), m_netgroupman.GetMappedAS(addr), tried_bucket, tried_bucket_pos);
+            const auto mapped_as{m_netgroupman.GetMappedAS(addr)};
+            LogPrint(BCLog::ADDRMAN, "Moved %s%s to tried[%i][%i]\n",
+                     addr.ToStringAddrPort(), (mapped_as ? strprintf(" mapped to AS%i", mapped_as) : ""), tried_bucket, tried_bucket_pos);
         }
         return true;
     }


### PR DESCRIPTION
Backports bitcoin/bitcoin#28729

Original commit: 02a4f1a3859ed7e865641b35ca1bc9ce711e696f

This PR changes the log to just print the ASN when using asmap, same logic presented in other logs. Previously, the AS mapping was always logged even when asmap wasn't being used, which could be misleading.

**Changes:**
- Modified `src/addrman.cpp` to conditionally log AS mapping only when it's available
- Wrapped `fLogIPs` check around the conditional AS logging in Dash

**Note:** The test file changes from Bitcoin were not applied as Dash doesn't have the addrv2 test methods that Bitcoin has.

Backported from Bitcoin Core v0.27