### PR TITLE
Merge bitcoin/bitcoin#29633: log: Remove error() reference

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -253,7 +253,7 @@ std::string SafeStringFormat(const std::string& fmt, const Args&... args)
     }
 }
 
-// Be conservative when using LogPrintf/error or other things which
+// Be conservative when using functions that
 // unconditionally log to debug.log! It should not be the case that an inbound
 // peer can fill up a user's disk with debug.log entries.
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#29633

Original commit: 1105aa46dd

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a comment to provide a more general caution regarding the use of certain functions. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->