### PR TITLE
Merge bitcoin/bitcoin#26720: wallet: coin selection, don't return results that exceed the max allowed weight

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -5,11 +5,16 @@
 #include <bench/bench.h>
 #include <interfaces/chain.h>
 #include <node/context.h>
+#include <policy/policy.h>
 #include <wallet/coinselection.h>
 #include <wallet/spend.h>
 #include <wallet/wallet.h>
 
 #include <set>
+
+// Dash doesn't use SegWit, but we use these constants for weight-based calculations
+static constexpr int WITNESS_SCALE_FACTOR = 4;
+static constexpr int MAX_STANDARD_TX_WEIGHT = MAX_STANDARD_TX_SIZE * WITNESS_SCALE_FACTOR;
 
 using node::NodeContext;
 using wallet::CHANGE_LOWER;
@@ -111,7 +116,7 @@ static void BnBExhaustion(benchmark::Bench& bench)
     bench.run([&] {
         // Benchmark
         CAmount target = make_hard_case(17, utxo_pool);
-        SelectCoinsBnB(utxo_pool, target, 0); // Should exhaust
+        SelectCoinsBnB(utxo_pool, target, 0, MAX_STANDARD_TX_WEIGHT); // Should exhaust
 
         // Cleanup
         utxo_pool.clear();

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -5,6 +5,7 @@
 #include <wallet/coinselection.h>
 
 #include <policy/feerate.h>
+#include <policy/policy.h>
 #include <util/check.h>
 #include <util/system.h>
 #include <util/moneystr.h>
@@ -13,8 +14,21 @@
 
 #include <numeric>
 #include <optional>
+#include <queue>
 
 namespace wallet {
+
+// Dash doesn't use SegWit, but we use these constants for weight-based calculations
+// to maintain compatibility with Bitcoin's coin selection logic
+static constexpr int WITNESS_SCALE_FACTOR = 4;
+
+// Common selection error across the algorithms
+static util::Result<SelectionResult> ErrorMaxWeightExceeded()
+{
+    return util::Error{_("The inputs size exceeds the maximum weight. "
+                         "Please try sending a smaller amount or manually consolidating your wallet's UTXOs")};
+}
+
 // Descending order comparator
 struct {
     bool operator()(const OutputGroup& a, const OutputGroup& b) const
@@ -63,13 +77,15 @@ struct {
 
 static const size_t TOTAL_TRIES = 100000;
 
-std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change)
+util::Result<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change,
+                                             int max_weight)
 {
-    if (utxo_pool.empty()) return std::nullopt;
+    if (utxo_pool.empty()) return util::Error();
 
     SelectionResult result(selection_target, SelectionAlgorithm::BNB);
     CAmount curr_value = 0;
     std::vector<size_t> curr_selection; // selected utxo indexes
+    int curr_selection_weight = 0; // sum of selected utxo weight
 
     // Calculate curr_available_value
     CAmount curr_available_value = 0;
@@ -80,7 +96,7 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
         curr_available_value += utxo.GetSelectionAmount();
     }
     if (curr_available_value < selection_target) {
-        return std::nullopt;
+        return util::Error();
     }
 
     // Sort the utxo_pool
@@ -91,6 +107,7 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
     CAmount best_waste = MAX_MONEY;
 
     bool is_feerate_high = utxo_pool.at(0).fee > utxo_pool.at(0).long_term_fee;
+    bool max_tx_weight_exceeded = false;
 
     // Depth First search loop for choosing the UTXOs
     for (size_t curr_try = 0, utxo_pool_index = 0; curr_try < TOTAL_TRIES; ++curr_try, ++utxo_pool_index) {
@@ -99,6 +116,9 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
         if (curr_value + curr_available_value < selection_target || // Cannot possibly reach target with the amount remaining in the curr_available_value.
             curr_value > selection_target + cost_of_change || // Selected value is out of range, go back and try other branch
             (curr_waste > best_waste && is_feerate_high)) { // Don't select things which we know will be more wasteful if the waste is increasing
+            backtrack = true;
+        } else if (curr_selection_weight > max_weight) { // Exceeding weight for standard tx, cannot find more solutions by adding more inputs
+            max_tx_weight_exceeded = true; // at least one selection attempt exceeded the max weight
             backtrack = true;
         } else if (curr_value >= selection_target) {       // Selected value is within range
             curr_waste += (curr_value - selection_target); // This is the excess value which is added to the waste for the below comparison
@@ -129,6 +149,7 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
             OutputGroup& utxo = utxo_pool.at(utxo_pool_index);
             curr_value -= utxo.GetSelectionAmount();
             curr_waste -= utxo.fee - utxo.long_term_fee;
+            curr_selection_weight -= utxo.m_weight;
             curr_selection.pop_back();
         } else { // Moving forwards, continuing down this branch
             OutputGroup& utxo = utxo_pool.at(utxo_pool_index);
@@ -148,13 +169,14 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
                 curr_selection.push_back(utxo_pool_index);
                 curr_value += utxo.GetSelectionAmount();
                 curr_waste += utxo.fee - utxo.long_term_fee;
+                curr_selection_weight += utxo.m_weight;
             }
         }
     }
 
     // Check for solution
     if (best_selection.empty()) {
-        return std::nullopt;
+        return max_tx_weight_exceeded ? ErrorMaxWeightExceeded() : util::Error();
     }
 
     // Set output set
@@ -167,11 +189,20 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
     return result;
 }
 
-std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng)
+class MinOutputGroupComparator
 {
-    if (utxo_pool.empty()) return std::nullopt;
+public:
+    int operator() (const OutputGroup& group1, const OutputGroup& group2) const
+    {
+        return group1.GetSelectionAmount() > group2.GetSelectionAmount();
+    }
+};
 
