### PR TITLE
Merge bitcoin-core/gui#553: Change address / amount error background

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -181,7 +181,7 @@ static const std::map<ThemedColor, QColor> themedDarkColors = {
 };
 
 static const std::map<ThemedStyle, QString> themedStyles = {
-    { ThemedStyle::TS_INVALID, "background:#a84832;" },
+    { ThemedStyle::TS_INVALID, "border: 3px solid #a84832;" },
     { ThemedStyle::TS_ERROR, "color:#a84832;" },
     { ThemedStyle::TS_WARNING, "color:#999900;" },
     { ThemedStyle::TS_SUCCESS, "color:#5e8c41;" },
@@ -191,7 +191,7 @@ static const std::map<ThemedStyle, QString> themedStyles = {
 };
 
 static const std::map<ThemedStyle, QString> themedDarkStyles = {
-    { ThemedStyle::TS_INVALID, "background:#a84832;" },
+    { ThemedStyle::TS_INVALID, "border: 3px solid #a84832;" },
     { ThemedStyle::TS_ERROR, "color:#a84832;" },
     { ThemedStyle::TS_WARNING, "color:#999900;" },
     { ThemedStyle::TS_SUCCESS, "color:#5e8c41;" },


### PR DESCRIPTION
Backports bitcoin-core/gui#553

Original commit: 7b39702513

Backported from Bitcoin Core v0.27

This PR changes the error styling for QLineEdit fields from a background color to a border. In Dash, this change was applied to the theming system in guiutil.cpp instead of guiconstants.h, as Dash uses a more sophisticated theming approach with separate light and dark theme definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated “invalid” state styling across light and dark themes: replaced the solid background highlight with a 3px solid border.
  * The highlight color remains #a84832 to maintain consistency.
  * This change affects UI elements marked as invalid, improving visibility without overwhelming background fill.
  * No other visual styles or behaviors were altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->