### PR TITLE
Merge bitcoin/bitcoin#27724: build: disable boost multi index safe mode in debug mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1595,10 +1595,6 @@ if test "$use_boost" = "yes"; then
   dnl we don't use multi_index serialization
   BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION"
 
-  if test "$enable_debug" = "yes" || test "$enable_fuzz" = "yes"; then
-    BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE"
-  fi
-
   dnl Prevent use of std::unary_function, which was removed in C++17,
   dnl and will generate warnings with newer compilers for Boost
   dnl older than 1.80.


### PR DESCRIPTION
Backports bitcoin/bitcoin#27724

## Summary
- Disables boost multi index safe mode by default when configuring with `--enable-debug` or `--enable-fuzz`
- This option can cause transactions to take a long time to be accepted into the mempool under certain conditions (iterator destruction takes O(n) time vs O(1))
- Fixes performance issues as described in bitcoin#27586

## Changes
- Removed the automatic enabling of `BOOST_MULTI_INDEX_ENABLE_SAFE_MODE` from `configure.ac`

## Notes
- Bitcoin's CI file changes (`00_setup_env_i686_multiprocess.sh`, `00_setup_env_native_fuzz_with_msan.sh`, `00_setup_env_native_qt5.sh`) were not applied because:
  - Two of these files don't exist in Dash
  - The third (`native_qt5.sh`) has a completely different configuration that doesn't use `--enable-debug`
- The core functional change (removing automatic safe mode) is applied

Original Bitcoin commit: fb4f04768634b1c494618f624e84c728f21e218e