### PR TITLE
Merge bitcoin/bitcoin#28956: Nuke adjusted time from validation (attempt 2)

### DIFF
--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -13,6 +13,7 @@
 #include <primitives/transaction.h>
 #include <sync.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <univalue.h>
 #include <util/translation.h>
 #include <version.h>
@@ -221,7 +222,7 @@ public:
     [[nodiscard]] bool CheckSignature(const CBLSPublicKey& blsPubKey) const;
 
     /// Check if a queue is too old or too far into the future
-    [[nodiscard]] bool IsTimeOutOfBounds(int64_t current_time = GetAdjustedTime()) const;
+    [[nodiscard]] bool IsTimeOutOfBounds(int64_t current_time = GetTime()) const;
 
     [[nodiscard]] std::string ToString() const;
 

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -343,7 +343,7 @@ void CCoinJoinServer::CommitFinalTransaction()
         CCoinJoinBroadcastTx dstxNew(finalTransaction,
                                     m_mn_activeman->GetOutPoint(),
                                     m_mn_activeman->GetProTxHash(),
-                                    GetAdjustedTime());
+                                    GetTime());
         dstxNew.Sign(*m_mn_activeman);
         m_dstxman.AddDSTX(dstxNew);
     }
@@ -511,7 +511,7 @@ void CCoinJoinServer::CheckForCompleteQueue()
         CCoinJoinQueue dsq(nSessionDenom,
                             m_mn_activeman->GetOutPoint(),
                             m_mn_activeman->GetProTxHash(),
-                            GetAdjustedTime(), true);
+                            GetTime(), true);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) " /* Continued */
                                      "with %d participants\n", dsq.ToString(), vecSessionCollaterals.size());
         dsq.Sign(*m_mn_activeman);
@@ -727,7 +727,7 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
         CCoinJoinQueue dsq(nSessionDenom,
                             m_mn_activeman->GetOutPoint(),
                             m_mn_activeman->GetProTxHash(),
-                            GetAdjustedTime(), false);
+                            GetTime(), false);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- signing and relaying new queue: %s\n", dsq.ToString());
         dsq.Sign(*m_mn_activeman);
         m_peerman->RelayDSQ(dsq);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -282,7 +282,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, PeerManager
 
     ScopedLockBool guard(cs, fRateChecksEnabled, false);
 
