### PR TITLE
Merge bitcoin/bitcoin#29037: Add multiplication operator to CFeeRate

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -69,6 +69,8 @@ public:
     friend bool operator!=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK != b.nSatoshisPerK; }
     CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
     std::string ToString(const FeeEstimateMode& fee_estimate_mode = FeeEstimateMode::DASH_KB) const;
+    friend CFeeRate operator*(const CFeeRate& f, int a) { return CFeeRate(a * f.nSatoshisPerK); }
+    friend CFeeRate operator*(int a, const CFeeRate& f) { return CFeeRate(a * f.nSatoshisPerK); }
 
     SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -85,6 +85,32 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<uint32_t>::max()).GetFeePerK();
+
+    // check multiplication operator
+    // check multiplying by zero
+    feeRate = CFeeRate(1000);
+    BOOST_CHECK(0 * feeRate == CFeeRate(0));
+    BOOST_CHECK(feeRate * 0 == CFeeRate(0));
+    // check multiplying by a positive integer
+    BOOST_CHECK(3 * feeRate == CFeeRate(3000));
+    BOOST_CHECK(feeRate * 3 == CFeeRate(3000));
+    // check multiplying by a negative integer
+    BOOST_CHECK(-3 * feeRate == CFeeRate(-3000));
+    BOOST_CHECK(feeRate * -3 == CFeeRate(-3000));
+    // check commutativity
+    BOOST_CHECK(2 * feeRate == feeRate * 2);
+    // check with large numbers
+    int largeNumber = 1000000;
+    BOOST_CHECK(largeNumber * feeRate == feeRate * largeNumber);
+    // check boundary values
+    int maxInt = std::numeric_limits<int>::max();
+    feeRate = CFeeRate(maxInt);
+    BOOST_CHECK(feeRate * 2 == CFeeRate(static_cast<int64_t>(maxInt) * 2));
+    BOOST_CHECK(2 * feeRate == CFeeRate(static_cast<int64_t>(maxInt) * 2));
+    // check with zero fee rate
+    feeRate = CFeeRate(0);
+    BOOST_CHECK(feeRate * 5 == CFeeRate(0));
+    BOOST_CHECK(5 * feeRate == CFeeRate(0));
 }
 
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)


### PR DESCRIPTION
Backports bitcoin/bitcoin#29037

Original commit: e3847f7ac4b74893d266770c456d57ed20b9bb8b

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for multiplying fee rates by integer values, allowing for more flexible fee calculations.

* **Tests**
  * Expanded test coverage to verify correct behavior when multiplying fee rates by various integer values, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->