### PR TITLE
Merge bitcoin/bitcoin#26508: RPC/Blockchain: Minor improvements for scanblocks & scantxoutset docs/errors

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2578,13 +2578,210 @@ static RPCHelpMan scantxoutset()
         result.pushKV("unspents", unspents);
         result.pushKV("total_amount", ValueFromAmount(total_in));
     } else {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
     }
     return result;
 },
     };
 }
 
+/** RAII object to prevent concurrency issue when scanning blockfilters */
+static std::atomic<int> g_scanfilter_progress;
+static std::atomic<int> g_scanfilter_progress_height;
+static std::atomic<bool> g_scanfilter_in_progress;
+static std::atomic<bool> g_scanfilter_should_abort_scan;
+class BlockFiltersScanReserver
+{
+private:
+    bool m_could_reserve{false};
+public:
+    explicit BlockFiltersScanReserver() = default;
+
+    bool reserve() {
+        CHECK_NONFATAL(!m_could_reserve);
+        if (g_scanfilter_in_progress.exchange(true)) {
+            return false;
+        }
+        m_could_reserve = true;
+        return true;
+    }
+
+    ~BlockFiltersScanReserver() {
+        if (m_could_reserve) {
+            g_scanfilter_in_progress = false;
+        }
+    }
+};
+
+static RPCHelpMan scanblocks()
+{
+    return RPCHelpMan{"scanblocks",
+        "\nReturn relevant blockhashes for given descriptors.\n"
+        "This call may take several minutes. Make sure to use no RPC timeout (dash-cli -rpcclienttimeout=0)",
+        {
+            scan_action_arg_desc,
+            scan_objects_arg_desc,
+            RPCArg{"start_height", RPCArg::Type::NUM, RPCArg::Default{0}, "Height to start to scan from"},
+            RPCArg{"stop_height", RPCArg::Type::NUM, RPCArg::DefaultHint{"chain tip"}, "Height to stop to scan"},
+            RPCArg{"filtertype", RPCArg::Type::STR, RPCArg::Default{BlockFilterTypeName(BlockFilterType::BASIC)}, "The type name of the filter"}
+        },
+        {
+            scan_result_status_none,
+            RPCResult{"When action=='start'; only returns after scan completes", RPCResult::Type::OBJ, "", "", {
+                {RPCResult::Type::NUM, "from_height", "The height we started the scan from"},
+                {RPCResult::Type::NUM, "to_height", "The height we ended the scan at"},
+                {RPCResult::Type::ARR, "relevant_blocks", "Blocks that may have matched a scanobject.", {
+                    {RPCResult::Type::STR_HEX, "blockhash", "A relevant blockhash"},
+                }},
+            }},
+            RPCResult{"when action=='status' and a scan is currently in progress", RPCResult::Type::OBJ, "", "", {
+                    {RPCResult::Type::NUM, "progress", "Approximate percent complete"},
+                    {RPCResult::Type::NUM, "current_height", "Height of the block currently being scanned"},
+                },
+            },
+            scan_result_abort,
+        },
+        RPCExamples{
+            HelpExampleCli("scanblocks", "start '[\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"]' 300000") +
+            HelpExampleCli("scanblocks", "start '[\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"]' 100 150 basic") +
+            HelpExampleCli("scanblocks", "status") +
+            HelpExampleRpc("scanblocks", "\"start\", [\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"], 300000") +
+            HelpExampleRpc("scanblocks", "\"start\", [\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"], 100, 150, \"basic\"") +
+            HelpExampleRpc("scanblocks", "\"status\"")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    UniValue ret(UniValue::VOBJ);
+    if (request.params[0].get_str() == "status") {
+        BlockFiltersScanReserver reserver;
+        if (reserver.reserve()) {
+            // no scan in progress
+            return NullUniValue;
+        }
+        ret.pushKV("progress", g_scanfilter_progress.load());
+        ret.pushKV("current_height", g_scanfilter_progress_height.load());
+        return ret;
+    } else if (request.params[0].get_str() == "abort") {
+        BlockFiltersScanReserver reserver;
+        if (reserver.reserve()) {
+            // reserve was possible which means no scan was running
+            return false;
+        }
+        // set the abort flag
+        g_scanfilter_should_abort_scan = true;
+        return true;
+    }
+    else if (request.params[0].get_str() == "start") {
+        BlockFiltersScanReserver reserver;
+        if (!reserver.reserve()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Scan already in progress, use action \"abort\" or \"status\"");
+        }
+        const std::string filtertype_name{request.params[4].isNull() ? "basic" : request.params[4].get_str()};
+
+        BlockFilterType filtertype;
+        if (!BlockFilterTypeByName(filtertype_name, filtertype)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unknown filtertype");
+        }
+
+        BlockFilterIndex* index = GetBlockFilterIndex(filtertype);
+        if (!index) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Index is not enabled for filtertype " + filtertype_name);
+        }
+
+        NodeContext& node = EnsureAnyNodeContext(request.context);
+        ChainstateManager& chainman = EnsureChainman(node);
+
+        // set the start-height
+        const CBlockIndex* block = nullptr;
+        const CBlockIndex* stop_block = nullptr;
+        {
+            LOCK(cs_main);
+            CChain& active_chain = chainman.ActiveChain();
+            block = active_chain.Genesis();
+            stop_block = active_chain.Tip();
+            if (!request.params[2].isNull()) {
+                block = active_chain[request.params[2].getInt<int>()];
+                if (!block) {
+                    throw JSONRPCError(RPC_MISC_ERROR, "Invalid start_height");
+                }
+            }
+            if (!request.params[3].isNull()) {
+                stop_block = active_chain[request.params[3].getInt<int>()];
+                if (!stop_block || stop_block->nHeight < block->nHeight) {
+                    throw JSONRPCError(RPC_MISC_ERROR, "Invalid stop_height");
+                }
+            }
+        }
+        CHECK_NONFATAL(block);
+
+        // loop through the scan objects, add scripts to the needle_set
+        GCSFilter::ElementSet needle_set;
+        for (const UniValue& scanobject : request.params[1].get_array().getValues()) {
+            FlatSigningProvider provider;
+            std::vector<CScript> scripts = EvalDescriptorStringOrObject(scanobject, provider);
+            for (const CScript& script : scripts) {
+                needle_set.emplace(script.begin(), script.end());
+            }
+        }
+        UniValue blocks(UniValue::VARR);
+        const int amount_per_chunk = 10000;
+        const CBlockIndex* start_index = block; // for remembering the start of a blockfilter range
+        std::vector<BlockFilter> filters;
+        const CBlockIndex* start_block = block; // for progress reporting
+        const int total_blocks_to_process = stop_block->nHeight - start_block->nHeight;
+
+        g_scanfilter_should_abort_scan = false;
+        g_scanfilter_progress = 0;
+        g_scanfilter_progress_height = start_block->nHeight;
+
+        while (block) {
+            node.rpc_interruption_point(); // allow a clean shutdown
+            if (g_scanfilter_should_abort_scan) {
+                LogPrintf("scanblocks RPC aborted at height %d.\n", block->nHeight);
+                break;
+            }
+            const CBlockIndex* next = nullptr;
+            {
+                LOCK(cs_main);
+                CChain& active_chain = chainman.ActiveChain();
+                next = active_chain.Next(block);
+                if (block == stop_block) next = nullptr;
+            }
+            if (start_index->nHeight + amount_per_chunk == block->nHeight || next == nullptr) {
+                LogPrint(BCLog::RPC, "Fetching blockfilters from height %d to height %d.\n", start_index->nHeight, block->nHeight);
+                if (index->LookupFilterRange(start_index->nHeight, block, filters)) {
+                    for (const BlockFilter& filter : filters) {
+                        // compare the elements-set with each filter
+                        if (filter.GetFilter().MatchAny(needle_set)) {
+                            blocks.push_back(filter.GetBlockHash().GetHex());
+                            LogPrint(BCLog::RPC, "scanblocks: found match in %s\n", filter.GetBlockHash().GetHex());
+                        }
+                    }
+                }
+                start_index = block;
+
+                // update progress
+                int blocks_processed = block->nHeight - start_block->nHeight;
+                if (total_blocks_to_process > 0) { // avoid division by zero
+                    g_scanfilter_progress = (int)(100.0 / total_blocks_to_process * blocks_processed);
+                } else {
+                    g_scanfilter_progress = 100;
+                }
+                g_scanfilter_progress_height = block->nHeight;
+            }
+            block = next;
+        }
+        ret.pushKV("from_height", start_block->nHeight);
+        ret.pushKV("to_height", g_scanfilter_progress_height.load());
+        ret.pushKV("relevant_blocks", blocks);
+    }
+    else {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
+    }
+    return ret;
+},
+    };
+}
 static RPCHelpMan getblockfilter()
 {
     return RPCHelpMan{"getblockfilter",

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the scanblocks RPC call."""
+from test_framework.blockfilter import (
+    bip158_basic_element_hash,
+    bip158_relevant_scriptpubkeys,
+)
+from test_framework.messages import COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    MiniWallet,
+    getnewdestination,
+)
+
+
+class ScanblocksTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [["-blockfilterindex=1"], []]
+
+    def run_test(self):
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+        wallet.rescan_utxos()
+
+        # send 1.0, mempool only
+        _, spk_1, addr_1 = getnewdestination()
+        wallet.send_to(from_node=node, scriptPubKey=spk_1, amount=1 * COIN)
+
+        parent_key = "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B"
+        # send 1.0, mempool only
+        # childkey 5 of `parent_key`
+        wallet.send_to(from_node=node,
+                       scriptPubKey=bytes.fromhex(node.validateaddress("mkS4HXoTYWRTescLGaUTGbtTTYX5EjJyEE")['scriptPubKey']),
+                       amount=1 * COIN)
+
+        # mine a block and assure that the mined blockhash is in the filterresult
+        blockhash = self.generate(node, 1)[0]
+        height = node.getblockheader(blockhash)['height']
+        self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
+
+        out = node.scanblocks("start", [f"addr({addr_1})"])
+        assert(blockhash in out['relevant_blocks'])
+        assert_equal(height, out['to_height'])
+        assert_equal(0, out['from_height'])
+
+        # mine another block
+        blockhash_new = self.generate(node, 1)[0]
+        height_new = node.getblockheader(blockhash_new)['height']
+
+        # make sure the blockhash is not in the filter result if we set the start_height
+        # to the just mined block (unlikely to hit a false positive)
+        assert(blockhash not in node.scanblocks(
+            "start", [f"addr({addr_1})"], height_new)['relevant_blocks'])
+
+        # make sure the blockhash is present when using the first mined block as start_height
+        assert(blockhash in node.scanblocks(
+            "start", [f"addr({addr_1})"], height)['relevant_blocks'])
+
+        # also test the stop height
+        assert(blockhash in node.scanblocks(
+            "start", [f"addr({addr_1})"], height, height)['relevant_blocks'])
+
+        # use the stop_height to exclude the relevant block
+        assert(blockhash not in node.scanblocks(
+            "start", [f"addr({addr_1})"], 0, height - 1)['relevant_blocks'])
+
+        # make sure the blockhash is present when using the first mined block as start_height
+        assert(blockhash in node.scanblocks(
+            "start", [{"desc": f"pkh({parent_key}/*)", "range": [0, 100]}], height)['relevant_blocks'])
+
+        # check that false-positives are included in the result now; note that
+        # finding a false-positive at runtime would take too long, hence we simply
+        # use a pre-calculated one that collides with the regtest genesis block's
+        # coinbase output and verify that their BIP158 ranged hashes match
+        genesis_blockhash = node.getblockhash(0)
+        genesis_spks = bip158_relevant_scriptpubkeys(node, genesis_blockhash)
+        assert_equal(len(genesis_spks), 1)
+        genesis_coinbase_spk = list(genesis_spks)[0]
+        false_positive_spk = bytes.fromhex("001400000000000000000000000000000000000cadcb")
+
+        genesis_coinbase_hash = bip158_basic_element_hash(genesis_coinbase_spk, 1, genesis_blockhash)
+        false_positive_hash = bip158_basic_element_hash(false_positive_spk, 1, genesis_blockhash)
+        assert_equal(genesis_coinbase_hash, false_positive_hash)
+
+        assert(genesis_blockhash in node.scanblocks(
+            "start", [{"desc": f"raw({genesis_coinbase_spk.hex()})"}], 0, 0)['relevant_blocks'])
+        assert(genesis_blockhash in node.scanblocks(
+            "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0)['relevant_blocks'])
+
+        # TODO: after an "accurate" mode for scanblocks is implemented (e.g. PR #26325)
+        # check here that it filters out the false-positive
+
+        # test node with disabled blockfilterindex
+        assert_raises_rpc_error(-1, "Index is not enabled for filtertype basic",
+                                self.nodes[1].scanblocks, "start", [f"addr({addr_1})"])
+
+        # test unknown filtertype
+        assert_raises_rpc_error(-5, "Unknown filtertype",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 0, 10, "extended")
+
+        # test invalid start_height
+        assert_raises_rpc_error(-1, "Invalid start_height",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 100000000)
+
+        # test invalid stop_height
+        assert_raises_rpc_error(-1, "Invalid stop_height",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 10, 0)
+        assert_raises_rpc_error(-1, "Invalid stop_height",
+                                node.scanblocks, "start", [f"addr({addr_1})"], 10, 100000000)
+
+        # test accessing the status (must be empty)
+        assert_equal(node.scanblocks("status"), None)
+
+        # test aborting the current scan (there is no, must return false)
+        assert_equal(node.scanblocks("abort"), False)
+
+        # test invalid command
+        assert_raises_rpc_error(-8, "Invalid action 'foobar'", node.scanblocks, "foobar")
+
+
+if __name__ == '__main__':
+    ScanblocksTest().main()


### PR DESCRIPTION
Backports bitcoin/bitcoin#26508

Original commit: df2f16666c05f8fef2eab0811f87e60b7fb18224

This backport improves documentation and error messages for the scanblocks and scantxoutset RPCs:
- Clarifies invalid-action error messages to show the actual invalid action
- Documents that action=='start' only returns after scan completes
- Documents the relevant_blocks field

Note: Dash did not previously have the scanblocks RPC, so this backport includes the entire function with the improvements already integrated. The scantxoutset error message improvement is included.

Backported from Bitcoin Core v0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scanblocks RPC command for scanning blockchain data using the blockfilter index, with support for progress tracking and start/status/abort operations.

* **Bug Fixes**
  * Improved error message clarity in scantxoutset for invalid action parameters.

* **Tests**
  * Added comprehensive functional tests for scanblocks RPC covering various scenarios and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->