### PR TITLE
Merge bitcoin/bitcoin#29434: rpc: Fixed signed integer overflow for large feerates

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1047,7 +1047,7 @@ RPCHelpMan sendrawtransaction()
                     {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex string of the raw transaction"},
                     {"maxfeerate", RPCArg::Type::AMOUNT, RPCArg::Default{FormatMoney(DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK())},
                         "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT +
-                            "/kB.\nSet to 0 to accept any fee rate.\n"},
+                            "/kvB.\nFee rates larger than 1BTC/kvB are rejected.\nSet to 0 to accept any fee rate.\n"},
                     {"instantsend", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Deprecated and ignored"},
                     {"bypasslimits", RPCArg::Type::BOOL, RPCArg::Default{false}, "Bypass transaction policy limits"},
                 },
@@ -1080,7 +1080,7 @@ RPCHelpMan sendrawtransaction()
 
     const CFeeRate max_raw_tx_fee_rate = request.params[1].isNull() ?
                                              DEFAULT_MAX_RAW_TX_FEE_RATE :
-                                             CFeeRate(AmountFromValue(request.params[1]));
+                                             ParseFeeRate(request.params[1]);
 
     int64_t virtual_size = GetVirtualTransactionSize(*tx);
     CAmount max_raw_tx_fee = max_raw_tx_fee_rate.GetFee(virtual_size);
@@ -1116,7 +1116,7 @@ static RPCHelpMan testmempoolaccept()
                         },
                         },
                     {"maxfeerate", RPCArg::Type::AMOUNT, RPCArg::Default{FormatMoney(DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK())},
-                     "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT + "/kB\n"},
+                     "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT + "/kvB.\nFee rates larger than 1BTC/kvB are rejected.\nSet to 0 to accept any fee rate.\n"},
                 },
                 RPCResult{
                     RPCResult::Type::ARR, "", "The result of the mempool acceptance test for each raw transaction in the input array.\n"
@@ -1162,7 +1162,7 @@ static RPCHelpMan testmempoolaccept()
 
     const CFeeRate max_raw_tx_fee_rate = request.params[1].isNull() ?
                                              DEFAULT_MAX_RAW_TX_FEE_RATE :
-                                             CFeeRate(AmountFromValue(request.params[1]));
+                                             ParseFeeRate(request.params[1]);
 
     std::vector<CTransactionRef> txns;
     txns.reserve(raw_transactions.size());

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -97,6 +97,13 @@ CAmount AmountFromValue(const UniValue& value, int decimals)
     return amount;
 }
 
+CFeeRate ParseFeeRate(const UniValue& json)
+{
+    CAmount val{AmountFromValue(json)};
+    if (val >= COIN) throw JSONRPCError(RPC_INVALID_PARAMETER, "Fee rates larger than or equal to 1BTC/kvB are not accepted");
+    return CFeeRate{val};
+}
+
 uint256 ParseHashV(const UniValue& v, std::string strName)
 {
     std::string strHex{v.get_str()};
@@ -539,6 +546,52 @@ UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest& request) const
     }
     return m_fun(*this, request);
 }
