### PR TITLE
Merge bitcoin/bitcoin#17786: refactor: Nuke policy/fees->mempool circular dependencies

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -370,6 +370,7 @@ BITCOIN_CORE_H = \
   torcontrol.h \
   txdb.h \
   txmempool.h \
+  txmempool_entry.h \
   txorphanage.h \
   undo.h \
   unordered_lru_cache.h \

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -6,6 +6,7 @@
 #include <policy/policy.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 
 
 static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -6,6 +6,7 @@
 #include <policy/policy.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 #include <validation.h>
 
 #include <vector>

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -7,6 +7,7 @@
 #include <rpc/mempool.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 
 #include <univalue.h>
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -32,6 +32,7 @@
 #include <timedata.h>
 #include <tinyformat.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 #include <txorphanage.h>
 #include <util/check.h>
 #include <util/strencodings.h>

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -49,6 +49,7 @@
 #include <support/allocators/secure.h>
 #include <sync.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/system.h>

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -16,7 +16,7 @@
 #include <streams.h>
 #include <sync.h>
 #include <tinyformat.h>
-#include <txmempool.h>
+#include <txmempool_entry.h>
 #include <uint256.h>
 #include <util/serfloat.h>
 #include <util/system.h>

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -13,6 +13,7 @@
 #include <rpc/server_util.h>
 #include <rpc/util.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 #include <univalue.h>
 #include <util/moneystr.h>
 #include <validation.h>

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -9,6 +9,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -35,7 +35,6 @@
 #include <test/util/index.h>
 #include <test/util/net.h>
 #include <txdb.h>
-#include <txmempool.h>
 #include <txmempool_entry.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -35,6 +35,8 @@
 #include <test/util/index.h>
 #include <test/util/net.h>
 #include <txdb.h>
+#include <txmempool.h>
+#include <txmempool_entry.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/thread.h>

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -48,42 +48,6 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
     return true;
 }
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
-                                 int64_t time, unsigned int entry_height,
-                                 bool spends_coinbase, int64_t sigops_count, LockPoints lp)
-    : tx{tx},
-      nFee{fee},
-      nTxSize(tx->GetTotalSize()),
-      nUsageSize{RecursiveDynamicUsage(tx)},
-      nTime{time},
-      entryHeight{entry_height},
-      spendsCoinbase{spends_coinbase},
-      sigOpCount{sigops_count},
-      m_modified_fee{nFee},
-      lockPoints{lp},
-      nSizeWithDescendants{GetTxSize()},
-      nModFeesWithDescendants{nFee},
-      nSizeWithAncestors{GetTxSize()},
-      nModFeesWithAncestors{nFee},
-      nSigOpCountWithAncestors{sigOpCount} {}
-
-void CTxMemPoolEntry::UpdateModifiedFee(CAmount newFeeDelta)
-{
-    nModFeesWithDescendants = SaturatingAdd(nModFeesWithDescendants, newFeeDelta);
-    nModFeesWithAncestors = SaturatingAdd(nModFeesWithAncestors, newFeeDelta);
-    m_modified_fee = SaturatingAdd(m_modified_fee, newFeeDelta);
-}
-
-void CTxMemPoolEntry::UpdateLockPoints(const LockPoints& lp)
-{
-    lockPoints = lp;
-}
-
-size_t CTxMemPoolEntry::GetTxSize() const
-{
-    return GetVirtualTransactionSize(nTxSize, sigOpCount);
-}
-
 void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendants,
                                       const std::set<uint256>& setExclude, std::set<uint256>& descendants_to_remove,
                                       uint64_t ancestor_size_limit, uint64_t ancestor_count_limit)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -28,6 +28,7 @@
 #include <random.h>
 #include <spentindex.h>
 #include <sync.h>
+#include <txmempool_entry.h>
 #include <util/epochguard.h>
 #include <util/hasher.h>
 
