### PR TITLE
Merge bitcoin/bitcoin#28966: test: Add missing CBlockPolicyEstimator::processBlockTx suppression

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -57,6 +57,7 @@ unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h
 implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:bech32.cpp
+implicit-integer-sign-change:CBlockPolicyEstimator::processBlockTx
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/


### PR DESCRIPTION
Backports bitcoin/bitcoin#28966

Original commit: 453c9ca59014b1aef85cb979cfb4fdb15518fc38

Backported from Bitcoin Core v0.27