### PR TITLE
Merge bitcoin/bitcoin#29079: fuzz: Limit p2p fuzz targets to MAX_PROTOCOL_MESSAGE_LENGTH

### DIFF
--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Bitcoin Core developers
+// Copyright (c) 2020-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,9 +8,6 @@
 #include <primitives/transaction.h>
 #include <protocol.h>
 #include <script/script.h>
-#include <serialize.h>
-#include <span.h>
-#include <streams.h>
 #include <sync.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -19,6 +16,8 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
+#include <util/check.h>
+#include <util/time.h>
 #include <validationinterface.h>
 #include <version.h>
 
@@ -28,7 +27,6 @@
 #include <llmq/signing.h>
 #include <llmq/signing_shares.h>
 
-#include <atomic>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -81,11 +79,21 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     const auto mock_time = ConsumeTime(fuzzed_data_provider);
     SetMockTime(mock_time);
 
-    // fuzzed_data_provider is fully consumed after this call, don't use it
-    CDataStream random_bytes_data_stream{fuzzed_data_provider.ConsumeRemainingBytes<unsigned char>(), SER_NETWORK, PROTOCOL_VERSION};
-    try {
-        g_setup->m_node.peerman->ProcessMessage(p2p_node, random_message_type, random_bytes_data_stream, GetTime<std::chrono::microseconds>(), std::atomic<bool>{false});
-    } catch (const std::ios_base::failure& e) {
+    CSerializedNetMsg net_msg;
+    net_msg.m_type = random_message_type;
+    net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);
+
+    connman.FlushSendBuffer(p2p_node);
+    (void)connman.ReceiveMsgFrom(p2p_node, std::move(net_msg));
+
+    bool more_work{true};
+    while (more_work) {
+        p2p_node.fPauseSend = false;
+        try {
+            more_work = connman.ProcessMessagesOnce(p2p_node);
+        } catch (const std::ios_base::failure&) {
+        }
+        g_setup->m_node.peerman->SendMessages(&p2p_node);
     }
     g_setup->m_node.peerman->SendMessages(&p2p_node);
     SyncWithValidationInterfaceQueue();

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -13,6 +13,7 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
+#include <util/time.h>
 #include <validation.h>
 #include <validationinterface.h>
 
@@ -62,7 +63,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
 
         CSerializedNetMsg net_msg;
         net_msg.m_type = random_message_type;
-        net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+        net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);
 
         CNode& random_node = *PickValue(fuzzed_data_provider, peers);
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29079

Original commit: 4b94578fd8562c9279768eb5d62f2a5c53eaa825

Backported from Bitcoin Core v0.27