### PR TITLE
Merge bitcoin/bitcoin#27021: Implement Mini version of BlockAssembler to calculate mining scores

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -307,6 +307,7 @@ BITCOIN_CORE_H = \
   node/context.h \
   node/eviction.h \
   node/miner.h \
+  node/mini_miner.h \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
@@ -565,6 +566,7 @@ libbitcoin_node_a_SOURCES = \
   node/eviction.cpp \
   node/interfaces.cpp \
   node/miner.cpp \
+  node/mini_miner.cpp \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -145,9 +145,9 @@ BITCOIN_TESTS =\
   test/mempool_tests.cpp \
   test/merkle_tests.cpp \
   test/merkleblock_tests.cpp \
+  test/miner_tests.cpp \
   test/miniscript_tests.cpp \
   test/minisketch_tests.cpp \
-  test/miner_tests.cpp \
   test/multisig_tests.cpp \
   test/net_peer_connection_tests.cpp \
   test/net_peer_eviction_tests.cpp \

--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -1,0 +1,366 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/mini_miner.h>
+
+#include <consensus/amount.h>
+#include <policy/feerate.h>
+#include <primitives/transaction.h>
+#include <timedata.h>
+#include <util/check.h>
+#include <util/moneystr.h>
+
+#include <algorithm>
+#include <numeric>
+#include <utility>
+
+namespace node {
+
+MiniMiner::MiniMiner(const CTxMemPool& mempool, const std::vector<COutPoint>& outpoints)
+{
+    LOCK(mempool.cs);
+    // Find which outpoints to calculate bump fees for.
+    // Anything that's spent by the mempool is to-be-replaced
+    // Anything otherwise unavailable just has a bump fee of 0
+    for (const auto& outpoint : outpoints) {
+        if (!mempool.exists(outpoint.hash)) {
+            // This UTXO is either confirmed or not yet submitted to mempool.
+            // If it's confirmed, no bump fee is required.
+            // If it's not yet submitted, we have no information, so return 0.
+            m_bump_fees.emplace(outpoint, 0);
+            continue;
+        }
+
+        // UXTO is created by transaction in mempool, add to map.
+        // Note: This will either create a missing entry or add the outpoint to an existing entry
+        m_requested_outpoints_by_txid[outpoint.hash].push_back(outpoint);
+
+        if (const auto ptx{mempool.GetConflictTx(outpoint)}) {
+            // This outpoint is already being spent by another transaction in the mempool. We
+            // assume that the caller wants to replace this transaction and its descendants. It
+            // would be unusual for the transaction to have descendants as the wallet won’t normally
+            // attempt to replace transactions with descendants. If the outpoint is from a mempool
+            // transaction, we still need to calculate its ancestors bump fees (added to
+            // m_requested_outpoints_by_txid below), but after removing the to-be-replaced entries.
+            //
+            // Note that the descendants of a transaction include the transaction itself. Also note,
+            // that this is only calculating bump fees. RBF fee rules should be handled separately.
+            CTxMemPool::setEntries descendants;
+            mempool.CalculateDescendants(mempool.GetIter(ptx->GetHash()).value(), descendants);
+            for (const auto& desc_txiter : descendants) {
+                m_to_be_replaced.insert(desc_txiter->GetTx().GetHash());
+            }
+        }
+    }
+
+    // No unconfirmed UTXOs, so nothing mempool-related needs to be calculated.
+    if (m_requested_outpoints_by_txid.empty()) return;
+
+    // Calculate the cluster and construct the entry map.
+    std::vector<uint256> txids_needed;
+    txids_needed.reserve(m_requested_outpoints_by_txid.size());
+    for (const auto& [txid, _]: m_requested_outpoints_by_txid) {
+        txids_needed.push_back(txid);
+    }
+    const auto cluster = mempool.GatherClusters(txids_needed);
+    if (cluster.empty()) {
+        // An empty cluster means that at least one of the transactions is missing from the mempool
+        // (should not be possible given processing above) or DoS limit was hit.
+        m_ready_to_calculate = false;
+        return;
+    }
+
+    // Add every entry to m_entries_by_txid and m_entries, except the ones that will be replaced.
+    for (const auto& txiter : cluster) {
+        if (!m_to_be_replaced.count(txiter->GetTx().GetHash())) {
+            auto [mapiter, success] = m_entries_by_txid.emplace(txiter->GetTx().GetHash(), MiniMinerMempoolEntry(txiter));
+            m_entries.push_back(mapiter);
+        } else {
+            auto outpoints_it = m_requested_outpoints_by_txid.find(txiter->GetTx().GetHash());
+            if (outpoints_it != m_requested_outpoints_by_txid.end()) {
+                // This UTXO is the output of a to-be-replaced transaction. Bump fee is 0; spending
+                // this UTXO is impossible as it will no longer exist after the replacement.
+                for (const auto& outpoint : outpoints_it->second) {
+                    m_bump_fees.emplace(outpoint, 0);
+                }
+                m_requested_outpoints_by_txid.erase(outpoints_it);
+            }
+        }
+    }
+
+    // Build the m_descendant_set_by_txid cache.
+    for (const auto& txiter : cluster) {
+        const auto& txid = txiter->GetTx().GetHash();
+        // Cache descendants for future use. Unlike the real mempool, a descendant MiniMinerMempoolEntry
+        // will not exist without its ancestor MiniMinerMempoolEntry, so these sets won't be invalidated.
+        std::vector<MockEntryMap::iterator> cached_descendants;
+        const bool remove{m_to_be_replaced.count(txid) > 0};
+        CTxMemPool::setEntries descendants;
+        mempool.CalculateDescendants(txiter, descendants);
+        Assume(descendants.count(txiter) > 0);
+        for (const auto& desc_txiter : descendants) {
+            const auto txid_desc = desc_txiter->GetTx().GetHash();
+            const bool remove_desc{m_to_be_replaced.count(txid_desc) > 0};
+            auto desc_it{m_entries_by_txid.find(txid_desc)};
+            Assume((desc_it == m_entries_by_txid.end()) == remove_desc);
+            if (remove) Assume(remove_desc);
+            // It's possible that remove=false but remove_desc=true.
+            if (!remove && !remove_desc) {
+                cached_descendants.push_back(desc_it);
+            }
+        }
+        if (remove) {
+            Assume(cached_descendants.empty());
+        } else {
+            m_descendant_set_by_txid.emplace(txid, cached_descendants);
+        }
+    }
+
+    // Release the mempool lock; we now have all the information we need for a subset of the entries
+    // we care about. We will solely operate on the MiniMinerMempoolEntry map from now on.
+    Assume(m_in_block.empty());
+    Assume(m_requested_outpoints_by_txid.size() <= outpoints.size());
+    SanityCheck();
+}
+
+// Compare by min(ancestor feerate, individual feerate), then iterator
+//
+// Under the ancestor-based mining approach, high-feerate children can pay for parents, but high-feerate
+// parents do not incentive inclusion of their children. Therefore the mining algorithm only considers
+// transactions for inclusion on basis of the minimum of their own feerate or their ancestor feerate.
+struct AncestorFeerateComparator
+{
+    template<typename I>
+    bool operator()(const I& a, const I& b) const {
+        auto min_feerate = [](const MiniMinerMempoolEntry& e) -> CFeeRate {
+            const CAmount ancestor_fee{e.GetModFeesWithAncestors()};
+            const int64_t ancestor_size{e.GetSizeWithAncestors()};
+            const CAmount tx_fee{e.GetModifiedFee()};
+            const int64_t tx_size{e.GetTxSize()};
+            // Comparing ancestor feerate with individual feerate:
+            //     ancestor_fee / ancestor_size <= tx_fee / tx_size
+            // Avoid division and possible loss of precision by
+            // multiplying both sides by the sizes:
+            return ancestor_fee * tx_size < tx_fee * ancestor_size ?
+                       CFeeRate(ancestor_fee, ancestor_size) :
+                       CFeeRate(tx_fee, tx_size);
+        };
+        CFeeRate a_feerate{min_feerate(a->second)};
+        CFeeRate b_feerate{min_feerate(b->second)};
+        if (a_feerate != b_feerate) {
+            return a_feerate > b_feerate;
+        }
+        // Use txid as tiebreaker for stable sorting
+        return a->first < b->first;
+    }
+};
+
+void MiniMiner::DeleteAncestorPackage(const std::set<MockEntryMap::iterator, IteratorComparator>& ancestors)
+{
+    Assume(ancestors.size() >= 1);
+    // "Mine" all transactions in this ancestor set.
+    for (auto& anc : ancestors) {
+        Assume(m_in_block.count(anc->first) == 0);
+        m_in_block.insert(anc->first);
+        m_total_fees += anc->second.GetModifiedFee();
+        m_total_vsize += anc->second.GetTxSize();
+        auto it = m_descendant_set_by_txid.find(anc->first);
+        // Each entry’s descendant set includes itself
+        Assume(it != m_descendant_set_by_txid.end());
+        for (auto& descendant : it->second) {
+            // If these fail, we must be double-deducting.
+            Assume(descendant->second.GetModFeesWithAncestors() >= anc->second.GetModifiedFee());
+            Assume(descendant->second.vsize_with_ancestors >= anc->second.GetTxSize());
+            descendant->second.fee_with_ancestors -= anc->second.GetModifiedFee();
+            descendant->second.vsize_with_ancestors -= anc->second.GetTxSize();
+        }
+    }
+    // Delete these entries.
+    for (const auto& anc : ancestors) {
+        m_descendant_set_by_txid.erase(anc->first);
+        // The above loop should have deducted each ancestor's size and fees from each of their
+        // respective descendants exactly once.
+        Assume(anc->second.GetModFeesWithAncestors() == 0);
+        Assume(anc->second.GetSizeWithAncestors() == 0);
+        auto vec_it = std::find(m_entries.begin(), m_entries.end(), anc);
+        Assume(vec_it != m_entries.end());
+        m_entries.erase(vec_it);
+        m_entries_by_txid.erase(anc);
+    }
+}
+
+void MiniMiner::SanityCheck() const
+{
+    // m_entries, m_entries_by_txid, and m_descendant_set_by_txid all same size
+    Assume(m_entries.size() == m_entries_by_txid.size());
+    Assume(m_entries.size() == m_descendant_set_by_txid.size());
+    // Cached ancestor values should be at least as large as the transaction's own fee and size
+    Assume(std::all_of(m_entries.begin(), m_entries.end(), [](const auto& entry) {
+        return entry->second.GetSizeWithAncestors() >= entry->second.GetTxSize() &&
+               entry->second.GetModFeesWithAncestors() >= entry->second.GetModifiedFee();}));
+    // None of the entries should be to-be-replaced transactions
+    Assume(std::all_of(m_to_be_replaced.begin(), m_to_be_replaced.end(),
+        [&](const auto& txid){return m_entries_by_txid.find(txid) == m_entries_by_txid.end();}));
+}
+
+void MiniMiner::BuildMockTemplate(const CFeeRate& target_feerate)
+{
+    while (!m_entries_by_txid.empty()) {
+        // Sort again, since transaction removal may change some m_entries' ancestor feerates.
+        std::sort(m_entries.begin(), m_entries.end(), AncestorFeerateComparator());
+
+        // Pick highest ancestor feerate entry.
+        auto best_iter = m_entries.begin();
+        Assume(best_iter != m_entries.end());
+        const auto ancestor_package_size = (*best_iter)->second.GetSizeWithAncestors();
+        const auto ancestor_package_fee = (*best_iter)->second.GetModFeesWithAncestors();
+        // Stop here. Everything that didn't "make it into the block" has bumpfee.
+        if (ancestor_package_fee < target_feerate.GetFee(ancestor_package_size)) {
+            break;
+        }
+
+        // Calculate ancestors on the fly. This lookup should be fairly cheap, and ancestor sets
+        // change at every iteration, so this is more efficient than maintaining a cache.
+        std::set<MockEntryMap::iterator, IteratorComparator> ancestors;
+        {
+            std::set<MockEntryMap::iterator, IteratorComparator> to_process;
+            to_process.insert(*best_iter);
+            while (!to_process.empty()) {
+                auto iter = to_process.begin();
+                Assume(iter != to_process.end());
+                ancestors.insert(*iter);
+                for (const auto& input : (*iter)->second.GetTx().vin) {
+                    if (auto parent_it{m_entries_by_txid.find(input.prevout.hash)}; parent_it != m_entries_by_txid.end()) {
+                        if (ancestors.count(parent_it) == 0) {
+                            to_process.insert(parent_it);
+                        }
+                    }
+                }
+                to_process.erase(iter);
+            }
+        }
+        DeleteAncestorPackage(ancestors);
+        SanityCheck();
+    }
+    Assume(m_in_block.empty() || m_total_fees >= target_feerate.GetFee(m_total_vsize));
+    // Do not try to continue building the block template with a different feerate.
+    m_ready_to_calculate = false;
+}
+
+std::map<COutPoint, CAmount> MiniMiner::CalculateBumpFees(const CFeeRate& target_feerate)
+{
+    if (!m_ready_to_calculate) return {};
+    // Build a block template until the target feerate is hit.
+    BuildMockTemplate(target_feerate);
+
+    // Each transaction that "made it into the block" has a bumpfee of 0, i.e. they are part of an
+    // ancestor package with at least the target feerate and don't need to be bumped.
+    for (const auto& txid : m_in_block) {
+        // Not all of the block transactions were necessarily requested.
+        auto it = m_requested_outpoints_by_txid.find(txid);
+        if (it != m_requested_outpoints_by_txid.end()) {
+            for (const auto& outpoint : it->second) {
+                m_bump_fees.emplace(outpoint, 0);
+            }
+            m_requested_outpoints_by_txid.erase(it);
+        }
+    }
+
+    // A transactions and its ancestors will only be picked into a block when
+    // both the ancestor set feerate and the individual feerate meet the target
+    // feerate.
+    //
+    // We had to convince ourselves that after running the mini miner and
+    // picking all eligible transactions into our MockBlockTemplate, there
+    // could still be transactions remaining that have a lower individual
+    // feerate than their ancestor feerate. So here is an example:
+    //
+    //               ┌─────────────────┐
+    //               │                 │
+    //               │   Grandparent   │
+    //               │    1700 vB      │
+    //               │    1700 sats    │                    Target feerate: 10    s/vB
+    //               │       1 s/vB    │    GP Ancestor Set Feerate (ASFR):  1    s/vB
+    //               │                 │                           P1_ASFR:  9.84 s/vB
+    //               └──────▲───▲──────┘                           P2_ASFR:  2.47 s/vB
+    //                      │   │                                   C_ASFR: 10.27 s/vB
+    // ┌───────────────┐    │   │    ┌──────────────┐
+    // │               ├────┘   └────┤              │             ⇒ C_FR < TFR < C_ASFR
+    // │   Parent 1    │             │   Parent 2   │
+    // │    200 vB     │             │    200 vB    │
+    // │  17000 sats   │             │   3000 sats  │
+    // │     85 s/vB   │             │     15 s/vB  │
+    // │               │             │              │
+    // └───────────▲───┘             └───▲──────────┘
+    //             │                     │
+    //             │    ┌───────────┐    │
+    //             └────┤           ├────┘
+    //                  │   Child   │
+    //                  │  100 vB   │
+    //                  │  900 sats │
+    //                  │    9 s/vB │
+    //                  │           │
+    //                  └───────────┘
+    //
+    // We therefore calculate both the bump fee that is necessary to elevate
+    // the individual transaction to the target feerate:
+    //         target_feerate × tx_size - tx_fees
+    // and the bump fee that is necessary to bump the entire ancestor set to
+    // the target feerate:
+    //         target_feerate × ancestor_set_size - ancestor_set_fees
+    // By picking the maximum from the two, we ensure that a transaction meets
+    // both criteria.
+    for (const auto& [txid, outpoints] : m_requested_outpoints_by_txid) {
+        auto it = m_entries_by_txid.find(txid);
+        Assume(it != m_entries_by_txid.end());
+        if (it != m_entries_by_txid.end()) {
+            Assume(target_feerate.GetFee(it->second.GetSizeWithAncestors()) > std::min(it->second.GetModifiedFee(), it->second.GetModFeesWithAncestors()));
+            CAmount bump_fee_with_ancestors = target_feerate.GetFee(it->second.GetSizeWithAncestors()) - it->second.GetModFeesWithAncestors();
+            CAmount bump_fee_individual = target_feerate.GetFee(it->second.GetTxSize()) - it->second.GetModifiedFee();
+            const CAmount bump_fee{std::max(bump_fee_with_ancestors, bump_fee_individual)};
+            Assume(bump_fee >= 0);
+            for (const auto& outpoint : outpoints) {
+                m_bump_fees.emplace(outpoint, bump_fee);
+            }
+        }
+    }
+    return m_bump_fees;
+}
+
+std::optional<CAmount> MiniMiner::CalculateTotalBumpFees(const CFeeRate& target_feerate)
+{
+    if (!m_ready_to_calculate) return std::nullopt;
+    // Build a block template until the target feerate is hit.
+    BuildMockTemplate(target_feerate);
+
+    // All remaining ancestors that are not part of m_in_block must be bumped, but no other relatives
+    std::set<MockEntryMap::iterator, IteratorComparator> ancestors;
+    std::set<MockEntryMap::iterator, IteratorComparator> to_process;
+    for (const auto& [txid, outpoints] : m_requested_outpoints_by_txid) {
+        // Skip any ancestors that already have a miner score higher than the target feerate
+        // (already "made it" into the block)
+        if (m_in_block.count(txid)) continue;
+        auto iter = m_entries_by_txid.find(txid);
+        if (iter == m_entries_by_txid.end()) continue;
+        to_process.insert(iter);
+        ancestors.insert(iter);
+    }
+    while (!to_process.empty()) {
+        auto iter = to_process.begin();
+        const CTransaction& tx = (*iter)->second.GetTx();
+        for (const auto& input : tx.vin) {
+            if (auto parent_it{m_entries_by_txid.find(input.prevout.hash)}; parent_it != m_entries_by_txid.end()) {
+                to_process.insert(parent_it);
+                ancestors.insert(parent_it);
+            }
+        }
+        to_process.erase(iter);
+    }
+    const auto ancestor_package_size = std::accumulate(ancestors.cbegin(), ancestors.cend(), int64_t{0},
+        [](int64_t sum, const auto it) {return sum + it->second.GetTxSize();});
+    const auto ancestor_package_fee = std::accumulate(ancestors.cbegin(), ancestors.cend(), CAmount{0},
+        [](CAmount sum, const auto it) {return sum + it->second.GetModifiedFee();});
+    return target_feerate.GetFee(ancestor_package_size) - ancestor_package_fee;
+}
+} // namespace node

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_MINI_MINER_H
+#define BITCOIN_NODE_MINI_MINER_H
+
+#include <txmempool.h>
+
+#include <memory>
+#include <optional>
+#include <stdint.h>
+
+namespace node {
+
+// Container for tracking updates to ancestor feerate as we include ancestors in the "block"
+class MiniMinerMempoolEntry
+{
+    const CAmount fee_individual;
+    const CTransactionRef tx;
+    const int64_t vsize_individual;
+
+// This class must be constructed while holding mempool.cs. After construction, the object's
+// methods can be called without holding that lock.
+public:
+    CAmount fee_with_ancestors;
+    int64_t vsize_with_ancestors;
+    explicit MiniMinerMempoolEntry(CTxMemPool::txiter entry) :
+        fee_individual{entry->GetModifiedFee()},
+        tx{entry->GetSharedTx()},
+        vsize_individual(entry->GetTxSize()),
+        fee_with_ancestors{entry->GetModFeesWithAncestors()},
+        vsize_with_ancestors(entry->GetSizeWithAncestors())
+    { }
+
+    CAmount GetModifiedFee() const { return fee_individual; }
+    CAmount GetModFeesWithAncestors() const { return fee_with_ancestors; }
+    int64_t GetTxSize() const { return vsize_individual; }
+    int64_t GetSizeWithAncestors() const { return vsize_with_ancestors; }
+    const CTransaction& GetTx() const LIFETIMEBOUND { return *tx; }
+};
+
+// Comparator needed for std::set<MockEntryMap::iterator>
+struct IteratorComparator
+{
+    template<typename I>
+    bool operator()(const I& a, const I& b) const
+    {
+        return &(*a) < &(*b);
+    }
+};
+
+/** A minimal version of BlockAssembler. Allows us to run the mining algorithm on a subset of
+ * mempool transactions, ignoring consensus rules, to calculate mining scores. */
+class MiniMiner
+{
+    // When true, a caller may use CalculateBumpFees(). Becomes false if we failed to retrieve
+    // mempool entries (i.e. cluster size too large) or bump fees have already been calculated.
+    bool m_ready_to_calculate{true};
+
+    // Set once per lifetime, fill in during initialization.
+    // txids of to-be-replaced transactions
+    std::set<uint256> m_to_be_replaced;
+
+    // If multiple argument outpoints correspond to the same transaction, cache them together in
+    // a single entry indexed by txid. Then we can just work with txids since all outpoints from
+    // the same tx will have the same bumpfee. Excludes non-mempool transactions.
+    std::map<uint256, std::vector<COutPoint>> m_requested_outpoints_by_txid;
+
+    // What we're trying to calculate.
+    std::map<COutPoint, CAmount> m_bump_fees;
+
+    // The constructed block template
+    std::set<uint256> m_in_block;
+
+    // Information on the current status of the block
+    CAmount m_total_fees{0};
+    int32_t m_total_vsize{0};
+
+    /** Main data structure holding the entries, can be indexed by txid */
+    std::map<uint256, MiniMinerMempoolEntry> m_entries_by_txid;
+    using MockEntryMap = decltype(m_entries_by_txid);
+
+    /** Vector of entries, can be sorted by ancestor feerate. */
+    std::vector<MockEntryMap::iterator> m_entries;
+
+    /** Map of txid to its descendants. Should be inclusive. */
+    std::map<uint256, std::vector<MockEntryMap::iterator>> m_descendant_set_by_txid;
+
+    /** Consider this ancestor package "mined" so remove all these entries from our data structures. */
+    void DeleteAncestorPackage(const std::set<MockEntryMap::iterator, IteratorComparator>& ancestors);
+
+    /** Perform some checks. */
+    void SanityCheck() const;
+
+public:
+    /** Returns true if CalculateBumpFees may be called, false if not. */
+    bool IsReadyToCalculate() const { return m_ready_to_calculate; }
+
+    /** Build a block template until the target feerate is hit. */
+    void BuildMockTemplate(const CFeeRate& target_feerate);
+
+    /** Returns set of txids in the block template if one has been constructed. */
+    std::set<uint256> GetMockTemplateTxids() const { return m_in_block; }
+
+    MiniMiner(const CTxMemPool& mempool, const std::vector<COutPoint>& outpoints);
+
+    /** Construct a new block template and, for each outpoint corresponding to a transaction that
+     * did not make it into the block, calculate the cost of bumping those transactions (and their
+     * ancestors) to the minimum feerate. Returns a map from outpoint to bump fee, or an empty map
+     * if they cannot be calculated. */
+    std::map<COutPoint, CAmount> CalculateBumpFees(const CFeeRate& target_feerate);
+
+    /** Construct a new block template and, calculate the cost of bumping all transactions that did
+     * not make it into the block to the target feerate. Returns the total bump fee, or std::nullopt
+     * if it cannot be calculated. */
+    std::optional<CAmount> CalculateTotalBumpFees(const CFeeRate& target_feerate);
+};
+} // namespace node
+
+#endif // BITCOIN_NODE_MINI_MINER_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -28,6 +28,7 @@
 #include <instantsend/instantsend.h>
 
 #include <cmath>
