### PR TITLE
Merge bitcoin/bitcoin#28136: refactor: move GetServicesNames from rpc/util.{h,cpp} to rpc/net.cpp

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -7,6 +7,8 @@
 #include <chainparams.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
+#include <logging.h>
+#include <netaddress.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <util/strencodings.h>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -29,6 +29,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <util/check.h>
+#include <util/strencodings.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -14,6 +14,10 @@
 #include <rpc/util.h>
 #include <txmempool.h>
 #include <univalue.h>
+#include <util/fs.h>
+#include <util/moneystr.h>
+#include <util/strencodings.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <instantsend/instantsend.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -16,6 +16,7 @@
 #include <netbase.h>
 #include <node/context.h>
 #include <policy/settings.h>
+#include <protocol.h>
 #include <rpc/blockchain.h>
 #include <rpc/protocol.h>
 #include <rpc/server_util.h>
@@ -93,6 +94,18 @@ static RPCHelpMan ping()
     return NullUniValue;
 },
     };
+}
+
+/** Returns, given services flags, a list of humanly readable (known) network services */
+static UniValue GetServicesNames(ServiceFlags services)
+{
+    UniValue servicesNames(UniValue::VARR);
+
+    for (const auto& flag : serviceFlagsToStr(services)) {
+        servicesNames.push_back(flag);
+    }
+
+    return servicesNames;
 }
 
 static RPCHelpMan getpeerinfo()

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1029,26 +1029,3 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
     }
     return ret;
 }
-
-/** Convert a vector of bilingual strings to a UniValue::VARR containing their original untranslated values. */
-[[nodiscard]] static UniValue BilingualStringsToUniValue(const std::vector<bilingual_str>& bilingual_strings)
-{
-    CHECK_NONFATAL(!bilingual_strings.empty());
-    UniValue result{UniValue::VARR};
-    for (const auto& s : bilingual_strings) {
-        result.push_back(s.original);
-    }
-    return result;
-}
-
-void PushWarnings(const UniValue& warnings, UniValue& obj)
-{
-    if (warnings.empty()) return;
-    obj.pushKV("warnings", warnings);
-}
-
-void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj)
-{
-    if (warnings.empty()) return;
-    obj.pushKV("warnings", BilingualStringsToUniValue(warnings));
-}

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -991,16 +991,6 @@ UniValue JSONRPCTransactionError(TransactionError terr, const std::string& err_s
     }
 }
 
-UniValue GetServicesNames(ServiceFlags services)
-{
-    UniValue servicesNames(UniValue::VARR);
-
-    for (const auto& flag : serviceFlagsToStr(services)) {
-        servicesNames.push_back(flag);
-    }
-
-    return servicesNames;
-}
 
 std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, FlatSigningProvider& provider)
 {
@@ -1038,4 +1028,27 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
         std::move(scripts.begin(), scripts.end(), std::back_inserter(ret));
     }
     return ret;
+}
+
+/** Convert a vector of bilingual strings to a UniValue::VARR containing their original untranslated values. */
+[[nodiscard]] static UniValue BilingualStringsToUniValue(const std::vector<bilingual_str>& bilingual_strings)
+{
+    CHECK_NONFATAL(!bilingual_strings.empty());
+    UniValue result{UniValue::VARR};
+    for (const auto& s : bilingual_strings) {
+        result.push_back(s.original);
+    }
+    return result;
+}
+
+void PushWarnings(const UniValue& warnings, UniValue& obj)
+{
+    if (warnings.empty()) return;
+    obj.pushKV("warnings", warnings);
+}
+
+void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj)
+{
+    if (warnings.empty()) return;
+    obj.pushKV("warnings", BilingualStringsToUniValue(warnings));
 }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -382,8 +382,6 @@ private:
     const RPCExamples m_examples;
 };
 
-void PushWarnings(const UniValue& warnings, UniValue& obj);
-void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj);
 RPCErrorCode RPCErrorFromTransactionError(TransactionError terr);
 UniValue JSONRPCTransactionError(TransactionError terr, const std::string& err_string = "");
 

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -7,7 +7,11 @@
 
 #include <node/coinstats.h>
 #include <node/transaction.h>
-#include <protocol.h>
+
+
+
+#include <outputtype.h>
+
 #include <pubkey.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
@@ -36,8 +40,6 @@ extern const std::string UNIX_EPOCH_TIME;
 extern const std::string EXAMPLE_ADDRESS[2];
 
 class FillableSigningProvider;
-class FillableSigningProvider;
-class CPubKey;
 class CScript;
 struct Sections;
 
@@ -116,10 +118,12 @@ UniValue DescribeAddress(const CTxDestination& dest);
 unsigned int ParseConfirmTarget(const UniValue& value, unsigned int max_target);
 
 /** Returns, given services flags, a list of humanly readable (known) network services */
-UniValue GetServicesNames(ServiceFlags services);
 
 //! Parse a JSON range specified as int64, or [int64, int64]
 std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value);
+
+/** Evaluate a descriptor given as a string, or as a {"desc":...,"range":...} object, with default range of 1000. */
+std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, FlatSigningProvider& provider, const bool expand_priv = false);
 
 /**
  * Serializing JSON objects depends on the outer type. Only arrays and
@@ -127,7 +131,6 @@ std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value);
  */
 enum class OuterType {
     ARR,
-    OBJ,
     NONE, // Only set on first recursion
 };
 /** Evaluate a descriptor given as a string, or as a {"desc":...,"range":...} object, with default range of 1000. */
@@ -379,6 +382,8 @@ private:
     const RPCExamples m_examples;
 };
 
+void PushWarnings(const UniValue& warnings, UniValue& obj);
+void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj);
 RPCErrorCode RPCErrorFromTransactionError(TransactionError terr);
 UniValue JSONRPCTransactionError(TransactionError terr, const std::string& err_string = "");
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28136

Original commit: e77339632e

This PR moves `GetServicesNames()` from `rpc/util` to `rpc/net.cpp`, as it is only called from that compilation unit and there is no reason for other ones to need it.

Also removes the `protocol.h` include in `rpc/util.h`, as it was only needed for `GetServicesNames()`, and adds missing include headers in other translation units that are needed to compile without `protocol.h` in `rpc/util.h`.

Additionally adds the `PushWarnings` functions that were introduced in a later Bitcoin commit but are needed for compilation.

Backported from Bitcoin Core v0.27