### PR TITLE
Merge bitcoin/bitcoin#28579: refactor: Remove redundant checks in compat/assumptions.h

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -6,7 +6,11 @@
 #ifndef BITCOIN_SERIALIZE_H
 #define BITCOIN_SERIALIZE_H
 
+#include <attributes.h>
+#include <compat/assumptions.h> // IWYU pragma: keep
 #include <compat/endian.h>
+#include <prevector.h>
+#include <span.h>
 
 #include <algorithm>
 #include <atomic>
@@ -20,16 +24,12 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <string.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <support/allocators/secure.h>
-#include <prevector.h>
-#include <span.h>
-
 /**
  * The maximum size of a serialized object in bytes or number of elements
  * (for eg vectors) when the size is encoded as CompactSize.

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -54,6 +54,7 @@
 
 #else
 
+#include <compat/compat.h>
 #include <codecvt>
 
 #include <io.h> /* for _commit */

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -16,8 +16,6 @@
 #endif
 
 #include <attributes.h>
-#include <compat/assumptions.h>
-#include <compat/compat.h>
 #include <consensus/amount.h>
 #include <fs.h>
 #include <logging.h>


### PR DESCRIPTION
Backports bitcoin/bitcoin#28579

Original commit: 16b5b4b674414c41f34b0d37e15a16521fb08013

Backported from Bitcoin Core v0.27

This PR removes redundant compile-time checks and reorganizes header includes:
- Moves compat.h include from system.h to system.cpp (Windows-specific)
- Removes redundant assumptions.h include from system.h
- Adds assumptions.h to serialize.h where it's actually needed
- Removes duplicate string.h include from serialize.h

Note: In Dash, system files are located in src/util/ instead of src/common/, and some of the checks Bitcoin removed (NDEBUG, __cplusplus) don't exist in our assumptions.h file.