### PR TITLE
Merge bitcoin/bitcoin#29456: docs: ci multi-arch requires qemu

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -15,10 +15,10 @@ testing compared to other parts of the codebase. If you want to keep the work tr
 system in a virtual machine with a Linux operating system of your choice.
 
 To allow for a wide range of tested environments, but also ensure reproducibility to some extent, the test stage
-requires `docker` to be installed. To install all requirements on Ubuntu, run
+requires `docker` to be installed. To run on different architectures than the host `qemu` is also required. To install all requirements on Ubuntu, run
 
 ```
-sudo apt install docker.io bash
+sudo apt install docker.io bash qemu-user-static
 ```
 
 To run the default test stage,


### PR DESCRIPTION
Backports bitcoin/bitcoin#29456

Original commit: 46d261631d

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI README to clarify that both Docker and QEMU are required for running tests on different architectures.
  * Revised Ubuntu installation instructions to include the qemu-user-static package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->