-    int64_t nNow = GetAdjustedTime();
+    int64_t nNow = GetTime();
     const auto tip_mn_list = Assert(m_dmnman)->GetListAtChainTip();
     for (const auto& pairVote : vecVotePairs) {
         bool fRemove = false;
@@ -703,7 +703,7 @@ std::optional<const CGovernanceObject> CGovernanceManager::CreateGovernanceTrigg
     LOCK2(::cs_main, cs);
 
     // Check if identical trigger (equal DataHash()) is already created (signed by other masternode)
-    CGovernanceObject gov_sb(uint256(), 1, GetAdjustedTime(), uint256(), sb_opt.value().GetHexStrData());
+    CGovernanceObject gov_sb(uint256(), 1, GetTime(), uint256(), sb_opt.value().GetHexStrData());
     if (auto identical_sb = FindGovernanceObjectByDataHash(gov_sb.GetDataHash())) {
         // Somebody submitted a trigger with the same data, support it instead of submitting a duplicate
         return std::make_optional<CGovernanceObject>(*identical_sb);
@@ -832,7 +832,7 @@ bool CGovernanceManager::VoteFundingTrigger(const uint256& nHash, const vote_out
                                             const CActiveMasternodeManager& mn_activeman)
 {
     CGovernanceVote vote(mn_activeman.GetOutPoint(), nHash, VOTE_SIGNAL_FUNDING, outcome);
-    vote.SetTime(GetAdjustedTime());
+    vote.SetTime(GetTime());
     vote.Sign(mn_activeman);
 
     CGovernanceException exception;
@@ -1066,7 +1066,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
 
     const COutPoint& masternodeOutpoint = govobj.GetMasternodeOutpoint();
     int64_t nTimestamp = govobj.GetCreationTime();
-    int64_t nNow = GetAdjustedTime();
+    int64_t nNow = GetTime();
     int64_t nSuperblockCycleSeconds = Params().GetConsensus().nSuperblockCycle * Params().GetConsensus().nPowTargetSpacing;
 
     std::string strHash = govobj.GetHash().ToString();
@@ -1210,7 +1210,7 @@ void CGovernanceManager::CheckPostponedObjects(PeerManager& peerman)
 
 
     // Perform additional relays for triggers
-    int64_t nNow = GetAdjustedTime();
+    int64_t nNow = GetTime();
     int64_t nSuperblockCycleSeconds = Params().GetConsensus().nSuperblockCycle * Params().GetConsensus().nPowTargetSpacing;
 
     for (auto it = setAdditionalRelayObjects.begin(); it != setAdditionalRelayObjects.end();) {

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -120,7 +120,7 @@ bool CGovernanceObject::ProcessVote(CMasternodeMetaMan& mn_metaman, CGovernanceM
         LogPrint(BCLog::GOBJECT, "%s\n", msg);
     }
 
-    int64_t nNow = GetAdjustedTime();
+    int64_t nNow = GetTime();
     int64_t nVoteTimeUpdate = voteInstanceRef.nTime;
     if (govman.AreRateChecksEnabled()) {
         int64_t nTimeDelta = nNow - voteInstanceRef.nTime;

--- a/src/governance/validators.cpp
+++ b/src/governance/validators.cpp
@@ -7,6 +7,7 @@
 
 #include <key_io.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 #include <util/underlying.h>
@@ -136,7 +137,7 @@ bool CProposalValidator::ValidateStartEndEpoch(bool fCheckExpiration)
         return false;
     }
 
-    if (fCheckExpiration && nEndEpoch <= GetAdjustedTime()) {
+    if (fCheckExpiration && nEndEpoch <= GetTime()) {
         strErrorMessages += "expired;";
         return false;
     }

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -13,6 +13,7 @@
 #include <messagesigner.h>
 #include <net_processing.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <util/string.h>
 
 std::string CGovernanceVoting::ConvertOutcomeToString(vote_outcome_enum_t nOutcome)
@@ -87,7 +88,7 @@ CGovernanceVote::CGovernanceVote(const COutPoint& outpointMasternodeIn, const ui
     nParentHash(nParentHashIn),
     nVoteOutcome(eVoteOutcomeIn),
     nVoteSignal(eVoteSignalIn),
-    nTime(GetAdjustedTime())
+    nTime(GetTime())
 {
     UpdateHash();
 }
@@ -181,8 +182,8 @@ bool CGovernanceVote::CheckSignature(const CBLSPublicKey& pubKey) const
 
 bool CGovernanceVote::IsValid(const CDeterministicMNList& tip_mn_list, bool useVotingKey) const
 {
-    if (nTime > GetAdjustedTime() + (60 * 60)) {
-        LogPrint(BCLog::GOBJECT, "CGovernanceVote::IsValid -- vote is too far ahead of current time - %s - nTime %lli - Max Time %lli\n", GetHash().ToString(), nTime, GetAdjustedTime() + (60 * 60));
+    if (nTime > GetTime() + (60 * 60)) {
+        LogPrint(BCLog::GOBJECT, "CGovernanceVote::IsValid -- vote is too far ahead of current time - %s - nTime %lli - Max Time %lli\n", GetHash().ToString(), nTime, GetTime() + (60 * 60));
         return false;
     }
 

--- a/src/llmq/debug.cpp
+++ b/src/llmq/debug.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <evo/deterministicmns.h>
@@ -152,7 +153,7 @@ void CDKGDebugManager::ResetLocalSessionStatus(Consensus::LLMQType llmqType, int
     }
 
     localStatus.sessions.erase(it);
-    localStatus.nTime = GetAdjustedTime();
+    localStatus.nTime = GetTime();
 }
 
 void CDKGDebugManager::InitLocalSessionStatus(const Consensus::LLMQParams& llmqParams, int quorumIndex, const uint256& quorumHash, int quorumHeight)
@@ -184,7 +185,7 @@ void CDKGDebugManager::UpdateLocalSessionStatus(Consensus::LLMQType llmqType, in
     }
 
     if (func(it->second)) {
-        localStatus.nTime = GetAdjustedTime();
+        localStatus.nTime = GetTime();
     }
 }
 
@@ -198,7 +199,7 @@ void CDKGDebugManager::UpdateLocalMemberStatus(Consensus::LLMQType llmqType, int
     }
 
     if (func(it->second.members.at(memberIdx))) {
-        localStatus.nTime = GetAdjustedTime();
+        localStatus.nTime = GetTime();
     }
 }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,6 +30,7 @@
 #include <streams.h>
 #include <sync.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <tinyformat.h>
 #include <index/txindex.h>
 #include <txmempool.h>
@@ -1314,7 +1315,7 @@ bool PeerManagerImpl::TipMayBeStale()
 
 bool PeerManagerImpl::CanDirectFetch()
 {
-    return m_chainman.ActiveChain().Tip()->GetBlockTime() > GetAdjustedTime() - m_chainparams.GetConsensus().nPowTargetSpacing * 20;
+    return m_chainman.ActiveChain().Tip()->GetBlockTime() > GetTime() - m_chainparams.GetConsensus().nPowTargetSpacing * 20;
 }
 
 static bool PeerHasHeader(CNodeState *state, const CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -5835,7 +5836,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
 
         if (!state.fSyncStarted && CanServeBlocks(*peer) && !fImporting && !fReindex && pto->CanRelay()) {
             // Only actively request headers from a single peer, unless we're close to end of initial download.
-            if ((nSyncStarted == 0 && sync_blocks_and_headers_from_peer) || m_chainman.m_best_header->GetBlockTime() > GetAdjustedTime() - nMaxTipAge) {
+            if ((nSyncStarted == 0 && sync_blocks_and_headers_from_peer) || m_chainman.m_best_header->GetBlockTime() > GetTime() - nMaxTipAge) {
                 const CBlockIndex* pindexStart = m_chainman.m_best_header;
                 /* If possible, start at the block preceding the currently
                    best known header.  This ensures that we always get a
@@ -5856,7 +5857,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                          // Convert HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER to microseconds before scaling
                          // to maintain precision
                          std::chrono::microseconds{HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER} *
-                         (GetAdjustedTime() - m_chainman.m_best_header->GetBlockTime()) / consensusParams.nPowTargetSpacing
+                         (GetTime() - m_chainman.m_best_header->GetBlockTime()) / consensusParams.nPowTargetSpacing
                         );
                     nSyncStarted++;
                 }
@@ -6235,7 +6236,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         // Check for headers sync timeouts
         if (state.fSyncStarted && state.m_headers_sync_timeout < std::chrono::microseconds::max()) {
             // Detect whether this is a stalling initial-headers-sync peer
-            if (m_chainman.m_best_header->GetBlockTime() <= GetAdjustedTime() - nMaxTipAge) {
+            if (m_chainman.m_best_header->GetBlockTime() <= GetTime() - nMaxTipAge) {
                 if (current_time > state.m_headers_sync_timeout && nSyncStarted == 1 && (m_num_preferred_download_peers - state.fPreferredDownload >= 1)) {
                     // Disconnect a peer (without NetPermissionFlags::NoBan permission) if it is our only sync peer,
                     // and we have others we could be using instead.

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -20,6 +20,7 @@
 #include <pow.h>
 #include <primitives/transaction.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <util/moneystr.h>
 #include <util/system.h>
 #include <validation.h>
@@ -49,7 +50,7 @@ namespace node {
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
-    int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast() + 1, GetAdjustedTime());
+    int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast() + 1, GetTime());
 
     if (nOldTime < nNewTime) {
         pblock->nTime = nNewTime;
@@ -219,7 +220,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         pblock->nVersion = gArgs.GetIntArg("-blockversion", pblock->nVersion);
     }
 
-    pblock->nTime = GetAdjustedTime();
+    pblock->nTime = GetTime();
     m_lock_time_cutoff = pindexPrev->GetMedianTimePast();
 
     if (fDIP0003Active_context) {

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -18,6 +18,7 @@
 #include <rpc/server_util.h>
 #include <rpc/util.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <validation.h>
@@ -106,7 +107,7 @@ static RPCHelpMan gobject_check()
 
     int nRevision = 1;
 
-    int64_t nTime = GetAdjustedTime();
+    int64_t nTime = GetTime();
     std::string strDataHex = request.params[0].get_str();
 
     CGovernanceObject govobj(hashParent, nRevision, nTime, uint256(), strDataHex);

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -15,6 +15,7 @@
 #include <protocol.h>
 #include <script/standard.h>
 #include <timedata.h>
+#include <util/time.h>
 #include <util/message.h> // for MESSAGE_MAGIC
 #include <util/ranges.h>
 #include <util/string.h>
@@ -147,7 +148,7 @@ PeerMsgRet CSporkManager::ProcessSpork(const CNode& peer, PeerManager& peerman, 
     std::string strLogMsg{strprintf("SPORK -- hash: %s id: %d value: %10d peer=%d", hash.ToString(), spork.nSporkID,
                                     spork.nValue, peer.GetId())};
 
-    if (spork.nTimeSigned > GetAdjustedTime() + 2 * 60 * 60) {
+    if (spork.nTimeSigned > GetTime() + 2 * 60 * 60) {
         LogPrint(BCLog::SPORK, "CSporkManager::ProcessSpork -- ERROR: too far into the future\n");
         return tl::unexpected{100};
     }
@@ -205,7 +206,7 @@ void CSporkManager::ProcessGetSporks(CNode& peer, CConnman& connman)
 
 bool CSporkManager::UpdateSpork(PeerManager& peerman, SporkId nSporkID, SporkValue nValue)
 {
-    CSporkMessage spork(nSporkID, nValue, GetAdjustedTime());
+    CSporkMessage spork(nSporkID, nValue, GetTime());
 
     {
         LOCK(cs);
@@ -246,7 +247,7 @@ bool CSporkManager::IsSporkActive(SporkId nSporkID) const
 
     SporkValue nSporkValue = GetSporkValue(nSporkID);
     // Get time is somewhat costly it looks like
-    bool ret = nSporkValue < GetAdjustedTime();
+    bool ret = nSporkValue < GetTime();
     // Only cache true values
     if (ret) {
         LOCK(cs_mapSporksCachedActive);

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -32,11 +32,6 @@ int64_t GetTimeOffset()
     return nTimeOffset;
 }
 
-int64_t GetAdjustedTime()
-{
-    return GetTime() + GetTimeOffset();
-}
-
 #define BITCOIN_TIMEDATA_MAX_SAMPLES 200
 
 static std::set<CNetAddr> g_sources;

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -75,7 +75,6 @@ public:
 
 /** Functions to keep track of adjusted P2P time */
 int64_t GetTimeOffset();
-int64_t GetAdjustedTime();
 void AddTimeData(const CNetAddr& ip, int64_t nTime);
 
 /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -36,6 +36,7 @@
 #include <shutdown.h>
 
 #include <timedata.h>
+#include <util/time.h>
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -2223,7 +2224,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     // Also, currently the rule against blocks more than 2 hours in the future
     // is enforced in ContextualCheckBlockHeader(); we wouldn't want to
     // re-enforce that rule here (at least until we make it impossible for
-    // GetAdjustedTime() to go backward).
+    // GetTime() to go backward).
     if (!CheckBlock(block, state, m_params.GetConsensus(), !fJustCheck, !fJustCheck)) {
         if (state.GetResult() == BlockValidationResult::BLOCK_MUTATED) {
             // We don't write down blocks to disk if they may have been
@@ -3981,7 +3982,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
  *  in ConnectBlock().
  *  Note that -reindex-chainstate skips the validation that happens here!
  */
-static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, BlockManager& blockman, const CChainParams& params, const CBlockIndex* pindexPrev, int64_t nAdjustedTime) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, BlockManager& blockman, const CChainParams& params, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     AssertLockHeld(::cs_main);
     assert(pindexPrev != nullptr);
@@ -4021,8 +4022,8 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-old", strprintf("block's timestamp is too early %d %d", block.GetBlockTime(), pindexPrev->GetMedianTimePast()));
 
     // Check timestamp
-    if (block.GetBlockTime() > nAdjustedTime + MAX_FUTURE_BLOCK_TIME)
-        return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", strprintf("block timestamp too far in the future %d %d", block.GetBlockTime(), nAdjustedTime + 2 * 60 * 60));
+    if (block.GetBlockTime() > GetTime() + MAX_FUTURE_BLOCK_TIME)
+        return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", strprintf("block timestamp too far in the future %d %d", block.GetBlockTime(), GetTime() + 2 * 60 * 60));
 
     // Reject blocks with outdated version
     if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
@@ -4160,7 +4161,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
             return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "bad-prevblk-chainlock");
         }
 
-        if (!ContextualCheckBlockHeader(block, state, m_blockman, chainparams, pindexPrev, GetAdjustedTime())) {
+        if (!ContextualCheckBlockHeader(block, state, m_blockman, chainparams, pindexPrev)) {
             LogPrint(BCLog::VALIDATION, "%s: Consensus::ContextualCheckBlockHeader: %s, %s\n", __func__, hash.ToString(), state.ToString());
             return false;
         }
@@ -4432,7 +4433,7 @@ bool TestBlockValidity(BlockValidationState& state,
     auto dbTx = evoDb.BeginTransaction();
 
     // NOTE: CheckBlockHeader is called by CheckBlock
-    if (!ContextualCheckBlockHeader(block, state, chainstate.m_blockman, chainparams, pindexPrev, GetAdjustedTime()))
+    if (!ContextualCheckBlockHeader(block, state, chainstate.m_blockman, chainparams, pindexPrev))
         return error("%s: Consensus::ContextualCheckBlockHeader: %s", __func__, state.ToString());
     if (!CheckBlock(block, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot))
         return error("%s: Consensus::CheckBlock: %s", __func__, state.ToString());


### PR DESCRIPTION
Backports bitcoin/bitcoin#28956

Original commit: 3c13f5d612

This removes the GetAdjustedTime() function and related time offset logic from validation code. The adjusted time feature is removed as it's no longer considered necessary for network consensus.

Changes:
- Remove GetAdjustedTime() function from timedata.cpp/h
- Replace all GetAdjustedTime() calls with GetTime() in core code
- Update ContextualCheckBlockHeader to remove time parameter
- Update Dash-specific modules (coinjoin, governance, llmq, spork) to use GetTime()

Note: Build validation skipped due to missing dependencies in the worktree. The changes are straightforward replacements of GetAdjustedTime() with GetTime().

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced usage of adjusted network time with system time across various features, including governance, coin mixing, mining, peer management, and spork management.
  * Removed the adjusted time function and its references.
  * Simplified time-related checks and function signatures for improved consistency and maintainability.

* **Bug Fixes**
  * Improved accuracy and reliability of time-based operations by standardizing on system time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->