+
+using CheckFn = void(const RPCArg&);
+static const UniValue* DetailMaybeArg(CheckFn* check, const std::vector<RPCArg>& params, const JSONRPCRequest* req, size_t i)
+{
+    CHECK_NONFATAL(i < params.size());
+    const UniValue& arg{CHECK_NONFATAL(req)->params[i]};
+    const RPCArg& param{params.at(i)};
+    if (check) check(param);
+
+    if (!arg.isNull()) return &arg;
+    if (!std::holds_alternative<RPCArg::Default>(param.m_fallback)) return nullptr;
+    return &std::get<RPCArg::Default>(param.m_fallback);
+}
+
+static void CheckRequiredOrDefault(const RPCArg& param)
+{
+    // Must use `Arg<Type>(i)` to get the argument or its default value.
+    const bool required{
+        std::holds_alternative<RPCArg::Optional>(param.m_fallback) && RPCArg::Optional::NO == std::get<RPCArg::Optional>(param.m_fallback),
+    };
+    CHECK_NONFATAL(required || std::holds_alternative<RPCArg::Default>(param.m_fallback));
+}
+
+#define TMPL_INST(check_param, ret_type, return_code)       \
+    template <>                                             \
+    ret_type RPCHelpMan::ArgValue<ret_type>(size_t i) const \
+    {                                                       \
+        const UniValue* maybe_arg{                          \
+            DetailMaybeArg(check_param, m_args, m_req, i),  \
+        };                                                  \
+        return return_code                                  \
+    }                                                       \
+    void force_semicolon(ret_type)
+
+// Optional arg (without default). Can also be called on required args, if needed.
+TMPL_INST(nullptr, const UniValue*, maybe_arg;);
+TMPL_INST(nullptr, std::optional<double>, maybe_arg ? std::optional{maybe_arg->get_real()} : std::nullopt;);
+TMPL_INST(nullptr, std::optional<bool>, maybe_arg ? std::optional{maybe_arg->get_bool()} : std::nullopt;);
+TMPL_INST(nullptr, const std::string*, maybe_arg ? &maybe_arg->get_str() : nullptr;);
+
+// Required arg or optional arg with default value.
+TMPL_INST(CheckRequiredOrDefault, const UniValue&, *CHECK_NONFATAL(maybe_arg););
+TMPL_INST(CheckRequiredOrDefault, bool, CHECK_NONFATAL(maybe_arg)->get_bool(););
+TMPL_INST(CheckRequiredOrDefault, int, CHECK_NONFATAL(maybe_arg)->getInt<int>(););
+TMPL_INST(CheckRequiredOrDefault, uint64_t, CHECK_NONFATAL(maybe_arg)->getInt<uint64_t>(););
+TMPL_INST(CheckRequiredOrDefault, const std::string&, CHECK_NONFATAL(maybe_arg)->get_str(););
 
 bool RPCHelpMan::IsValidNumArgs(size_t num_args) const
 {

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -547,51 +547,6 @@ UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest& request) const
     return m_fun(*this, request);
 }
 
