### PR TITLE
Merge bitcoin/bitcoin#27739: ci: Add missing set -e to 01_base_install.sh

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -21,12 +21,6 @@ requires `docker` to be installed. To run on different architectures than the ho
 sudo apt install docker.io bash qemu-user-static
 ```
 
-To run the default test stage,
-
-```
-./ci/test_run_all.sh
-```
-
 To run the test stage with a specific configuration,
 
 ```

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
+set -ex
+
 # The root dir.
 # The ci system copies this folder.
 # This is where the depends build is done.


### PR DESCRIPTION
## Backport of bitcoin/bitcoin#27739

Original Bitcoin commit: b5ed656c3ba5198f58e771cc5f7147e02247a789

### Changes Applied
- `ci/README.md`: Removed "default test stage" documentation section
- `ci/test/00_setup_env.sh`: Added `set -ex` for proper error handling

### Changes Not Applied (Dash-specific)
- `ci/test/01_base_install.sh`: File does not exist in Dash's CI structure
- `ci/test/04_install.sh`: The HOME filtering change doesn't apply because Dash uses a different env var export mechanism (`env | grep` instead of python3)

### Scope
- Bitcoin: 14 lines across 4 files
- Dash: 8 lines across 2 files
- Ratio: 57% (lower than expected but justified due to structural differences)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified testing documentation by removing redundant instructions.

* **Chores**
  * Enhanced test setup with improved error handling and command tracing for better reliability and debugging during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->