### PR TITLE
Merge bitcoin/bitcoin#27039: blockstorage: do not flush block to disk if it is already there

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -641,8 +641,20 @@ bool BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigne
     if ((int)nFile != m_last_blockfile) {
         if (!fKnown) {
             LogPrint(BCLog::BLOCKSTORE, "Leaving block file %i: %s\n", m_last_blockfile, m_blockfile_info[m_last_blockfile].ToString());
+
+            // Do not propagate the return code. The flush concerns a previous block
+            // and undo file that has already been written to. If a flush fails
+            // here, and we crash, there is no expected additional block data
+            // inconsistency arising from the flush failure here. However, the undo
+            // data may be inconsistent after a crash if the flush is called during
+            // a reindex. A flush error might also leave some of the data files
+            // untrimmed.
+            if (!FlushBlockFile(m_last_blockfile, !fKnown, finalize_undo)) {
+                LogPrintLevel(BCLog::BLOCKSTORE, BCLog::Level::Warning,
+                              "Failed to flush previous block file %05i (finalize=%i, finalize_undo=%i) before opening new block file %05i\n",
+                              m_last_blockfile, !fKnown, finalize_undo, nFile);
+            }
         }
-        FlushBlockFile(!fKnown, finalize_undo);
         m_last_blockfile = nFile;
     }
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -650,7 +650,7 @@ bool BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigne
             // a reindex. A flush error might also leave some of the data files
             // untrimmed.
             if (!FlushBlockFile(m_last_blockfile, !fKnown, finalize_undo)) {
-                LogPrintLevel(BCLog::BLOCKSTORE, BCLog::Level::Warning,
+                LogPrintLevel(BCLog::BLOCKSTORE, BCLog::Level::Warning, /* Continued */
                               "Failed to flush previous block file %05i (finalize=%i, finalize_undo=%i) before opening new block file %05i\n",
                               m_last_blockfile, !fKnown, finalize_undo, nFile);
             }

--- a/test/functional/feature_reindex_readonly.py
+++ b/test/functional/feature_reindex_readonly.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test running dashd with -reindex from a read-only blockstore
+- Start a node, generate blocks, then restart with -reindex after setting blk files to read-only
+"""
+
+import os
+import stat
+import subprocess
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class BlockstoreReindexTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-fastprune"]]
+
+    def reindex_readonly(self):
+        self.log.debug("Generate block big enough to start second block file")
+        fastprune_blockfile_size = 0x10000
+        opreturn = "6a"
+        nulldata = fastprune_blockfile_size * "ff"
+        self.generateblock(self.nodes[0], output=f"raw({opreturn}{nulldata})", transactions=[])
+        block_count = self.nodes[0].getblockcount()
+        self.stop_node(0)
+
+        assert (self.nodes[0].chain_path / "blocks" / "blk00000.dat").exists()
+        assert (self.nodes[0].chain_path / "blocks" / "blk00001.dat").exists()
+
+        self.log.debug("Make the first block file read-only")
+        filename = self.nodes[0].chain_path / "blocks" / "blk00000.dat"
+        filename.chmod(stat.S_IREAD)
+
+        undo_immutable = lambda: None
+        # Linux
+        try:
+            subprocess.run(['chattr'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            try:
+                subprocess.run(['chattr', '+i', filename], capture_output=True, check=True)
+                undo_immutable = lambda: subprocess.check_call(['chattr', '-i', filename])
+                self.log.info("Made file immutable with chattr")
+            except subprocess.CalledProcessError as e:
+                self.log.warning(str(e))
+                if e.stdout:
+                    self.log.warning(f"stdout: {e.stdout}")
+                if e.stderr:
+                    self.log.warning(f"stderr: {e.stderr}")
+                if os.getuid() == 0:
+                    self.log.warning("Return early on Linux under root, because chattr failed.")
+                    self.log.warning("This should only happen due to missing capabilities in a container.")
+                    self.log.warning("Make sure to --cap-add LINUX_IMMUTABLE if you want to run this test.")
+                    undo_immutable = False
+        except Exception:
+            # macOS, and *BSD
+            try:
+                subprocess.run(['chflags'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                try:
+                    subprocess.run(['chflags', 'uchg', filename], capture_output=True, check=True)
+                    undo_immutable = lambda: subprocess.check_call(['chflags', 'nouchg', filename])
+                    self.log.info("Made file immutable with chflags")
+                except subprocess.CalledProcessError as e:
+                    self.log.warning(str(e))
+                    if e.stdout:
+                        self.log.warning(f"stdout: {e.stdout}")
+                    if e.stderr:
+                        self.log.warning(f"stderr: {e.stderr}")
+                    if os.getuid() == 0:
+                        self.log.warning("Return early on BSD under root, because chflags failed.")
+                        undo_immutable = False
+            except Exception:
+                pass
+
+        if undo_immutable:
+            self.log.debug("Attempt to restart and reindex the node with the unwritable block file")
+            with self.nodes[0].wait_for_debug_log([b"Reindexing finished"]):
+                self.start_node(0, extra_args=['-reindex', '-fastprune'])
+            assert block_count == self.nodes[0].getblockcount()
+            undo_immutable()
+
+        filename.chmod(0o777)
+
+    def run_test(self):
+        self.reindex_readonly()
+
+
+if __name__ == '__main__':
+    BlockstoreReindexTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#27039

Original commit: 69ddee6f39

Backported from Bitcoin Core v0.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved warnings when a block file flush fails, aiding troubleshooting during sync or reindex.
- Bug Fixes
  - More robust handling when switching block files, reducing risk of interruptions or crashes during reindexing and recovery scenarios.
- Tests
  - Added functional test to validate reindex behavior with read-only/immutable block files, ensuring no unintended block progress and safe recovery paths.
- Chores
  - Enhanced documentation comments clarifying behavior in crash and reindex edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->