### PR TITLE
Merge bitcoin/bitcoin#28924: refactor: Remove unused and fragile string interface from arith_uint256

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -8,14 +8,7 @@
 #include <uint256.h>
 #include <crypto/common.h>
 
-
-template <unsigned int BITS>
-base_uint<BITS>::base_uint(const std::string& str)
-{
-    static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
-
-    SetHex(str);
-}
+#include <cassert>
 
 template <unsigned int BITS>
 base_uint<BITS>& base_uint<BITS>::operator<<=(unsigned int shift)
@@ -151,22 +144,6 @@ std::string base_uint<BITS>::GetHex() const
         WriteLE32(b.begin() + x*4, this->pn[x]);
     }
     return b.GetHex();
-}
-
-template <unsigned int BITS>
-void base_uint<BITS>::SetHex(const char* psz)
-{
-    base_blob<BITS> b;
-    b.SetHex(psz);
-    for (int x = 0; x < this->WIDTH; ++x) {
-        this->pn[x] = ReadLE32(b.begin() + x*4);
-    }
-}
-
-template <unsigned int BITS>
-void base_uint<BITS>::SetHex(const std::string& str)
-{
-    SetHex(str.c_str());
 }
 
 template <unsigned int BITS>

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,10 +6,10 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
-#include <stdint.h>
 #include <string>
 
 class uint256;
@@ -55,8 +55,6 @@ public:
         for (int i = 2; i < WIDTH; i++)
             pn[i] = 0;
     }
