### PR TITLE
Merge bitcoin/bitcoin#29237: depends: Allow PATH with spaces in directory names.

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -138,9 +138,9 @@ $(1)_config_env+=PKG_CONFIG_LIBDIR=$($($(1)_type)_prefix)/lib/pkgconfig
 $(1)_config_env+=PKG_CONFIG_PATH=$($($(1)_type)_prefix)/share/pkgconfig
 $(1)_config_env+=PKG_CONFIG_SYSROOT_DIR=/
 $(1)_config_env+=CMAKE_MODULE_PATH=$($($(1)_type)_prefix)/lib/cmake
-$(1)_config_env+=PATH=$(build_prefix)/bin:$(PATH)
-$(1)_build_env+=PATH=$(build_prefix)/bin:$(PATH)
-$(1)_stage_env+=PATH=$(build_prefix)/bin:$(PATH)
+$(1)_config_env+=PATH="$(build_prefix)/bin:$(PATH)"
+$(1)_build_env+=PATH="$(build_prefix)/bin:$(PATH)"
+$(1)_stage_env+=PATH="$(build_prefix)/bin:$(PATH)"
 
 # Setting a --build type that differs from --host will explicitly enable
 # cross-compilation mode. Note that --build defaults to the output of


### PR DESCRIPTION
Backports bitcoin/bitcoin#29237

Original commit: 17e33fb578

Backported from Bitcoin Core v0.27

Note: The ci/test/02_run_container.sh file doesn't exist in Dash, so only the depends/funcs.mk changes were applied. This change adds quotes around PATH variables in the depends build system to support directories with spaces in their names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of environment variables to ensure correct processing of the `PATH` value during package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->