### PR TITLE
Merge bitcoin/bitcoin#27673: log: don't log total disk read time in ConnectTip bench

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3105,7 +3105,6 @@ bool CChainState::DisconnectTip(BlockValidationState& state, DisconnectedBlockTr
     return true;
 }
 
-static int64_t nTimeReadFromDiskTotal = 0;
 static int64_t nTimeConnectTotal = 0;
 static int64_t nTimeFlush = 0;
 static int64_t nTimeChainState = 0;
@@ -3178,9 +3177,11 @@ bool CChainState::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew
     }
     const CBlock& blockConnecting = *pthisBlock;
     // Apply the block atomically to the chain state.
-    int64_t nTime2 = GetTimeMicros(); nTimeReadFromDiskTotal += nTime2 - nTime1;
+    int64_t nTime2 = GetTimeMicros();
     int64_t nTime3;
-    LogPrint(BCLog::BENCHMARK, "  - Load block from disk: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime2 - nTime1) * MILLI, nTimeReadFromDiskTotal * MICRO, nTimeReadFromDiskTotal * MILLI / nBlocksTotal);
+    // When adding aggregate statistics in the future, keep in mind that
+    // nBlocksTotal may be zero until the ConnectBlock() call below.
+    LogPrint(BCLog::BENCHMARK, "  - Load block from disk: %.2fms\n", (nTime2 - nTime1) * MILLI);
     {
         auto dbTx = m_evoDb.BeginTransaction();
 


### PR DESCRIPTION
## Summary

Backport of bitcoin/bitcoin#27673

The "Load block from disk" log incorrectly assumed `nBlocksTotal` would be greater than 0. This is not guaranteed until the `ConnectBlock` call right below it.

The total and average metric is not very useful because it does not distinguish between blocks read from disk and those loaded from memory. So rather than fixing the divide by zero issue, we just drop the metric.

## Changes
- Remove `nTimeReadFromDiskTotal` static variable
- Simplify log message to only show per-block timing
- Add comment explaining why aggregate stats are not included

## Original PR
- https://github.com/bitcoin/bitcoin/pull/27673
- Fixes bitcoin#27635

## Validation
- Size: Bitcoin 10 LOC, Dash 7 LOC (70% - slightly below 80% due to Dash having combined statements)
- Files: 1 file changed (src/validation.cpp) ✓
- No new dependencies introduced ✓