### PR TITLE
Merge bitcoin/bitcoin#26859: fuzz: extend ConsumeNetAddr() to return I2P and CJDNS addresses

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -267,6 +267,18 @@ public:
         }
     }
 
+    /**
+     * BIP155 network ids recognized by this software.
+     */
+    enum BIP155Network : uint8_t {
+        IPV4 = 1,
+        IPV6 = 2,
+        TORV2 = 3,
+        TORV3 = 4,
+        I2P = 5,
+        CJDNS = 6,
+    };
+
     friend class CSubNet;
 
 private:
@@ -287,18 +299,6 @@ private:
      * @see CNetAddr::IsI2P()
      */
     bool SetI2P(const std::string& addr);
-
-    /**
-     * BIP155 network ids recognized by this software.
-     */
-    enum BIP155Network : uint8_t {
-        IPV4 = 1,
-        IPV6 = 2,
-        TORV2 = 3,
-        TORV3 = 4,
-        I2P = 5,
-        CJDNS = 6,
-    };
 
     /**
      * Size of CNetAddr when serialized as ADDRv1 (pre-BIP155) (in bytes).

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Bitcoin Core developers
+// Copyright (c) 2020-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +6,7 @@
 #include <addrman.h>
 #include <addrman_impl.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <merkleblock.h>
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -15,7 +16,7 @@
 #include <test/util/setup_common.h>
 #include <time.h>
 #include <util/asmap.h>
-#include <util/system.h>
+#include <util/chaintype.h>
 
 #include <cassert>
 #include <cstdint>
@@ -34,11 +35,11 @@ int32_t GetCheckRatio()
 
 void initialize_addrman()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>(CBaseChainParams::REGTEST);
+    static const auto testing_setup = MakeNoLogFileContext<>(ChainType::REGTEST);
     g_setup = testing_setup.get();
 }
 
-[[nodiscard]] NetGroupManager ConsumeNetGroupManager(FuzzedDataProvider& fuzzed_data_provider) noexcept
+[[nodiscard]] inline NetGroupManager ConsumeNetGroupManager(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
     std::vector<bool> asmap = ConsumeRandomLengthBitVector(fuzzed_data_provider);
     if (!SanityCheckASMap(asmap, 128)) asmap.clear();
@@ -48,7 +49,7 @@ void initialize_addrman()
 FUZZ_TARGET(data_stream_addr_man, .init = initialize_addrman)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    CDataStream data_stream = ConsumeDataStream(fuzzed_data_provider);
+    DataStream data_stream = ConsumeDataStream(fuzzed_data_provider);
     NetGroupManager netgroupman{ConsumeNetGroupManager(fuzzed_data_provider)};
     AddrMan addr_man(netgroupman, /*deterministic=*/false, GetCheckRatio());
     try {
@@ -63,26 +64,13 @@ FUZZ_TARGET(data_stream_addr_man, .init = initialize_addrman)
 CNetAddr RandAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext& fast_random_context)
 {
     CNetAddr addr;
-    if (fuzzed_data_provider.remaining_bytes() > 1 && fuzzed_data_provider.ConsumeBool()) {
-        addr = ConsumeNetAddr(fuzzed_data_provider);
-    } else {
-        // The networks [1..6] correspond to CNetAddr::BIP155Network (private).
-        static const std::map<uint8_t, uint8_t> net_len_map = {{1, ADDR_IPV4_SIZE},
-                                                               {2, ADDR_IPV6_SIZE},
-                                                               {4, ADDR_TORV3_SIZE},
-                                                               {5, ADDR_I2P_SIZE},
-                                                               {6, ADDR_CJDNS_SIZE}};
-        uint8_t net = fast_random_context.randrange(5) + 1; // [1..5]
-        if (net == 3) {
-            net = 6;
+    assert(!addr.IsValid());
+    for (size_t i = 0; i < 8 && !addr.IsValid(); ++i) {
+        if (fuzzed_data_provider.remaining_bytes() > 1 && fuzzed_data_provider.ConsumeBool()) {
+            addr = ConsumeNetAddr(fuzzed_data_provider);
+        } else {
+            addr = ConsumeNetAddr(fuzzed_data_provider, &fast_random_context);
         }
-
-        CDataStream s(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
-
-        s << net;
-        s << fast_random_context.randbytes(net_len_map.at(net));
-
-        s >> addr;
     }
 
     // Return a dummy IPv4 5.5.5.5 if we generated an invalid address.
@@ -170,8 +158,8 @@ public:
             hasher.Write(a.source.GetNetwork());
             hasher.Write(addr_key.size());
             hasher.Write(source_key.size());
-            hasher.Write(addr_key.data(), addr_key.size());
-            hasher.Write(source_key.data(), source_key.size());
+            hasher.Write(addr_key);
+            hasher.Write(source_key);
             return (size_t)hasher.Finalize();
         };
 
@@ -240,9 +228,7 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
     auto addr_man_ptr = std::make_unique<AddrManDeterministic>(netgroupman, fuzzed_data_provider);
     if (fuzzed_data_provider.ConsumeBool()) {
         const std::vector<uint8_t> serialized_data{ConsumeRandomLengthByteVector(fuzzed_data_provider)};
-        CDataStream ds(serialized_data, SER_DISK, INIT_PROTO_VERSION);
-        const auto ser_version{fuzzed_data_provider.ConsumeIntegral<int32_t>()};
-        ds.SetVersion(ser_version);
+        DataStream ds{serialized_data};
         try {
             ds >> *addr_man_ptr;
         } catch (const std::ios_base::failure&) {
@@ -258,15 +244,6 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
             },
             [&] {
                 (void)addr_man.SelectTriedCollision();
-            },
-            [&] {
-                (void)addr_man.Select(fuzzed_data_provider.ConsumeBool());
-            },
-            [&] {
-                (void)addr_man.GetAddr(
-                    /*max_addresses=*/fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096),
-                    /*max_pct=*/fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096),
-                    /*network=*/std::nullopt);
             },
             [&] {
                 std::vector<CAddress> addresses;
@@ -288,9 +265,24 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
                 addr_man.SetServices(ConsumeService(fuzzed_data_provider), ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS));
             });
     }
