### PR TITLE
Merge bitcoin/bitcoin#27666: wallet, bench: Move commonly used functions to their own file and fix a bug

### DIFF
--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -16,7 +16,6 @@
 
 using wallet::CreateMockWalletDatabase;
 using wallet::CWallet;
-using wallet::DBErrors;
 using wallet::WALLET_FLAG_DESCRIPTORS;
 
 static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_mine, const uint32_t epoch_iters)
@@ -29,7 +28,6 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
         LOCK(wallet.cs_wallet);
         wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
         wallet.SetupDescriptorScriptPubKeyMans("", "");
-        if (wallet.LoadWallet() != DBErrors::LOAD_OK) assert(false);
     }
     auto handler = test_setup->m_node.chain->handleNotifications({&wallet, [](CWallet*) {}});
 


### PR DESCRIPTION
## Summary
Backports bitcoin/bitcoin#27666

This is a partial backport applying only the bug fix portion of the Bitcoin commit:
- **Applied**: Removes incorrect `LoadWallet()` call from the `WalletBalance` benchmark

The refactoring parts (moving `TestLoadWallet`/`TestUnloadWallet` to `util.h/cpp`) are not applicable to Dash because:
- Dash's `TestLoadWallet`/`TestUnloadWallet` have different signatures including `WalletContext&` parameter for `TestUnloadWallet` and CoinJoin-specific code (`AddWallet`/`RemoveWallet`)
- Dash uses `CreateMockWalletDatabase(DatabaseOptions&)` with different signature than Bitcoin's `CreateMockableWalletDatabase()`
- Dash uses `ADDRESS_B58T_UNSPENDABLE` (base58) instead of `ADDRESS_BCRT1_UNSPENDABLE` (bech32)

Original commit: 05ec664632

## Test plan
- [x] Build succeeded
- [x] Bug fix verified: Removed unnecessary `LoadWallet()` call from wallet_balance benchmark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified wallet initialization sequence to remove wallet loading logic from the benchmark suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->