+#include <numeric>
 #include <optional>
 #include <ranges>
 
@@ -1505,6 +1506,19 @@ CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>& hashes) c
     return ret;
 }
 
+std::vector<CTxMemPool::txiter> CTxMemPool::GetIterVec(const std::vector<uint256>& txids) const
+{
+    AssertLockHeld(cs);
+    std::vector<txiter> ret;
+    ret.reserve(txids.size());
+    for (const auto& txid : txids) {
+        const auto it{GetIter(txid)};
+        if (!it) return {};
+        ret.push_back(*it);
+    }
+    return ret;
+}
+
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
     for (unsigned int i = 0; i < tx.vin.size(); i++)
@@ -1743,7 +1757,6 @@ void CTxMemPool::SetIsLoaded(bool loaded)
     m_is_loaded = loaded;
 }
 
-
 std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
 {
     switch (r) {
@@ -1755,4 +1768,31 @@ std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
         case MemPoolRemovalReason::MANUAL: return "manual";
     }
     assert(false);
+}
+
+std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const
+{
+    AssertLockHeld(cs);
+    std::vector<txiter> clustered_txs{GetIterVec(txids)};
+    // Use epoch: visiting an entry means we have added it to the clustered_txs vector. It does not
+    // necessarily mean the entry has been processed.
+    WITH_FRESH_EPOCH(m_epoch);
+    for (const auto& it : clustered_txs) {
+        visited(it);
+    }
+    // i = index of where the list of entries to process starts
+    for (size_t i{0}; i < clustered_txs.size(); ++i) {
+        // DoS protection: if there are 500 or more entries to process, just quit.
+        if (clustered_txs.size() > 500) return {};
+        const txiter& tx_iter = clustered_txs.at(i);
+        for (const auto& entries : {tx_iter->GetMemPoolParentsConst(), tx_iter->GetMemPoolChildrenConst()}) {
+            for (const CTxMemPoolEntry& entry : entries) {
+                const auto entry_it = mapTx.iterator_to(entry);
+                if (!visited(entry_it)) {
+                    clustered_txs.push_back(entry_it);
+                }
+            }
+        }
+    }
+    return clustered_txs;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -662,8 +662,15 @@ public:
     /** Returns an iterator to the given hash, if found */
     std::optional<txiter> GetIter(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups */
+    /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups.
+     * Does not require that all of the hashes correspond to actual transactions in the mempool,
+     * only returns the ones that exist. */
     setEntries GetIterSet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    /** Translate a list of hashes into a list of mempool iterators to avoid repeated lookups.
+     * The nth element in txids becomes the nth element in the returned vector. If any of the txids
+     * don't actually exist in the mempool, returns an empty vector. */
+    std::vector<txiter> GetIterVec(const std::vector<uint256>& txids) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must
@@ -705,6 +712,12 @@ public:
      *    look up parents from mapLinks. Must be true for entries not in the mempool
      */
     bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    /** Collect the entire cluster of connected transactions for each transaction in txids.
+     * All txids must correspond to transaction entries in the mempool, otherwise this returns an
+     * empty vector. This call will also exit early and return an empty vector if it collects 500 or
+     * more transactions as a DoS protection. */
+    std::vector<txiter> GatherClusters(const std::vector<uint256>& txids) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Calculate all in-mempool ancestors of a set of transactions not already in the mempool and
      * check ancestor and descendant limits. Heuristics are used to estimate the ancestor and


### PR DESCRIPTION
## Summary

Backports bitcoin/bitcoin#27021 (commit 0f8c95dccd)

Implements a Mini version of BlockAssembler to calculate mining scores. This runs the mining algorithm on a subset of the mempool, only disturbing the mempool to copy out fee information for relevant entries. Intended to be used by wallet to calculate amounts needed for fee-bumping unconfirmed transactions.

### Dash adaptations:
- Use `mempool.exists(hash)` instead of `mempool.exists(GenTxid::Txid(hash))` since Dash uses the simpler uint256 API
- Remove test/fuzz/mini_miner.cpp and test/miniminer_tests.cpp which require test/util/txmempool.h from bitcoin#26286 (not yet backported)

### Files included:
- src/node/mini_miner.cpp (366 lines) - Core MiniMiner implementation
- src/node/mini_miner.h (121 lines) - MiniMiner header
- src/txmempool.cpp/h - GatherClusters functionality
- src/Makefile.am - Build system updates

### Files excluded (missing test infrastructure dependencies):
- test/fuzz/mini_miner.cpp - Requires test/fuzz/util/mempool.h
- test/miniminer_tests.cpp - Requires test/util/txmempool.h from bitcoin#26286

## Test plan
- [x] Build succeeds (dashd, dash-cli, dash-tx)
- [x] Core MiniMiner functionality compiles and links
- [ ] Unit tests require backport of bitcoin#26286 first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced fee bump calculation capabilities for improved transaction replacement and cost estimation
  * Added transaction clustering utilities to improve mempool analysis and optimization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->