### PR TITLE
Merge bitcoin/bitcoin#29254: log: Don't use scientific notation in log messages

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -1025,5 +1025,5 @@ void CBlockPolicyEstimator::FlushUnconfirmed() {
         _removeTx(mi->first, false); // this calls erase() on mapMemPoolTxs
     }
     int64_t endclear = GetTimeMicros();
-    LogPrint(BCLog::ESTIMATEFEE, "Recorded %u unconfirmed txs from mempool in %ld micros\n", num_entries, endclear - startclear);
+    LogPrint(BCLog::ESTIMATEFEE, "Recorded %u unconfirmed txs from mempool in %.3fs\n", num_entries, (endclear - startclear) * MICRO);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5535,7 +5535,7 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
             throw std::runtime_error("Rename failed");
         }
         int64_t last = GetTimeMicros();
-        LogPrintf("Dumped mempool: %gs to copy, %gs to dump\n", (mid-start)*MICRO, (last-mid)*MICRO);
+        LogPrintf("Dumped mempool: %.3fs to copy, %.3fs to dump\n", (mid-start)*MICRO, (last-mid)*MICRO);
     } catch (const std::exception& e) {
         LogPrintf("Failed to dump mempool: %s. Continuing anyway.\n", e.what());
         return false;


### PR DESCRIPTION
Backports bitcoin/bitcoin#29254

Original commit: 9eeee7caa3f95ee17a645e12d330261f8e3c2dbf

Backported from Bitcoin Core v0.27

## Changes
- Updated log format strings from `%gs` (which can produce scientific notation) to `%.3fs` (which always shows decimal format)
- In Dash, the mempool dump code is in `validation.cpp` instead of `kernel/mempool_persist.cpp`, so the change was applied there
- Both log messages now use consistent decimal format for better readability