### PR TITLE
Merge bitcoin-core/gui#752: Modify command line help to show support for BIP21 URIs

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -62,7 +62,8 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, HelpMode helpMode) :
         ui->helpMessage->setVisible(false);
     } else if (helpMode == cmdline) {
         setWindowTitle(tr("Command-line options"));
-        QString header = "Usage:  dash-qt [command-line options]                     \n";
+        QString header = "Usage:  dash-qt [command-line options] [URI]\n\n"
+                         "Optional URI is a Dash address in BIP21 URI format.\n";
         QTextCursor cursor(ui->helpMessage->document());
         cursor.insertText(version);
         cursor.insertBlock();


### PR DESCRIPTION
## Summary
Backport of bitcoin-core/gui#752

This PR updates the dash-qt command-line help message to indicate that the program accepts an optional BIP21 URI parameter. This reflects the actual behavior of dash-qt which already supports BIP21 URIs.

## Bitcoin PR Information
- **Original PR**: bitcoin-core/gui#752
- **Commit**: ede5014c445dcb40ddcfdede2c51236bbfe85f5e
- **Author**: Hernan Marino
- **Merge commit**: 9e68a8208f75327a301b84da6bf86b84868104d3

## Changes
- Updates help text from `dash-qt [command-line options]` to `dash-qt [command-line options] [URI]`
- Adds explanation that the optional URI is a Dash address in BIP21 URI format

## Dash Adaptations
- Changed "bitcoin-qt" to "dash-qt"
- Changed "Bitcoin address" to "Dash address"

## Test Plan
- [x] Code review
- [ ] Verify help text displays correctly with `dash-qt --help`
- [ ] Verify dash-qt still accepts BIP21 URIs as command-line arguments

🤖 Generated by [Claude AI Assistant](https://claude.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the command-line help dialog to include information about an optional URI parameter, clarifying its usage and format for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->