### PR TITLE
Merge bitcoin/bitcoin#29003: rpc: fix getrawtransaction segfault

### DIFF
--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -27,7 +27,7 @@ std::vector<bool> BytesToBits(const std::vector<unsigned char>& bytes)
     return ret;
 }
 
-CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std::set<uint256>* txids)
+CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std::set<Txid>* txids)
 {
     header = block.GetBlockHeader();
 
@@ -51,9 +51,8 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std:
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const auto& tx = *block.vtx[i];
-        const uint256& hash = tx.GetHash();
+        const Txid& hash{tx.GetHash()};
         bool isAllowedType = !tx.IsSpecialTxVersion() || allowedTxTypes.count(tx.nType) != 0;
-
         if (txids && txids->count(hash)) {
             vMatch.push_back(true);
         } else if (isAllowedType && filter && filter->IsRelevantAndUpdate(*block.vtx[i])) {

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -11,6 +11,7 @@
 #include <serialize.h>
 #include <uint256.h>
 
+#include <set>
 #include <vector>
 
 // Helper functions for serialization.
@@ -144,7 +145,7 @@ public:
     CMerkleBlock(const CBlock& block, CBloomFilter& filter) : CMerkleBlock(block, &filter, nullptr) { }
 
     // Create from a CBlock, matching the txids in the set
-    CMerkleBlock(const CBlock& block, const std::set<uint256>& txids) : CMerkleBlock(block, nullptr, &txids) { }
+    CMerkleBlock(const CBlock& block, const std::set<Txid>& txids) : CMerkleBlock{block, nullptr, &txids} {}
 
     CMerkleBlock() {}
 
@@ -152,7 +153,7 @@ public:
 
 private:
     // Combined constructor to consolidate code
-    CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std::set<uint256>* txids);
+    CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std::set<Txid>* txids);
 };
 
 #endif // BITCOIN_MERKLEBLOCK_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -406,18 +406,21 @@ void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHead
         qInfo() << "Platform customization:" << gArgs.GetArg("-uiplatform", BitcoinGUI::DEFAULT_UIPLATFORM).c_str();
         clientModel = new ClientModel(node(), optionsModel);
         window->setClientModel(clientModel, &tip_info);
+
+        // If '-min' option passed, start window minimized (iconified) or minimized to tray
+        bool start_minimized = gArgs.GetBoolArg("-min", false);
 #ifdef ENABLE_WALLET
         if (WalletModel::isWalletEnabled()) {
             m_wallet_controller = new WalletController(*clientModel, this);
-            window->setWalletController(m_wallet_controller);
+            window->setWalletController(m_wallet_controller, /*show_loading_minimized=*/start_minimized);
             if (paymentServer) {
                 paymentServer->setOptionsModel(optionsModel);
             }
         }
 #endif // ENABLE_WALLET
 
-        // If -min option passed, start window minimized (iconified) or minimized to tray
-        if (!gArgs.GetBoolArg("-min", false)) {
+        // Show or minimize window
+        if (!start_minimized) {
             window->show();
         } else if (clientModel->getOptionsModel()->getMinimizeToTray() && window->hasTrayIcon()) {
             // do nothing as the window is managed by the tray icon

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -917,7 +917,13 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
 }
 
 #ifdef ENABLE_WALLET
-void BitcoinGUI::setWalletController(WalletController* wallet_controller)
+void BitcoinGUI::enableHistoryAction(bool privacy)
+{
+    historyAction->setEnabled(!privacy);
+    if (historyAction->isChecked()) gotoOverviewPage();
+}
+
+void BitcoinGUI::setWalletController(WalletController* wallet_controller, bool show_loading_minimized)
 {
     assert(!m_wallet_controller);
     assert(wallet_controller);
@@ -937,7 +943,7 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller)
     });
 
     auto activity = new LoadWalletsActivity(m_wallet_controller, this);
-    activity->load();
+    activity->load(show_loading_minimized);
 }
 
 WalletController* BitcoinGUI::getWalletController()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -82,7 +82,7 @@ public:
     */
     void setClientModel(ClientModel *clientModel = nullptr, interfaces::BlockAndHeaderTipInfo* tip_info = nullptr);
 #ifdef ENABLE_WALLET
-    void setWalletController(WalletController* wallet_controller);
+    void setWalletController(WalletController* wallet_controller, bool show_loading_minimized);
     WalletController* getWalletController();
 #endif
 

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -190,7 +190,7 @@ WalletControllerActivity::WalletControllerActivity(WalletController* wallet_cont
     connect(this, &WalletControllerActivity::finished, this, &QObject::deleteLater);
 }
 
