### PR TITLE
Merge bitcoin-core/gui#658: Intro: Never change the prune checkbox after the user has touched it

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -144,6 +144,7 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     const int min_prune_target_GB = std::ceil(MIN_DISK_SPACE_FOR_BLOCK_FILES / 1e9);
     ui->pruneGB->setRange(min_prune_target_GB, std::numeric_limits<int>::max());
     if (gArgs.IsArgSet("-prune")) {
+        m_prune_checkbox_is_default = false;
         ui->prune->setChecked(gArgs.GetIntArg("-prune", 0) >= 1);
         ui->prune->setEnabled(false);
     }
@@ -153,6 +154,7 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     UpdatePruneLabels(ui->prune->isChecked());
 
     connect(ui->prune, &QCheckBox::toggled, [this](bool prune_checked) {
+        m_prune_checkbox_is_default = false;
         UpdatePruneLabels(prune_checked);
         UpdateFreeSpaceLabel();
     });
@@ -293,7 +295,7 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
         ui->freeSpace->setText("");
     } else {
         m_bytes_available = bytesAvailable;
-        if (ui->prune->isEnabled() && !(gArgs.IsArgSet("-prune") && gArgs.GetIntArg("-prune", 0) == 0)) {
+        if (ui->prune->isEnabled() && m_prune_checkbox_is_default) {
             ui->prune->setChecked(m_bytes_available < (m_blockchain_size_gb + m_chain_state_size_gb + 10) * GB_BYTES);
         }
         UpdateFreeSpaceLabel();

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -143,8 +143,8 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
 
     const int min_prune_target_GB = std::ceil(MIN_DISK_SPACE_FOR_BLOCK_FILES / 1e9);
     ui->pruneGB->setRange(min_prune_target_GB, std::numeric_limits<int>::max());
-    if (gArgs.GetIntArg("-prune", 0) > 1) { // -prune=1 means enabled, above that it's a size in MiB
-        ui->prune->setChecked(true);
+    if (gArgs.IsArgSet("-prune")) {
+        ui->prune->setChecked(gArgs.GetIntArg("-prune", 0) >= 1);
         ui->prune->setEnabled(false);
     }
     ui->pruneGB->setValue(m_prune_target_gb);

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -64,12 +64,8 @@ private Q_SLOTS:
 
 private:
     Ui::Intro *ui;
-<<<<<<< HEAD
-    QThread *thread;
-=======
     bool m_prune_checkbox_is_default{true};
     QThread* thread{nullptr};
->>>>>>> bee0ffbecf (GUI/Intro: Never change the prune checkbox after the user has touched it)
     QMutex mutex;
     bool signalled;
     QString pathToCheck;

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -64,7 +64,12 @@ private Q_SLOTS:
 
 private:
     Ui::Intro *ui;
+<<<<<<< HEAD
     QThread *thread;
+=======
+    bool m_prune_checkbox_is_default{true};
+    QThread* thread{nullptr};
+>>>>>>> bee0ffbecf (GUI/Intro: Never change the prune checkbox after the user has touched it)
     QMutex mutex;
     bool signalled;
     QString pathToCheck;


### PR DESCRIPTION
## Summary
Backport of bitcoin-core/gui#658 to Dash Core v0.27

This PR contains two commits:
1. **Bugfix: GUI/Intro: Disable GUI prune option if -prune is set, regardless of set value** - Fixes a bug where `-prune=0/1` did not disable the checkbox while `-prune=2+` did
2. **GUI/Intro: Never change the prune checkbox after the user has touched it** - Prevents the GUI from automatically changing the prune checkbox after user interaction

## Changes
- Adds `m_prune_checkbox_is_default` member variable to track whether the user has interacted with the prune checkbox
- Updates the logic to only auto-adjust the prune checkbox if the user hasn't touched it
- Fixes the `-prune` command line option to properly disable the GUI checkbox for all values

## Test Plan
- [ ] Verify that `-prune=0` and `-prune=1` properly disable the prune checkbox in the GUI
- [ ] Verify that once the user toggles the prune checkbox, it doesn't automatically change based on available disk space
- [ ] Verify that the prune checkbox still auto-adjusts based on disk space if the user hasn't touched it

## Original PR Description
Re-PR from https://github.com/bitcoin/bitcoin/pull/18729

Now includes a bugfix too (`-prune=2+` disabled the checkbox, but `-prune=0/1` did not; this behaviour is necessary since `-prune` overrides GUI settings)

🤖 Generated by Claude AI

Co-Authored-By: Luke Dashjr <luke-jr+git@utopios.org>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pruning option now correctly respects explicit settings and user choices.
  * Checkbox reflects configuration: checked when pruning is enabled, and disabled when controlled by startup arguments.
  * Prevents unwanted auto-toggling of the prune checkbox after the user interacts with it.
  * More predictable initial state of the prune option in the intro screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->