### PR TITLE
Merge bitcoin/bitcoin#28530: tests, bug fix: DisconnectedBlockTransactions rewrite followups

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -494,23 +494,6 @@ libbitcoin_node_a_SOURCES = \
   index/coinstatsindex.cpp \
   index/txindex.cpp \
   init.cpp \
-  instantsend/db.cpp \
-  instantsend/instantsend.cpp \
-  instantsend/lock.cpp \
-  instantsend/signing.cpp \
-  llmq/blockprocessor.cpp \
-  llmq/chainlocks.cpp \
-  llmq/clsig.cpp \
-  llmq/commitment.cpp \
-  llmq/context.cpp \
-  llmq/debug.cpp \
-  llmq/dkgsession.cpp \
-  llmq/dkgsessionhandler.cpp \
-  llmq/dkgsessionmgr.cpp \
-  llmq/ehf_signals.cpp \
-  llmq/options.cpp \
-  llmq/quorums.cpp \
-  llmq/signing.cpp \
   llmq/signing_shares.cpp \
   llmq/snapshot.cpp \
   llmq/utils.cpp \
@@ -531,6 +514,7 @@ libbitcoin_node_a_SOURCES = \
   node/coinstats.cpp \
   node/connection_types.cpp \
   node/context.cpp \
+  node/disconnected_transactions.cpp \
   node/eviction.cpp \
   node/interfaces.cpp \
   node/miner.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -107,6 +107,7 @@ BITCOIN_TESTS =\
   test/denialofservice_tests.cpp \
   test/dip0020opcodes_tests.cpp \
   test/descriptor_tests.cpp \
+  test/disconnected_transactions.cpp \
   test/dynamic_activation_thresholds_tests.cpp \
   test/evo_assetlocks_tests.cpp \
   test/evo_deterministicmns_tests.cpp \