-void WalletControllerActivity::showProgressDialog(const QString& title_text, const QString& label_text)
+void WalletControllerActivity::showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized)
 {
     auto progress_dialog = new QProgressDialog(m_parent_widget);
     progress_dialog->setAttribute(Qt::WA_DeleteOnClose);
@@ -205,6 +205,8 @@ void WalletControllerActivity::showProgressDialog(const QString& title_text, con
     // The setValue call forces QProgressDialog to start the internal duration estimation.
     // See details in https://bugreports.qt.io/browse/QTBUG-47042.
     progress_dialog->setValue(0);
+    // When requested, launch dialog minimized
+    if (show_minimized) progress_dialog->showMinimized();
 }
 
 CreateWalletActivity::CreateWalletActivity(WalletController* wallet_controller, QWidget* parent_widget)
@@ -343,9 +345,9 @@ LoadWalletsActivity::LoadWalletsActivity(WalletController* wallet_controller, QW
 {
 }
 
-void LoadWalletsActivity::load()
+void LoadWalletsActivity::load(bool show_loading_minimized)
 {
-    showProgressDialog(tr("Loading wallets…"), tr("Loading wallets…"));
+    showProgressDialog(tr("Loading wallets…"), tr("Loading wallets…"), /*show_minimized=*/show_loading_minimized);
 
     QTimer::singleShot(0, worker(), [this] {
         for (auto& wallet : node().walletLoader().getWallets()) {

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -99,7 +99,7 @@ protected:
     interfaces::Node& node() const { return m_wallet_controller->m_node; }
     QObject* worker() const { return m_wallet_controller->m_activity_worker; }
 
-    void showProgressDialog(const QString& title_text, const QString& label_text);
+    void showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized=false);
 
     WalletController* const m_wallet_controller;
     QWidget* const m_parent_widget;
@@ -155,7 +155,7 @@ class LoadWalletsActivity : public WalletControllerActivity
 public:
     LoadWalletsActivity(WalletController* wallet_controller, QWidget* parent_widget);
 
-    void load();
+    void load(bool show_loading_minimized);
 };
 
 class RestoreWalletActivity : public WalletControllerActivity

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -45,81 +45,82 @@ static RPCHelpMan gettxoutproof()
             + HelpExampleRpc("gettxoutproof", "[\"mytxid\",...], \"blockhash\"")
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    std::set<uint256> setTxids;
-    UniValue txids = request.params[0].get_array();
-    if (txids.empty()) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'txids' cannot be empty");
-    }
-    for (unsigned int idx = 0; idx < txids.size(); idx++) {
-        auto ret = setTxids.insert(ParseHashV(txids[idx], "txid"));
-        if (!ret.second) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated txid: ") + txids[idx].get_str());
-        }
-    }
-
-    const CBlockIndex* pblockindex = nullptr;
-    uint256 hashBlock;
-    ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    if (!request.params[1].isNull()) {
-        LOCK(cs_main);
-        hashBlock = ParseHashV(request.params[1], "blockhash");
-        pblockindex = chainman.m_blockman.LookupBlockIndex(hashBlock);
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
-    } else {
-        LOCK(cs_main);
-        CChainState& active_chainstate = chainman.ActiveChainstate();
-
-        // Loop through txids and try to find which block they're in. Exit loop once a block is found.
-        for (const auto& tx : setTxids) {
-            const Coin& coin = AccessByTxid(active_chainstate.CoinsTip(), tx);
-            if (!coin.IsSpent()) {
-                pblockindex = active_chainstate.m_chain[coin.nHeight];
-                break;
+        {
+            std::set<Txid> setTxids;
+            UniValue txids = request.params[0].get_array();
+            if (txids.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'txids' cannot be empty");
             }
-        }
-    }
+            for (unsigned int idx = 0; idx < txids.size(); idx++) {
+                auto ret{setTxids.insert(Txid::FromUint256(ParseHashV(txids[idx], "txid")))};
+                if (!ret.second) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated txid: ") + txids[idx].get_str());
+                }
+            }
+
+            const CBlockIndex* pblockindex = nullptr;
+            uint256 hashBlock;
+            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+            if (!request.params[1].isNull()) {
+                LOCK(cs_main);
+                hashBlock = ParseHashV(request.params[1], "blockhash");
+                pblockindex = chainman.m_blockman.LookupBlockIndex(hashBlock);
+                if (!pblockindex) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+                }
+            } else {
+                LOCK(cs_main);
+                CChainState& active_chainstate = chainman.ActiveChainstate();
+
+                // Loop through txids and try to find which block they're in. Exit loop once a block is found.
+                for (const auto& tx : setTxids) {
+                    const Coin& coin{AccessByTxid(active_chainstate.CoinsTip(), tx)};
+                    if (!coin.IsSpent()) {
+                        pblockindex = active_chainstate.m_chain[coin.nHeight];
+                        break;
+                    }
+                }
+            }
 
 
-    // Allow txindex to catch up if we need to query it and before we acquire cs_main.
-    if (g_txindex && !pblockindex) {
-        g_txindex->BlockUntilSyncedToCurrentChain();
-    }
+            // Allow txindex to catch up if we need to query it and before we acquire cs_main.
+            if (g_txindex && !pblockindex) {
+                g_txindex->BlockUntilSyncedToCurrentChain();
+            }
 
-    if (pblockindex == nullptr) {
-        const CTransactionRef tx = GetTransaction(/* block_index */ nullptr, /* mempool */ nullptr, *setTxids.begin(), Params().GetConsensus(), hashBlock);
-        if (!tx || hashBlock.IsNull()) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
-        }
-        pblockindex = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(hashBlock));
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");
-        }
-    }
+            if (pblockindex == nullptr) {
+                const CTransactionRef tx = GetTransaction(/* block_index */ nullptr, /* mempool */ nullptr, *setTxids.begin(), Params().GetConsensus(), hashBlock);
+                if (!tx || hashBlock.IsNull()) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
+                }
 
