### PR TITLE
Merge bitcoin/bitcoin#28814: test: symbolizer improvements

### DIFF
--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -15,4 +15,6 @@ export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export GOAL="install"
+export CI_CONTAINER_CAP="--cap-add SYS_PTRACE"  # If run with (ASan + LSan), the container needs access to ptrace (https://github.com/google/sanitizers/issues/764)
 export BITCOIN_CONFIG="--enable-zmq --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address,undefined,integer CC='clang-18 -ftrivial-auto-var-init=pattern' CXX='clang++-18 -ftrivial-auto-var-init=pattern' --with-boost-process"
+export LLVM_SYMBOLIZER_PATH="/usr/bin/llvm-symbolizer-18"

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -17,11 +17,14 @@ import sys
 
 
 def get_fuzz_env(*, target, source_dir):
+    symbolizer = os.environ.get('LLVM_SYMBOLIZER_PATH', "/usr/bin/llvm-symbolizer")
     return {
         'FUZZ': target,
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
+        'UBSAN_SYMBOLIZER_PATH':symbolizer,
         "ASAN_OPTIONS": "detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
+        'ASAN_SYMBOLIZER_PATH':symbolizer,
     }
 
 

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -22,9 +22,9 @@ def get_fuzz_env(*, target, source_dir):
         'FUZZ': target,
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
-        'UBSAN_SYMBOLIZER_PATH':symbolizer,
+        'UBSAN_SYMBOLIZER_PATH': symbolizer,
         "ASAN_OPTIONS": "detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
-        'ASAN_SYMBOLIZER_PATH':symbolizer,
+        'ASAN_SYMBOLIZER_PATH': symbolizer,
     }
 
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28814

Original commit: b5d8f001a8

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment configuration for fuzz testing by setting container capabilities and specifying symbolizer paths for sanitizer tools. This enhances the accuracy and reliability of sanitizer output during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->