### PR TITLE
Merge bitcoin/bitcoin#28900: doc: remove mingw-w64 install for "older" systems

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -39,16 +39,9 @@ See [dependencies.md](dependencies.md) for a complete overview.
 ## Building for 64-bit Windows
 
 The first step is to install the mingw-w64 cross-compilation tool chain:
-  - on modern systems (Ubuntu 21.04 Hirsute Hippo or newer, Debian 11 Bullseye or newer):
 
 ```sh
 sudo apt install g++-mingw-w64-x86-64-posix
-```
-
-  - on older systems:
-
-```sh
-sudo apt install g++-mingw-w64-x86-64
 ```
 
 Once the toolchain is installed the build steps are common:


### PR DESCRIPTION
Backports bitcoin/bitcoin#28900

Original commit: d752349029

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Windows build instructions by providing a single installation command for the mingw-w64 toolchain, removing outdated alternatives for older systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->