+util::Result<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng,
+                                             int max_weight)
+{
     SelectionResult result(target_value, SelectionAlgorithm::SRD);
+    std::priority_queue<OutputGroup, std::vector<OutputGroup>, MinOutputGroupComparator> heap;
 
     std::vector<size_t> indexes;
     indexes.resize(utxo_pool.size());
@@ -179,16 +210,40 @@ std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& ut
     Shuffle(indexes.begin(), indexes.end(), rng);
 
     CAmount selected_eff_value = 0;
+    int weight = 0;
+    bool max_tx_weight_exceeded = false;
     for (const size_t i : indexes) {
         const OutputGroup& group = utxo_pool.at(i);
         Assume(group.GetSelectionAmount() > 0);
+
+        // Add group to selection
+        heap.push(group);
         selected_eff_value += group.GetSelectionAmount();
-        result.AddInput(group);
+        weight += group.m_weight;
+
+        // If the selection weight exceeds the maximum allowed size, remove the least valuable inputs until we
+        // are below max weight.
+        if (weight > max_weight) {
+            max_tx_weight_exceeded = true; // mark it in case we don't find any useful result.
+            do {
+                const OutputGroup& to_remove_group = heap.top();
+                selected_eff_value -= to_remove_group.GetSelectionAmount();
+                weight -= to_remove_group.m_weight;
+                heap.pop();
+            } while (!heap.empty() && weight > max_weight);
+        }
+
+        // Now check if we are above the target
         if (selected_eff_value >= target_value) {
+            // Result found, add it.
+            while (!heap.empty()) {
+                result.AddInput(heap.top());
+                heap.pop();
+            }
             return result;
         }
     }
-    return std::nullopt;
+    return max_tx_weight_exceeded ? ErrorMaxWeightExceeded() : util::Error();
 }
 
 /** Find a subset of the OutputGroups that is at least as large as, but as close as possible to, the
@@ -277,10 +332,10 @@ bool less_then_denom (const OutputGroup& group1, const OutputGroup& group2)
     return (!found1 && found2);
 }
 
-std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue,
-                                              CAmount change_target, FastRandomContext& rng, bool fFullyMixedOnly, CAmount maxTxFee)
+util::Result<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue,
+                                             CAmount change_target, FastRandomContext& rng, int max_weight, bool fFullyMixedOnly, CAmount maxTxFee)
 {
-    if (groups.empty()) return std::nullopt;
+    if (groups.empty()) return util::Error();
 
     SelectionResult result(nTargetValue, SelectionAlgorithm::KNAPSACK);
 
@@ -342,7 +397,7 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
                     continue;
                 else
                     // we looked at everything possible and didn't find anything, no luck
-                    return std::nullopt;
+                    return util::Error();
             }
             result.AddInput(*lowest_larger);
             // There is no change in PS, so we know the fee beforehand,
@@ -350,7 +405,7 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
             if (!fFullyMixedOnly || (result.GetSelectedValue() - nTargetValue <= maxTxFee)) {
                 return result;
             }
-            return std::nullopt;
+            return util::Error();
         }
 
         // nTotalLower > nTargetValue
@@ -380,6 +435,17 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
                 log_message += strprintf("%s ", FormatMoney(applicable_groups[i].m_value));
             }
         }
+
+        // If the result exceeds the maximum allowed size, return closest UTXO above the target
+        if (result.GetWeight() > max_weight) {
+            // No coin above target, nothing to do.
+            if (!lowest_larger) return ErrorMaxWeightExceeded();
+
+            // Return closest UTXO above target
+            result.Clear();
+            result.AddInput(*lowest_larger);
+        }
+
         LogPrint(BCLog::SELECTCOINS, "%stotal %s\n", log_message, FormatMoney(nBest));
     }
 
@@ -388,7 +454,7 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
     if (!fFullyMixedOnly || (result.GetSelectedValue() - nTargetValue <= maxTxFee)) {
         return result;
     }
-    return std::nullopt;
+    return util::Error();
 }
 
 /******************************************************************************
@@ -414,6 +480,9 @@ void OutputGroup::Insert(const COutput& output, size_t ancestors, size_t descend
     m_from_me &= coin.from_me;
     m_value += coin.txout.nValue;
     m_depth = std::min(m_depth, coin.depth);
+    // Track the weight of inputs in this group (input_bytes * WITNESS_SCALE_FACTOR for weight units)
+    // Note: Dash doesn't use SegWit, but we still track weight for max tx size limits
+    m_weight += coin.input_bytes < 0 ? 0 : coin.input_bytes * WITNESS_SCALE_FACTOR;
     // ancestors here express the number of ancestors the new coin will end up having, which is
     // the sum, rather than the max; this will overestimate in the cases where multiple inputs
     // have common ancestors
@@ -492,12 +561,14 @@ void SelectionResult::Clear()
 {
     m_selected_inputs.clear();
     m_waste.reset();
+    m_weight = 0;
 }
 
 void SelectionResult::AddInput(const OutputGroup& group)
 {
     util::insert(m_selected_inputs, group.m_outputs);
     m_use_effective = !group.m_subtract_fee_outputs;
+    m_weight += group.m_weight;
 }
 
 const std::set<COutput>& SelectionResult::GetInputSet() const

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -9,6 +9,7 @@
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <random.h>
+#include <util/result.h>
 
 #include <optional>
 
@@ -215,6 +216,8 @@ struct OutputGroup
     /** Indicate that we are subtracting the fee from outputs.
      * When true, the value that is used for coin selection is the UTXO's real value rather than effective value */
     bool m_subtract_fee_outputs{false};
