### PR TITLE
Merge bitcoin/bitcoin#25975: contrib/init: Better systemd integration

### DIFF
--- a/contrib/init/dashd.service
+++ b/contrib/init/dashd.service
@@ -18,10 +18,11 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/bin/dashd -daemonwait \
-                                                            -pid=/run/dashd/dashd.pid \
-                                                            -conf=/etc/dash/dash.conf  \
-                                                            -datadir=/var/lib/dashd
+ExecStart=/usr/bin/dashd -pid=/run/dashd/dashd.pid \
+                            -conf=/etc/dash/dash.conf \
+                            -datadir=/var/lib/dashd \
+                            -startupnotify='systemd-notify --ready' \
+                            -shutdownnotify='systemd-notify --stopping'
 
 # Make sure the config directory is readable by the service user
 PermissionsStartOnly=true
@@ -30,8 +31,10 @@ ExecStartPre=/bin/chgrp dashcore /etc/dash
 # Process management
 ####################
 
-Type=forking
+Type=notify
+NotifyAccess=all
 PIDFile=/run/dashd/dashd.pid
+
 Restart=on-failure
 TimeoutStartSec=infinity
 TimeoutStopSec=600


### PR DESCRIPTION
## Summary
Backports bitcoin/bitcoin#25975

This PR improves systemd integration for dashd:
- Remove `-daemonwait` to make logs available to journalctl
- Add `-startupnotify='systemd-notify --ready'` to signal readiness
- Add `-shutdownnotify='systemd-notify --stopping'` to signal shutdown
- Change service type from `forking` to `notify` for proper systemd notification
- Add `NotifyAccess=all` to allow spawned threads to notify systemd

Original Bitcoin commit: 769dd1e826

## Test plan
- This is a configuration file change only (no code changes)
- Verify the systemd service file syntax is correct
- Test on a Linux system with systemd to confirm proper integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved daemon service reliability with enhanced systemd integration, including automatic restart on failure and better service lifecycle notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->