### PR TITLE
Merge bitcoin-core/gui#797: test: Recognize dialog object by name

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -506,6 +506,7 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
         msgBox.setInformativeText("The PSBT has been copied to the clipboard. You can also save it.");
         msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard);
         msgBox.setDefaultButton(QMessageBox::Discard);
+        msgBox.setObjectName("psbt_copied_message");
         switch (msgBox.exec()) {
         case QMessageBox::Save: {
             QString selectedFilter;


### PR DESCRIPTION
Backports bitcoin-core/gui#797

Original commit: d301c99554

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved identification of the message box shown when a PSBT is copied to the clipboard. No changes to functionality or user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->