-    (void)addr_man.Size();
-    CDataStream data_stream(SER_NETWORK, PROTOCOL_VERSION);
-    data_stream << addr_man;
+    const AddrMan& const_addr_man{addr_man};
+    std::optional<Network> network;
+    if (fuzzed_data_provider.ConsumeBool()) {
+        network = fuzzed_data_provider.PickValueInArray(ALL_NETWORKS);
+    }
+    (void)const_addr_man.GetAddr(
+        /*max_addresses=*/fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096),
+        /*max_pct=*/fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096),
+        network,
+        /*filtered=*/fuzzed_data_provider.ConsumeBool());
+    (void)const_addr_man.Select(fuzzed_data_provider.ConsumeBool(), network);
+    std::optional<bool> in_new;
+    if (fuzzed_data_provider.ConsumeBool()) {
+        in_new = fuzzed_data_provider.ConsumeBool();
+    }
+    (void)const_addr_man.Size(network, in_new);
+    DataStream data_stream{};
+    data_stream << const_addr_man;
 }
 
 // Check that serialize followed by unserialize produces the same addrman.
@@ -303,7 +295,7 @@ FUZZ_TARGET(addrman_serdeser, .init = initialize_addrman)
     AddrManDeterministic addr_man1{netgroupman, fuzzed_data_provider};
     AddrManDeterministic addr_man2{netgroupman, fuzzed_data_provider};
 
