### PR TITLE
Merge bitcoin/bitcoin#28894: wallet: batch all individual spkms setup db writes in a single db txn

### DIFF
--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -49,8 +49,8 @@ static void WalletCreatePlain(benchmark::Bench& bench) { WalletCreate(bench, /*e
 static void WalletCreateEncrypted(benchmark::Bench& bench) { WalletCreate(bench, /*encrypted=*/true); }
 
 #ifdef USE_SQLITE
-BENCHMARK(WalletCreatePlain);
-BENCHMARK(WalletCreateEncrypted);
+BENCHMARK(WalletCreatePlain, benchmark::PriorityLevel::LOW);
+BENCHMARK(WalletCreateEncrypted, benchmark::PriorityLevel::LOW);
 #endif
 
 } // namespace wallet

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1949,6 +1949,15 @@ std::map<CKeyID, CKey> DescriptorScriptPubKeyMan::GetKeys() const
 
 bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
 {
+    WalletBatch batch(m_storage.GetDatabase());
+    if (!batch.TxnBegin()) return false;
+    bool res = TopUpWithDB(batch, size);
+    if (!batch.TxnCommit()) throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet %s", m_storage.GetDisplayName()));
+    return res;
+}
+
+bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int size)
+{
     LOCK(cs_desc_man);
     unsigned int target_size;
     if (size > 0) {
@@ -1970,7 +1979,6 @@ bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
     FlatSigningProvider provider;
     provider.keys = GetKeys();
 
-    WalletBatch batch(m_storage.GetDatabase());
     uint256 id = GetID();
     for (int32_t i = m_max_cached_index + 1; i < new_range_end; ++i) {
         FlatSigningProvider out_keys;
@@ -2121,6 +2129,8 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
 
     // Store the master private key, and descriptor
     WalletBatch batch(m_storage.GetDatabase());
+    if (!batch.TxnBegin()) throw std::runtime_error(std::string(__func__) + ": cannot start db transaction");
+
     if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey(), secure_mnemonic, secure_mnemonic_passphrase)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
     }
@@ -2129,9 +2139,11 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     }
 
     // TopUp
-    TopUp();
+    TopUpWithDB(batch);
 
     m_storage.UnsetBlankWalletFlag(batch);
+
+    if (!batch.TxnCommit()) throw std::runtime_error(std::string(__func__) + ": error committing db transaction");
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -542,6 +542,9 @@ private:
     // Fetch the SigningProvider for a given index and optionally include private keys. Called by the above functions.
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
+protected:
+    //! Same as 'TopUp' but designed for use within a batch transaction context
+    bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0);
 public:
     DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor)
         :   ScriptPubKeyMan(storage),


### PR DESCRIPTION
Backports bitcoin/bitcoin#28894

Original commit: a7f4f1a09c767e8f6921d24505d868744026091b

Backported from Bitcoin Core v0.27

Note: This is a partial backport. Only 2 out of 5 commits from the original Bitcoin PR were applied:
- bb4554c81e: bench: add benchmark for wallet creation procedure
- 075aa44ceb: wallet: batch descriptor spkm TopUp

The following commits were skipped due to architectural differences:
- 3eb769f150: wallet: batch legacy spkm TopUp (conflicts with Dash's different legacy wallet implementation)
- 1f65241b73: wallet: descriptors setup, batch db operations (conflicts with Dash's mnemonic handling)
- f053024273: wallet: batch external signer descriptor import (Dash doesn't support external signers)

The applied changes improve wallet creation performance by batching descriptor TopUp operations within a single database transaction.