### PR TITLE
Merge bitcoin/bitcoin#29299: validation: fix misleading checkblockindex comments

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5248,6 +5248,15 @@ void CChainState::CheckBlockIndex()
             // Checks for not-conflciting blocks.
             assert((pindex->nStatus & BLOCK_CONFLICT_CHAINLOCK) == 0); // The conflicting mask cannot be set for blocks without conflicting parents.
         }
+        // Make sure nChainTx sum is correctly computed.
+        unsigned int prev_chain_tx = pindex->pprev ? pindex->pprev->nChainTx : 0;
+        assert((pindex->nChainTx == pindex->nTx + prev_chain_tx)
+               // Transaction may be completely unset - happens if only the header was accepted but the block hasn't been processed.
+               || (pindex->nChainTx == 0 && pindex->nTx == 0)
+               // nChainTx may be unset, but nTx set (if a block has been accepted, but one of its predecessors hasn't been processed yet)
+               || (pindex->nChainTx == 0 && prev_chain_tx == 0 && pindex->pprev)
+               // Transaction counts prior to snapshot are unknown.
+               || pindex->IsAssumedValid());
         if (!CBlockIndexWorkComparator()(pindex, m_chain.Tip()) && pindexFirstNeverProcessed == nullptr) {
             if (pindexFirstInvalid == nullptr && pindexFirstConflicing == nullptr) {
                 const bool is_active = this == &m_chainman.ActiveChainstate();


### PR DESCRIPTION
Backports bitcoin/bitcoin#29299

Original commit: 7005766492

Backported from Bitcoin Core v0.27

This PR fixes misleading comments in CheckBlockIndex() that incorrectly described certain conditions as "test-only". The changes:
1. Update comments to accurately explain when nChainTx conditions can occur in normal operation
2. Move the nChainTx assertion to the consistency checks section where it belongs

The size validation shows 47.4% because Bitcoin moved the assertion from one location to another (removing it from early in the loop and adding it to the consistency checks section), while in Dash we only add it to the consistency checks section as it was already removed from the early location.