### PR TITLE
partial bitcoin/bitcoin#26094: rpc: Return block hash & height in getbalances, gettransaction and getwalletinfo

### DIFF
--- a/doc/release-notes-26094.md
+++ b/doc/release-notes-26094.md
@@ -1,0 +1,6 @@
+- The `getbalances` RPC now returns a `lastprocessedblock` JSON object which contains the wallet's last processed block
+  hash and height at the time the balances were calculated. This result shouldn't be cached because importing new keys could invalidate it.
+- The `gettransaction` RPC now returns a `lastprocessedblock` JSON object which contains the wallet's last processed block
+  hash and height at the time the transaction information was generated.
+- The `getwalletinfo` RPC now returns a `lastprocessedblock` JSON object which contains the wallet's last processed block
+  hash and height at the time the wallet information was generated.

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -452,6 +452,7 @@ RPCHelpMan getbalances()
                                 {RPCResult::Type::STR_AMOUNT, "untrusted_pending", " untrusted pending balance (outputs created by others that are in the mempool)"},
                                 {RPCResult::Type::STR_AMOUNT, "immature", " balance from immature coinbase outputs"},
                         }},
+                        RESULT_LAST_PROCESSED_BLOCK,
                     },
                 },
                 RPCExamples{
@@ -494,6 +495,8 @@ RPCHelpMan getbalances()
         balances_watchonly.pushKV("immature", ValueFromAmount(bal.m_watchonly_immature));
         balances.pushKV("watchonly", balances_watchonly);
     }
+
+    AppendLastProcessedBlock(balances, wallet);
     return balances;
 },
     };

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -736,6 +736,7 @@ RPCHelpMan gettransaction()
                   {
                         {RPCResult::Type::ELISION, "", "RPC decoderawtransaction method, or the RPC getrawtransaction method when `verbose` is passed."},
                   }},
+                  RESULT_LAST_PROCESSED_BLOCK,
                 }),
         },
         RPCExamples{
@@ -795,6 +796,7 @@ RPCHelpMan gettransaction()
         entry.pushKV("decoded", decoded);
     }
 
+    AppendLastProcessedBlock(entry, *pwallet);
     return entry;
 },
     };

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -164,4 +164,14 @@ void HandleWalletError(const std::shared_ptr<CWallet> wallet, DatabaseStatus& st
         throw JSONRPCError(code, error.original);
     }
 }
+
+void AppendLastProcessedBlock(UniValue& entry, const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    UniValue lastprocessedblock{UniValue::VOBJ};
+    lastprocessedblock.pushKV("hash", wallet.GetLastBlockHash().GetHex());
+    lastprocessedblock.pushKV("height", wallet.GetLastBlockHeight());
+    entry.pushKV("lastprocessedblock", lastprocessedblock);
+}
+
 } // namespace wallet

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -6,6 +6,8 @@
 #define BITCOIN_WALLET_RPC_UTIL_H
 
 #include <context.h>
+#include <rpc/util.h>
+#include <wallet/wallet.h>
 
 #include <memory>
 #include <string>
