### PR TITLE
Merge bitcoin/bitcoin#28791: snapshots: don't core dump when running -checkblockindex after `loadtxoutset`

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5168,8 +5168,20 @@ void CChainState::CheckBlockIndex()
     CBlockIndex* pindexFirstNotTransactionsValid = nullptr; // Oldest ancestor of pindex which does not have BLOCK_VALID_TRANSACTIONS (regardless of being valid or not).
     CBlockIndex* pindexFirstNotChainValid = nullptr; // Oldest ancestor of pindex which does not have BLOCK_VALID_CHAIN (regardless of being valid or not).
     CBlockIndex* pindexFirstNotScriptsValid = nullptr; // Oldest ancestor of pindex which does not have BLOCK_VALID_SCRIPTS (regardless of being valid or not).
+    CBlockIndex* pindexFirstAssumeValid = nullptr; // Oldest ancestor of pindex which has BLOCK_ASSUMED_VALID
     while (pindex != nullptr) {
         nNodes++;
+        // Make sure nChainTx sum is correctly computed.
+        unsigned int prev_chain_tx = pindex->pprev ? pindex->pprev->nChainTx : 0;
+        assert((pindex->nChainTx == pindex->nTx + prev_chain_tx)
+               // For testing, allow transaction counts to be completely unset.
+               || (pindex->nChainTx == 0 && pindex->nTx == 0)
+               // For testing, allow this nChainTx to be unset if previous is also unset.
+               || (pindex->nChainTx == 0 && prev_chain_tx == 0 && pindex->pprev)
+               // Transaction counts prior to snapshot are unknown.
+               || pindex->IsAssumedValid());
+
+        if (pindexFirstAssumeValid == nullptr && pindex->nStatus & BLOCK_ASSUMED_VALID) pindexFirstAssumeValid = pindex;
         if (pindexFirstInvalid == nullptr && pindex->nStatus & BLOCK_FAILED_VALID) pindexFirstInvalid = pindex;
         if (pindexFirstConflicing == nullptr && pindex->nStatus & BLOCK_CONFLICT_CHAINLOCK) pindexFirstConflicing = pindex;
         // Assumed-valid index entries will not have data since we haven't downloaded the


### PR DESCRIPTION
Backports bitcoin/bitcoin#28791

Original commit: a3fb1f80ac

This PR adds a safety check to prevent core dumps when running with `-checkblockindex` after loading a snapshot. The change adds an additional condition to the assert statement that checks transaction counts, allowing for assumed-valid blocks (snapshots) to have unknown transaction counts.

Note: The backport is larger than the original Bitcoin change (12 lines vs 4 lines) because Dash was missing the entire assert block that Bitcoin modified. This is not a scope expansion but rather adding the complete safety check that Bitcoin already had.