@@ -52,133 +53,10 @@ using CBLSLazyPublicKey = CBLSLazyWrapper<CBLSPublicKey>;
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
-struct LockPoints {
-    // Will be set to the blockchain height and median time past
-    // values that would be necessary to satisfy all relative locktime
-    // constraints (BIP68) of this tx given our view of block chain history
-    int height{0};
-    int64_t time{0};
-    // As long as the current chain descends from the highest height block
-    // containing one of the inputs used in the calculation, then the cached
-    // values are still valid even after a reorg.
-    CBlockIndex* maxInputBlock{nullptr};
-};
-
 /**
  * Test whether the LockPoints height and time are still valid on the current chain
  */
 bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-struct CompareIteratorByHash {
-    // SFINAE for T where T is either a pointer type (e.g., a txiter) or a reference_wrapper<T>
-    // (e.g. a wrapped CTxMemPoolEntry&)
-    template <typename T>
-    bool operator()(const std::reference_wrapper<T>& a, const std::reference_wrapper<T>& b) const
-    {
-        return a.get().GetTx().GetHash() < b.get().GetTx().GetHash();
-    }
-    template <typename T>
-    bool operator()(const T& a, const T& b) const
-    {
-        return a->GetTx().GetHash() < b->GetTx().GetHash();
-    }
-};
-/** \class CTxMemPoolEntry
- *
- * CTxMemPoolEntry stores data about the corresponding transaction, as well
- * as data about all in-mempool transactions that depend on the transaction
- * ("descendant" transactions).
- *
- * When a new entry is added to the mempool, we update the descendant state
- * (nCountWithDescendants, nSizeWithDescendants, and nModFeesWithDescendants) for
- * all ancestors of the newly added transaction.
- *
- */
-
-class CTxMemPoolEntry
-{
-public:
-    typedef std::reference_wrapper<const CTxMemPoolEntry> CTxMemPoolEntryRef;
-    // two aliases, should the types ever diverge
-    typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> Parents;
-    typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> Children;
-
-private:
-    const CTransactionRef tx;
-    mutable Parents m_parents;
-    mutable Children m_children;
-    const CAmount nFee;             //!< Cached to avoid expensive parent-transaction lookups
-    const size_t nTxSize;           //!< ... and avoid recomputing tx size
-    const size_t nUsageSize;        //!< ... and total memory usage
-    const int64_t nTime;            //!< Local time when entering the mempool
-    const unsigned int entryHeight; //!< Chain height when entering the mempool
-    const bool spendsCoinbase;      //!< keep track of transactions that spend a coinbase
-    const int64_t sigOpCount;       //!< Legacy sig ops plus P2SH sig op count
-    CAmount m_modified_fee;         //!< Used for determining the priority of the transaction for mining in a block
-    LockPoints lockPoints;          //!< Track the height and time at which tx was final
-
-    // Information about descendants of this transaction that are in the
-    // mempool; if we remove this transaction we must remove all of these
-    // descendants as well.
-    uint64_t nCountWithDescendants{1}; //!< number of descendant transactions
-    uint64_t nSizeWithDescendants;   //!< ... and size
-    CAmount nModFeesWithDescendants; //!< ... and total fees (all including us)
-
-    // Analogous statistics for ancestor transactions
-    uint64_t nCountWithAncestors{1};
-    uint64_t nSizeWithAncestors;
-    CAmount nModFeesWithAncestors;
-    int64_t nSigOpCountWithAncestors;
-
-public:
-    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
-                    int64_t time, unsigned int entry_height,
-                    bool spends_coinbase,
-                    int64_t sigops_count, LockPoints lp);
-
-    const CTransaction& GetTx() const { return *this->tx; }
-    CTransactionRef GetSharedTx() const { return this->tx; }
-    const CAmount& GetFee() const { return nFee; }
-    size_t GetTxSize() const;
-    std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
-    unsigned int GetHeight() const { return entryHeight; }
-    int64_t GetSigOpCount() const { return sigOpCount; }
-    CAmount GetModifiedFee() const { return m_modified_fee; }
-    size_t DynamicMemoryUsage() const { return nUsageSize; }
-    const LockPoints& GetLockPoints() const { return lockPoints; }
-
-    // Adjusts the descendant state.
-    void UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);
-    // Adjusts the ancestor state
-    void UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps);
-    // Updates the modified fees with descendants/ancestors.
-    void UpdateModifiedFee(CAmount newFeeDelta);
-    // Update the LockPoints after a reorg
-    void UpdateLockPoints(const LockPoints& lp);
-
-    uint64_t GetCountWithDescendants() const { return nCountWithDescendants; }
-    uint64_t GetSizeWithDescendants() const { return nSizeWithDescendants; }
-    CAmount GetModFeesWithDescendants() const { return nModFeesWithDescendants; }
-
-    bool GetSpendsCoinbase() const { return spendsCoinbase; }
-
-    uint64_t GetCountWithAncestors() const { return nCountWithAncestors; }
-    uint64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
-    CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }
-    int64_t GetSigOpCountWithAncestors() const { return nSigOpCountWithAncestors; }
-
-    const Parents& GetMemPoolParentsConst() const { return m_parents; }
-    const Children& GetMemPoolChildrenConst() const { return m_children; }
-    Parents& GetMemPoolParents() const { return m_parents; }
-    Children& GetMemPoolChildren() const { return m_children; }
-
-    mutable size_t vTxHashesIdx; //!< Index in mempool's vTxHashes
-
-    // If this is a proTx, this will be the hash of the key for which this ProTx was valid
-    mutable uint256 validForProTxKey;
-    mutable bool isKeyChangeProTx{false};
-    mutable Epoch::Marker m_epoch_marker; //!< epoch when last touched, useful for graph algorithms
-};
 
 // extracts a transaction hash from CTxMemPoolEntry or CTransactionRef
 struct mempoolentry_txid