@@ -16,12 +18,16 @@ class JSONRPCRequest;
 class UniValue;
 
 namespace wallet {
-class CWallet;
 class LegacyScriptPubKeyMan;
 enum class DatabaseStatus;
 struct WalletContext;
 
 extern const std::string HELP_REQUIRING_PASSPHRASE;
+
+static const RPCResult RESULT_LAST_PROCESSED_BLOCK { RPCResult::Type::OBJ, "lastprocessedblock", "hash and height of the block this information was generated on",{
+    {RPCResult::Type::STR_HEX, "hash", "hash of the block this information was generated on"},
+    {RPCResult::Type::NUM, "height", "height of the block this information was generated on"}}
+};
 
 /**
  * Figures out what wallet, if any, to use for a JSONRPCRequest.
@@ -43,6 +49,7 @@ std::string LabelFromValue(const UniValue& value);
 
 void HandleWalletError(const std::shared_ptr<CWallet> wallet, DatabaseStatus& status, bilingual_str& error);
 int64_t ParseISO8601DateTime(const std::string& str);
+void AppendLastProcessedBlock(UniValue& entry, const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_RPC_UTIL_H

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -192,6 +192,7 @@ static RPCHelpMan getwalletinfo()
                                 }},
                             {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for scriptPubKey management"},
                             {RPCResult::Type::BOOL, "external_signer", "whether this wallet is configured to use an external signer such as a hardware wallet"},
+                            RESULT_LAST_PROCESSED_BLOCK,
                         },
                 },
                 RPCExamples{
@@ -270,6 +271,8 @@ static RPCHelpMan getwalletinfo()
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     obj.pushKV("external_signer", pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
+
+    AppendLastProcessedBlock(obj, *pwallet);
     return obj;
 },
     };

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -11,6 +11,7 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_is_hash_string,
     assert_raises_rpc_error,
 )
 
@@ -174,8 +175,13 @@ class WalletTest(BitcoinTestFramework):
                                                  'untrusted_pending': Decimal('30.0') - fee_node_1}}  # Doesn't include output of node 0's send since it was spent
             if self.options.descriptors:
                 del expected_balances_0["watchonly"]
-            assert_equal(self.nodes[0].getbalances(), expected_balances_0)
-            assert_equal(self.nodes[1].getbalances(), expected_balances_1)
+            balances_0 = self.nodes[0].getbalances()
+            balances_1 = self.nodes[1].getbalances()
+            # remove lastprocessedblock keys (they will be tested later)
+            del balances_0['lastprocessedblock']
+            del balances_1['lastprocessedblock']
+            assert_equal(balances_0, expected_balances_0)
+            assert_equal(balances_1, expected_balances_1)
             # getbalance without any arguments includes unconfirmed transactions, but not untrusted transactions
             assert_equal(self.nodes[0].getbalance(), Decimal('9.99'))  # change from node 0's send
             assert_equal(self.nodes[1].getbalance(), Decimal('0'))  # node 1's send had an unsafe input
@@ -303,6 +309,31 @@ class WalletTest(BitcoinTestFramework):
             self.nodes[0].importprivkey(privkey)
             assert_equal(self.nodes[0].getbalances()['mine']['untrusted_pending'], Decimal('0.1'))
 
+
+        # Tests the lastprocessedblock JSON object in getbalances, getwalletinfo
+        # and gettransaction by checking for valid hex strings and by comparing
+        # the hashes & heights between generated blocks.
+        self.log.info("Test getbalances returns expected lastprocessedblock json object")
+        prev_hash = self.nodes[0].getbestblockhash()
+        prev_height = self.nodes[0].getblock(prev_hash)['height']
+        self.generatetoaddress(self.nodes[0], 5, self.nodes[0].get_deterministic_priv_key().address)
+        lastblock = self.nodes[0].getbalances()['lastprocessedblock']
+        assert_is_hash_string(lastblock['hash'])
+        assert_equal((prev_hash == lastblock['hash']), False)
+        assert_equal(lastblock['height'], prev_height + 5)
+
+        prev_hash = self.nodes[0].getbestblockhash()
+        prev_height = self.nodes[0].getblock(prev_hash)['height']
+        self.log.info("Test getwalletinfo returns expected lastprocessedblock json object")
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['lastprocessedblock']['height'], prev_height)
+        assert_equal(walletinfo['lastprocessedblock']['hash'], prev_hash)
+
+        self.log.info("Test gettransaction returns expected lastprocessedblock json object")
+        txid = self.nodes[1].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
+        tx_info = self.nodes[1].gettransaction(txid)
+        assert_equal(tx_info['lastprocessedblock']['height'], prev_height)
+        assert_equal(tx_info['lastprocessedblock']['hash'], prev_hash)
 
 if __name__ == '__main__':
     WalletTest().main()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -710,8 +710,7 @@ class WalletTest(BitcoinTestFramework):
                                  "vout":     baz["vout"]}
         expected_fields = frozenset({'amount', 'chainlock', 'confirmations', 'details', 'fee',
                                      'instantlock', 'instantlock_internal',
-                                     'hex', 'timereceived', 'time', 'trusted', 'txid', 'walletconflicts'})
-
+                                     'hex', 'lastprocessedblock', 'timereceived', 'time', 'trusted', 'txid', 'walletconflicts'})
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#26094

MISSING CHANGES in test/functional/wallet_orphanedreward.py

Original commit: da9f62f912294de07a595df0b4898aba4be6b69c

This PR adds a `lastprocessedblock` JSON object to the following RPC responses:
- `getbalances` - contains the wallet's last processed block hash and height at the time the balances were calculated
- `gettransaction` - contains the wallet's last processed block hash and height at the time the transaction information was generated
- `getwalletinfo` - contains the wallet's last processed block hash and height at the time the wallet information was generated

## Changes
- Added `RESULT_LAST_PROCESSED_BLOCK` constant and `AppendLastProcessedBlock` function in `src/wallet/rpc/util.h/.cpp`
- Updated `getbalances`, `gettransaction`, and `getwalletinfo` to include the new field
- Updated functional tests in `wallet_balance.py` and `wallet_basic.py` to test the new field

## Dash-specific notes
- Preserved Dash-specific RPC fields (coinjoin, chainlock, instantlock)
- `wallet_orphanedreward.py` was not modified since Dash's test structure differs from Bitcoin's and only compares `getbalances()["mine"]` which is unaffected by the new top-level field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lastprocessedblock to getbalances, gettransaction, and getwalletinfo responses, showing the wallet’s last processed block hash and height.
  * Do not cache this field, as importing keys can invalidate it.

* **Tests**
  * Functional tests updated to validate lastprocessedblock consistency across wallet RPC responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->