### PR TITLE
Merge bitcoin/bitcoin#26564: test: test_bitcoin: allow -testdatadir=<datadir>

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -24,6 +24,8 @@ const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 namespace {
 
 void GenerateTemplateResults(const std::vector<ankerl::nanobench::Result>& benchmarkResults, const fs::path& file, const char* tpl)

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -19,6 +19,8 @@ extern const std::function<std::string(const char*)> G_TRANSLATION_FUN = [](cons
 };
 UrlDecodeFn* const URL_DECODE = urlDecode;
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 MAIN_FUNCTION
 {
     return GuiMain(argc, argv);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -51,6 +51,8 @@ const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 // This is all you need to run all the tests
 int main(int argc, char* argv[])
 {

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -42,17 +42,18 @@ test_dash --log_level=all --run_test=getarg_tests
 ```
 
 `log_level` controls the verbosity of the test framework, which logs when a
-test case is entered, for example. `test_dash` also accepts the command
-line arguments accepted by `dashd`. Use `--` to separate both types of
-arguments:
+test case is entered, for example.
+
+`test_dash` also accepts some of the command line arguments accepted by
+`dashd`. Use `--` to separate these sets of arguments:
 
 ```bash
 test_dash --log_level=all --run_test=getarg_tests -- -printtoconsole=1
 ```
 
-The `-printtoconsole=1` after the two dashes redirects the debug log, which
-would normally go to a file in the test datadir
-(`BasicTestingSetup::m_path_root`), to the standard terminal output.
+The `-printtoconsole=1` after the two dashes sends debug logging, which
+normally goes only to `debug.log` within the data directory, also to the
+standard terminal output.
 
 ... or to run just the doubledash test:
 
@@ -60,7 +61,42 @@ would normally go to a file in the test datadir
 test_dash --run_test=getarg_tests/doubledash
 ```
 
-Run `test_dash --help` for the full list.
+`test_dash` creates a temporary working (data) directory with a randomly
+generated pathname within `test_common_Dash Core/`, which in turn is within
+the system's temporary directory (see
+[`temp_directory_path`](https://en.cppreference.com/w/cpp/filesystem/temp_directory_path)).
+This data directory looks like a simplified form of the standard `dashd` data
+directory. Its content will vary depending on the test, but it will always
+have a `debug.log` file, for example.
+
+The location of the temporary data directory can be specified with the
+`-testdatadir` option. This can make debugging easier. The directory
+path used is the argument path appended with
+`/test_common_Dash Core/<test-name>/datadir`.
+The directory path is created if necessary.
+Specifying this argument also causes the data directory
+not to be removed after the last test. This is useful for looking at
+what the test wrote to `debug.log` after it completes, for example.
+(The directory is removed at the start of the next test run,
+so no leftover state is used.)
+
+```bash
+$ test_dash --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
+Test directory (will not be deleted): "/somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir
+Running 1 test case...
+
+*** No errors detected
+$ ls -l '/somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir'
+total 8
+drwxrwxr-x 2 admin admin 4096 Nov 27 22:45 blocks
+-rw-rw-r-- 1 admin admin 1003 Nov 27 22:45 debug.log
+```
+
+If you run an entire test suite, such as `--run_test=getarg_tests`, or all the test suites
+(by not specifying `--run_test`), a separate directory
+will be created for each individual test.
+
+Run `test_dash --help` for the full list of tests.
 
 ### Adding test cases
 

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -82,7 +82,7 @@ so no leftover state is used.)
 
 ```bash
 $ test_dash --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
-Test directory (will not be deleted): "/somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir"
+Test directory (will not be deleted): /somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir
 Running 1 test case...
 
 *** No errors detected

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -82,7 +82,7 @@ so no leftover state is used.)
 
 ```bash
 $ test_dash --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
-Test directory (will not be deleted): "/somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir
+Test directory (will not be deleted): "/somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir"
 Running 1 test case...
 
 *** No errors detected

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -33,6 +33,8 @@ __AFL_FUZZ_INIT();
 
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 /**
  * A copy of the command line arguments that start with `--`.
  * First `LLVMFuzzerInitialize()` is called, which saves the arguments to `g_args`.

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -39,3 +39,10 @@ const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS = 
     }
     return args;
 };
+
+/**
+ * Retrieve the boost unit test name.
+ */
+const std::function<std::string()> G_TEST_GET_FULL_NAME = []() {
+    return boost::unit_test::framework::current_test_case().full_name();
+};

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -188,8 +188,9 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
 
         // Try to obtain the lock; if unsuccessful don't disturb the existing test.
         TryCreateDirectories(m_path_lock);
-        if (util::LockDirectory(m_path_lock, ".lock", /*probe_only=*/false) != util::LockResult::Success) {
-            ExitFailure("Cannot obtain a lock on test data lock directory " + fs::PathToString(m_path_lock) + '\n' + "The test executable is probably already running.");
+        if (!LockDirectory(m_path_lock, ".lock", /*probe_only=*/false)) {
+            ExitFailure("Cannot obtain a lock on test data lock directory " + fs::PathToString(m_path_lock) +
+                        '\n' + "The test executable is probably already running.");
         }
 
         // Always start with a fresh data directory; this doesn't delete the .lock file located one level above.

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -102,6 +102,11 @@ static uint256 GetUintFromEnv(const std::string& env_name)
     return uint256S(num);
 }
 
+void SetupUnitTestArgs(ArgsManager& args)
+{
+    args.AddArg("-testdatadir=<dir>", "Custom data directory for unit tests", false, OptionsCategory::DEBUG_TEST);
+}
+
 void Seed(FastRandomContext& ctx)
 {
     // Should be enough to get the seed once for the process

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -159,18 +159,48 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
         arguments = Cat(arguments, G_TEST_COMMAND_LINE_ARGUMENTS());
     }
     util::ThreadRename("test");
-    fs::create_directories(m_path_root);
-    m_args.ForceSetArg("-datadir", fs::PathToString(m_path_root));
-    gArgs.ForceSetArg("-datadir", fs::PathToString(m_path_root));
     gArgs.ClearPathCache();
     {
         SetupServerArgs(*m_node.args);
+        SetupUnitTestArgs(*m_node.args);
         std::string error;
         if (!m_node.args->ParseParameters(arguments.size(), arguments.data(), error)) {
             m_node.args->ClearArgs();
             throw std::runtime_error{error};
         }
     }
+
+    if (!m_node.args->IsArgSet("-testdatadir")) {
+        // By default, the data directory has a random name
+        const auto rand_str{g_insecure_rand_ctx_temp_path.rand256().ToString()};
+        m_path_root = fs::temp_directory_path() / "test_common_" PACKAGE_NAME / rand_str;
+        TryCreateDirectories(m_path_root);
+    } else {
+        // Custom data directory
+        m_has_custom_datadir = true;
+        fs::path root_dir{m_node.args->GetPathArg("-testdatadir")};
+        if (root_dir.empty()) ExitFailure("-testdatadir argument is empty, please specify a path");
+
+        root_dir = fs::absolute(root_dir);
+        const std::string test_path{G_TEST_GET_FULL_NAME ? G_TEST_GET_FULL_NAME() : ""};
+        m_path_lock = root_dir / "test_common_" PACKAGE_NAME / fs::PathFromString(test_path);
+        m_path_root = m_path_lock / "datadir";
+
+        // Try to obtain the lock; if unsuccessful don't disturb the existing test.
+        TryCreateDirectories(m_path_lock);
+        if (util::LockDirectory(m_path_lock, ".lock", /*probe_only=*/false) != util::LockResult::Success) {
+            ExitFailure("Cannot obtain a lock on test data lock directory " + fs::PathToString(m_path_lock) + '\n' + "The test executable is probably already running.");
+        }
+
+        // Always start with a fresh data directory; this doesn't delete the .lock file located one level above.
+        fs::remove_all(m_path_root);
+        if (!TryCreateDirectories(m_path_root)) ExitFailure("Cannot create test data directory");
+
+        // Print the test directory name if custom.
+        std::cout << "Test directory (will not be deleted): " << m_path_root << std::endl;
+    }
+    m_args.ForceSetArg("-datadir", fs::PathToString(m_path_root));
+    gArgs.ForceSetArg("-datadir", fs::PathToString(m_path_root));
     SelectParams(chainName);
     SeedInsecureRand();
     if (G_TEST_LOG_FUN) LogInstance().PushBackCallback(G_TEST_LOG_FUN);
@@ -227,7 +257,13 @@ BasicTestingSetup::~BasicTestingSetup()
     ::g_stats_client.reset();
 
     LogInstance().DisconnectTestLogger();
-    fs::remove_all(m_path_root);
+    if (m_has_custom_datadir) {
+        // Only remove the lock file, preserve the data directory.
+        UnlockDirectory(m_path_lock, ".lock");
+        fs::remove(m_path_lock / ".lock");
+    } else {
+        fs::remove_all(m_path_root);
+    }
     gArgs.ClearArgs();
     ECC_Stop();
 }

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -36,6 +36,9 @@ extern const std::function<void(const std::string&)> G_TEST_LOG_FUN;
 /** Retrieve the command line arguments. */
 extern const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS;
 
+/** Retrieve the unit test name. */
+extern const std::function<std::string()> G_TEST_GET_FULL_NAME;
+
 // Enable BOOST_CHECK_EQUAL for enum class types
 namespace std {
 template <typename T>
@@ -101,7 +104,9 @@ struct BasicTestingSetup {
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~BasicTestingSetup();
 
-    const fs::path m_path_root;
+    fs::path m_path_root;
+    fs::path m_path_lock;
+    bool m_has_custom_datadir{false};
     ArgsManager m_args;
 };
 

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -87,6 +87,9 @@ static inline bool InsecureRandBool() { return g_insecure_rand_ctx.randbool(); }
 
 static constexpr CAmount CENT{1000000};
 
+/** Setup unit test specific arguments */
+void SetupUnitTestArgs(ArgsManager& args);
+
 /** Initialize Dash-specific components during chainstate initialization (NodeContext-friendly aliases) */
 void DashChainstateSetup(ChainstateManager& chainman,
                          node::NodeContext& node,


### PR DESCRIPTION
## Summary
- Backports Bitcoin PR #26564 which adds `-testdatadir=<datadir>` option to test_dash
- Allows specifying a custom data directory for unit tests that persists after test completion
- Useful for debugging tests by examining debug.log and other test artifacts

## Test plan
- [ ] Verify test_dash builds successfully
- [ ] Test running with custom data directory: `test_dash --run_test=getarg_tests -- -testdatadir=/tmp/test`
- [ ] Verify custom directory is preserved after test completion
- [ ] Run full unit test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom persistent test data directory using the -testdatadir option, allowing easier debugging and test data management.
  * Introduced a mechanism to retrieve the full name of the current test case via a new global callable.

* **Documentation**
  * Expanded test documentation to clarify command line arguments, describe data directory behavior, and provide usage examples for the new -testdatadir option.

* **Refactor**
  * Enhanced test setup to manage custom and temporary data directories more flexibly, including improved directory locking and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->