### PR TITLE
Merge bitcoin/bitcoin#28193: test: add script compression coverage for not-on-curve P2PK outputs

### DIFF
--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -3,7 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compressor.h>
+#include <script/script.h>
 #include <script/standard.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <stdint.h>
@@ -132,6 +134,38 @@ BOOST_AUTO_TEST_CASE(compress_script_to_uncompressed_pubkey_id)
     BOOST_CHECK_EQUAL(out.size(), 33U);
     BOOST_CHECK_EQUAL(memcmp(out.data() + 1, script.data() + 2, 32), 0); // first 32 chars of CPubKey are copied into out[1:]
     BOOST_CHECK_EQUAL(out[0], 0x04 | (script[65] & 0x01)); // least significant bit (lsb) of last char of pubkey is mapped into out[0]
+}
+
+BOOST_AUTO_TEST_CASE(compress_p2pk_scripts_not_on_curve)
+{
+    XOnlyPubKey x_not_on_curve;
+    do {
+        x_not_on_curve = XOnlyPubKey(g_insecure_rand_ctx.randbytes(32));
+    } while (x_not_on_curve.IsFullyValid());
+
+    // Check that P2PK script with uncompressed pubkey [=> OP_PUSH65 <0x04 .....> OP_CHECKSIG]
+    // which is not fully valid (i.e. point is not on curve) can't be compressed
+    std::vector<unsigned char> pubkey_raw(65, 0);
+    pubkey_raw[0] = 4;
+    std::copy(x_not_on_curve.begin(), x_not_on_curve.end(), &pubkey_raw[1]);
+    CPubKey pubkey_not_on_curve(pubkey_raw);
+    assert(pubkey_not_on_curve.IsValid());
+    assert(!pubkey_not_on_curve.IsFullyValid());
+    CScript script = CScript() << ToByteVector(pubkey_not_on_curve) << OP_CHECKSIG;
+    BOOST_CHECK_EQUAL(script.size(), 67U);
+
+    CompressedScript out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, false);
+
+    // Check that compressed P2PK script with uncompressed pubkey that is not fully
+    // valid (i.e. x coordinate of the pubkey is not on curve) can't be decompressed
+    CompressedScript compressed_script(x_not_on_curve.begin(), x_not_on_curve.end());
+    for (unsigned int compression_id : {4, 5}) {
+        CScript uncompressed_script;
+        bool success = DecompressScript(uncompressed_script, compression_id, compressed_script);
+        BOOST_CHECK_EQUAL(success, false);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Backports bitcoin/bitcoin#28193

Original commit: ef6329f052

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify that compression and decompression correctly handle P2PK scripts with uncompressed, invalid public keys not on the elliptic curve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->