### PR TITLE
Merge bitcoin/bitcoin#29225: ci: move CMake into base packages

### DIFF
--- a/ci/test/00_setup_env_native_multiprocess.sh
+++ b/ci/test/00_setup_env_native_multiprocess.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_multiprocess
 export HOST=x86_64-pc-linux-gnu
-export PACKAGES="cmake python3 llvm clang"
+export PACKAGES="python3 llvm clang"
 export DEP_OPTS="MULTIPROCESS=1 CC=clang-18 CXX=clang++-18"
 export RUN_TIDY=true
 export GOAL="install"


### PR DESCRIPTION
Backports bitcoin/bitcoin#29225

Original commit: 12865d21ef6c746128775e6b02496c4f8273b439

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default packages in the Docker environment to include cmake.
  * Removed cmake from the list of packages installed in the macOS CI environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->