-    CDataStream data_stream(SER_NETWORK, PROTOCOL_VERSION);
+    DataStream data_stream{};
 
     FillAddrman(addr_man1, fuzzed_data_provider);
     data_stream << addr_man1;

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -1,17 +1,17 @@
-// Copyright (c) 2020 The Bitcoin Core developers
+// Copyright (c) 2020-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <banman.h>
-#include <fs.h>
+#include <common/args.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
-#include <util/readwritefile.h>
 #include <test/util/setup_common.h>
-#include <util/system.h>
+#include <util/fs.h>
+#include <util/readwritefile.h>
 
 #include <cassert>
 #include <cstdint>
@@ -63,17 +63,30 @@ FUZZ_TARGET(banman, .init = initialize_banman)
         // The complexity is O(N^2), where N is the input size, because each call
         // might call DumpBanlist (or other methods that are at least linear
         // complexity of the input size).
+        bool contains_invalid{false};
         LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 300)
         {
             CallOneOf(
                 fuzzed_data_provider,
                 [&] {
-                    ban_man.Ban(ConsumeNetAddr(fuzzed_data_provider),
-                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                    CNetAddr net_addr{ConsumeNetAddr(fuzzed_data_provider)};
+                    if (!net_addr.IsCJDNS() || !net_addr.IsValid()) {
+                        const std::optional<CNetAddr>& addr{LookupHost(net_addr.ToStringAddr(), /*fAllowLookup=*/false)};
+                        if (addr.has_value() && addr->IsValid()) {
+                            net_addr = *addr;
+                        } else {
+                            contains_invalid = true;
+                        }
+                    }
+                    ban_man.Ban(net_addr, ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },
                 [&] {
-                    ban_man.Ban(ConsumeSubNet(fuzzed_data_provider),
-                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                    CSubNet subnet{ConsumeSubNet(fuzzed_data_provider)};
+                    subnet = LookupSubNet(subnet.ToString());
+                    if (!subnet.IsValid()) {
+                        contains_invalid = true;
+                    }
+                    ban_man.Ban(subnet, ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },
                 [&] {
                     ban_man.ClearBanned();
@@ -109,7 +122,9 @@ FUZZ_TARGET(banman, .init = initialize_banman)
             BanMan ban_man_read{banlist_file, /*client_interface=*/nullptr, /*default_ban_time=*/0};
             banmap_t banmap_read;
             ban_man_read.GetBanned(banmap_read);
-            assert(banmap == banmap_read);
+            if (!contains_invalid) {
+                assert(banmap == banmap_read);
+            }
         }
     }
     fs::remove(fs::PathToString(banlist_file + ".json"));

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -26,6 +26,12 @@ FUZZ_TARGET(netaddress)
     if (net_addr.GetNetwork() == Network::NET_ONION) {
         assert(net_addr.IsTor());
     }
+    if (net_addr.GetNetwork() == Network::NET_I2P) {
+        assert(net_addr.IsI2P());
+    }
+    if (net_addr.GetNetwork() == Network::NET_CJDNS) {
+        assert(net_addr.IsCJDNS());
+    }
     if (net_addr.GetNetwork() == Network::NET_INTERNAL) {
         assert(net_addr.IsInternal());
     }
@@ -68,6 +74,12 @@ FUZZ_TARGET(netaddress)
     }
     if (net_addr.IsTor()) {
         assert(net_addr.GetNetwork() == Network::NET_ONION);
+    }
+    if (net_addr.IsI2P()) {
+        assert(net_addr.GetNetwork() == Network::NET_I2P);
+    }
+    if (net_addr.IsCJDNS()) {
+        assert(net_addr.GetNetwork() == Network::NET_CJDNS);
     }
     (void)net_addr.IsValid();
     (void)net_addr.ToStringAddr();

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -1,40 +1,414 @@
-// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Copyright (c) 2009-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <test/fuzz/util/net.h>
+
 #include <compat/compat.h>
 #include <netaddress.h>
+#include <node/protocol_version.h>
+#include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
-#include <util/strencodings.h>
+#include <test/fuzz/util.h>
+#include <test/util/net.h>
+#include <util/sock.h>
+#include <util/time.h>
 
+#include <array>
+#include <cassert>
+#include <cerrno>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
 #include <vector>
 
-CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
+class CNode;
+
+CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext* rand) noexcept
 {
-    const Network network = fuzzed_data_provider.PickValueInArray({Network::NET_IPV4, Network::NET_IPV6, Network::NET_INTERNAL, Network::NET_ONION});
-    CNetAddr net_addr;
-    if (network == Network::NET_IPV4) {
-        in_addr v4_addr = {};
-        v4_addr.s_addr = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
-        net_addr = CNetAddr{v4_addr};
-    } else if (network == Network::NET_IPV6) {
-        if (fuzzed_data_provider.remaining_bytes() >= 16) {
-            in6_addr v6_addr = {};
-            auto addr_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(16);
-            if (addr_bytes[0] == CJDNS_PREFIX) { // Avoid generating IPv6 addresses that look like CJDNS.
-                addr_bytes[0] = 0x55; // Just an arbitrary number, anything != CJDNS_PREFIX would do.
-            }
-            memcpy(v6_addr.s6_addr, addr_bytes.data(), 16);
-            net_addr = CNetAddr{v6_addr, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+    struct NetAux {
+        Network net;
+        CNetAddr::BIP155Network bip155;
+        size_t len;
+    };
+
+    static constexpr std::array<NetAux, 6> nets{
+        NetAux{.net = Network::NET_IPV4, .bip155 = CNetAddr::BIP155Network::IPV4, .len = ADDR_IPV4_SIZE},
+        NetAux{.net = Network::NET_IPV6, .bip155 = CNetAddr::BIP155Network::IPV6, .len = ADDR_IPV6_SIZE},
+        NetAux{.net = Network::NET_ONION, .bip155 = CNetAddr::BIP155Network::TORV3, .len = ADDR_TORV3_SIZE},
+        NetAux{.net = Network::NET_I2P, .bip155 = CNetAddr::BIP155Network::I2P, .len = ADDR_I2P_SIZE},
+        NetAux{.net = Network::NET_CJDNS, .bip155 = CNetAddr::BIP155Network::CJDNS, .len = ADDR_CJDNS_SIZE},
+        NetAux{.net = Network::NET_INTERNAL, .bip155 = CNetAddr::BIP155Network{0}, .len = 0},
+    };
+
+    const size_t nets_index{rand == nullptr
+        ? fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, nets.size() - 1)
+        : static_cast<size_t>(rand->randrange(nets.size()))};
+
+    const auto& aux = nets[nets_index];
+
+    CNetAddr addr;
+
+    if (aux.net == Network::NET_INTERNAL) {
+        if (rand == nullptr) {
+            addr.SetInternal(fuzzed_data_provider.ConsumeBytesAsString(32));
+        } else {
+            const auto v = rand->randbytes(32);
+            addr.SetInternal(std::string{v.begin(), v.end()});
         }
-    } else if (network == Network::NET_INTERNAL) {
-        net_addr.SetInternal(fuzzed_data_provider.ConsumeBytesAsString(32));
-    } else if (network == Network::NET_ONION) {
-        auto pub_key{fuzzed_data_provider.ConsumeBytes<uint8_t>(ADDR_TORV3_SIZE)};
-        pub_key.resize(ADDR_TORV3_SIZE);
-        const bool ok{net_addr.SetSpecial(OnionToString(pub_key))};
-        assert(ok);
+        return addr;
     }
-    return net_addr;
+
+    DataStream s;
+
+    s << static_cast<uint8_t>(aux.bip155);
+
+    std::vector<uint8_t> addr_bytes;
+    if (rand == nullptr) {
+        addr_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(aux.len);
+        addr_bytes.resize(aux.len);
+    } else {
+        addr_bytes = rand->randbytes(aux.len);
+    }
+    if (aux.net == NET_IPV6 && addr_bytes[0] == CJDNS_PREFIX) { // Avoid generating IPv6 addresses that look like CJDNS.
+        addr_bytes[0] = 0x55; // Just an arbitrary number, anything != CJDNS_PREFIX would do.
+    }
+    if (aux.net == NET_CJDNS) { // Avoid generating CJDNS addresses that don't start with CJDNS_PREFIX because those are !IsValid().
+        addr_bytes[0] = CJDNS_PREFIX;
+    }
+    s << addr_bytes;
+
+    s >> CAddress::V2_NETWORK(addr);
+
+    return addr;
+}
+
+CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return {ConsumeService(fuzzed_data_provider), ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS), NodeSeconds{std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<uint32_t>()}}};
+}
+
+template <typename P>
+P ConsumeDeserializationParams(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    constexpr std::array ADDR_ENCODINGS{
+        CNetAddr::Encoding::V1,
+        CNetAddr::Encoding::V2,
+    };
+    constexpr std::array ADDR_FORMATS{
+        CAddress::Format::Disk,
+        CAddress::Format::Network,
+    };
+    if constexpr (std::is_same_v<P, CNetAddr::SerParams>) {
+        return P{PickValue(fuzzed_data_provider, ADDR_ENCODINGS)};
+    }
+    if constexpr (std::is_same_v<P, CAddress::SerParams>) {
+        return P{{PickValue(fuzzed_data_provider, ADDR_ENCODINGS)}, PickValue(fuzzed_data_provider, ADDR_FORMATS)};
+    }
+}
+template CNetAddr::SerParams ConsumeDeserializationParams(FuzzedDataProvider&) noexcept;
+template CAddress::SerParams ConsumeDeserializationParams(FuzzedDataProvider&) noexcept;
+
+FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
+    : Sock{fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET)},
+      m_fuzzed_data_provider{fuzzed_data_provider},
+      m_selectable{fuzzed_data_provider.ConsumeBool()}
+{
+}
+
+FuzzedSock::~FuzzedSock()
+{
+    // Sock::~Sock() will be called after FuzzedSock::~FuzzedSock() and it will call
+    // close(m_socket) if m_socket is not INVALID_SOCKET.
+    // Avoid closing an arbitrary file descriptor (m_socket is just a random very high number which
+    // theoretically may concide with a real opened file descriptor).
+    m_socket = INVALID_SOCKET;
+}
+
+FuzzedSock& FuzzedSock::operator=(Sock&& other)
+{
+    assert(false && "Move of Sock into FuzzedSock not allowed.");
+    return *this;
+}
+
+ssize_t FuzzedSock::Send(const void* data, size_t len, int flags) const
+{
+    constexpr std::array send_errnos{
+        EACCES,
+        EAGAIN,
+        EALREADY,
+        EBADF,
+        ECONNRESET,
+        EDESTADDRREQ,
+        EFAULT,
+        EINTR,
+        EINVAL,
+        EISCONN,
+        EMSGSIZE,
+        ENOBUFS,
+        ENOMEM,
+        ENOTCONN,
+        ENOTSOCK,
+        EOPNOTSUPP,
+        EPIPE,
+        EWOULDBLOCK,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        return len;
+    }
+    const ssize_t r = m_fuzzed_data_provider.ConsumeIntegralInRange<ssize_t>(-1, len);
+    if (r == -1) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, send_errnos);
+    }
+    return r;
+}
+
+ssize_t FuzzedSock::Recv(void* buf, size_t len, int flags) const
+{
+    // Have a permanent error at recv_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always return the first element and we want to avoid Recv()
+    // returning -1 and setting errno to EAGAIN repeatedly.
+    constexpr std::array recv_errnos{
+        ECONNREFUSED,
+        EAGAIN,
+        EBADF,
+        EFAULT,
+        EINTR,
+        EINVAL,
+        ENOMEM,
+        ENOTCONN,
+        ENOTSOCK,
+        EWOULDBLOCK,
+    };
+    assert(buf != nullptr || len == 0);
+    if (len == 0 || m_fuzzed_data_provider.ConsumeBool()) {
+        const ssize_t r = m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
+        if (r == -1) {
+            SetFuzzedErrNo(m_fuzzed_data_provider, recv_errnos);
+        }
+        return r;
+    }
+    std::vector<uint8_t> random_bytes;
+    bool pad_to_len_bytes{m_fuzzed_data_provider.ConsumeBool()};
+    if (m_peek_data.has_value()) {
+        // `MSG_PEEK` was used in the preceding `Recv()` call, return `m_peek_data`.
+        random_bytes.assign({m_peek_data.value()});
+        if ((flags & MSG_PEEK) == 0) {
+            m_peek_data.reset();
+        }
+        pad_to_len_bytes = false;
+    } else if ((flags & MSG_PEEK) != 0) {
+        // New call with `MSG_PEEK`.
+        random_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(1);
+        if (!random_bytes.empty()) {
+            m_peek_data = random_bytes[0];
+            pad_to_len_bytes = false;
+        }
+    } else {
+        random_bytes = m_fuzzed_data_provider.ConsumeBytes<uint8_t>(
+            m_fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, len));
+    }
+    if (random_bytes.empty()) {
+        const ssize_t r = m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
+        if (r == -1) {
+            SetFuzzedErrNo(m_fuzzed_data_provider, recv_errnos);
+        }
+        return r;
+    }
+    std::memcpy(buf, random_bytes.data(), random_bytes.size());
+    if (pad_to_len_bytes) {
+        if (len > random_bytes.size()) {
+            std::memset((char*)buf + random_bytes.size(), 0, len - random_bytes.size());
+        }
+        return len;
+    }
+    if (m_fuzzed_data_provider.ConsumeBool() && std::getenv("FUZZED_SOCKET_FAKE_LATENCY") != nullptr) {
+        std::this_thread::sleep_for(std::chrono::milliseconds{2});
+    }
+    return random_bytes.size();
+}
+
+int FuzzedSock::Connect(const sockaddr*, socklen_t) const
+{
+    // Have a permanent error at connect_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always return the first element and we want to avoid Connect()
+    // returning -1 and setting errno to EAGAIN repeatedly.
+    constexpr std::array connect_errnos{
+        ECONNREFUSED,
+        EAGAIN,
+        ECONNRESET,
+        EHOSTUNREACH,
+        EINPROGRESS,
+        EINTR,
+        ENETUNREACH,
+        ETIMEDOUT,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, connect_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+int FuzzedSock::Bind(const sockaddr*, socklen_t) const
+{
+    // Have a permanent error at bind_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always set the global errno to bind_errnos[0]. We want to
+    // avoid this method returning -1 and setting errno to a temporary error (like EAGAIN)
+    // repeatedly because proper code should retry on temporary errors, leading to an
+    // infinite loop.
+    constexpr std::array bind_errnos{
+        EACCES,
+        EADDRINUSE,
+        EADDRNOTAVAIL,
+        EAGAIN,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, bind_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+int FuzzedSock::Listen(int) const
+{
+    // Have a permanent error at listen_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always set the global errno to listen_errnos[0]. We want to
+    // avoid this method returning -1 and setting errno to a temporary error (like EAGAIN)
+    // repeatedly because proper code should retry on temporary errors, leading to an
+    // infinite loop.
+    constexpr std::array listen_errnos{
+        EADDRINUSE,
+        EINVAL,
+        EOPNOTSUPP,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, listen_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) const
+{
+    constexpr std::array accept_errnos{
+        ECONNABORTED,
+        EINTR,
+        ENOMEM,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, accept_errnos);
+        return std::unique_ptr<FuzzedSock>();
+    }
+    return std::make_unique<FuzzedSock>(m_fuzzed_data_provider);
+}
+
+int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
+{
+    constexpr std::array getsockopt_errnos{
+        ENOMEM,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, getsockopt_errnos);
+        return -1;
+    }
+    if (opt_val == nullptr) {
+        return 0;
+    }
+    std::memcpy(opt_val,
+                ConsumeFixedLengthByteVector(m_fuzzed_data_provider, *opt_len).data(),
+                *opt_len);
+    return 0;
+}
+
+int FuzzedSock::SetSockOpt(int, int, const void*, socklen_t) const
+{
+    constexpr std::array setsockopt_errnos{
+        ENOMEM,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, setsockopt_errnos);
+        return -1;
+    }
+    return 0;
+}
+
+int FuzzedSock::GetSockName(sockaddr* name, socklen_t* name_len) const
+{
+    constexpr std::array getsockname_errnos{
+        ECONNRESET,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, getsockname_errnos);
+        return -1;
+    }
+    *name_len = m_fuzzed_data_provider.ConsumeData(name, *name_len);
+    return 0;
+}
+
+bool FuzzedSock::SetNonBlocking() const
+{
+    constexpr std::array setnonblocking_errnos{
+        EBADF,
+        EPERM,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, setnonblocking_errnos);
+        return false;
+    }
+    return true;
+}
+
+bool FuzzedSock::IsSelectable() const
+{
+    return m_selectable;
+}
+
+bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
+{
+    constexpr std::array wait_errnos{
+        EBADF,
+        EINTR,
+        EINVAL,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, wait_errnos);
+        return false;
+    }
+    if (occurred != nullptr) {
+        *occurred = m_fuzzed_data_provider.ConsumeBool() ? requested : 0;
+    }
+    return true;
+}
+
+bool FuzzedSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock) const
+{
+    for (auto& [sock, events] : events_per_sock) {
+        (void)sock;
+        events.occurred = m_fuzzed_data_provider.ConsumeBool() ? events.requested : 0;
+    }
+    return true;
+}
+
+bool FuzzedSock::IsConnected(std::string& errmsg) const
+{
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        return true;
+    }
+    errmsg = "disconnected at random by the fuzzer";
+    return false;
+}
+
+void FillNode(FuzzedDataProvider& fuzzed_data_provider, ConnmanTestMsg& connman, CNode& node) noexcept
+{
+    connman.Handshake(node,
+                      /*successfully_connected=*/fuzzed_data_provider.ConsumeBool(),
+                      /*remote_services=*/ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS),
+                      /*local_services=*/ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS),
+                      /*version=*/fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(MIN_PEER_PROTO_VERSION, std::numeric_limits<int32_t>::max()),
+                      /*relay_txs=*/fuzzed_data_provider.ConsumeBool());
 }

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -9,6 +9,14 @@
 
 class FuzzedDataProvider;
 
-CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept;
+/**
+ * Create a CNetAddr. It may have `addr.IsValid() == false`.
+ * @param[in,out] fuzzed_data_provider Take data for the address from this, if `rand` is `nullptr`.
+ * @param[in,out] rand If not nullptr, take data from it instead of from `fuzzed_data_provider`.
+ * Prefer generating addresses using `fuzzed_data_provider` because it is not uniform. Only use
+ * `rand` if `fuzzed_data_provider` is exhausted or its data is needed for other things.
+ * @return a "random" network address.
+ */
+CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext* rand = nullptr) noexcept;
 
 #endif // BITCOIN_TEST_FUZZ_UTIL_NET_H


### PR DESCRIPTION
Backports bitcoin/bitcoin#26859

Original commit: aa9231fafe45513134ec8953a217cda07446fae8

Backported from Bitcoin Core v0.27