--- a/src/bench/disconnected_transactions.cpp
+++ b/src/bench/disconnected_transactions.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <kernel/disconnected_transactions.h>
+#include <primitives/block.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+
+constexpr size_t BLOCK_VTX_COUNT{4000};
+constexpr size_t BLOCK_VTX_COUNT_10PERCENT{400};
+
+using BlockTxns = decltype(CBlock::vtx);
+
+/** Reorg where 1 block is disconnected and 2 blocks are connected. */
+struct ReorgTxns {
+    /** Disconnected block. */
+    BlockTxns disconnected_txns;
+    /** First connected block. */
+    BlockTxns connected_txns_1;
+    /** Second connected block, new chain tip. Has no overlap with disconnected_txns. */
+    BlockTxns connected_txns_2;
+    /** Transactions shared between disconnected_txns and connected_txns_1. */
+    size_t num_shared;
+};
+
+static BlockTxns CreateRandomTransactions(size_t num_txns)
+{
+    // Ensure every transaction has a different txid by having each one spend the previous one.
+    static uint256 prevout_hash{uint256::ZERO};
+
+    BlockTxns txns;
+    txns.reserve(num_txns);
+    // Simplest spk for every tx
+    CScript spk = CScript() << OP_TRUE;
+    for (uint32_t i = 0; i < num_txns; ++i) {
+        CMutableTransaction tx;
+        tx.vin.emplace_back(COutPoint{prevout_hash, 0});
+        tx.vout.emplace_back(CENT, spk);
+        auto ptx{MakeTransactionRef(tx)};
+        txns.emplace_back(ptx);
+        prevout_hash = ptx->GetHash();
+    }
+    return txns;
+}
+
+/** Creates blocks for a Reorg, each with BLOCK_VTX_COUNT transactions. Between the disconnected
+ * block and the first connected block, there will be num_not_shared transactions that are
+ * different, and all other transactions the exact same. The second connected block has all unique
+ * transactions. This is to simulate a reorg in which all but num_not_shared transactions are
+ * confirmed in the new chain. */
+static ReorgTxns CreateBlocks(size_t num_not_shared)
+{
+    auto num_shared{BLOCK_VTX_COUNT - num_not_shared};
+    const auto shared_txns{CreateRandomTransactions(/*num_txns=*/num_shared)};
+
+    // Create different sets of transactions...
+    auto disconnected_block_txns{CreateRandomTransactions(/*num_txns=*/num_not_shared)};
+    std::copy(shared_txns.begin(), shared_txns.end(), std::back_inserter(disconnected_block_txns));
+
+    auto connected_block_txns{CreateRandomTransactions(/*num_txns=*/num_not_shared)};
+    std::copy(shared_txns.begin(), shared_txns.end(), std::back_inserter(connected_block_txns));
+
+    assert(disconnected_block_txns.size() == BLOCK_VTX_COUNT);
+    assert(connected_block_txns.size() == BLOCK_VTX_COUNT);
+
+    return ReorgTxns{/*disconnected_txns=*/disconnected_block_txns,
+                     /*connected_txns_1=*/connected_block_txns,
+                     /*connected_txns_2=*/CreateRandomTransactions(BLOCK_VTX_COUNT),
+                     /*num_shared=*/num_shared};
+}
+
+static void Reorg(const ReorgTxns& reorg)
+{
+    DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
+    // Disconnect block
+    const auto evicted = disconnectpool.AddTransactionsFromBlock(reorg.disconnected_txns);
+    assert(evicted.empty());
+
+    // Connect first block
+    disconnectpool.removeForBlock(reorg.connected_txns_1);
+    // Connect new tip
+    disconnectpool.removeForBlock(reorg.connected_txns_2);
+
+    // Sanity Check
+    assert(disconnectpool.size() == BLOCK_VTX_COUNT - reorg.num_shared);
+
+    disconnectpool.clear();
+}
+
+/** Add transactions from DisconnectedBlockTransactions, remove all but one (the disconnected
+ * block's coinbase transaction) of them, and then pop from the front until empty. This is a reorg
+ * in which all of the non-coinbase transactions in the disconnected chain also exist in the new
+ * chain. */
+static void AddAndRemoveDisconnectedBlockTransactionsAll(benchmark::Bench& bench)
+{
+    const auto chains{CreateBlocks(/*num_not_shared=*/1)};
+    assert(chains.num_shared == BLOCK_VTX_COUNT - 1);
+
+    bench.minEpochIterations(10).run([&]() {
+        Reorg(chains);
+    });
+}
+
+/** Add transactions from DisconnectedBlockTransactions, remove 90% of them, and then pop from the front until empty. */
+static void AddAndRemoveDisconnectedBlockTransactions90(benchmark::Bench& bench)
+{
+    const auto chains{CreateBlocks(/*num_not_shared=*/BLOCK_VTX_COUNT_10PERCENT)};
+    assert(chains.num_shared == BLOCK_VTX_COUNT - BLOCK_VTX_COUNT_10PERCENT);
+
+    bench.minEpochIterations(10).run([&]() {
+        Reorg(chains);
+    });
+}
+
+/** Add transactions from DisconnectedBlockTransactions, remove 10% of them, and then pop from the front until empty. */
+static void AddAndRemoveDisconnectedBlockTransactions10(benchmark::Bench& bench)
+{
+    const auto chains{CreateBlocks(/*num_not_shared=*/BLOCK_VTX_COUNT - BLOCK_VTX_COUNT_10PERCENT)};
+    assert(chains.num_shared == BLOCK_VTX_COUNT_10PERCENT);
+
+    bench.minEpochIterations(10).run([&]() {
+        Reorg(chains);
+    });
+}
+
+BENCHMARK(AddAndRemoveDisconnectedBlockTransactionsAll, benchmark::PriorityLevel::HIGH);
+BENCHMARK(AddAndRemoveDisconnectedBlockTransactions90, benchmark::PriorityLevel::HIGH);
+BENCHMARK(AddAndRemoveDisconnectedBlockTransactions10, benchmark::PriorityLevel::HIGH);

--- a/src/bench/disconnected_transactions.cpp
+++ b/src/bench/disconnected_transactions.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <kernel/disconnected_transactions.h>
+#include <node/disconnected_transactions.h>
 #include <primitives/block.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>

