### PR TITLE
Merge bitcoin/bitcoin#28992: ci: Use Ubuntu 24.04 Noble for asan,tsan,tidy,fuzz

### DIFF
--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
 export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
 export NO_DEPENDS=1
 export TEST_RUNNER_EXTRA="--timeout-factor=4"  # Increase timeout because sanitizers slow down

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
 export CONTAINER_NAME=ci_native_fuzz
 export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev"
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
 export CONTAINER_NAME=ci_native_tsan
 export PACKAGES="clang-18 llvm-18 libclang-rt-18-dev libc++abi-18-dev libc++-18-dev python3-zmq"
 export DEP_OPTS="CC=clang-18 CXX='clang++-18 -stdlib=libc++'"


### PR DESCRIPTION
Backports bitcoin/bitcoin#28992

Original commit: d854914043

This PR updates CI test environments from Ubuntu 23.10 to Ubuntu 24.04 Noble for asan, tsan, and fuzz tests.

Note: Dash does not use .cirrus.yml or the tidy test configuration, so those changes were intentionally omitted.

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration to set a new variable for the image tag used in testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->