-
-    explicit base_uint(const std::string& str);
 
     base_uint operator~() const
     {
@@ -219,8 +217,6 @@ public:
     friend inline bool operator!=(const base_uint& a, uint64_t b) { return !a.EqualTo(b); }
 
     std::string GetHex() const;
-    void SetHex(const char* psz);
-    void SetHex(const std::string& str);
     std::string ToString() const;
 
     unsigned int size() const
@@ -247,7 +243,6 @@ public:
     arith_uint256() {}
     arith_uint256(const base_uint<256>& b) : base_uint<256>(b) {}
     arith_uint256(uint64_t b) : base_uint<256>(b) {}
-    explicit arith_uint256(const std::string& str) : base_uint<256>(str) {}
 
     /**
      * The "compact" format is a representation of a whole

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -22,6 +22,7 @@ static inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch
 {
     return UintToArith256(uint256(vch));
 }
+static inline arith_uint256 arith_uint256S(const std::string& str) { return UintToArith256(uint256S(str)); }
 
 const unsigned char R1Array[] =
     "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"
@@ -95,25 +96,25 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(ZeroL == (OneL << 256));
 
     // String Constructor and Copy Constructor
-    BOOST_CHECK(arith_uint256("0x"+R1L.ToString()) == R1L);
-    BOOST_CHECK(arith_uint256("0x"+R2L.ToString()) == R2L);
-    BOOST_CHECK(arith_uint256("0x"+ZeroL.ToString()) == ZeroL);
-    BOOST_CHECK(arith_uint256("0x"+OneL.ToString()) == OneL);
-    BOOST_CHECK(arith_uint256("0x"+MaxL.ToString()) == MaxL);
-    BOOST_CHECK(arith_uint256(R1L.ToString()) == R1L);
-    BOOST_CHECK(arith_uint256("   0x"+R1L.ToString()+"   ") == R1L);
-    BOOST_CHECK(arith_uint256("") == ZeroL);
-    BOOST_CHECK(R1L == arith_uint256(R1ArrayHex));
+    BOOST_CHECK(arith_uint256S("0x" + R1L.ToString()) == R1L);
+    BOOST_CHECK(arith_uint256S("0x" + R2L.ToString()) == R2L);
+    BOOST_CHECK(arith_uint256S("0x" + ZeroL.ToString()) == ZeroL);
+    BOOST_CHECK(arith_uint256S("0x" + OneL.ToString()) == OneL);
+    BOOST_CHECK(arith_uint256S("0x" + MaxL.ToString()) == MaxL);
+    BOOST_CHECK(arith_uint256S(R1L.ToString()) == R1L);
+    BOOST_CHECK(arith_uint256S("   0x" + R1L.ToString() + "   ") == R1L);
+    BOOST_CHECK(arith_uint256S("") == ZeroL);
+    BOOST_CHECK(R1L == arith_uint256S(R1ArrayHex));
     BOOST_CHECK(arith_uint256(R1L) == R1L);
     BOOST_CHECK((arith_uint256(R1L^R2L)^R2L) == R1L);
     BOOST_CHECK(arith_uint256(ZeroL) == ZeroL);
     BOOST_CHECK(arith_uint256(OneL) == OneL);
 
     // uint64_t constructor
-    BOOST_CHECK( (R1L & arith_uint256("0xffffffffffffffff")) == arith_uint256(R1LLow64));
+    BOOST_CHECK((R1L & arith_uint256S("0xffffffffffffffff")) == arith_uint256(R1LLow64));
     BOOST_CHECK(ZeroL == arith_uint256(0));
     BOOST_CHECK(OneL == arith_uint256(1));
-    BOOST_CHECK(arith_uint256("0xffffffffffffffff") == arith_uint256(0xffffffffffffffffULL));
+    BOOST_CHECK(arith_uint256S("0xffffffffffffffff") == arith_uint256(0xffffffffffffffffULL));
 
     // Assignment (from base_uint)
     arith_uint256 tmpL = ~ZeroL; BOOST_CHECK(tmpL == ~ZeroL);
@@ -282,7 +283,7 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
 BOOST_AUTO_TEST_CASE( plusMinus )
 {
     arith_uint256 TmpL = 0;
-    BOOST_CHECK(R1L+R2L == arith_uint256(R1LplusR2L));
+    BOOST_CHECK(R1L + R2L == arith_uint256S(R1LplusR2L));
     TmpL += R1L;
     BOOST_CHECK(TmpL == R1L);
     TmpL += R2L;
@@ -346,8 +347,8 @@ BOOST_AUTO_TEST_CASE( multiply )
 
 BOOST_AUTO_TEST_CASE( divide )
 {
-    arith_uint256 D1L("AD7133AC1977FA2B7");
-    arith_uint256 D2L("ECD751716");
+    arith_uint256 D1L{arith_uint256S("AD7133AC1977FA2B7")};
+    arith_uint256 D2L{arith_uint256S("ECD751716")};
     BOOST_CHECK((R1L / D1L).ToString() == "00000000000000000b8ac01106981635d9ed112290f8895545a7654dde28fb3a");
     BOOST_CHECK((R1L / D2L).ToString() == "000000000873ce8efec5b67150bad3aa8c5fcb70e947586153bf2cec7c37c57a");
     BOOST_CHECK(R1L / OneL == R1L);
@@ -368,7 +369,7 @@ static bool almostEqual(double d1, double d2)
     return fabs(d1-d2) <= 4*fabs(d1)*std::numeric_limits<double>::epsilon();
 }
 
-BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex size() GetLow64 GetSerializeSize, Serialize, Unserialize
+BOOST_AUTO_TEST_CASE(methods) // GetHex operator= size() GetLow64 GetSerializeSize, Serialize, Unserialize
 {
     BOOST_CHECK(R1L.GetHex() == R1L.ToString());
     BOOST_CHECK(R2L.GetHex() == R2L.ToString());
@@ -376,11 +377,14 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex size() GetLow64 GetSerializeSiz
     BOOST_CHECK(MaxL.GetHex() == MaxL.ToString());
     arith_uint256 TmpL(R1L);
     BOOST_CHECK(TmpL == R1L);
-    TmpL.SetHex(R2L.ToString());   BOOST_CHECK(TmpL == R2L);
-    TmpL.SetHex(ZeroL.ToString()); BOOST_CHECK(TmpL == 0);
-    TmpL.SetHex(HalfL.ToString()); BOOST_CHECK(TmpL == HalfL);
+    TmpL = R2L;
+    BOOST_CHECK(TmpL == R2L);
+    TmpL = ZeroL;
+    BOOST_CHECK(TmpL == 0);
+    TmpL = HalfL;
+    BOOST_CHECK(TmpL == HalfL);
 
-    TmpL.SetHex(R1L.ToString());
+    TmpL = R1L;
     BOOST_CHECK(R1L.size() == 32);
     BOOST_CHECK(R2L.size() == 32);
     BOOST_CHECK(ZeroL.size() == 32);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -181,4 +181,50 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
     }
 }
 
+void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
+{
+    const auto chainParams = CreateChainParams(args, chain_type);
+    const auto consensus = chainParams->GetConsensus();
+
+    // hash genesis is correct
+    BOOST_CHECK_EQUAL(consensus.hashGenesisBlock, chainParams->GenesisBlock().GetHash());
+
+    // target timespan is an even multiple of spacing
+    BOOST_CHECK_EQUAL(consensus.nPowTargetTimespan % consensus.nPowTargetSpacing, 0);
+
+    // genesis nBits is positive, doesn't overflow and is lower than powLimit
+    arith_uint256 pow_compact;
+    bool neg, over;
+    pow_compact.SetCompact(chainParams->GenesisBlock().nBits, &neg, &over);
+    BOOST_CHECK(!neg && pow_compact != 0);
+    BOOST_CHECK(!over);
+    BOOST_CHECK(UintToArith256(consensus.powLimit) >= pow_compact);
+
+    // check max target * 4*nPowTargetTimespan doesn't overflow -- see pow.cpp:CalculateNextWorkRequired()
+    if (!consensus.fPowNoRetargeting) {
+        arith_uint256 targ_max{UintToArith256(uint256S("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))};
+        targ_max /= consensus.nPowTargetTimespan*4;
+        BOOST_CHECK(UintToArith256(consensus.powLimit) < targ_max);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ChainParams_MAIN_sanity)
+{
+    sanity_check_chainparams(*m_node.args, ChainType::MAIN);
+}
+
+BOOST_AUTO_TEST_CASE(ChainParams_REGTEST_sanity)
+{
+    sanity_check_chainparams(*m_node.args, ChainType::REGTEST);
+}
+
+BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
+{
+    sanity_check_chainparams(*m_node.args, ChainType::TESTNET);
+}
+
+BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
+{
+    sanity_check_chainparams(*m_node.args, ChainType::SIGNET);
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -260,8 +260,8 @@ BOOST_AUTO_TEST_CASE( conversion )
     BOOST_CHECK(UintToArith256(OneL) == 1);
     BOOST_CHECK(ArithToUint256(0) == ZeroL);
     BOOST_CHECK(ArithToUint256(1) == OneL);
-    BOOST_CHECK(arith_uint256(R1L.GetHex()) == UintToArith256(R1L));
-    BOOST_CHECK(arith_uint256(R2L.GetHex()) == UintToArith256(R2L));
+    BOOST_CHECK(arith_uint256(UintToArith256(uint256S(R1L.GetHex()))) == UintToArith256(R1L));
+    BOOST_CHECK(arith_uint256(UintToArith256(uint256S(R2L.GetHex()))) == UintToArith256(R2L));
     BOOST_CHECK(R1L.GetHex() == UintToArith256(R1L).GetHex());
     BOOST_CHECK(R2L.GetHex() == UintToArith256(R2L).GetHex());
 }
@@ -296,6 +296,34 @@ BOOST_AUTO_TEST_CASE( operator_with_self )
 #if defined(__clang__)
 #    pragma clang diagnostic pop
 #endif
+}
+
+BOOST_AUTO_TEST_CASE(parse)
+{
+    {
+        std::string s_12{"0000000000000000000000000000000000000000000000000000000000000012"};
+        BOOST_CHECK_EQUAL(uint256S("12\0").GetHex(), s_12);
+        BOOST_CHECK_EQUAL(uint256S(std::string{"12\0", 3}).GetHex(), s_12);
+        BOOST_CHECK_EQUAL(uint256S("0x12").GetHex(), s_12);
+        BOOST_CHECK_EQUAL(uint256S(" 0x12").GetHex(), s_12);
+        BOOST_CHECK_EQUAL(uint256S(" 12").GetHex(), s_12);
+    }
+    {
+        std::string s_1{uint256::ONE.GetHex()};
+        BOOST_CHECK_EQUAL(uint256S("1\0").GetHex(), s_1);
+        BOOST_CHECK_EQUAL(uint256S(std::string{"1\0", 2}).GetHex(), s_1);
+        BOOST_CHECK_EQUAL(uint256S("0x1").GetHex(), s_1);
+        BOOST_CHECK_EQUAL(uint256S(" 0x1").GetHex(), s_1);
+        BOOST_CHECK_EQUAL(uint256S(" 1").GetHex(), s_1);
+    }
+    {
+        std::string s_0{uint256::ZERO.GetHex()};
+        BOOST_CHECK_EQUAL(uint256S("\0").GetHex(), s_0);
+        BOOST_CHECK_EQUAL(uint256S(std::string{"\0", 1}).GetHex(), s_0);
+        BOOST_CHECK_EQUAL(uint256S("0x").GetHex(), s_0);
+        BOOST_CHECK_EQUAL(uint256S(" 0x").GetHex(), s_0);
+        BOOST_CHECK_EQUAL(uint256S(" ").GetHex(), s_0);
+    }
 }
 
 BOOST_AUTO_TEST_CASE( check_ONE )


### PR DESCRIPTION
Backports bitcoin/bitcoin#28924

Original commit: fcdb39d3ee

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the ability to construct or set certain numeric objects directly from hex strings via specific methods and constructors.

* **Tests**
  * Updated existing tests to use new helper functions for constructing numeric objects from strings.
  * Added new tests to verify parsing behavior for various string formats and to validate chain parameter consistency across different network types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->