--- a/src/node/disconnected_transactions.cpp
+++ b/src/node/disconnected_transactions.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/disconnected_transactions.h>
+
+#include <assert.h>
+#include <core_memusage.h>
+#include <memusage.h>
+#include <primitives/transaction.h>
+#include <util/hasher.h>
+
+#include <memory>
+#include <utility>
+
+// It's almost certainly a logic bug if we don't clear out queuedTx before
+// destruction, as we add to it while disconnecting blocks, and then we
+// need to re-process remaining transactions to ensure mempool consistency.
+// For now, assert() that we've emptied out this object on destruction.
+// This assert() can always be removed if the reorg-processing code were
+// to be refactored such that this assumption is no longer true (for
+// instance if there was some other way we cleaned up the mempool after a
+// reorg, besides draining this object).
+DisconnectedBlockTransactions::~DisconnectedBlockTransactions()
+{
+    assert(queuedTx.empty());
+    assert(iters_by_txid.empty());
+    assert(cachedInnerUsage == 0);
+}
+
+std::vector<CTransactionRef> DisconnectedBlockTransactions::LimitMemoryUsage()
+{
+    std::vector<CTransactionRef> evicted;
+
+    while (!queuedTx.empty() && DynamicMemoryUsage() > m_max_mem_usage) {
+        evicted.emplace_back(queuedTx.front());
+        cachedInnerUsage -= RecursiveDynamicUsage(queuedTx.front());
+        iters_by_txid.erase(queuedTx.front()->GetHash());
+        queuedTx.pop_front();
+    }
+    return evicted;
+}
+
+size_t DisconnectedBlockTransactions::DynamicMemoryUsage() const
+{
+    return cachedInnerUsage + memusage::DynamicUsage(iters_by_txid) + memusage::DynamicUsage(queuedTx);
+}
+
+[[nodiscard]] std::vector<CTransactionRef> DisconnectedBlockTransactions::AddTransactionsFromBlock(const std::vector<CTransactionRef>& vtx)
+{
+    iters_by_txid.reserve(iters_by_txid.size() + vtx.size());
+    for (auto block_it = vtx.rbegin(); block_it != vtx.rend(); ++block_it) {
+        auto it = queuedTx.insert(queuedTx.end(), *block_it);
+        auto [_, inserted] = iters_by_txid.emplace((*block_it)->GetHash(), it);
+        assert(inserted); // callers may never pass multiple transactions with the same txid
+        cachedInnerUsage += RecursiveDynamicUsage(*block_it);
+    }
+    return LimitMemoryUsage();
+}
+
+void DisconnectedBlockTransactions::removeForBlock(const std::vector<CTransactionRef>& vtx)
+{
+    // Short-circuit in the common case of a block being added to the tip
+    if (queuedTx.empty()) {
+        return;
+    }
+    for (const auto& tx : vtx) {
+        auto iter = iters_by_txid.find(tx->GetHash());
+        if (iter != iters_by_txid.end()) {
+            auto list_iter = iter->second;
+            iters_by_txid.erase(iter);
+            cachedInnerUsage -= RecursiveDynamicUsage(*list_iter);
+            queuedTx.erase(list_iter);
+        }
+    }
+}
+
+void DisconnectedBlockTransactions::clear()
+{
+    cachedInnerUsage = 0;
+    iters_by_txid.clear();
+    queuedTx.clear();
+}
+
+std::list<CTransactionRef> DisconnectedBlockTransactions::take()
+{
+    std::list<CTransactionRef> ret = std::move(queuedTx);
+    clear();
+    return ret;
+}

