### PR TITLE
Merge bitcoin/bitcoin#29195: build: Fix `-Xclang -internal-isystem` option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -792,7 +792,7 @@ case $host in
          dnl option to system-ify all /usr/local/include paths without adding it to the list
          dnl of search paths in case it's not already there.
          if test "$suppress_external_warnings" != "no"; then
-           AX_CHECK_PREPROC_FLAG([-Xclang -internal-isystem/usr/local/include], [CORE_CPPFLAGS="$CORE_CPPFLAGS -Xclang -internal-isystem/usr/local/include"], [], [$CXXFLAG_WERROR])
+           AX_CHECK_PREPROC_FLAG([-Xclang -internal-isystem -Xclang /usr/local/include/], [CORE_CPPFLAGS="$CORE_CPPFLAGS -Xclang -internal-isystem -Xclang /usr/local/include/"], [], [$CXXFLAG_WERROR])
          fi
 
          if test "$use_bdb" != "no" && $BREW list --versions berkeley-db@4 >/dev/null && test "$BDB_CFLAGS" = "" && test "$BDB_LIBS" = ""; then


### PR DESCRIPTION
Backports bitcoin/bitcoin#29195

Original commit: 9e1306fc88

Backported from Bitcoin Core v0.27

Note: Only the configure.ac change was applied as Dash does not have .github/workflows/ci.yml