+    /** Total weight of the UTXOs in this group. */
+    int m_weight{0};
 
     OutputGroup() {}
     OutputGroup(const CoinSelectionParams& params) :
@@ -281,6 +284,8 @@ private:
     bool m_use_effective{false};
     /** The computed waste */
     std::optional<CAmount> m_waste;
+    /** Total weight of the selected inputs */
+    int m_weight{0};
 
 public:
     /** The target the algorithm selected for. Note that this may not be equal to the recipient amount as it can include non-input fees */
@@ -310,22 +315,29 @@ public:
     std::vector<COutput> GetShuffledInputVector() const;
 
     bool operator<(SelectionResult other) const;
+
+    /** Get the total weight of the selection result */
+    int GetWeight() const { return m_weight; }
 };
 
-std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change);
+util::Result<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change,
+                                             int max_weight);
 
 /** Select coins by Single Random Draw. OutputGroups are selected randomly from the eligible
  * outputs until the target is satisfied
  *
  * @param[in]  utxo_pool    The positive effective value OutputGroups eligible for selection
  * @param[in]  target_value The target value to select for
- * @returns If successful, a SelectionResult, otherwise, std::nullopt
+ * @param[in]  rng The randomness source to shuffle coins
+ * @param[in]  max_weight The maximum allowed weight for a selection result to be valid
+ * @returns If successful, a valid SelectionResult, otherwise, util::Error
  */