--- a/src/node/disconnected_transactions.h
+++ b/src/node/disconnected_transactions.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
+#define BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
+
+#include <primitives/transaction.h>
+#include <util/hasher.h>
+
+#include <list>
+#include <unordered_map>
+#include <vector>
+
+/** Maximum bytes for transactions to store for processing during reorg */
+static const unsigned int MAX_DISCONNECTED_TX_POOL_BYTES{20'000'000};
+/**
+ * DisconnectedBlockTransactions
+
+ * During the reorg, it's desirable to re-add previously confirmed transactions
+ * to the mempool, so that anything not re-confirmed in the new chain is
+ * available to be mined. However, it's more efficient to wait until the reorg
+ * is complete and process all still-unconfirmed transactions at that time,
+ * since we expect most confirmed transactions to (typically) still be
+ * confirmed in the new chain, and re-accepting to the memory pool is expensive
+ * (and therefore better to not do in the middle of reorg-processing).
+ * Instead, store the disconnected transactions (in order!) as we go, remove any
+ * that are included in blocks in the new chain, and then process the remaining
+ * still-unconfirmed transactions at the end.
+ *
+ * Order of queuedTx:
+ * The front of the list should be the most recently-confirmed transactions (transactions at the
+ * end of vtx of blocks closer to the tip). If memory usage grows too large, we trim from the front
+ * of the list. After trimming, transactions can be re-added to the mempool from the back of the
+ * list to the front without running into missing inputs.
+ */
+class DisconnectedBlockTransactions {
+private:
+    /** Cached dynamic memory usage for the `CTransactionRef`s */
+    uint64_t cachedInnerUsage = 0;
+    const size_t m_max_mem_usage;
+    std::list<CTransactionRef> queuedTx;
+    using TxList = decltype(queuedTx);
+    std::unordered_map<uint256, TxList::iterator, SaltedTxidHasher> iters_by_txid;
+
+    /** Trim the earliest-added entries until we are within memory bounds. */
+    std::vector<CTransactionRef> LimitMemoryUsage();
+
+public:
+    DisconnectedBlockTransactions(size_t max_mem_usage)
+        : m_max_mem_usage{max_mem_usage} {}
+
+    ~DisconnectedBlockTransactions();
+
+    size_t DynamicMemoryUsage() const;
+
+    /** Add transactions from the block, iterating through vtx in reverse order. Callers should call
+     * this function for blocks in descending order by block height.
+     * We assume that callers never pass multiple transactions with the same txid, otherwise things
+     * can go very wrong in removeForBlock due to queuedTx containing an item without a
+     * corresponding entry in iters_by_txid.
+     * @returns vector of transactions that were evicted for size-limiting.
+     */
+    [[nodiscard]] std::vector<CTransactionRef> AddTransactionsFromBlock(const std::vector<CTransactionRef>& vtx);
+
+    /** Remove any entries that are in this block. */
+    void removeForBlock(const std::vector<CTransactionRef>& vtx);
+
+    size_t size() const { return queuedTx.size(); }
+
+    void clear();
+
+    /** Clear all data structures and return the list of transactions. */
+    std::list<CTransactionRef> take();
+};
+#endif // BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H

--- a/src/node/disconnected_transactions.h
+++ b/src/node/disconnected_transactions.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
-#define BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
+#ifndef BITCOIN_NODE_DISCONNECTED_TRANSACTIONS_H
+#define BITCOIN_NODE_DISCONNECTED_TRANSACTIONS_H
 
 #include <primitives/transaction.h>
 #include <util/hasher.h>
@@ -73,4 +73,4 @@ public:
     /** Clear all data structures and return the list of transactions. */
     std::list<CTransactionRef> take();
 };
-#endif // BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
+#endif // BITCOIN_NODE_DISCONNECTED_TRANSACTIONS_H

