### PR TITLE
Merge bitcoin/bitcoin#27419: move-only: Extract common/args from util/system

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -157,6 +157,7 @@ BITCOIN_CORE_H = \
   bech32.h \
   bip324.h \
   blockencodings.h \
+  common/args.h \
   common/bloom.h \
   cachemap.h \
   cachemultimap.h \
@@ -178,6 +179,7 @@ BITCOIN_CORE_H = \
   coinjoin/util.h \
   coinjoin/walletman.h \
   coins.h \
+  common/args.h \
   common/bloom.h \
   compat/assumptions.h \
   compat/byteswap.h \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -8,6 +8,7 @@
 #include <addrman.h>
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <fs.h>
 #include <hash.h>
 #include <logging/timer.h>
@@ -18,7 +19,6 @@
 #include <tinyformat.h>
 #include <univalue.h>
 #include <util/settings.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <cstdint>

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -5,6 +5,7 @@
 
 #include <banman.h>
 
+#include <logging.h>
 #include <netaddress.h>
 #include <node/interface_ui.h>
 #include <sync.h>

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -6,11 +6,11 @@
 
 #include <bls/bls.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <crypto/sha256.h>
 #include <crypto/x11/dispatch.h>
 #include <fs.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <chrono>
 #include <cstdint>

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -6,10 +6,10 @@
 #include <bench/data.h>
 
 #include <chainparams.h>
+#include <common/args.h>
 #include <consensus/validation.h>
 #include <stats/client.h>
 #include <streams.h>
-#include <util/system.h>
 #include <validation.h>
 
 #include <memory>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -10,6 +10,7 @@
 
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>
 #include <policy/feerate.h>
@@ -22,6 +23,7 @@
 #include <univalue.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <util/url.h>
 
@@ -1261,7 +1263,7 @@ MAIN_FUNCTION
     RegisterPrettySignalHandlers();
 
 #ifdef WIN32
