### PR TITLE
Merge bitcoin/bitcoin#27574: doc: Add post branch-off note about fuzz input pruning

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -28,6 +28,9 @@ Before every major release:
 * [ ] Update [`src/chainparams.cpp`](/src/chainparams.cpp) `m_assumed_blockchain_size` and `m_assumed_chain_state_size` with the current size plus some overhead (see [this](#how-to-calculate-assumed-blockchain-and-chain-state-size) for information on how to calculate them).
 * [ ] Update [`src/chainparams.cpp`](/src/chainparams.cpp) `chainTxData` with statistics about the transaction count and rate. Use the output of the `getchaintxstats` RPC, see
   [this pull request](https://github.com/dashpay/dash/pull/5692) for an example. Reviewers can verify the results by running `getchaintxstats <window_block_count> <window_last_block_hash>` with the `window_block_count` and `window_last_block_hash` from your output.
+* [ ] Prune inputs from the qa-assets repo (See [pruning inputs](https://github.com/bitcoin-core/qa-assets#pruning-inputs)).
+
+## Building
 
 ### First time / New builders
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -30,8 +30,6 @@ Before every major release:
   [this pull request](https://github.com/dashpay/dash/pull/5692) for an example. Reviewers can verify the results by running `getchaintxstats <window_block_count> <window_last_block_hash>` with the `window_block_count` and `window_last_block_hash` from your output.
 * [ ] Prune inputs from the qa-assets repo (See [pruning inputs](https://github.com/bitcoin-core/qa-assets#pruning-inputs)).
 
-## Building
-
 ### First time / New builders
 
 Install Guix using one of the installation methods detailed in


### PR DESCRIPTION
## Backport Information

- **Bitcoin Commit**: 5d1014d5a1196ff97c1f88b6052c8bef1ebeb43e
- **Bitcoin PR**: #27574
- **Target Version**: 0.26
- **Batch**: 415

## Summary

This backport adds a documentation note about pruning inputs from the qa-assets repository to the release process documentation.

## Changes

- Added a checklist item in `doc/release-process.md` reminding developers to prune inputs from the qa-assets repo during major releases

## Dash-Specific Adaptations

- Resolved conflict by integrating the new pruning note into Dash's existing "Before every major release" checklist structure
- Preserved Dash's simplified release process format rather than adopting Bitcoin's more complex subsection structure

## Testing

No code changes - documentation only. No build or functional tests required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated release process documentation with a new checklist item for major releases: prune inputs from the QA assets repository.
  - Improves clarity and consistency of pre-release steps, helping maintain a lean test asset set and streamline quality checks.
  - No changes to application functionality, APIs, or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->