### PR TITLE
Merge bitcoin/bitcoin#27695: test: Add test to check tx in the last block can be downloaded

### DIFF
--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test that we don't leak txs to inbound peers that we haven't yet announced to"""
+"""Test transaction upload"""
 
 from test_framework.messages import msg_getdata, CInv, MSG_TX
 from test_framework.p2p import p2p_lock, P2PDataStore
@@ -23,19 +23,40 @@ class P2PLeakTxTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def run_test(self):
-        gen_node = self.nodes[0]  # The block and tx generating node
-        miniwallet = MiniWallet(gen_node)
+        self.gen_node = self.nodes[0]  # The block and tx generating node
+        self.miniwallet = MiniWallet(self.gen_node)
         # Add enough mature utxos to the wallet, so that all txs spend confirmed coins
-        self.generate(miniwallet, 1)
-        self.generate(gen_node, 100)
+        self.generate(self.miniwallet, 1)
+        self.generate(self.gen_node, 100)
 
-        inbound_peer = self.nodes[0].add_p2p_connection(P2PNode())  # An "attacking" inbound peer
+        self.test_tx_in_block()
+        self.test_notfound_on_unannounced_tx()
+
+    def test_tx_in_block(self):
+        self.log.info("Check that a transaction in the last block is uploaded (beneficial for compact block relay)")
+        inbound_peer = self.gen_node.add_p2p_connection(P2PNode())
+
+        self.log.debug("Generate transaction and block")
+        inbound_peer.last_message.pop("inv", None)
+        txid = self.miniwallet.send_self_transfer(from_node=self.gen_node)["txid"]
+        inbound_peer.wait_until(lambda: "inv" in inbound_peer.last_message and inbound_peer.last_message.get("inv").inv[0].hash == int(txid, 16))
+        want_tx = msg_getdata(inv=inbound_peer.last_message.get("inv").inv)
+        self.generate(self.gen_node, 1)
+
+        self.log.debug("Request transaction")
+        inbound_peer.last_message.pop("tx", None)
+        inbound_peer.send_and_ping(want_tx)
+        assert_equal(inbound_peer.last_message.get("tx").tx.rehash(), txid)
+
+    def test_notfound_on_unannounced_tx(self):
+        self.log.info("Check that we don't leak txs to inbound peers that we haven't yet announced to")
+        inbound_peer = self.gen_node.add_p2p_connection(P2PNode())  # An "attacking" inbound peer
 
         MAX_REPEATS = 100
         self.log.info("Running test up to {} times.".format(MAX_REPEATS))
         for i in range(MAX_REPEATS):
             self.log.info('Run repeat {}'.format(i + 1))
-            txid = miniwallet.send_self_transfer(from_node=gen_node)['txid']
+            txid = self.miniwallet.send_self_transfer(from_node=self.gen_node)["txid"]
 
             want_tx = msg_getdata()
             want_tx.inv.append(CInv(t=MSG_TX, h=int(txid, 16)))


### PR DESCRIPTION
## Summary
Backports bitcoin/bitcoin#27695

Original commit: 7be7e62fdf4623e0cc680ea8205750c16414453e

This PR adds a test to verify that a transaction in the last block can be downloaded. This is beneficial for compact block relay when a peer receives an `inv` about a transaction which was included in a block before receiving the corresponding `getdata`.

### Dash-specific adaptations:
- Changed `wtxid` to `txid` (Dash doesn't have SegWit)
- Changed `getwtxid()` to `rehash()` for transaction ID verification
- Preserved Dash's MiniWallet setup with mature utxos

## Test plan
- CI will run functional tests including `p2p_leak_tx.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)