-using CheckFn = void(const RPCArg&);
-static const UniValue* DetailMaybeArg(CheckFn* check, const std::vector<RPCArg>& params, const JSONRPCRequest* req, size_t i)
-{
-    CHECK_NONFATAL(i < params.size());
-    const UniValue& arg{CHECK_NONFATAL(req)->params[i]};
-    const RPCArg& param{params.at(i)};
-    if (check) check(param);
-
-    if (!arg.isNull()) return &arg;
-    if (!std::holds_alternative<RPCArg::Default>(param.m_fallback)) return nullptr;
-    return &std::get<RPCArg::Default>(param.m_fallback);
-}
-
-static void CheckRequiredOrDefault(const RPCArg& param)
-{
-    // Must use `Arg<Type>(i)` to get the argument or its default value.
-    const bool required{
-        std::holds_alternative<RPCArg::Optional>(param.m_fallback) && RPCArg::Optional::NO == std::get<RPCArg::Optional>(param.m_fallback),
-    };
-    CHECK_NONFATAL(required || std::holds_alternative<RPCArg::Default>(param.m_fallback));
-}
-
-#define TMPL_INST(check_param, ret_type, return_code)       \
-    template <>                                             \
-    ret_type RPCHelpMan::ArgValue<ret_type>(size_t i) const \
-    {                                                       \
-        const UniValue* maybe_arg{                          \
-            DetailMaybeArg(check_param, m_args, m_req, i),  \
-        };                                                  \
-        return return_code                                  \
-    }                                                       \
-    void force_semicolon(ret_type)
-
-// Optional arg (without default). Can also be called on required args, if needed.
-TMPL_INST(nullptr, const UniValue*, maybe_arg;);
-TMPL_INST(nullptr, std::optional<double>, maybe_arg ? std::optional{maybe_arg->get_real()} : std::nullopt;);
-TMPL_INST(nullptr, std::optional<bool>, maybe_arg ? std::optional{maybe_arg->get_bool()} : std::nullopt;);
-TMPL_INST(nullptr, const std::string*, maybe_arg ? &maybe_arg->get_str() : nullptr;);
-
-// Required arg or optional arg with default value.
-TMPL_INST(CheckRequiredOrDefault, const UniValue&, *CHECK_NONFATAL(maybe_arg););
-TMPL_INST(CheckRequiredOrDefault, bool, CHECK_NONFATAL(maybe_arg)->get_bool(););
-TMPL_INST(CheckRequiredOrDefault, int, CHECK_NONFATAL(maybe_arg)->getInt<int>(););
-TMPL_INST(CheckRequiredOrDefault, uint64_t, CHECK_NONFATAL(maybe_arg)->getInt<uint64_t>(););
-TMPL_INST(CheckRequiredOrDefault, const std::string&, CHECK_NONFATAL(maybe_arg)->get_str(););
 
 bool RPCHelpMan::IsValidNumArgs(size_t num_args) const
 {

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -99,6 +99,11 @@ bool ParseBoolV(const UniValue& v, const std::string &strName);
  * @returns a CAmount if the various checks pass.
  */
 CAmount AmountFromValue(const UniValue& value, int decimals = 8);
+/**
+ * Parse a json number or string, denoting BTC/kvB, into a CFeeRate (sat/kvB).
+ * Reject negative values or rates larger than 1BTC/kvB.
+ */
+CFeeRate ParseFeeRate(const UniValue& json);
 
 using RPCArgList = std::vector<std::pair<std::string, UniValue>>;
 std::string HelpExampleCli(const std::string& methodname, const std::string& args);

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -77,9 +77,17 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         txid_in_block = self.wallet.sendrawtransaction(from_node=node, tx_hex=raw_tx_in_block)
         self.generate(node, 1)
         self.mempool_size = 0
+        # Also check feerate. 1BTC/kvB fails
+        assert_raises_rpc_error(-8, "Fee rates larger than or equal to 1BTC/kvB are not accepted", lambda: self.check_mempool_result(
+            result_expected=None,
+            rawtxs=[raw_tx_in_block],
+            maxfeerate=1,
+        ))
+        # ... 0.99 passes
         self.check_mempool_result(
             result_expected=[{'txid': txid_in_block, 'allowed': False, 'reject-reason': 'txn-already-known'}],
             rawtxs=[raw_tx_in_block],
+            maxfeerate=0.99,
         )
 
         self.log.info('A transaction not in the mempool')


### PR DESCRIPTION
## Summary
This PR backports Bitcoin Core PR #29434 which fixes a signed integer overflow issue for large feerates in RPC commands.

The main changes include:
- Adding `ParseFeeRate` helper function that validates fee rates and rejects rates >= 1BTC/kvB
- Updating `sendrawtransaction` and `testmempoolaccept` RPC methods to use the new `ParseFeeRate` function
- Updating help text to specify fee rates in kvB instead of kB and document the 1BTC/kvB limit
- Adding template instantiations for `RPCHelpMan::ArgValue<>` to support UniValue types

Note: Unlike Bitcoin which moved these functions from `rawtransaction.cpp` to `mempool.cpp`, this backport keeps them in their original location in Dash to minimize changes.

## Test plan
- [ ] Unit tests pass
- [ ] Functional tests pass, particularly `mempool_accept.py` which tests the new fee rate validation

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fee rate arguments in relevant RPCs now parse BTC/kvB consistently and enforce an upper bound, rejecting values ≥ 1 BTC/kvB with clearer errors.

* **Documentation**
  * Updated RPC help for sendrawtransaction and testmempoolaccept to use “/kvB” and note the rejection of rates > 1 BTC/kvB.
  * Expanded getrawtransaction help with four new examples, including verbose=true and blockhash usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->