### PR TITLE
Merge bitcoin/bitcoin#29055: tests, bench: Fix issue with CWallet::LoadWallet() being called in the wrong places

### DIFF
--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -23,7 +23,6 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, interfaces
         LOCK(wallet->cs_wallet);
         wallet->SetLastBlockProcessed(cchain.Height(), cchain.Tip()->GetBlockHash());
     }
-    wallet->LoadWallet();
     {
         LOCK(wallet->cs_wallet);
         wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2160,6 +2160,8 @@ DBErrors CWallet::LoadWallet()
 {
     LOCK(cs_wallet);
 
+    Assert(m_spk_managers.empty());
+    Assert(m_wallet_flags == 0);
     DBErrors nLoadWalletRet = WalletBatch(GetDatabase()).LoadWallet(this);
     if (nLoadWalletRet == DBErrors::NEED_REWRITE)
     {


### PR DESCRIPTION
Backports bitcoin/bitcoin#29055

Original commit: 60f677375e52832536a599afae3226f8e2155d88

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet loading process to ensure the wallet is in a clean initial state before loading data, enhancing reliability and preventing potential issues during wallet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->