### PR TITLE
partial bitcoin-core/gui#803: test: Set organization name

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -10,6 +10,7 @@
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <qt/bitcoin.h>
+#include <qt/guiconstants.h>
 #include <qt/test/apptests.h>
 #include <qt/test/optiontests.h>
 #include <qt/test/rpcnestedtests.h>
@@ -25,6 +26,7 @@
 #include <QApplication>
 #include <QDebug>
 #include <QObject>
+#include <QSettings>
 #include <QTest>
 
 #include <functional>
@@ -84,38 +86,47 @@ int main(int argc, char* argv[])
         setenv("QT_QPA_PLATFORM", "minimal", 0 /* overwrite */);
     #endif
 
-    BitcoinApplication app;
-    app.setApplicationName("Dash-Qt-test");
-    app.createNode(*init);
+
+    QCoreApplication::setOrganizationName(QAPP_ORG_NAME);
+    QCoreApplication::setApplicationName(QAPP_APP_NAME_DEFAULT "-test");
 
     int num_test_failures{0};
 
-    AppTests app_tests(app);
-    num_test_failures += QTest::qExec(&app_tests);
+    {
+        BitcoinApplication app;
+        app.createNode(*init);
 
-    OptionTests options_tests(app.node());
-    num_test_failures += QTest::qExec(&options_tests);
+        AppTests app_tests(app);
+        num_test_failures += QTest::qExec(&app_tests);
 
-    URITests test1;
-    num_test_failures += QTest::qExec(&test1);
+        OptionTests options_tests(app.node());
+        num_test_failures += QTest::qExec(&options_tests);
 
-    RPCNestedTests test3(app.node());
-    num_test_failures += QTest::qExec(&test3);
+        URITests test1;
+        num_test_failures += QTest::qExec(&test1);
+
+        RPCNestedTests test3(app.node());
+        num_test_failures += QTest::qExec(&test3);
 
 #ifdef ENABLE_WALLET
-    WalletTests test5(app.node());
-    num_test_failures += QTest::qExec(&test5);
+        WalletTests test5(app.node());
+        num_test_failures += QTest::qExec(&test5);
 
-    AddressBookTests test6(app.node());
-    num_test_failures += QTest::qExec(&test6);
+        AddressBookTests test6(app.node());
+        num_test_failures += QTest::qExec(&test6);
 #endif
     TrafficGraphDataTests test7;
     num_test_failures += QTest::qExec(&test7);
 
-    if (num_test_failures) {
-        qWarning("\nFailed tests: %d\n", num_test_failures);
-    } else {
-        qDebug("\nAll tests passed.\n");
+        if (num_test_failures) {
+            qWarning("\nFailed tests: %d\n", num_test_failures);
+        } else {
+            qDebug("\nAll tests passed.\n");
+        }
     }
+
+    QSettings settings;
+    settings.clear();
+
     return num_test_failures;
 }


### PR DESCRIPTION
Backports bitcoin-core/gui#803

Original commit: c2c6a7d1dc162945fa56deb6eaf2bdd7f84999e8

Backported from Bitcoin Core v0.28

## Changes
- Sets Qt organization name and application name for proper QSettings functionality in tests
- Only applied changes to test_main.cpp as Dash has a different test structure in optiontests.cpp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application initialization in tests by explicitly setting organization and application names.
  * Updated application name to use a macro-based format.
  * Enhanced cleanup by clearing persistent settings after tests.
  * Adjusted code structure for better resource management during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->