### PR TITLE
Merge bitcoin/bitcoin#29189: RFC: Deprecate libconsensus

### DIFF
--- a/doc/release-notes-29189.md
+++ b/doc/release-notes-29189.md
@@ -8,7 +8,7 @@ has become a maintenance burden.
 
 The underlying functionality does not change between versions, so any users of
 the library can continue to use the final release indefinitely, with the
-understanding that its final consensus update.
+understanding that this is its final consensus update.
 
 In the future, libdashkernel will provide a much more useful API that is
 aware of the UTXO set, and therefore be able to fully validate transactions and

--- a/doc/release-notes-29189.md
+++ b/doc/release-notes-29189.md
@@ -1,0 +1,15 @@
+libdashconsensus
+========================
+
+This library is deprecated and will be removed for v28.
+
+It has existed for nearly 10 years with very little known uptake or impact. It
+has become a maintenance burden.
+
+The underlying functionality does not change between versions, so any users of
+the library can continue to use the final release indefinitely, with the
+understanding that its final consensus update.
+
+In the future, libdashkernel will provide a much more useful API that is
+aware of the UTXO set, and therefore be able to fully validate transactions and
+blocks.

--- a/doc/shared-libraries.md
+++ b/doc/shared-libraries.md
@@ -2,6 +2,7 @@ Shared Libraries
 ================
 
 ## dashconsensus
+***This library is deprecated and will be removed in v28***
 
 The purpose of this library is to make the verification functionality that is critical to Dash's consensus available to other applications, e.g. to language bindings.
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29189

Original commit: 5b8c5970bd

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Announced deprecation of libdashconsensus library with removal targeted for v28. The final release will remain functional indefinitely, and an alternative UTXO-aware API will be provided for transaction and block validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->