### PR TITLE
Merge bitcoin/bitcoin#29327: fuzz: also set MSAN_SYMBOLIZER_PATH

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -17,15 +17,12 @@ import sys
 
 
 def get_fuzz_env(*, target, source_dir):
-    symbolizer = os.environ.get('LLVM_SYMBOLIZER_PATH', "/usr/bin/llvm-symbolizer")
     return {
         'FUZZ': target,
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
-        'UBSAN_SYMBOLIZER_PATH':symbolizer,
         "ASAN_OPTIONS": "detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
-        'ASAN_SYMBOLIZER_PATH':symbolizer,
-        'MSAN_SYMBOLIZER_PATH':symbolizer,
+        'MSAN_SYMBOLIZER_PATH': os.environ.get('LLVM_SYMBOLIZER_PATH', "/usr/bin/llvm-symbolizer"),
     }
 
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29327

Original commit: 6bacd11b09390353d75606d738b2fcbccffcb2b2

Backported from Bitcoin Core v0.27

This change adds MSAN_SYMBOLIZER_PATH to the fuzz test environment. Due to differences between Bitcoin and Dash codebases, this backport also includes the necessary infrastructure (symbolizer variable and other symbolizer paths) that was already present in Bitcoin but missing in Dash.