-    CBlock block;
-    if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus())) {
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
-    }
+                pblockindex = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(hashBlock));
+                if (!pblockindex) {
+                    throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");
+                }
+            }
 
-    unsigned int ntxFound = 0;
-    for (const auto& tx : block.vtx) {
-        if (setTxids.count(tx->GetHash())) {
-            ntxFound++;
-        }
-    }
-    if (ntxFound != setTxids.size()) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not all transactions found in specified or retrieved block");
-    }
+            CBlock block;
+            if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus())) {
+                throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
+            }
 
-    CDataStream ssMB(SER_NETWORK, PROTOCOL_VERSION);
-    CMerkleBlock mb(block, setTxids);
-    ssMB << mb;
-    std::string strHex = HexStr(ssMB);
-    return strHex;
-},
+            unsigned int ntxFound = 0;
+            for (const auto& tx : block.vtx) {
+                if (setTxids.count(tx->GetHash())) {
+                    ntxFound++;
+                }
+            }
+            if (ntxFound != setTxids.size()) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not all transactions found in specified or retrieved block");
+            }
+
+            CDataStream ssMB(SER_NETWORK, PROTOCOL_VERSION);
+            CMerkleBlock mb(block, setTxids);
+            ssMB << mb;
+            std::string strHex = HexStr(ssMB);
+            return strHex;
+        },
     };
 }
 
@@ -142,43 +143,41 @@ static RPCHelpMan verifytxoutproof()
             + HelpExampleRpc("gettxoutproof", "\"proof\"")
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    CDataStream ssMB(ParseHexV(request.params[0], "proof"), SER_NETWORK, PROTOCOL_VERSION);
-    CMerkleBlock merkleBlock;
-    ssMB >> merkleBlock;
+        {
+            CDataStream ssMB(ParseHexV(request.params[0], "proof"), SER_NETWORK, PROTOCOL_VERSION);
+            CMerkleBlock merkleBlock;
+            ssMB >> merkleBlock;
 
-    UniValue res(UniValue::VARR);
+            UniValue res(UniValue::VARR);
 
-    std::vector<uint256> vMatch;
-    std::vector<unsigned int> vIndex;
-    if (merkleBlock.txn.ExtractMatches(vMatch, vIndex) != merkleBlock.header.hashMerkleRoot)
-        return res;
+            std::vector<uint256> vMatch;
+            std::vector<unsigned int> vIndex;
+            if (merkleBlock.txn.ExtractMatches(vMatch, vIndex) != merkleBlock.header.hashMerkleRoot)
+                return res;
 
-    ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    LOCK(cs_main);
+            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+            LOCK(cs_main);
 
-    const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(merkleBlock.header.GetHash());
-    if (!pindex || !chainman.ActiveChain().Contains(pindex) || pindex->nTx == 0) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
-    }
+            const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(merkleBlock.header.GetHash());
+            if (!pindex || !chainman.ActiveChain().Contains(pindex) || pindex->nTx == 0) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
+            }
 
-    // Check if proof is valid, only add results if so
-    if (pindex->nTx == merkleBlock.txn.GetNumTransactions()) {
-        for (const uint256& hash : vMatch) {
-            res.push_back(hash.GetHex());
-        }
-    }
+            // Check if proof is valid, only add results if so
+            if (pindex->nTx == merkleBlock.txn.GetNumTransactions()) {
+                for (const uint256& hash : vMatch) {
+                    res.push_back(hash.GetHex());
+                }
+            }
 
