### PR TITLE
Merge bitcoin/bitcoin#29243: wallet: Reset chain notifications handler if AttachChain fails

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3064,6 +3064,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     walletInstance->TopUpKeyPool();
 
     if (chain && !AttachChain(walletInstance, *chain, error, warnings)) {
+        walletInstance->m_chain_notifications_handler.reset(); // Reset this pointer so that the wallet will actually be unloaded
         return nullptr;
     }
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29243

Original commit: fe1eccd4d720937acbf9d914bc034fd0531dddaa

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet handling to ensure that resources are properly cleaned up if wallet initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->