### PR TITLE
Merge bitcoin/bitcoin#26651: test: Avoid intermittent timeout in feature_assumevalid.py

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -89,8 +89,6 @@ class AssumeValidTest(BitcoinTestFramework):
                 break
 
     def run_test(self):
-        p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
-
         # Build the blockchain
         self.tip = int(self.nodes[0].getbestblockhash(), 16)
         self.block_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time'] + 1
@@ -148,36 +146,29 @@ class AssumeValidTest(BitcoinTestFramework):
             self.block_time += 1
             height += 1
 
-        self.nodes[0].disconnect_p2ps()
-
         # Start node1 and node2 with assumevalid so they accept a block with a bad signature.
         self.start_node(1, extra_args=self.extra_args + ["-assumevalid=" + hex(block102.sha256)])
         self.start_node(2, extra_args=self.extra_args + ["-assumevalid=" + hex(block102.sha256)])
-
-        p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
-        p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
-        p2p2 = self.nodes[2].add_p2p_connection(BaseNode())
 
         # Make sure nodes actually accept the many headers
         self.mocktime = self.block_time
         set_node_times(self.nodes, self.mocktime)
 
-        # send header lists to all three nodes.
-        # node0 does not need to receive all headers
-        # node1 must receive all headers as otherwise assumevalid is ignored in ConnectBlock
-        # node2 should NOT receive all headers to force skipping of the assumevalid check in ConnectBlock
+        p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
         p2p0.send_header_for_blocks(self.blocks[0:2000])
-        p2p1.send_header_for_blocks(self.blocks[0:2000])
-        p2p1.send_header_for_blocks(self.blocks[2000:4000])
-        p2p1.send_header_for_blocks(self.blocks[4000:6000])
-        p2p1.send_header_for_blocks(self.blocks[6000:8000])
-        p2p1.send_header_for_blocks(self.blocks[8000:])
-        p2p2.send_header_for_blocks(self.blocks[0:200])
 
         # Send blocks to node0. Block 102 will be rejected.
         self.send_blocks_until_disconnected(p2p0)
         self.wait_until(lambda: self.nodes[0].getblockcount() >= COINBASE_MATURITY + 1)
         assert_equal(self.nodes[0].getblockcount(), COINBASE_MATURITY + 1)
+
+        p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
+        # node1 must receive all headers as otherwise assumevalid is ignored in ConnectBlock
+        p2p1.send_header_for_blocks(self.blocks[0:2000])
+        p2p1.send_header_for_blocks(self.blocks[2000:4000])
+        p2p1.send_header_for_blocks(self.blocks[4000:6000])
+        p2p1.send_header_for_blocks(self.blocks[6000:8000])
+        p2p1.send_header_for_blocks(self.blocks[8000:])
 
         # Send 200 blocks to node1. All blocks, including block 102, will be accepted.
         for i in range(200):
@@ -185,6 +176,9 @@ class AssumeValidTest(BitcoinTestFramework):
         # Syncing so many blocks can take a while on slow systems. Give it plenty of time to sync.
         p2p1.sync_with_ping(timeout=960)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 200)
+
+        p2p2 = self.nodes[2].add_p2p_connection(BaseNode())
+        p2p2.send_header_for_blocks(self.blocks[0:200])
 
         # Send blocks to node2. Block 102 will be rejected.
         self.send_blocks_until_disconnected(p2p2)


### PR DESCRIPTION
Backports bitcoin/bitcoin#26651

Original commit: 9a72119e7e277be5fc4ecb2c81f255fe90c36f4c

## Summary
- Fixes intermittent timeout issues in feature_assumevalid.py test
- Delays P2P connection setup to just before they're needed
- Prevents timeouts from nodes waiting while blocks are sent sequentially

## Changes
- Move p2p0 connection to after mocktime setup and just before use
- Move p2p1 connection to after p2p0 completes
- Move p2p2 connection to after p2p1 completes
- Remove early connection setup and disconnect_p2ps() call

## Dash-specific adaptations
- Preserved mocktime setup for header validation
- Preserved Dash-specific header sending pattern (chunked sends)
- Preserved Dash-specific block counts (8400 deep burial, 200 blocks to node1)

Backported from Bitcoin Core v0.25