### PR TITLE
Merge bitcoin/bitcoin#27707: ci, iwyu: Double maximum line length for includes

### DIFF
--- a/ci/dash/lint-tidy.sh
+++ b/ci/dash/lint-tidy.sh
@@ -50,6 +50,7 @@ iwyu_tool.py \
   "src/util/url.cpp" \
   -p . "${MAKEJOBS}" \
   -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
+  -Xiwyu --max_line_length=160 \
   2>&1 | tee "/tmp/iwyu_ci.out"
 
 cd "${BASE_ROOT_DIR}/build-ci/dashcore-${BUILD_TARGET}/src"


### PR DESCRIPTION
## Summary

Backport of bitcoin/bitcoin#27707

This PR makes the IWYU output in the CI lint task more useful by avoiding most cases where a comment ends with an ellipsis like:
```
#include "primitives/transaction.h"  // for CTxIn, CMutableTransaction, CTra...
```

**Dash Adaptation:** Applied the change to `ci/dash/lint-tidy.sh` instead of Bitcoin's `ci/test/06_script_b.sh` since Dash uses different CI infrastructure.

## Bitcoin PR details
- Original: https://github.com/bitcoin/bitcoin/pull/27707
- Commit: 98ea79841177cf7492ec1de1ba1979f75390c63b

## Changes
- Add `-Xiwyu --max_line_length=160` to the iwyu invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)