### PR TITLE
Merge bitcoin/bitcoin#27685: doc: Rework build-unix.md

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -58,6 +58,7 @@ To build dependencies for the current arch+OS:
 **Dash Core's `configure` script by default will ignore the depends output.** In
 order for it to pick up libraries, tools, and settings from the depends build,
 you must set the `CONFIG_SITE` environment variable to point to a `config.site` settings file.
+Make sure that `CONFIG_SITE` is an absolute path.
 In the above example, a file named `depends/x86_64-w64-mingw32/share/config.site` will be
 created. To use it during compilation:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -4,18 +4,6 @@ Some notes on how to build Dash Core in Unix.
 
 (For BSD specific instructions, see `build-*bsd.md` in this directory.)
 
-Note
----------------------
-Always use absolute paths to configure and compile Dash Core and the dependencies.
-For example, when specifying the path of the dependency:
-
-```sh
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
-```
-
-Here `BDB_PREFIX` must be an absolute path - it is defined using $(pwd) which ensures
-the usage of the absolute path.
-
 To Build
 ---------------------
 
@@ -26,12 +14,11 @@ make # use "-j N" for N parallel jobs
 make install # optional
 ```
 
-This will build dash-qt as well, if the dependencies are met.
+See below for instructions on how to [install the dependencies on popular Linux
+distributions](#linux-distribution-specific-instructions), or the
+[dependencies](#dependencies) section for a complete overview.
 
-See [dependencies.md](dependencies.md) for a complete overview.
-
-Memory Requirements
---------------------
+## Memory Requirements
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
 memory available when compiling Dash Core. On systems with less, gcc can be
@@ -55,7 +42,7 @@ Build requirements:
 sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils bison python3
 ```
 
-Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
+Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
 
 ```sh
 sudo apt-get install libbacktrace-dev libevent-dev libboost-dev
@@ -70,7 +57,7 @@ SQLite is required for the descriptor wallet:
 sudo apt-get install libsqlite3-dev
 ```
 
-Berkeley DB is required for the legacy wallet. Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages,
+Berkeley DB is only required for the legacy wallet. Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages,
 but these will install Berkeley DB 5.1 or later. This will break binary wallet compatibility with the distributed
 executables, which are based on BerkeleyDB 4.8. If you do not care about wallet compatibility, pass
 `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
@@ -139,7 +126,7 @@ Build requirements:
 sudo dnf install gcc-c++ libtool make autoconf automake python3
 ```
 
-Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
+Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
 
 ```sh
 sudo dnf install libevent-devel boost-devel
@@ -159,7 +146,7 @@ Berkeley DB is required for the legacy wallet:
 sudo dnf install libdb4-devel libdb4-cxx-devel
 ```
 
-Newer Fedora releases, since Fedora 33, have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
+Berkeley DB is only required for the legacy wallet. Newer Fedora releases have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
 Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed executables, which
 are based on Berkeley DB 4.8. If you do not care about wallet compatibility,
 pass `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
@@ -217,28 +204,13 @@ sudo dnf install qrencode-devel
 Once these are installed, they will be found by configure and a dash-qt executable will be
 built by default.
 
-Notes
------
-The release is built with GCC and then "strip dashd" to strip the debug
-symbols, which reduces the executable size by about 90%.
+## Dependencies
 
+See [dependencies.md](dependencies.md) for a complete overview, and
+[depends](/depends/README.md) on how to compile them yourself, if you wish to
+not use the packages of your Linux distribution.
 
-miniupnpc
----------
-
-[miniupnpc](https://miniupnp.tuxfamily.org) may be used for UPnP port mapping.  It can be downloaded from [here](
-https://miniupnp.tuxfamily.org/files/).  UPnP support is compiled in and
-turned off by default.
-
-libnatpmp
----------
-
-[libnatpmp](https://miniupnp.tuxfamily.org/libnatpmp.html) may be used for NAT-PMP port mapping. It can be downloaded
-from [here](https://miniupnp.tuxfamily.org/files/). NAT-PMP support is compiled in and
-turned off by default.
-
-Berkeley DB
------------
+### Berkeley DB
 
 The legacy wallet uses Berkeley DB. To ensure backwards compatibility it is
 recommended to use Berkeley DB 4.8. If you have to build it yourself, and don't
@@ -256,6 +228,8 @@ export BDB_PREFIX="/path/to/dash/depends/x86_64-pc-linux-gnu"
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
+
+**Note**: Make sure that `BDB_PREFIX` is an absolute path.
 
 **Note**: You only need Berkeley DB if the legacy wallet is enabled (see [*Disable-wallet mode*](#disable-wallet-mode)).
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#27685

Original commit: 5f70cd39974dcb966f2a7913dda216258c2d24c1

## Summary
This commit reworks `doc/build-unix.md` to improve clarity:
- Removes the outdated "Note" section about absolute paths (moves the important part to depends/README.md)
- Removes redundant "Notes" section about GCC stripping (miniupnpc/libnatpmp info is already covered in the package install sections)
- Adds a new "Dependencies" section with proper links
- Updates the "To Build" section to reference dependency installation instructions

## Conflict Resolution
Three minor conflicts were resolved by taking the Bitcoin changes:
1. Removed the "Note" section about absolute paths (Dash had a slightly different version)
2. Replaced "This will build dash-qt..." with the new dependency links
3. Replaced the "Notes" section with the new "Dependencies" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Reorganized Unix build guide with improved cross-distribution dependency installation instructions
* Clarified legacy wallet-specific requirements and absolute path configuration guidance
* Added memory requirements section for better build preparation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->