### PR TITLE
Merge bitcoin/bitcoin#28120: p2p: make block download logic aware of limited peers threshold

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1441,7 +1441,7 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
                 // We reached the end of the window.
                 if (vBlocks.size() == 0 && waitingfor != peer.m_id) {
                     // We aren't able to fetch anything, but we would be if the download window was one larger.
-                    if (nodeStaller) *nodeStaller = waitingfor;
+                    nodeStaller = waitingfor;
                 }
                 return;
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1397,6 +1397,7 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // download that next block if the window were 1 larger.
     int nWindowEnd = state->pindexLastCommonBlock->nHeight + BLOCK_DOWNLOAD_WINDOW;
     int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
+    bool is_limited_peer = IsLimitedPeer(peer);
     NodeId waitingfor = -1;
     while (pindexWalk->nHeight < nMaxHeight) {
         // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
@@ -1420,25 +1421,39 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
                 return;
             }
             if (pindex->nStatus & BLOCK_HAVE_DATA || m_chainman.ActiveChain().Contains(pindex)) {
-                if (pindex->HaveTxsDownloaded())
+                if (pindex->HaveTxsDownloaded()) {
                     state->pindexLastCommonBlock = pindex;
-            } else if (!IsBlockRequested(pindex->GetBlockHash())) {
-                // The block is not already downloaded, and not yet in flight.
-                if (pindex->nHeight > nWindowEnd) {
-                    // We reached the end of the window.
-                    if (vBlocks.size() == 0 && waitingfor != peer.m_id) {
-                        // We aren't able to fetch anything, but we would be if the download window was one larger.
-                        nodeStaller = waitingfor;
-                    }
-                    return;
                 }
-                vBlocks.push_back(pindex);
-                if (vBlocks.size() == count) {
-                    return;
+                continue;
+            }
+
+            // Is block in-flight?
+            if (IsBlockRequested(pindex->GetBlockHash())) {
+                if (waitingfor == -1) {
+                    // This is the first already-in-flight block.
+                    waitingfor = mapBlocksInFlight.lower_bound(pindex->GetBlockHash())->second.first;
                 }
-            } else if (waitingfor == -1) {
-                // This is the first already-in-flight block.
-                waitingfor = mapBlocksInFlight[pindex->GetBlockHash()].first;
+                continue;
+            }
+
+            // The block is not already downloaded, and not yet in flight.
+            if (pindex->nHeight > nWindowEnd) {
+                // We reached the end of the window.
+                if (vBlocks.size() == 0 && waitingfor != peer.m_id) {
+                    // We aren't able to fetch anything, but we would be if the download window was one larger.
+                    if (nodeStaller) *nodeStaller = waitingfor;
+                }
+                return;
+            }
+
+            // Don't request blocks that go further than what limited peers can provide
+            if (is_limited_peer && (state->pindexBestKnownBlock->nHeight - pindex->nHeight >= static_cast<int>(NODE_NETWORK_LIMITED_MIN_BLOCKS) - 2 /* two blocks buffer for possible races */)) {
+                continue;
+            }
+
+            vBlocks.push_back(pindex);
+            if (vBlocks.size() == count) {
+                return;
             }
         }
     }

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -20,7 +20,14 @@ from test_framework.messages import (
 from test_framework.governance import EXPECTED_STDERR_NO_GOV_PRUNE
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    try_rpc
+)
+
+# Minimum blocks required to signal NODE_NETWORK_LIMITED #
+NODE_NETWORK_LIMITED_MIN_BLOCKS = 288
 
 class P2PIgnoreInv(P2PInterface):
     firstAddrnServices = 0
@@ -51,6 +58,63 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
     def setup_network(self):
         self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
+
+    def test_avoid_requesting_historical_blocks(self):
+        self.log.info("Test full node does not request blocks beyond the limited peer threshold")
+        pruned_node = self.nodes[0]
+        miner = self.nodes[1]
+        full_node = self.nodes[2]
+
+        # Connect and generate block to ensure IBD=false
+        self.connect_nodes(1, 0)
+        self.connect_nodes(1, 2)
+        self.generate(miner, 1)
+
+        # Verify peers are out of IBD
+        for node in self.nodes:
+            assert not node.getblockchaininfo()['initialblockdownload']
+
+        # Isolate full_node (the node will remain out of IBD)
+        full_node.setnetworkactive(False)
+        self.wait_until(lambda: len(full_node.getpeerinfo()) == 0)
+
+        # Mine blocks and sync the pruned node. Surpass the NETWORK_NODE_LIMITED threshold.
+        # Blocks deeper than the threshold are considered "historical blocks"
+        num_historial_blocks = 12
+        self.generate(miner, NODE_NETWORK_LIMITED_MIN_BLOCKS + num_historial_blocks, sync_fun=self.no_op)
+        self.sync_blocks([miner, pruned_node])
+
+        # Connect full_node to prune_node and check peers don't disconnect right away.
+        # (they will disconnect if full_node, which is chain-wise behind, request blocks
+        # older than NODE_NETWORK_LIMITED_MIN_BLOCKS)
+        start_height_full_node = full_node.getblockcount()
+        full_node.setnetworkactive(True)
+        self.connect_nodes(2, 0)
+        assert_equal(len(full_node.getpeerinfo()), 1)
+
+        # Wait until the full_node is headers-wise sync
+        best_block_hash = pruned_node.getbestblockhash()
+        self.wait_until(lambda: next(filter(lambda x: x['hash'] == best_block_hash, full_node.getchaintips()))['status'] == "headers-only")
+
+        # Now, since the node aims to download a window of 1024 blocks,
+        # ensure it requests the blocks below the threshold only (with a
+        # 2-block buffer). And also, ensure it does not request any
+        # historical block.
+        tip_height = pruned_node.getblockcount()
+        limit_buffer = 2
+        # Prevent races by waiting for the tip to arrive first
+        self.wait_until(lambda: not try_rpc(-1, "Block not found", full_node.getblock, pruned_node.getbestblockhash()))
+        for height in range(start_height_full_node + 1, tip_height + 1):
+            if height <= tip_height - (NODE_NETWORK_LIMITED_MIN_BLOCKS - limit_buffer):
+                assert_raises_rpc_error(-1, "Block not found on disk", full_node.getblock, pruned_node.getblockhash(height))
+            else:
+                full_node.getblock(pruned_node.getblockhash(height))  # just assert it does not throw an exception
+
+        # Lastly, ensure the full_node is not sync and verify it can get synced by
+        # establishing a connection with another full node capable of providing them.
+        assert_equal(full_node.getblockcount(), start_height_full_node)
+        self.connect_nodes(2, 1)
+        self.sync_blocks([miner, full_node])
 
     def run_test(self):
         node = self.nodes[0].add_p2p_connection(P2PIgnoreInv())
@@ -107,6 +171,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.sync_blocks([self.nodes[0], self.nodes[1]])
         self.stop_node(0, expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
 
+        self.test_avoid_requesting_historical_blocks()
 
 if __name__ == '__main__':
     NodeNetworkLimitedTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#28120

Original commit: 4a903741b0bc128745b1096586329456d1f1c447

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Nodes running in limited-network mode now avoid requesting historical blocks beyond a defined buffered threshold, reducing unnecessary traffic and improving syncing behavior with pruned peers. Non-limited nodes continue to operate unchanged.

- Tests
  - Added an integration test that verifies limited-network nodes do not request blocks older than the configured threshold, while still fetching recent blocks as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->