-std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng);
+util::Result<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng,
+                                             int max_weight);
 
 // Original coin selection algorithm as a fallback
-std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue,
-                                              CAmount change_target, FastRandomContext& rng, bool fFullyMixedOnly, CAmount maxTxFee);
+util::Result<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue,
+                                             CAmount change_target, FastRandomContext& rng, int max_weight, bool fFullyMixedOnly, CAmount maxTxFee);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_COINSELECTION_H

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -28,6 +28,19 @@ using interfaces::FoundBlock;
 namespace wallet {
 static constexpr size_t OUTPUT_GROUP_MAX_ENTRIES{100};
 
+// Dash doesn't use SegWit, but we use these constants for weight-based calculations
+// to maintain compatibility with Bitcoin's coin selection logic
+static constexpr int WITNESS_SCALE_FACTOR = 4;
+// MAX_STANDARD_TX_WEIGHT is MAX_STANDARD_TX_SIZE * WITNESS_SCALE_FACTOR in Bitcoin
+// Since Dash doesn't use SegWit, weight equals size, so we use MAX_STANDARD_TX_SIZE directly
+static constexpr int MAX_STANDARD_TX_WEIGHT = MAX_STANDARD_TX_SIZE * WITNESS_SCALE_FACTOR;
+
+// Helper to check if a Result contains an error message
+template<typename T>
+bool HasErrorMsg(const util::Result<T>& result) {
+    return !result && !util::ErrorString(result).empty();
+}
+
 int CalculateMaximumSignedInputSize(const CTxOut& txout, const COutPoint outpoint, const SigningProvider* provider, const CCoinControl* coin_control)
 {
     CMutableTransaction txn;
@@ -466,13 +479,27 @@ std::optional<SelectionResult> ChooseSelectionResult(const CWallet& wallet, cons
 {
     // Vector of results. We will choose the best one based on waste.
     std::vector<SelectionResult> results;
+    std::vector<util::Result<SelectionResult>> errors;
+    auto append_error = [&] (const util::Result<SelectionResult>& result) {
+        // If any specific error message appears here, then something different from a simple "no selection found" happened.
+        // Let's save it, so it can be retrieved to the user if no other selection algorithm succeeded.
+        if (HasErrorMsg(result)) {
+            errors.emplace_back(result);
+        }
+    };
+
+    // Maximum allowed weight
+    int max_inputs_weight = MAX_STANDARD_TX_WEIGHT - (coin_selection_params.tx_noinputs_size * WITNESS_SCALE_FACTOR);
 
     // Note that unlike KnapsackSolver, we do not include the fee for creating a change output as BnB will not create a change output.
     std::vector<OutputGroup> positive_groups = GroupOutputs(wallet, available_coins, coin_selection_params, eligibility_filter, true /* positive_only */);
     positive_groups.clear(); // Cleared to skip BnB and SRD as they're unaware of mixed coins
-    if (auto bnb_result{SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change)}) {
+    if (auto bnb_result{SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change, max_inputs_weight)}) {
         results.push_back(*bnb_result);
-    }
+    } else append_error(bnb_result);
+
+    // As Knapsack and SRD can create change, also deduce change weight.
+    max_inputs_weight -= (coin_selection_params.change_output_size * WITNESS_SCALE_FACTOR);
 
     // The knapsack solver has some legacy behavior where it will spend dust outputs. We retain this behavior, so don't filter for positive only here.
     std::vector<OutputGroup> all_groups = GroupOutputs(wallet, available_coins, coin_selection_params, eligibility_filter, false /* positive_only */);
@@ -484,31 +511,30 @@ std::optional<SelectionResult> ChooseSelectionResult(const CWallet& wallet, cons
         target_with_change += coin_selection_params.m_change_fee;
     }
     if (auto knapsack_result{KnapsackSolver(all_groups, target_with_change, coin_selection_params.m_min_change_target,
-                                            coin_selection_params.rng_fast, nCoinType == CoinType::ONLY_FULLY_MIXED,
+                                            coin_selection_params.rng_fast, max_inputs_weight, nCoinType == CoinType::ONLY_FULLY_MIXED,
                                             wallet.m_default_max_tx_fee)}) {
         knapsack_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
         results.push_back(*knapsack_result);
-    }
+    } else append_error(knapsack_result);
 
     // Include change for SRD as we want to avoid making really small change if the selection just
     // barely meets the target. Just use the lower bound change target instead of the randomly
     // generated one, since SRD will result in a random change amount anyway; avoid making the
     // target needlessly large.
     const CAmount srd_target = target_with_change + CHANGE_LOWER;
-    if (auto srd_result{SelectCoinsSRD(positive_groups, srd_target, coin_selection_params.rng_fast)}) {
+    if (auto srd_result{SelectCoinsSRD(positive_groups, srd_target, coin_selection_params.rng_fast, max_inputs_weight)}) {
         srd_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
         results.push_back(*srd_result);
-    }
+    } else append_error(srd_result);
 
-    if (results.size() == 0) {
+    if (results.empty()) {
         // No solution found
         return std::nullopt;
     }
 
     // Choose the result with the least waste
     // If the waste is the same, choose the one which spends more inputs.
-    auto& best_result = *std::min_element(results.begin(), results.end());
-    return best_result;
+    return *std::min_element(results.begin(), results.end());
 }
 
 std::optional<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& available_coins, const CAmount& nTargetValue, const CCoinControl& coin_control, const CoinSelectionParams& coin_selection_params)

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -15,12 +15,18 @@
 #include <wallet/spend.h>
 #include <wallet/test/wallet_test_fixture.h>
 #include <wallet/wallet.h>
