### PR TITLE
Merge bitcoin/bitcoin#27325: test: various `converttopsbt` check cleanups in rpc_psbt.py

### DIFF
--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -225,16 +225,14 @@ class PSBTTest(BitcoinTestFramework):
         new_psbt = self.nodes[0].converttopsbt(rawtx['hex'])
         self.nodes[0].decodepsbt(new_psbt)
 
-        # Make sure that a psbt with signatures cannot be converted
+        # Make sure that a non-psbt with signatures cannot be converted
         signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx['hex'])
-        assert_raises_rpc_error(-22, "Inputs must not have scriptSigs", self.nodes[0].converttopsbt, hexstring=signedtx['hex'])
-        assert_raises_rpc_error(-22, "Inputs must not have scriptSigs", self.nodes[0].converttopsbt, hexstring=signedtx['hex'], permitsigdata=False)
+        assert_raises_rpc_error(-22, "Inputs must not have scriptSigs",
+                                self.nodes[0].converttopsbt, hexstring=signedtx['hex'])  # permitsigdata=False by default
+        assert_raises_rpc_error(-22, "Inputs must not have scriptSigs",
+                                self.nodes[0].converttopsbt, hexstring=signedtx['hex'], permitsigdata=False)
         # Unless we allow it to convert and strip signatures
-        self.nodes[0].converttopsbt(signedtx['hex'], True)
-
-        # Explicitly allow converting non-empty txs
-        new_psbt = self.nodes[0].converttopsbt(rawtx['hex'])
-        self.nodes[0].decodepsbt(new_psbt)
+        self.nodes[0].converttopsbt(hexstring=signedtx['hex'], permitsigdata=True)
 
         # Create outputs to nodes 1 and 2
         node1_addr = self.nodes[1].getnewaddress()


### PR DESCRIPTION
Backports bitcoin/bitcoin#27325

Original commit: 30bf70c8b60f070c47ce9b51b5d2520c386d3559

## Changes

This backport applies the test cleanup changes from Bitcoin PR #27325 to Dash:

- Updated comment from "psbt with signatures" to "non-psbt with signatures"
- Reformatted `assert_raises_rpc_error` calls for better readability
- Added clarifying comment about `permitsigdata=False by default`
- Removed redundant `converttopsbt` calls that duplicated earlier tests
- Updated final call to use explicit keyword argument `permitsigdata=True`

## Dash-specific adaptations

- Kept Dash's error message "Inputs must not have scriptSigs" (without "and scriptWitnesses") since Dash doesn't support SegWit/witness
- Skipped the `iswitness=True` assertion variant since Dash doesn't have witness functionality

## Validation

- Bitcoin: 16 lines changed (7+, 9-)
- Dash: 14 lines changed (6+, 8-)
- Size ratio: 87.5% (within acceptable 80-150% range)