### PR TITLE
Merge bitcoin/bitcoin#29088: tests: Don't depend on value of DEFAULT_PERMIT_BAREMULTISIG

### DIFF
--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -18,6 +18,17 @@
 #include <boost/test/unit_test.hpp>
 
 // Helpers:
+static bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, std::string& reason)
+{
+    return ::IsStandardTx(tx, permit_bare_multisig, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+}
+
+static bool IsStandardTx(const CTransaction& tx, std::string& reason)
+{
+    return IsStandardTx(tx, /*permit_bare_multisig=*/true, reason) &&
+           IsStandardTx(tx, /*permit_bare_multisig=*/false, reason);
+}
+
 static std::vector<unsigned char>
 Serialize(const CScript& s)
 {
@@ -197,7 +208,9 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, CTransaction(txFrom), txTo[i], 0, SIGHASH_ALL), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(CTransaction(txTo[i]), reason), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK_MESSAGE(IsStandardTx(CTransaction(txTo[i]), /*permit_bare_multisig=*/true, reason), strprintf("txTo[%d].IsStandard", i));
+        bool no_pbms_is_std = IsStandardTx(CTransaction(txTo[i]), /*permit_bare_multisig=*/false, reason);
+        BOOST_CHECK_MESSAGE((i == 0 ? no_pbms_is_std : !no_pbms_is_std), strprintf("txTo[%d].IsStandard(permbaremulti=false)", i));
     }
 }
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29088

Original commit: 3695ecbf68

Backported from Bitcoin Core v0.27

Note: test/functional/mempool_dust.py and test/functional/mempool_sigoplimit.py 
do not exist in Dash, so those changes were omitted.