### PR TITLE
Merge bitcoin/bitcoin#29025: doc: Add link to needs-release-notes label

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -7,6 +7,7 @@ Release Process
 Before every minor and major release:
 
 * [ ] Review ["Needs backport" labels](https://github.com/dashpay/dash/labels?q=backport).
+* [ ] Ensure the ["Needs release note" label](https://github.com/dashpay/dash/issues?q=label%3A%22Needs+release+note%22) is removed from all relevant pull requests and issues.
 * [ ] Update DIPs with any changes introduced by this release (see [this pull request](https://github.com/dashpay/dips/pull/142) for an example)
 * [ ] Update version in `configure.ac` (don't forget to set `CLIENT_VERSION_IS_RELEASE` to `true`)
 * [ ] Write release notes (see below)

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -7,7 +7,9 @@ Release Process
 Before every minor and major release:
 
 * [ ] Review ["Needs backport" labels](https://github.com/dashpay/dash/labels?q=backport).
-* [ ] Ensure the ["Needs release note" label](https://github.com/dashpay/dash/issues?q=label%3A%22Needs+release+note%22) is removed from all relevant pull requests and issues.
+* [ ] Ensure the "Needs release note" label is removed from all relevant pull
+  requests and issues:
+  https://github.com/dashpay/dash/issues?q=label%3A%22Needs+release+note%22
 * [ ] Update DIPs with any changes introduced by this release (see [this pull request](https://github.com/dashpay/dips/pull/142) for an example)
 * [ ] Update version in `configure.ac` (don't forget to set `CLIENT_VERSION_IS_RELEASE` to `true`)
 * [ ] Write release notes (see below)


### PR DESCRIPTION
Backports bitcoin/bitcoin#29025

Original commit: 14d1732602

Backported from Bitcoin Core v0.27

This change adds a link to the "Needs release note" label query in the release process documentation to make it easier to find and ensure all relevant issues are addressed before release.