--- a/src/test/disconnected_transactions.cpp
+++ b/src/test/disconnected_transactions.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+#include <boost/test/unit_test.hpp>
+#include <core_memusage.h>
+#include <kernel/disconnected_transactions.h>
+#include <test/util/setup_common.h>
+
+BOOST_FIXTURE_TEST_SUITE(disconnected_transactions, TestChain100Setup)
+
+//! Tests that DisconnectedBlockTransactions limits its own memory properly
+BOOST_AUTO_TEST_CASE(disconnectpool_memory_limits)
+{
+    // Use the coinbase transactions from TestChain100Setup. It doesn't matter whether these
+    // transactions would realistically be in a block together, they just need distinct txids and
+    // uniform size for this test to work.
+    std::vector<CTransactionRef> block_vtx(m_coinbase_txns);
+    BOOST_CHECK_EQUAL(block_vtx.size(), 100);
+
+    // Roughly estimate sizes to sanity check that DisconnectedBlockTransactions::DynamicMemoryUsage
+    // is within an expected range.
+
+    // Overhead for the hashmap depends on number of buckets
+    std::unordered_map<uint256, CTransaction*, SaltedTxidHasher> temp_map;
+    temp_map.reserve(1);
+    const size_t MAP_1{memusage::DynamicUsage(temp_map)};
+    temp_map.reserve(100);
+    const size_t MAP_100{memusage::DynamicUsage(temp_map)};
+
+    const size_t TX_USAGE{RecursiveDynamicUsage(block_vtx.front())};
+    for (const auto& tx : block_vtx)
+        BOOST_CHECK_EQUAL(RecursiveDynamicUsage(tx), TX_USAGE);
+
+    // Our overall formula is unordered map overhead + usage per entry.
+    // Implementations may vary, but we're trying to guess the usage of data structures.
+    const size_t ENTRY_USAGE_ESTIMATE{
+        TX_USAGE
+        // list entry: 2 pointers (next pointer and prev pointer) + element itself
+        + memusage::MallocUsage((2 * sizeof(void*)) + sizeof(decltype(block_vtx)::value_type))
+        // unordered map: 1 pointer for the hashtable + key and value
+        + memusage::MallocUsage(sizeof(void*) + sizeof(decltype(temp_map)::key_type)
+                                + sizeof(decltype(temp_map)::value_type))};
+
+    // DisconnectedBlockTransactions that's just big enough for 1 transaction.
+    {
+        DisconnectedBlockTransactions disconnectpool{MAP_1 + ENTRY_USAGE_ESTIMATE};
+        // Add just 2 (and not all 100) transactions to keep the unordered map's hashtable overhead
+        // to a minimum and avoid all (instead of all but 1) transactions getting evicted.
+        std::vector<CTransactionRef> two_txns({block_vtx.at(0), block_vtx.at(1)});
+        auto evicted_txns{disconnectpool.AddTransactionsFromBlock(two_txns)};
+        BOOST_CHECK(disconnectpool.DynamicMemoryUsage() <= MAP_1 + ENTRY_USAGE_ESTIMATE);
+
+        // Only 1 transaction can be kept
+        BOOST_CHECK_EQUAL(1, evicted_txns.size());
+        // Transactions are added from back to front and eviction is FIFO.
+        BOOST_CHECK_EQUAL(block_vtx.at(1), evicted_txns.front());
+
+        disconnectpool.clear();
+    }
+
+    // DisconnectedBlockTransactions with a comfortable maximum memory usage so that nothing is evicted.
+    // Record usage so we can check size limiting in the next test.
+    size_t usage_full{0};
+    {
+        const size_t USAGE_100_OVERESTIMATE{MAP_100 + ENTRY_USAGE_ESTIMATE * 100};
+        DisconnectedBlockTransactions disconnectpool{USAGE_100_OVERESTIMATE};
+        auto evicted_txns{disconnectpool.AddTransactionsFromBlock(block_vtx)};
+        BOOST_CHECK_EQUAL(evicted_txns.size(), 0);
+        BOOST_CHECK(disconnectpool.DynamicMemoryUsage() <= USAGE_100_OVERESTIMATE);
+
+        usage_full = disconnectpool.DynamicMemoryUsage();
+
+        disconnectpool.clear();
+    }
+
+    // DisconnectedBlockTransactions that's just a little too small for all of the transactions.
+    {
+        const size_t MAX_MEMUSAGE_99{usage_full - sizeof(void*)};
+        DisconnectedBlockTransactions disconnectpool{MAX_MEMUSAGE_99};
+        auto evicted_txns{disconnectpool.AddTransactionsFromBlock(block_vtx)};
+        BOOST_CHECK(disconnectpool.DynamicMemoryUsage() <= MAX_MEMUSAGE_99);
+
+        // Only 1 transaction needed to be evicted
+        BOOST_CHECK_EQUAL(1, evicted_txns.size());
+
+        // Transactions are added from back to front and eviction is FIFO.
+        // The last transaction of block_vtx should be the first to be evicted.
+        BOOST_CHECK_EQUAL(block_vtx.back(), evicted_txns.front());
+
+        disconnectpool.clear();
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/disconnected_transactions.cpp
+++ b/src/test/disconnected_transactions.cpp
@@ -4,7 +4,7 @@
 //
 #include <boost/test/unit_test.hpp>
 #include <core_memusage.h>
-#include <kernel/disconnected_transactions.h>
+#include <node/disconnected_transactions.h>
 #include <test/util/setup_common.h>
 
 BOOST_FIXTURE_TEST_SUITE(disconnected_transactions, TestChain100Setup)

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -415,4 +415,225 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_loadblockindex, TestChain100Setup)
     BOOST_CHECK_EQUAL(cs2.setBlockIndexCandidates.size(), num_indexes);
 }
 