+#include <policy/policy.h>
 
 #include <algorithm>
 #include <boost/test/unit_test.hpp>
 #include <random>
 
 namespace wallet {
+
+// Dash doesn't use SegWit, but we use these constants for weight-based calculations
+static constexpr int WITNESS_SCALE_FACTOR = 4;
+static constexpr int MAX_STANDARD_TX_WEIGHT = MAX_STANDARD_TX_SIZE * WITNESS_SCALE_FACTOR;
+
 BOOST_FIXTURE_TEST_SUITE(coinselector_tests, WalletTestingSetup)
 
 // how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
@@ -140,9 +146,25 @@ inline std::vector<OutputGroup>& GroupCoins(const std::vector<COutput>& availabl
     return static_groups;
 }
 
+// Helper wrapper for tests - converts util::Result to std::optional and provides max_weight
 inline std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue, CAmount change_target, FastRandomContext& rng)
 {
-    return KnapsackSolver(groups, nTargetValue, change_target, rng, /*fFullyMixedOnly=*/false, /*maxTxFee=*/DEFAULT_TRANSACTION_MAXFEE);
+    auto res = wallet::KnapsackSolver(groups, nTargetValue, change_target, rng, MAX_STANDARD_TX_WEIGHT, /*fFullyMixedOnly=*/false, /*maxTxFee=*/DEFAULT_TRANSACTION_MAXFEE);
+    return res ? std::optional<SelectionResult>(*res) : std::nullopt;
+}
+
+// Helper wrapper for BnB tests
+inline std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change)
+{
+    auto res = wallet::SelectCoinsBnB(utxo_pool, selection_target, cost_of_change, MAX_STANDARD_TX_WEIGHT);
+    return res ? std::optional<SelectionResult>(*res) : std::nullopt;
+}
+
+// Helper wrapper for SRD tests
+inline std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng)
+{
+    auto res = wallet::SelectCoinsSRD(utxo_pool, target_value, rng, MAX_STANDARD_TX_WEIGHT);
+    return res ? std::optional<SelectionResult>(*res) : std::nullopt;
 }
 
 inline std::vector<OutputGroup>& KnapsackGroupOutputs(const std::vector<COutput>& available_coins, CWallet& wallet, const CoinEligibilityFilter& filter)

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/feerate.h>
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -14,6 +15,10 @@
 #include <vector>
 
 namespace wallet {
+
+// Dash doesn't use SegWit, but we use these constants for weight-based calculations
+static constexpr int WITNESS_SCALE_FACTOR = 4;
+static constexpr int MAX_STANDARD_TX_WEIGHT = MAX_STANDARD_TX_SIZE * WITNESS_SCALE_FACTOR;
 
 static void AddCoin(const CAmount& value, int n_input, int n_input_bytes, int locktime, std::vector<COutput>& coins, CFeeRate fee_rate)
 {
@@ -42,6 +47,9 @@ static void GroupCoins(FuzzedDataProvider& fuzzed_data_provider, const std::vect
     }
     if (valid_outputgroup) output_groups.push_back(output_group);
 }
+
+// Returns true if the result contains an error and the message is not empty
+static bool HasErrorMsg(const util::Result<SelectionResult>& res) { return !util::ErrorString(res).empty(); }
 
 FUZZ_TARGET(coinselection)
 {
@@ -81,19 +89,19 @@ FUZZ_TARGET(coinselection)
     GroupCoins(fuzzed_data_provider, utxo_pool, coin_params, /*positive_only=*/false, group_all);
 
     // Run coinselection algorithms
-    const auto result_bnb = SelectCoinsBnB(group_pos, target, cost_of_change);
+    const auto result_bnb = SelectCoinsBnB(group_pos, target, cost_of_change, MAX_STANDARD_TX_WEIGHT);
 
-    auto result_srd = SelectCoinsSRD(group_pos, target, fast_random_context);
+    auto result_srd = SelectCoinsSRD(group_pos, target, fast_random_context, MAX_STANDARD_TX_WEIGHT);
     if (result_srd) result_srd->ComputeAndSetWaste(cost_of_change);
 
     CAmount change_target{GenerateChangeTarget(target, fast_random_context)};
-    auto result_knapsack = KnapsackSolver(group_all, target, change_target, fast_random_context,
+    auto result_knapsack = KnapsackSolver(group_all, target, change_target, fast_random_context, MAX_STANDARD_TX_WEIGHT,
                                           /*fFullyMixedOnly=*/false, /*maxTxFee=*/DEFAULT_TRANSACTION_MAXFEE);
     if (result_knapsack) result_knapsack->ComputeAndSetWaste(cost_of_change);
 
     // If the total balance is sufficient for the target and we are not using
-    // effective values, Knapsack should always find a solution.
-    if (total_balance >= target && subtract_fee_outputs) {
+    // effective values, Knapsack should always find a solution (unless the selection exceeded the max tx weight).
+    if (total_balance >= target && subtract_fee_outputs && !HasErrorMsg(result_knapsack)) {
         assert(result_knapsack);
     }
 }


### PR DESCRIPTION
## Summary
Backports Bitcoin PR #26720 which improves coin selection algorithms to not return results that exceed the maximum allowed transaction weight.

Key changes:
- Changed coin selection algorithm return types from `std::optional` to `util::Result`
- Added `max_weight` parameter to `SelectCoinsBnB`, `SelectCoinsSRD`, and `KnapsackSolver`
- Added weight tracking to `OutputGroup` and `SelectionResult`
- `SelectCoinsBnB` and `SelectCoinsSRD` now return error when selection exceeds max weight
- `KnapsackSolver` returns the closest UTXO above target if result exceeds max weight

Dash-specific adaptations:
- Added `WITNESS_SCALE_FACTOR` and `MAX_STANDARD_TX_WEIGHT` constants where needed (Dash doesn't use SegWit)
- Preserved Dash's CoinJoin-specific parameters (`fFullyMixedOnly`, `maxTxFee`) in `KnapsackSolver`
- Added `HasErrorMsg` helper for Result error checking
- Kept Dash's test infrastructure rather than importing Bitcoin's refactored tests

## Test plan
- [x] Build succeeds
- [x] `coinselector_tests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coin selection algorithms now enforce maximum transaction weight constraints, ensuring selected inputs remain within blockchain network limits.

* **Bug Fixes**
  * Enhanced error handling for coin selection failures with improved error reporting when weight constraints are exceeded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->