--- a/src/txmempool_entry.h
+++ b/src/txmempool_entry.h
@@ -1,0 +1,177 @@
+// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TXMEMPOOL_ENTRY_H
+#define BITCOIN_TXMEMPOOL_ENTRY_H
+
+#include <consensus/amount.h>
+#include <consensus/validation.h>
+#include <core_memusage.h>
+#include <policy/policy.h>
+#include <policy/settings.h>
+#include <primitives/transaction.h>
+#include <util/epochguard.h>
+#include <util/overflow.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <set>
+#include <stddef.h>
+#include <stdint.h>
+
+class CBlockIndex;
+
+struct LockPoints {
+    // Will be set to the blockchain height and median time past
+    // values that would be necessary to satisfy all relative locktime
+    // constraints (BIP68) of this tx given our view of block chain history
+    int height{0};
+    int64_t time{0};
+    // As long as the current chain descends from the highest height block
+    // containing one of the inputs used in the calculation, then the cached
+    // values are still valid even after a reorg.
+    CBlockIndex* maxInputBlock{nullptr};
+};
+
+struct CompareIteratorByHash {
+    // SFINAE for T where T is either a pointer type (e.g., a txiter) or a reference_wrapper<T>
+    // (e.g. a wrapped CTxMemPoolEntry&)
+    template <typename T>
+    bool operator()(const std::reference_wrapper<T>& a, const std::reference_wrapper<T>& b) const
+    {
+        return a.get().GetTx().GetHash() < b.get().GetTx().GetHash();
+    }
+    template <typename T>
+    bool operator()(const T& a, const T& b) const
+    {
+        return a->GetTx().GetHash() < b->GetTx().GetHash();
+    }
+};
+
+/** \class CTxMemPoolEntry
+ *
+ * CTxMemPoolEntry stores data about the corresponding transaction, as well
+ * as data about all in-mempool transactions that depend on the transaction
+ * ("descendant" transactions).
+ *
+ * When a new entry is added to the mempool, we update the descendant state
+ * (nCountWithDescendants, nSizeWithDescendants, and nModFeesWithDescendants) for
+ * all ancestors of the newly added transaction.
+ *
+ */
+
+class CTxMemPoolEntry
+{
+public:
+    typedef std::reference_wrapper<const CTxMemPoolEntry> CTxMemPoolEntryRef;
+    // two aliases, should the types ever diverge
+    typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> Parents;
+    typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> Children;
+
+private:
+    const CTransactionRef tx;
+    mutable Parents m_parents;
+    mutable Children m_children;
+    const CAmount nFee;             //!< Cached to avoid expensive parent-transaction lookups
+    const size_t nTxSize;           //!< ... and avoid recomputing tx size
+    const size_t nUsageSize;        //!< ... and total memory usage
+    const int64_t nTime;            //!< Local time when entering the mempool
+    const unsigned int entryHeight; //!< Chain height when entering the mempool
+    const bool spendsCoinbase;      //!< keep track of transactions that spend a coinbase
+    const int64_t sigOpCount;       //!< Legacy sig ops plus P2SH sig op count
+    CAmount m_modified_fee;         //!< Used for determining the priority of the transaction for mining in a block
+    LockPoints lockPoints;          //!< Track the height and time at which tx was final
+
+    // Information about descendants of this transaction that are in the
+    // mempool; if we remove this transaction we must remove all of these
+    // descendants as well.
+    uint64_t nCountWithDescendants{1}; //!< number of descendant transactions
+    uint64_t nSizeWithDescendants;   //!< ... and size
+    CAmount nModFeesWithDescendants; //!< ... and total fees (all including us)
+
+    // Analogous statistics for ancestor transactions
+    uint64_t nCountWithAncestors{1};
+    uint64_t nSizeWithAncestors;
+    CAmount nModFeesWithAncestors;
+    int64_t nSigOpCountWithAncestors;
+
+public:
+    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
+                    int64_t time, unsigned int entry_height,
+                    bool spends_coinbase,
+                    int64_t sigops_count, LockPoints lp)
+        : tx{tx},
+          nFee{fee},
+          nTxSize(tx->GetTotalSize()),
+          nUsageSize{RecursiveDynamicUsage(tx)},
+          nTime{time},
+          entryHeight{entry_height},
+          spendsCoinbase{spends_coinbase},
+          sigOpCount{sigops_count},
+          m_modified_fee{nFee},
+          lockPoints{lp},
+          nSizeWithDescendants{GetTxSize()},
+          nModFeesWithDescendants{nFee},
+          nSizeWithAncestors{GetTxSize()},
+          nModFeesWithAncestors{nFee},
+          nSigOpCountWithAncestors{sigOpCount} {}
+
+    const CTransaction& GetTx() const { return *this->tx; }
+    CTransactionRef GetSharedTx() const { return this->tx; }
+    const CAmount& GetFee() const { return nFee; }
+    size_t GetTxSize() const
+    {
+        return GetVirtualTransactionSize(nTxSize, sigOpCount);
+    }
+    std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
+    unsigned int GetHeight() const { return entryHeight; }
+    int64_t GetSigOpCount() const { return sigOpCount; }
+    CAmount GetModifiedFee() const { return m_modified_fee; }
+    size_t DynamicMemoryUsage() const { return nUsageSize; }
+    const LockPoints& GetLockPoints() const { return lockPoints; }
+
+    // Adjusts the descendant state.
+    void UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);
+    // Adjusts the ancestor state
+    void UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps);
+    // Updates the modified fees with descendants/ancestors.
+    void UpdateModifiedFee(CAmount fee_diff)
+    {
+        nModFeesWithDescendants = SaturatingAdd(nModFeesWithDescendants, fee_diff);
+        nModFeesWithAncestors = SaturatingAdd(nModFeesWithAncestors, fee_diff);
+        m_modified_fee = SaturatingAdd(m_modified_fee, fee_diff);
+    }
+
+    // Update the LockPoints after a reorg
+    void UpdateLockPoints(const LockPoints& lp)
+    {
+        lockPoints = lp;
+    }
+
+    uint64_t GetCountWithDescendants() const { return nCountWithDescendants; }
+    uint64_t GetSizeWithDescendants() const { return nSizeWithDescendants; }
+    CAmount GetModFeesWithDescendants() const { return nModFeesWithDescendants; }
+
+    bool GetSpendsCoinbase() const { return spendsCoinbase; }
+
+    uint64_t GetCountWithAncestors() const { return nCountWithAncestors; }
+    uint64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
+    CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }
+    int64_t GetSigOpCountWithAncestors() const { return nSigOpCountWithAncestors; }
+
+    const Parents& GetMemPoolParentsConst() const { return m_parents; }
+    const Children& GetMemPoolChildrenConst() const { return m_children; }
+    Parents& GetMemPoolParents() const { return m_parents; }
+    Children& GetMemPoolChildren() const { return m_children; }
+
+    mutable size_t vTxHashesIdx; //!< Index in mempool's vTxHashes
+
+    // If this is a proTx, this will be the hash of the key for which this ProTx was valid
+    mutable uint256 validForProTxKey;
+    mutable bool isKeyChangeProTx{false};
+    mutable Epoch::Marker m_epoch_marker; //!< epoch when last touched, useful for graph algorithms
+};
+
+#endif // BITCOIN_TXMEMPOOL_ENTRY_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -39,6 +39,7 @@
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
+#include <txmempool_entry.h>
 #include <uint256.h>
 #include <undo.h>
 #include <util/check.h>

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -14,7 +14,7 @@ import sys
 EXPECTED_CIRCULAR_DEPENDENCIES = (
     "chainparamsbase -> util/system -> chainparamsbase",
     "node/blockstorage -> validation -> node/blockstorage",
-    "policy/fees -> txmempool -> policy/fees",
+    "node/utxo_snapshot -> validation -> node/utxo_snapshot",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -14,7 +14,6 @@ import sys
 EXPECTED_CIRCULAR_DEPENDENCIES = (
     "chainparamsbase -> util/system -> chainparamsbase",
     "node/blockstorage -> validation -> node/blockstorage",
-    "node/utxo_snapshot -> validation -> node/utxo_snapshot",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -50,6 +50,7 @@ unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:EvalScript
 unsigned-integer-overflow:txmempool.cpp
+unsigned-integer-overflow:txmempool_entry.h
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h
 implicit-integer-sign-change:addrman.h
@@ -64,6 +65,7 @@ implicit-integer-sign-change:script/bitcoinconsensus.cpp
 implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:txmempool.cpp
+implicit-integer-sign-change:txmempool_entry.h
 implicit-integer-sign-change:util/strencodings.cpp
 implicit-integer-sign-change:util/strencodings.h
 implicit-integer-sign-change:validation.cpp


### PR DESCRIPTION
Backports bitcoin/bitcoin#17786

Original commit: d0b1f613c

This PR refactors the mempool code to eliminate circular dependencies between policy/fees and txmempool by:
- Moving CTxMemPoolEntry class to its own module (txmempool_entry.h)
- Inlining CTxMemPoolEntry member functions
- Removing the policy/fees -> txmempool -> policy/fees circular dependency

## Dash-specific adaptations:
- Preserved Dash's `nTxSize` and `sigOpCount` fields instead of Bitcoin's `nTxWeight` and `sigOpCost`
- Added Dash-specific fields `validForProTxKey` and `isKeyChangeProTx` to the new txmempool_entry.h
- Removed references to files that don't exist in Dash (src/policy/rbf.cpp, src/test/fuzz/util/mempool.cpp)

## Changes:
- 16 files changed, 193 insertions(+), 161 deletions(-)
- Size ratio: 101% (354 vs 350 lines in Bitcoin)

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized mempool entry types into a dedicated public header and updated code to use the new entry type.

* **Tests / Lint**
  * Adjusted lint expectations for a previously allowed circular dependency.

* **Chores**
  * Added sanitizer suppressions for the new header.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->