+//! Ensure that snapshot chainstates initialize properly when found on disk.
+BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_init, SnapshotTestSetup)
+{
+    ChainstateManager& chainman = *Assert(m_node.chainman);
+    Chainstate& bg_chainstate = chainman.ActiveChainstate();
+
+    this->SetupSnapshot();
+
+    fs::path snapshot_chainstate_dir = *node::FindSnapshotChainstateDir(chainman.m_options.datadir);
+    BOOST_CHECK(fs::exists(snapshot_chainstate_dir));
+    BOOST_CHECK_EQUAL(snapshot_chainstate_dir, gArgs.GetDataDirNet() / "chainstate_snapshot");
+
+    BOOST_CHECK(chainman.IsSnapshotActive());
+    const uint256 snapshot_tip_hash = WITH_LOCK(chainman.GetMutex(),
+        return chainman.ActiveTip()->GetBlockHash());
+
+    auto all_chainstates = chainman.GetAll();
+    BOOST_CHECK_EQUAL(all_chainstates.size(), 2);
+
+    // "Rewind" the background chainstate so that its tip is not at the
+    // base block of the snapshot - this is so after simulating a node restart,
+    // it will initialize instead of attempting to complete validation.
+    //
+    // Note that this is not a realistic use of DisconnectTip().
+    DisconnectedBlockTransactions unused_pool{MAX_DISCONNECTED_TX_POOL_BYTES};
+    BlockValidationState unused_state;
+    {
+        LOCK2(::cs_main, bg_chainstate.MempoolMutex());
+        BOOST_CHECK(bg_chainstate.DisconnectTip(unused_state, &unused_pool));
+        unused_pool.clear();  // to avoid queuedTx assertion errors on teardown
+    }
+    BOOST_CHECK_EQUAL(bg_chainstate.m_chain.Height(), 109);
+
+    // Test that simulating a shutdown (resetting ChainstateManager) and then performing
+    // chainstate reinitializing successfully cleans up the background-validation
+    // chainstate data, and we end up with a single chainstate that is at tip.
+    ChainstateManager& chainman_restarted = this->SimulateNodeRestart();
+
+    BOOST_TEST_MESSAGE("Performing Load/Verify/Activate of chainstate");
+
+    // This call reinitializes the chainstates.
+    this->LoadVerifyActivateChainstate();
+
+    {
+        LOCK(chainman_restarted.GetMutex());
+        BOOST_CHECK_EQUAL(chainman_restarted.GetAll().size(), 2);
+        BOOST_CHECK(chainman_restarted.IsSnapshotActive());
+        BOOST_CHECK(!chainman_restarted.IsSnapshotValidated());
+
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveTip()->GetBlockHash(), snapshot_tip_hash);
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 210);
+    }
+
+    BOOST_TEST_MESSAGE(
+        "Ensure we can mine blocks on top of the initialized snapshot chainstate");
+    mineBlocks(10);
+    {
+        LOCK(chainman_restarted.GetMutex());
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 220);
+
+        // Background chainstate should be unaware of new blocks on the snapshot
+        // chainstate.
+        for (Chainstate* cs : chainman_restarted.GetAll()) {
+            if (cs != &chainman_restarted.ActiveChainstate()) {
+                BOOST_CHECK_EQUAL(cs->m_chain.Height(), 109);
+            }
+        }
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup)
+{
+    this->SetupSnapshot();
+
+    ChainstateManager& chainman = *Assert(m_node.chainman);
+    Chainstate& active_cs = chainman.ActiveChainstate();
+    auto tip_cache_before_complete = active_cs.m_coinstip_cache_size_bytes;
+    auto db_cache_before_complete = active_cs.m_coinsdb_cache_size_bytes;
+
+    SnapshotCompletionResult res;
+    m_node.notifications->m_shutdown_on_fatal_error = false;
+
+    fs::path snapshot_chainstate_dir = *node::FindSnapshotChainstateDir(chainman.m_options.datadir);
+    BOOST_CHECK(fs::exists(snapshot_chainstate_dir));
+    BOOST_CHECK_EQUAL(snapshot_chainstate_dir, gArgs.GetDataDirNet() / "chainstate_snapshot");
+
+    BOOST_CHECK(chainman.IsSnapshotActive());
+    const uint256 snapshot_tip_hash = WITH_LOCK(chainman.GetMutex(),
+        return chainman.ActiveTip()->GetBlockHash());
+
+    res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
+    BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SUCCESS);
+
+    WITH_LOCK(::cs_main, BOOST_CHECK(chainman.IsSnapshotValidated()));
+    BOOST_CHECK(chainman.IsSnapshotActive());
+
+    // Cache should have been rebalanced and reallocated to the "only" remaining
+    // chainstate.
+    BOOST_CHECK(active_cs.m_coinstip_cache_size_bytes > tip_cache_before_complete);
+    BOOST_CHECK(active_cs.m_coinsdb_cache_size_bytes > db_cache_before_complete);
+
+    auto all_chainstates = chainman.GetAll();
+    BOOST_CHECK_EQUAL(all_chainstates.size(), 1);
+    BOOST_CHECK_EQUAL(all_chainstates[0], &active_cs);
+
+    // Trying completion again should return false.
+    res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
+    BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::SKIPPED);
+
+    // The invalid snapshot path should not have been used.
+    fs::path snapshot_invalid_dir = gArgs.GetDataDirNet() / "chainstate_snapshot_INVALID";
+    BOOST_CHECK(!fs::exists(snapshot_invalid_dir));
+    // chainstate_snapshot should still exist.
+    BOOST_CHECK(fs::exists(snapshot_chainstate_dir));
+
+    // Test that simulating a shutdown (resetting ChainstateManager) and then performing
+    // chainstate reinitializing successfully cleans up the background-validation
+    // chainstate data, and we end up with a single chainstate that is at tip.
+    ChainstateManager& chainman_restarted = this->SimulateNodeRestart();
+
+    BOOST_TEST_MESSAGE("Performing Load/Verify/Activate of chainstate");
+
+    // This call reinitializes the chainstates, and should clean up the now unnecessary
+    // background-validation leveldb contents.
+    this->LoadVerifyActivateChainstate();
+
+    BOOST_CHECK(!fs::exists(snapshot_invalid_dir));
+    // chainstate_snapshot should now *not* exist.
+    BOOST_CHECK(!fs::exists(snapshot_chainstate_dir));
+
+    const Chainstate& active_cs2 = chainman_restarted.ActiveChainstate();
+
+    {
+        LOCK(chainman_restarted.GetMutex());
+        BOOST_CHECK_EQUAL(chainman_restarted.GetAll().size(), 1);
+        BOOST_CHECK(!chainman_restarted.IsSnapshotActive());
+        BOOST_CHECK(!chainman_restarted.IsSnapshotValidated());
+        BOOST_CHECK(active_cs2.m_coinstip_cache_size_bytes > tip_cache_before_complete);
+        BOOST_CHECK(active_cs2.m_coinsdb_cache_size_bytes > db_cache_before_complete);
+
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveTip()->GetBlockHash(), snapshot_tip_hash);
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 210);
+    }
+
+    BOOST_TEST_MESSAGE(
+        "Ensure we can mine blocks on top of the \"new\" IBD chainstate");
+    mineBlocks(10);
+    {
+        LOCK(chainman_restarted.GetMutex());
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 220);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion_hash_mismatch, SnapshotTestSetup)
+{
+    auto chainstates = this->SetupSnapshot();
+    Chainstate& validation_chainstate = *std::get<0>(chainstates);
+    ChainstateManager& chainman = *Assert(m_node.chainman);
+    SnapshotCompletionResult res;
+    m_node.notifications->m_shutdown_on_fatal_error = false;
+
+    // Test tampering with the IBD UTXO set with an extra coin to ensure it causes
+    // snapshot completion to fail.
+    CCoinsViewCache& ibd_coins = WITH_LOCK(::cs_main,
+        return validation_chainstate.CoinsTip());
+    Coin badcoin;
+    badcoin.out.nValue = InsecureRand32();
+    badcoin.nHeight = 1;
+    badcoin.out.scriptPubKey.assign(InsecureRandBits(6), 0);
+    uint256 txid = InsecureRand256();
+    ibd_coins.AddCoin(COutPoint(txid, 0), std::move(badcoin), false);
+
+    fs::path snapshot_chainstate_dir = gArgs.GetDataDirNet() / "chainstate_snapshot";
+    BOOST_CHECK(fs::exists(snapshot_chainstate_dir));
+
+    {
+        ASSERT_DEBUG_LOG("failed to validate the -assumeutxo snapshot state");
+        res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
+        BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::HASH_MISMATCH);
+    }
+
+    auto all_chainstates = chainman.GetAll();
+    BOOST_CHECK_EQUAL(all_chainstates.size(), 1);
+    BOOST_CHECK_EQUAL(all_chainstates[0], &validation_chainstate);
+    BOOST_CHECK_EQUAL(&chainman.ActiveChainstate(), &validation_chainstate);
+
+    fs::path snapshot_invalid_dir = gArgs.GetDataDirNet() / "chainstate_snapshot_INVALID";
+    BOOST_CHECK(fs::exists(snapshot_invalid_dir));
+
+    // Test that simulating a shutdown (resetting ChainstateManager) and then performing
+    // chainstate reinitializing successfully loads only the fully-validated
+    // chainstate data, and we end up with a single chainstate that is at tip.
+    ChainstateManager& chainman_restarted = this->SimulateNodeRestart();
+
+    BOOST_TEST_MESSAGE("Performing Load/Verify/Activate of chainstate");
+
+    // This call reinitializes the chainstates, and should clean up the now unnecessary
+    // background-validation leveldb contents.
+    this->LoadVerifyActivateChainstate();
+
+    BOOST_CHECK(fs::exists(snapshot_invalid_dir));
+    BOOST_CHECK(!fs::exists(snapshot_chainstate_dir));
+
+    {
+        LOCK(::cs_main);
+        BOOST_CHECK_EQUAL(chainman_restarted.GetAll().size(), 1);
+        BOOST_CHECK(!chainman_restarted.IsSnapshotActive());
+        BOOST_CHECK(!chainman_restarted.IsSnapshotValidated());
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 210);
+    }
+
+    BOOST_TEST_MESSAGE(
+        "Ensure we can mine blocks on top of the \"new\" IBD chainstate");
+    mineBlocks(10);
+    {
+        LOCK(::cs_main);
+        BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 220);
+    }
+>>>>>>> 023418a140 (Merge bitcoin/bitcoin#28530: tests, bug fix: DisconnectedBlockTransactions rewrite followups)
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3257,7 +3257,7 @@ bool CChainState::ActivateBestChainStep(BlockValidationState& state, CBlockIndex
 
     // Disconnect active blocks which are no longer in the best chain.
     bool fBlocksDisconnected = false;
-    DisconnectedBlockTransactions disconnectpool;
+    DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
     while (m_chain.Tip() && m_chain.Tip() != pindexFork) {
         if (!DisconnectTip(state, &disconnectpool)) {
             // This is likely a fatal error, but keep the mempool consistent,
@@ -3578,7 +3578,7 @@ bool CChainState::InvalidateBlock(BlockValidationState& state, CBlockIndex* pind
 
         // ActivateBestChain considers blocks already in m_chain
         // unconditionally valid already, so force disconnect away from it.
-        DisconnectedBlockTransactions disconnectpool;
+        DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
         bool ret = DisconnectTip(state, &disconnectpool);
         // DisconnectTip will add transactions to disconnectpool.
         // Adjust the mempool to be consistent with the new tip, adding


### PR DESCRIPTION
Backports bitcoin/bitcoin#28530

Original commit: 023418a140

This PR is a follow-up to fix review comments and a bugfix from bitcoin#28385

The PR
- Updated `DisconnectedBlockTransactions`'s `MAX_DISCONNECTED_TX_POOL` from kb to bytes.
- Moved `DisconnectedBlockTransactions` implementation code to `kernel/disconnected_transactions.cpp`.
- `AddTransactionsFromBlock` now assume duplicate transactions are not passed by asserting after inserting each transaction to `iters_by_txid`.
- Included a Bug fix: In the current master we are underestimating the memory usage of `DisconnectedBlockTransactions`.

Note: In Dash, the DisconnectedBlockTransactions files are located in src/node/ instead of src/kernel/

Backported from Bitcoin Core v0.27