### PR TITLE
Merge bitcoin/bitcoin#27657: doc: Remove unused NO_BLOOM_VERSION constant

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -134,7 +134,8 @@ extern const char* GETADDR;
 /**
  * The mempool message requests the TXIDs of transactions that the receiving
  * node has verified as valid but which have not yet appeared in a block.
- * @since protocol version 60002.
+ * @since protocol version 60002 as described by BIP35.
+ *   Only available with service bit NODE_BLOOM, see also BIP111.
  */
 extern const char* MEMPOOL;
 /**
@@ -315,8 +316,6 @@ enum ServiceFlags : uint64_t {
     // set by all Dash Core non pruned nodes, and is unset by SPV clients or other light clients.
     NODE_NETWORK = (1 << 0),
     // NODE_BLOOM means the node is capable and willing to handle bloom-filtered connections.
-    // Dash Core nodes used to support this by default, without advertising this bit,
-    // but no longer do as of protocol version 70201 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
     // NODE_COMPACT_FILTERS means the node will service basic block filter requests.
     // See BIP157 and BIP158 for details on how this is implemented.


### PR DESCRIPTION
Backports bitcoin/bitcoin#27657

Original Bitcoin commit: 30d6c7d8c0441956fac37252921c795569002d07

## Changes
This PR removes references to the unused `NO_BLOOM_VERSION` constant from documentation comments.

Note: The `src/version.h` change from the Bitcoin commit was not needed because Dash doesn't have the `NO_BLOOM_VERSION` constant (it was already removed or never added).

## Files Modified
- `src/protocol.h`: Updated mempool message documentation and removed obsolete NO_BLOOM_VERSION reference in comments

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MEMPOOL feature documentation to clarify protocol version requirements and associated service flags.
  * Removed outdated historical compatibility note from protocol documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->