### PR TITLE
Merge bitcoin/bitcoin#29541: test: remove file-wide interpreter.cpp ubsan suppression

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -51,7 +51,7 @@ unsigned-integer-overflow:hash.cpp
 unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:pubkey.h
-unsigned-integer-overflow:script/interpreter.cpp
+unsigned-integer-overflow:EvalScript
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h


### PR DESCRIPTION
Backports bitcoin/bitcoin#29541

Original commit: faff279fdc5e65443dba70f1342b087ee494bfc7

Backported from Bitcoin Core v0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated suppression entry for unsigned integer overflow to reference a different module in the sanitizer suppressions list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->