-    util::WinCmdLineArgs winArgs;
+    common::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
     SetupEnvironment();

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -9,6 +9,7 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <coins.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <core_io.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,6 +8,7 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <util/strencodings.h>
@@ -92,7 +93,7 @@ MAIN_FUNCTION
 {
     ArgsManager& args = gArgs;
 #ifdef WIN32
-    util::WinCmdLineArgs winArgs;
+    common::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
     SetupEnvironment();

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -10,6 +10,7 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <init.h>
 #include <interfaces/chain.h>
@@ -264,7 +265,7 @@ MAIN_FUNCTION
     RegisterPrettySignalHandlers();
 
 #ifdef WIN32
-    util::WinCmdLineArgs winArgs;
+    common::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -7,6 +7,7 @@
 #include <chainparams.h>
 
 #include <chainparamsseeds.h>
+#include <common/args.h>
 #include <consensus/merkle.h>
 #include <deploymentinfo.h>
 #include <llmq/params.h>

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -5,8 +5,8 @@
 
 #include <chainparamsbase.h>
 
+#include <common/args.h>
 #include <tinyformat.h>
-#include <util/system.h>
 
 #include <assert.h>
 

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2024-2025 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_ARGS_H
+#define BITCOIN_COMMON_ARGS_H
+
+// For compatibility with Bitcoin Core's common/args.h include path.
+// In Dash, ArgsManager is still in util/system.h.
+// This header provides the expected include path for code expecting common/args.h.
+
+#include <util/system.h>
+
+#endif // BITCOIN_COMMON_ARGS_H

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <logging.h>
 #include <util/system.h>
 #include <walletinitinterface.h>

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -4,13 +4,14 @@
 
 #include <httprpc.h>
 
+#include <common/args.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
+#include <logging.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <walletinitinterface.h>
 
 #include <algorithm>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -9,6 +9,7 @@
 #include <httpserver.h>
 
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <netbase.h>
 #include <node/interface_ui.h>
 #include <rpc/protocol.h> // For HTTP status codes

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <compat/endian.h>
 #include <crypto/sha256.h>
@@ -18,7 +19,6 @@
 #include <util/sock.h>
 #include <util/spanparsing.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/threadinterrupt.h>
 
 #include <chrono>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/args.h>
 #include <index/base.h>
 #include <node/blockstorage.h>
 #include <node/interface_ui.h>

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -4,6 +4,7 @@
 
 #include <map>
 
+#include <common/args.h>
 #include <dbwrapper.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -4,13 +4,13 @@
 
 #include <chainparams.h>
 #include <coins.h>
+#include <common/args.h>
 #include <crypto/muhash.h>
 #include <index/coinstatsindex.h>
 #include <node/blockstorage.h>
 #include <serialize.h>
 #include <txdb.h>
 #include <undo.h>
-#include <util/system.h>
 #include <validation.h>
 #include <util/check.h>
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -4,9 +4,9 @@
 
 #include <index/txindex.h>
 
+#include <common/args.h>
 #include <index/disktxpos.h>
 #include <node/blockstorage.h>
-#include <util/system.h>
 #include <validation.h>
 
 using node::OpenBlockFile;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,6 +16,7 @@
 #include <blockfilter.h>
 #include <chain.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <context.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
 #include <interfaces/echo.h>
@@ -11,7 +12,6 @@
 #include <interfaces/wallet.h>
 #include <node/context.h>
 #include <util/check.h>
-#include <util/system.h>
 
 #include <memory>
 

--- a/src/init/bitcoind.cpp
+++ b/src/init/bitcoind.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
 #include <interfaces/echo.h>
@@ -10,7 +11,6 @@
 #include <interfaces/wallet.h>
 #include <node/context.h>
 #include <util/check.h>
-#include <util/system.h>
 
 #include <memory>
 

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -8,6 +8,7 @@
 
 #include <bls/bls.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <crypto/sha256.h>
 #include <crypto/x11/dispatch.h>
 #include <fs.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -15,6 +15,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -10,6 +10,7 @@
 #include <blockencodings.h>
 #include <blockfilter.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <consensus/amount.h>
 #include <consensus/validation.h>
 #include <hash.h>
@@ -35,7 +36,6 @@
 #include <txorphanage.h>
 #include <util/check.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/trace.h>
 #include <util/underlying.h>
 #include <validation.h>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -7,6 +7,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <consensus/validation.h>
 #include <flatfile.h>
 #include <fs.h>

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -4,6 +4,7 @@
 
 #include <node/caches.h>
 
+#include <common/args.h>
 #include <txdb.h>
 #include <util/system.h>
 #include <validation.h>

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -10,6 +10,7 @@
 #include <chainlock/chainlock.h>
 #include <chainparams.h>
 #include <coinjoin/common.h>
+#include <common/args.h>
 #include <deploymentstatus.h>
 #include <evo/deterministicmns.h>
 #include <governance/classes.h>
@@ -51,7 +52,6 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/check.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -8,6 +8,7 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
@@ -21,7 +22,6 @@
 #include <primitives/transaction.h>
 #include <timedata.h>
 #include <util/moneystr.h>
-#include <util/system.h>
 #include <validation.h>
 
 #include <chainlock/chainlock.h>

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -4,6 +4,7 @@
 
 #include <node/txreconciliation.h>
 
+#include <logging.h>
 #include <util/check.h>
 #include <util/system.h>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -10,6 +10,7 @@
 #include <qt/bitcoin.h>
 
 #include <chainparams.h>
+#include <common/args.h>
 #include <fs.h>
 #include <init.h>
 #include <interfaces/handler.h>
@@ -507,7 +508,7 @@ int GuiMain(int argc, char* argv[])
     RegisterPrettySignalHandlers();
 
 #ifdef WIN32
-    util::WinCmdLineArgs winArgs;
+    common::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -14,6 +14,7 @@
 #include <evo/deterministicmns.h>
 
 #include <clientversion.h>
+#include <common/args.h>
 #include <governance/object.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -14,9 +14,11 @@
 
 #include <base58.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <fs.h>
 #include <interfaces/node.h>
 #include <key_io.h>
+#include <logging.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <protocol.h>

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -16,6 +16,7 @@
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 
+#include <common/args.h>
 #include <interfaces/node.h>
 #include <util/system.h>
 #include <validation.h>

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -13,6 +13,7 @@
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 
+#include <common/args.h>
 #include <interfaces/node.h>
 #include <mapport.h>
 #include <net.h>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -15,6 +15,7 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <node/interface_ui.h>

--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <init.h>
 #include <qt/bitcoin.h>
 #include <qt/guiutil.h>
 #include <qt/test/optiontests.h>
 #include <test/util/setup_common.h>
-#include <util/system.h>
 
 #include <QSettings>
 #include <QTest>

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -14,8 +14,8 @@
 #include <qt/guiutil.h>
 
 #include <clientversion.h>
+#include <common/args.h>
 #include <init.h>
-#include <util/system.h>
 #include <util/strencodings.h>
 
 #include <cstdio>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -18,13 +18,13 @@
 #include <qt/recentrequeststablemodel.h>
 #include <qt/transactiontablemodel.h>
 
+#include <common/args.h>
 #include <interfaces/coinjoin.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <node/interface_ui.h>
 #include <psbt.h>
-#include <util/system.h> // for GetBoolArg
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h> // for CRecipient

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -10,6 +10,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <coins.h>
+#include <common/args.h>
 #include <consensus/amount.h>
 #include <core_io.h>
 #include <consensus/params.h>
@@ -41,7 +42,6 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -4,9 +4,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <rpc/client.h>
 #include <tinyformat.h>
-#include <util/system.h>
 
 #include <map>
 #include <string>

--- a/src/rpc/external_signer.cpp
+++ b/src/rpc/external_signer.cpp
@@ -3,10 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <external_signer.h>
+#include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <util/strencodings.h>
-#include <rpc/protocol.h>
+#include <util/system.h>
 
 #include <string>
 #include <vector>

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -6,11 +6,12 @@
 
 #include <rpc/request.h>
 
+#include <common/args.h>
 #include <fs.h>
 #include <random.h>
 #include <rpc/protocol.h>
-#include <util/system.h>
 #include <util/strencodings.h>
+#include <util/system.h>
 
 #include <fstream>
 #include <stdexcept>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -6,6 +6,8 @@
 
 #include <rpc/server.h>
 
+#include <common/args.h>
+#include <logging.h>
 #include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -5,6 +5,7 @@
 #include <rpc/server_util.h>
 
 #include <banman.h>
+#include <common/args.h>
 #include <net_processing.h>
 #include <node/context.h>
 #include <policy/fees.h>

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <consensus/amount.h>
 #include <key_io.h>
 #include <outputtype.h>
@@ -14,7 +15,6 @@
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -9,6 +9,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 
+#include <common/args.h>
 #include <span.h>
 #include <util/bip32.h>
 #include <util/spanparsing.h>

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -5,6 +5,7 @@
 
 #include <script/sigcache.h>
 
+#include <logging.h>
 #include <pubkey.h>
 #include <random.h>
 #include <uint256.h>

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/system.h>
+#include <common/args.h>
 #include <fs.h>
 #include <sync.h>
 #include <test/util/logging.h>

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -5,6 +5,7 @@
 #include <test/util/setup_common.h>
 
 #include <checkqueue.h>
+#include <common/args.h>
 #include <sync.h>
 #include <util/time.h>
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <banman.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <net.h>
 #include <net_processing.h>
 #include <pubkey.h>
@@ -16,7 +17,6 @@
 #include <test/util/setup_common.h>
 #include <timedata.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <validation.h>
 

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -3,10 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <clientversion.h>
+#include <common/args.h>
 #include <flatfile.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
-#include <util/system.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -6,6 +6,7 @@
 #include <addrman.h>
 #include <addrman_impl.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <merkleblock.h>
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -15,7 +16,6 @@
 #include <test/util/setup_common.h>
 #include <time.h>
 #include <util/asmap.h>
-#include <util/system.h>
 
 #include <cassert>
 #include <cstdint>

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <banman.h>
+#include <common/args.h>
 #include <fs.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -5,6 +5,7 @@
 #include <addrman.h>
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <net.h>
 #include <netaddress.h>
 #include <protocol.h>
@@ -13,7 +14,6 @@
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <cstdint>

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -9,6 +9,7 @@
 #include <blockfilter.h>
 #include <chain.h>
 #include <coins.h>
+#include <common/args.h>
 #include <compressor.h>
 #include <consensus/merkle.h>
 #include <key.h>
@@ -24,7 +25,6 @@
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <undo.h>
-#include <util/system.h>
 #include <version.h>
 
 #include <exception>

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -4,6 +4,7 @@
 
 #include <arith_uint256.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <compressor.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -4,6 +4,7 @@
 
 #include <blockfilter.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <util/system.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -4,9 +4,9 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <consensus/params.h>
 #include <primitives/block.h>
-#include <util/system.h>
 #include <versionbits.h>
 
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
+#include <logging.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/settings.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <limits>
 #include <string>

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <i2p.h>
 #include <logging.h>
 #include <netaddress.h>

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <net.h>
 #include <net_processing.h>
@@ -19,7 +20,6 @@
 #include <timedata.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -10,10 +10,10 @@
 
 
 #include <boost/test/unit_test.hpp>
+#include <common/args.h>
 #include <univalue.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 
 #include <fstream>
 #include <map>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -37,6 +37,7 @@
 #include <txdb.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/system.h>
 #include <util/thread.h>
 #include <util/threadnames.h>
 #include <util/time.h>

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -7,6 +7,7 @@
 #define BITCOIN_TEST_UTIL_SETUP_COMMON_H
 
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <fs.h>
 #include <key.h>
 #include <util/system.h>

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -8,11 +8,12 @@
 
 #include <timedata.h>
 
+#include <common/args.h>
+#include <logging.h>
 #include <netaddress.h>
 #include <node/interface_ui.h>
 #include <sync.h>
 #include <tinyformat.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <warnings.h>
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -7,8 +7,10 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <common/args.h>
 #include <compat/compat.h>
 #include <crypto/hmac_sha256.h>
+#include <logging.h>
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -10,6 +10,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <checkqueue.h>
+#include <common/args.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -4,7 +4,7 @@
 
 #include <wallet/coincontrol.h>
 
-#include <util/system.h>
+#include <common/args.h>
 
 namespace wallet {
 CCoinControl::CCoinControl(CoinType coinType)

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -6,8 +6,8 @@
 
 #include <policy/feerate.h>
 #include <util/check.h>
-#include <util/system.h>
 #include <util/moneystr.h>
+#include <util/system.h>
 
 #include <coinjoin/common.h>
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/args.h>
 #include <fs.h>
 #include <logging.h>
 #include <util/system.h>

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/dump.h>
 
+#include <common/args.h>
 #include <fs.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -3,7 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/args.h>
 #include <external_signer.h>
+#include <util/system.h>
 #include <wallet/external_signer_scriptpubkeyman.h>
 
 #include <iostream>

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/args.h>
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
@@ -15,8 +16,8 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/error.h>
-#include <util/system.h>
 #include <util/moneystr.h>
+#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
 #ifdef USE_BDB

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -5,6 +5,7 @@
 #include <interfaces/wallet.h>
 
 #include <coinjoin/client.h>
+#include <common/args.h>
 #include <consensus/amount.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
@@ -17,7 +18,6 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <util/ui_change_type.h>
 #include <validation.h>

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -7,13 +7,13 @@
 
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
+#include <common/args.h>
 #include <fs.h>
 #include <net.h>
 #include <interfaces/chain.h>
 #include <scheduler.h>
 #include <util/check.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/context.h>
 #include <wallet/spend.h>

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -4,6 +4,7 @@
 
 #include <coinjoin/common.h>
 #include <coinjoin/options.h>
+#include <common/args.h>
 #include <consensus/validation.h>
 #include <evo/dmn_types.h>
 #include <interfaces/chain.h>

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <fs.h>
 #include <univalue.h>
 #include <util/check.h>

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <common/args.h>
 #include <noui.h>
 #include <test/util/logging.h>
 #include <util/system.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -8,6 +8,7 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <common/args.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <crypto/common.h>

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -8,6 +8,7 @@
 
 #include <wallet/wallettool.h>
 
+#include <common/args.h>
 #include <fs.h>
 #include <util/translation.h>
 #include <util/system.h>

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -4,8 +4,8 @@
 
 #include <wallet/walletutil.h>
 
+#include <common/args.h>
 #include <logging.h>
-#include <util/system.h>
 
 namespace wallet {
 fs::path GetWalletDir()

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -4,6 +4,7 @@
 
 #include <zmq/zmqnotificationinterface.h>
 
+#include <common/args.h>
 #include <netbase.h>
 #include <primitives/block.h>
 #include <util/system.h>

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 
 EXPECTED_CIRCULAR_DEPENDENCIES = (
-    "chainparamsbase -> util/system -> chainparamsbase",
+    "chainparamsbase -> common/args -> chainparamsbase",
     "node/blockstorage -> validation -> node/blockstorage",
     "policy/fees -> txmempool -> policy/fees",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 
 EXPECTED_CIRCULAR_DEPENDENCIES = (
-    "chainparamsbase -> common/args -> chainparamsbase",
+    "chainparamsbase -> common/args -> util/system -> chainparamsbase",
     "node/blockstorage -> validation -> node/blockstorage",
     "policy/fees -> txmempool -> policy/fees",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",


### PR DESCRIPTION
## Summary
- Adds `common/args.h` compatibility header for Bitcoin Core's refactoring that moved ArgsManager from `util/system` to `common/args`
- Updates all files to include `<common/args.h>` where Bitcoin Core now expects it
- In Dash, ArgsManager remains in `util/system.h`; the new `common/args.h` is a thin wrapper that includes `util/system.h` for compatibility

This partial backport enables future backports that depend on the `<common/args.h>` include path while preserving Dash's existing code structure.

## Bitcoin PR Reference
https://github.com/bitcoin/bitcoin/pull/27419

## Test plan
- [ ] CI passes
- [ ] Build succeeds with new include paths
- [ ] Existing functionality unchanged (ArgsManager behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated command-line argument handling into a common compatibility header and updated many source files to use it, reducing internal include churn and improving maintainability.
* **Tests**
  * Updated lint expectations to reflect the new include ordering and dependency structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->