### PR TITLE
Merge bitcoin/bitcoin#28349: build: Require C++20 compiler

### DIFF
--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -983,7 +983,7 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 202002L
+#elif __cplusplus < 201709L  // Temporary patch on top of upstream to allow g++-10
 
 #error "This is not a C++20 compiler"
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#28349

Original commit: 3e691258d8789a4a89cce42e7e71b130491594d7

Backported from Bitcoin Core v0.27

Note: This is an empty commit as Dash Core already has C++20 support enabled in the build system. All the required changes have already been applied:
- configure.ac: Already requires C++20
- depends/Makefile: Already sets CXX_STANDARD to c++20
- depends/packages/qt.mk: Already uses c++2a
- src/.clang-format: Already set to c++20
- src/test/fuzz/fuzz.h: Already has simplified macros
- src/test/fuzz/rpc.cpp: Already uses starts_with
- src/util/trace.h: Already has simplified TRACE macros

Files that don't exist in Dash and were skipped:
- .github/workflows/ci.yml
- src/txrequest.cpp