-    return res;
-},
+            return res;
+        },
     };
 }
 
 void RegisterTxoutProofRPCCommands(CRPCTable& t)
 {
     static const CRPCCommand commands[]{
-        // category     actor (function)
-        // --------     ----------------
         {"blockchain", &gettxoutproof},
         {"blockchain", &verifytxoutproof},
     };

--- a/src/test/fuzz/merkleblock.cpp
+++ b/src/test/fuzz/merkleblock.cpp
@@ -29,13 +29,13 @@ FUZZ_TARGET(merkleblock)
             CMerkleBlock merkle_block;
             const std::optional<CBlock> opt_block = ConsumeDeserializable<CBlock>(fuzzed_data_provider);
             CBloomFilter bloom_filter;
-            std::set<uint256> txids;
+            std::set<Txid> txids;
             if (opt_block && !opt_block->vtx.empty()) {
                 if (fuzzed_data_provider.ConsumeBool()) {
                     merkle_block = CMerkleBlock{*opt_block, bloom_filter};
                 } else if (fuzzed_data_provider.ConsumeBool()) {
                     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
-                        txids.insert(ConsumeUInt256(fuzzed_data_provider));
+                        txids.insert(Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider)));
                     }
                     merkle_block = CMerkleBlock{*opt_block, txids};
                 }

--- a/src/test/merkleblock_tests.cpp
+++ b/src/test/merkleblock_tests.cpp
@@ -21,13 +21,13 @@ BOOST_AUTO_TEST_CASE(merkleblock_construct_from_txids_found)
 {
     CBlock block = getBlock13b8a();
 
-    std::set<uint256> txids;
+    std::set<Txid> txids;
 
     // Last txn in block.
-    uint256 txhash1 = uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20");
+    Txid txhash1{TxidFromString("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20")};
 
     // Second txn in block.
-    uint256 txhash2 = uint256S("0xf9fc751cb7dc372406a9f8d738d5e6f8f63bab71986a39cf36ee70ee17036d07");
+    Txid txhash2{TxidFromString("0xf9fc751cb7dc372406a9f8d738d5e6f8f63bab71986a39cf36ee70ee17036d07")};
 
     txids.insert(txhash1);
     txids.insert(txhash2);
@@ -62,8 +62,8 @@ BOOST_AUTO_TEST_CASE(merkleblock_construct_from_txids_not_found)
 {
     CBlock block = getBlock13b8a();
 
-    std::set<uint256> txids2;
-    txids2.insert(uint256S("0xc0ffee00003bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+    std::set<Txid> txids2;
+    txids2.insert(TxidFromString("0xc0ffee00003bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
     CMerkleBlock merkleBlock(block, txids2);
 
     BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHash().GetHex());

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -23,6 +23,7 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
     find_vout_for_address,
 )
@@ -57,7 +58,7 @@ class RawTransactionsTest(BitcoinTestFramework):
             [],  # by default Tx Index is enabled
             ["-txindex"],
             ["-txindex"],
-            ["-notxindex"],
+            ["-notxindex", "-fastprune", "-prune=1"],
         ]
         # whitelist all peers to speed up tx relay / mempool sync
         for args in self.extra_args:
@@ -184,6 +185,23 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.log.info("Test getrawtransaction on genesis block coinbase returns an error")
         block = self.nodes[0].getblock(self.nodes[0].getblockhash(0))
         assert_raises_rpc_error(-5, "The genesis block coinbase is not considered an ordinary transaction", self.nodes[0].getrawtransaction, block['merkleroot'])
+
+        self.log.info("Test getrawtransaction with pruned node (regression test for bitcoin#29003)")
+        # Generate blocks and prune to test mempool tx behavior
+        self.generate(self.nodes[3], 400)
+        assert_greater_than(self.nodes[3].pruneblockchain(250), 0)
+        
+        # Create a mempool transaction
+        addr = self.nodes[3].getnewaddress()
+        mempool_txid = self.nodes[3].sendtoaddress(addr, 1.0)
+        
+        # This should not crash even with verbosity=true on a pruned node
+        try:
+            tx_verbose = self.nodes[3].getrawtransaction(mempool_txid, True)
+            assert 'hex' in tx_verbose
+        except Exception as e:
+            self.log.error(f"getrawtransaction failed on pruned node: {e}")
+            raise
 
     def createrawtransaction_tests(self):
         self.log.info("Test createrawtransaction")


### PR DESCRIPTION
Backports bitcoin/bitcoin#29003

Original commit: dde7ac5c70

This backport adds the regression test for getrawtransaction with pruned nodes. The actual segfault fix from Bitcoin does not apply to Dash as we don't have the verbosity=2 code path that calls IsBlockPruned. However, the test ensures our implementation handles pruned nodes correctly.

Backported from Bitcoin Core v0.27