### PR TITLE
Merge bitcoin/bitcoin#24304: [kernel 0/n] Introduce `bitcoin-chainstate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/dash-gui
 src/dash-node
 src/dash-tx
 src/dash-wallet
+src/dash-chainstate
 src/test/fuzz/fuzz
 src/test/test_dash
 src/qt/test/test_dash-qt

--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -27,7 +27,7 @@ elif [ "$BUILD_TARGET" = "linux64_fuzz" ]; then
 elif [ "$BUILD_TARGET" = "linux64_multiprocess" ]; then
   source ./ci/test/00_setup_env_native_multiprocess.sh
 elif [ "$BUILD_TARGET" = "linux64_nowallet" ]; then
-  source ./ci/test/00_setup_env_native_nowallet.sh
+  source ./ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
 elif [ "$BUILD_TARGET" = "linux64_sqlite" ]; then
   source ./ci/test/00_setup_env_native_sqlite.sh
 elif [ "$BUILD_TARGET" = "linux64_tsan" ]; then

--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_native_nowallet
+export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq"
 export DEP_OPTS="NO_WALLET=1 CC=gcc-14 CXX=g++-14"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-reduce-exports CC=gcc-14 CXX=g++-14"
+export BITCOIN_CONFIG="--enable-reduce-exports CC=gcc-14 CXX=g++-14 --enable-experimental-util-chainstate"

--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -11,4 +11,8 @@ export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq"
 export DEP_OPTS="NO_WALLET=1 CC=gcc-14 CXX=g++-14"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-reduce-exports CC=gcc-14 CXX=g++-14 --enable-experimental-util-chainstate"
+export BITCOIN_CONFIG="--enable-reduce-exports CC=gcc-14 CXX=g++-14"
+# NOTE: --enable-experimental-util-chainstate disabled for Dash
+# dash-chainstate cannot build yet due to API differences (requires Dash-specific
+# masternode/governance parameters not in Bitcoin's LoadChainstate API).
+# See src/dash-chainstate.cpp lines 13-18 for details.

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ BITCOIN_GUI_NAME=dash-qt
 BITCOIN_TEST_NAME=test_dash
 BITCOIN_CLI_NAME=dash-cli
 BITCOIN_TX_NAME=dash-tx
+BITCOIN_CHAINSTATE_NAME=dash-chainstate
 BITCOIN_WALLET_TOOL_NAME=dash-wallet
 dnl Multi Process
 BITCOIN_MP_NODE_NAME=dash-node
@@ -762,6 +763,12 @@ AC_ARG_ENABLE([util-wallet],
   [build_bitcoin_wallet=$enableval],
   [build_bitcoin_wallet=$build_bitcoin_utils])
 
+AC_ARG_ENABLE([experimental-util-chainstate],
+  [AS_HELP_STRING([--enable-experimental-util-chainstate],
+  [build experimental dash-chainstate executable (default=no)])],
+  [build_bitcoin_chainstate=$enableval],
+  [build_bitcoin_chainstate=no])
+
 AC_ARG_WITH([libs],
   [AS_HELP_STRING([--with-libs],
   [build libraries (default=yes)])],
@@ -1429,6 +1436,7 @@ if test "$enable_fuzz" = "yes"; then
   build_bitcoin_utils=no
   build_bitcoin_cli=no
   build_bitcoin_tx=no
+  build_bitcoin_chainstate=no
   build_bitcoin_wallet=no
   build_bitcoind=no
   build_bitcoin_libs=no
@@ -1763,6 +1771,10 @@ AC_MSG_CHECKING([whether to build dash-wallet])
 AM_CONDITIONAL([BUILD_BITCOIN_WALLET], [test $build_bitcoin_wallet = "yes"])
 AC_MSG_RESULT($build_bitcoin_wallet)
 
+AC_MSG_CHECKING([whether to build experimental dash-chainstate])
+AM_CONDITIONAL([BUILD_BITCOIN_CHAINSTATE], [test $build_bitcoin_chainstate = "yes"])
+AC_MSG_RESULT($build_bitcoin_chainstate)
+
 AC_MSG_CHECKING([whether to build libraries])
 AM_CONDITIONAL([BUILD_BITCOIN_LIBS], [test $build_bitcoin_libs = "yes"])
 if test "$build_bitcoin_libs" = "yes"; then
@@ -1976,6 +1988,7 @@ AC_SUBST(BITCOIN_GUI_NAME)
 AC_SUBST(BITCOIN_TEST_NAME)
 AC_SUBST(BITCOIN_CLI_NAME)
 AC_SUBST(BITCOIN_TX_NAME)
+AC_SUBST(BITCOIN_CHAINSTATE_NAME)
 AC_SUBST(BITCOIN_WALLET_TOOL_NAME)
 AC_SUBST(BITCOIN_MP_NODE_NAME)
 AC_SUBST(BITCOIN_MP_GUI_NAME)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1126,7 +1126,6 @@ dash_chainstate_SOURCES = \
   chainparams.cpp \
   clientversion.cpp \
   coins.cpp \
-  compat/glibcxx_sanity.cpp \
   compressor.cpp \
   consensus/merkle.cpp \
   consensus/tx_check.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -142,6 +142,10 @@ if BUILD_BITCOIN_WALLET
 endif
 endif
 
+if BUILD_BITCOIN_CHAINSTATE
+  bin_PROGRAMS += dash-chainstate
+endif
+
 .PHONY: FORCE check-symbols check-security
 # dash core #
 BITCOIN_CORE_H = \
@@ -1110,6 +1114,102 @@ dash_wallet_LDADD = \
 if TARGET_WINDOWS
 dash_wallet_SOURCES += dash-wallet-res.rc
 endif
+#
+
+# dash-chainstate binary #
+dash_chainstate_SOURCES = \
+  dash-chainstate.cpp \
+  arith_uint256.cpp \
+  blockfilter.cpp \
+  chain.cpp \
+  chainparamsbase.cpp \
+  chainparams.cpp \
+  clientversion.cpp \
+  coins.cpp \
+  compat/glibcxx_sanity.cpp \
+  compressor.cpp \
+  consensus/merkle.cpp \
+  consensus/tx_check.cpp \
+  consensus/tx_verify.cpp \
+  core_read.cpp \
+  dbwrapper.cpp \
+  deploymentinfo.cpp \
+  deploymentstatus.cpp \
+  flatfile.cpp \
+  fs.cpp \
+  hash.cpp \
+  index/base.cpp \
+  index/blockfilterindex.cpp \
+  index/coinstatsindex.cpp \
+  init/common.cpp \
+  key.cpp \
+  logging.cpp \
+  netaddress.cpp \
+  node/blockstorage.cpp \
+  node/chainstate.cpp \
+  node/coinstats.cpp \
+  node/interface_ui.cpp \
+  policy/feerate.cpp \
+  policy/fees.cpp \
+  policy/packages.cpp \
+  policy/policy.cpp \
+  policy/rbf.cpp \
+  policy/settings.cpp \
+  pow.cpp \
+  primitives/block.cpp \
+  primitives/transaction.cpp \
+  pubkey.cpp \
+  random.cpp \
+  randomenv.cpp \
+  scheduler.cpp \
+  script/interpreter.cpp \
+  script/script.cpp \
+  script/script_error.cpp \
+  script/sigcache.cpp \
+  script/standard.cpp \
+  shutdown.cpp \
+  signet.cpp \
+  support/cleanse.cpp \
+  support/lockedpool.cpp \
+  sync.cpp \
+  threadinterrupt.cpp \
+  timedata.cpp \
+  txdb.cpp \
+  txmempool.cpp \
+  uint256.cpp \
+  util/asmap.cpp \
+  util/bytevectorhash.cpp \
+  util/getuniquepath.cpp \
+  util/hasher.cpp \
+  util/moneystr.cpp \
+  util/rbf.cpp \
+  util/serfloat.cpp \
+  util/settings.cpp \
+  util/strencodings.cpp \
+  util/syscall_sandbox.cpp \
+  util/system.cpp \
+  util/thread.cpp \
+  util/threadnames.cpp \
+  util/time.cpp \
+  util/tokenpipe.cpp \
+  validation.cpp \
+  validationinterface.cpp \
+  versionbits.cpp \
+  warnings.cpp
+dash_chainstate_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+dash_chainstate_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+dash_chainstate_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
+dash_chainstate_LDADD = \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBUNIVALUE) \
+  $(LIBSECP256K1) \
+  $(LIBLEVELDB) \
+  $(LIBLEVELDB_SSE42) \
+  $(LIBMEMENV)
+
+# Required for obj/build.h to be generated first.
+# More details: https://www.gnu.org/software/automake/manual/html_node/Built-Sources-Example.html
+dash_chainstate-clientversion.$(OBJEXT): obj/build.h
 #
 
 # dashconsensus library #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1146,13 +1146,11 @@ dash_chainstate_SOURCES = \
   netaddress.cpp \
   node/blockstorage.cpp \
   node/chainstate.cpp \
-  node/coinstats.cpp \
   node/interface_ui.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \
   policy/packages.cpp \
   policy/policy.cpp \
-  policy/rbf.cpp \
   policy/settings.cpp \
   pow.cpp \
   primitives/block.cpp \
@@ -1167,11 +1165,10 @@ dash_chainstate_SOURCES = \
   script/sigcache.cpp \
   script/standard.cpp \
   shutdown.cpp \
-  signet.cpp \
   support/cleanse.cpp \
   support/lockedpool.cpp \
   sync.cpp \
-  threadinterrupt.cpp \
+  util/threadinterrupt.cpp \
   timedata.cpp \
   txdb.cpp \
   txmempool.cpp \
@@ -1181,11 +1178,9 @@ dash_chainstate_SOURCES = \
   util/getuniquepath.cpp \
   util/hasher.cpp \
   util/moneystr.cpp \
-  util/rbf.cpp \
   util/serfloat.cpp \
   util/settings.cpp \
   util/strencodings.cpp \
-  util/syscall_sandbox.cpp \
   util/system.cpp \
   util/thread.cpp \
   util/threadnames.cpp \

--- a/src/dash-chainstate.cpp
+++ b/src/dash-chainstate.cpp
@@ -1,0 +1,269 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2025 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// The dash-chainstate executable serves to surface the dependencies required
+// by a program wishing to use Dash Core's consensus engine as it is right
+// now.
+//
+// DEVELOPER NOTE: Since this is a "demo-only", experimental, etc. executable,
+//                 it may diverge from Dash Core's coding style.
+//
+// NOTE: This executable is currently non-functional in Dash because the
+//       LoadChainstate API differs significantly from Bitcoin (requires
+//       Dash-specific parameters for masternodes, governance, etc.).
+//       This file is included to track build dependencies as part of the
+//       libbitcoinkernel project backport.
+//
+// It is part of the libbitcoinkernel project.
+
+#include <chainparams.h>
+#include <consensus/validation.h>
+#include <core_io.h>
+#include <init/common.h>
+#include <node/blockstorage.h>
+#include <node/chainstate.h>
+#include <scheduler.h>
+#include <script/sigcache.h>
+#include <util/system.h>
+#include <util/thread.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <filesystem>
+#include <functional>
+#include <iosfwd>
+
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
+int main(int argc, char* argv[])
+{
+    // SETUP: Argument parsing and handling
+    if (argc != 2) {
+        std::cerr
+            << "Usage: " << argv[0] << " DATADIR" << std::endl
+            << "Display DATADIR information, and process hex-encoded blocks on standard input." << std::endl
+            << std::endl
+            << "IMPORTANT: THIS EXECUTABLE IS EXPERIMENTAL, FOR TESTING ONLY, AND EXPECTED TO" << std::endl
+            << "           BREAK IN FUTURE VERSIONS. DO NOT USE ON YOUR ACTUAL DATADIR." << std::endl;
+        return 1;
+    }
+    std::filesystem::path abs_datadir = std::filesystem::absolute(argv[1]);
+    std::filesystem::create_directories(abs_datadir);
+    gArgs.ForceSetArg("-datadir", abs_datadir.string());
+
+
+    // SETUP: Misc Globals
+    SelectParams(CBaseChainParams::MAIN);
+    const CChainParams& chainparams = Params();
+
+    init::SetGlobals(); // ECC_Start, etc.
+
+    // Necessary for CheckInputScripts (eventually called by ProcessNewBlock),
+    // which will try the script cache first and fall back to actually
+    // performing the check with the signature cache.
+    InitSignatureCache();
+    InitScriptExecutionCache();
+
+
+    // SETUP: Scheduling and Background Signals
+    CScheduler scheduler{};
+    // Start the lightweight task scheduler thread
+    scheduler.m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { scheduler.serviceQueue(); });
+
+    // Gather some entropy once per minute.
+    scheduler.scheduleEvery(RandAddPeriodic, std::chrono::minutes{1});
+
+    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+
+
+    // SETUP: Chainstate
+    ChainstateManager chainman;
+
+    auto rv = node::LoadChainstate(false,
+                                   std::ref(chainman),
+                                   nullptr,
+                                   false,
+                                   chainparams.GetConsensus(),
+                                   false,
+                                   2 << 20,
+                                   2 << 22,
+                                   (450 << 20) - (2 << 20) - (2 << 22),
+                                   false,
+                                   false,
+                                   []() { return false; });
+    if (rv.has_value()) {
+        std::cerr << "Failed to load Chain state from your datadir." << std::endl;
+        goto epilogue;
+    } else {
+        auto maybe_verify_error = node::VerifyLoadedChainstate(std::ref(chainman),
+                                                               false,
+                                                               false,
+                                                               chainparams.GetConsensus(),
+                                                               DEFAULT_CHECKBLOCKS,
+                                                               DEFAULT_CHECKLEVEL,
+                                                               /*get_unix_time_seconds=*/static_cast<int64_t (*)()>(GetTime));
+        if (maybe_verify_error.has_value()) {
+            std::cerr << "Failed to verify loaded Chain state from your datadir." << std::endl;
+            goto epilogue;
+        }
+    }
+
+    for (CChainState* chainstate : WITH_LOCK(::cs_main, return chainman.GetAll())) {
+        BlockValidationState state;
+        if (!chainstate->ActivateBestChain(state, nullptr)) {
+            std::cerr << "Failed to connect best block (" << state.ToString() << ")" << std::endl;
+            goto epilogue;
+        }
+    }
+
+    // Main program logic starts here
+    std::cout
+        << "Hello! I'm going to print out some information about your datadir." << std::endl
+        << "\t" << "Path: " << gArgs.GetDataDirNet() << std::endl
+        << "\t" << "Reindexing: " << std::boolalpha << node::fReindex.load() << std::noboolalpha << std::endl
+        << "\t" << "Snapshot Active: " << std::boolalpha << chainman.IsSnapshotActive() << std::noboolalpha << std::endl
+        << "\t" << "Active Height: " << chainman.ActiveHeight() << std::endl
+        << "\t" << "Active IBD: " << std::boolalpha << chainman.ActiveChainstate().IsInitialBlockDownload() << std::noboolalpha << std::endl;
+    {
+        CBlockIndex* tip = chainman.ActiveTip();
+        if (tip) {
+            std::cout << "\t" << tip->ToString() << std::endl;
+        }
+    }
+
+    for (std::string line; std::getline(std::cin, line);) {
+        if (line.empty()) {
+            std::cerr << "Empty line found" << std::endl;
+            break;
+        }
+
+        std::shared_ptr<CBlock> blockptr = std::make_shared<CBlock>();
+        CBlock& block = *blockptr;
+
+        if (!DecodeHexBlk(block, line)) {
+            std::cerr << "Block decode failed" << std::endl;
+            break;
+        }
+
+        if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
+            std::cerr << "Block does not start with a coinbase" << std::endl;
+            break;
+        }
+
+        uint256 hash = block.GetHash();
+        {
+            LOCK(cs_main);
+            const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(hash);
+            if (pindex) {
+                if (pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
+                    std::cerr << "duplicate" << std::endl;
+                    break;
+                }
+                if (pindex->nStatus & BLOCK_FAILED_MASK) {
+                    std::cerr << "duplicate-invalid" << std::endl;
+                    break;
+                }
+            }
+        }
+
+        {
+            LOCK(cs_main);
+            const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock);
+            if (pindex) {
+                UpdateUncommittedBlockStructures(block, pindex, chainparams.GetConsensus());
+            }
+        }
+
+        // Adapted from rpc/mining.cpp
+        class submitblock_StateCatcher final : public CValidationInterface
+        {
+        public:
+            uint256 hash;
+            bool found;
+            BlockValidationState state;
+
+            explicit submitblock_StateCatcher(const uint256& hashIn) : hash(hashIn), found(false), state() {}
+
+        protected:
+            void BlockChecked(const CBlock& block, const BlockValidationState& stateIn) override
+            {
+                if (block.GetHash() != hash)
+                    return;
+                found = true;
+                state = stateIn;
+            }
+        };
+
+        bool new_block;
+        auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
+        RegisterSharedValidationInterface(sc);
+        bool accepted = chainman.ProcessNewBlock(chainparams, blockptr, /* force_processing */ true, /* new_block */ &new_block);
+        UnregisterSharedValidationInterface(sc);
+        if (!new_block && accepted) {
+            std::cerr << "duplicate" << std::endl;
+            break;
+        }
+        if (!sc->found) {
+            std::cerr << "inconclusive" << std::endl;
+            break;
+        }
+        std::cout << sc->state.ToString() << std::endl;
+        switch (sc->state.GetResult()) {
+        case BlockValidationResult::BLOCK_RESULT_UNSET:
+            std::cerr << "initial value. Block has not yet been rejected" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_CONSENSUS:
+            std::cerr << "invalid by consensus rules (excluding any below reasons)" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_RECENT_CONSENSUS_CHANGE:
+            std::cerr << "Invalid by a change to consensus rules more recent than SegWit." << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_CACHED_INVALID:
+            std::cerr << "this block was cached as being invalid and we didn't store the reason why" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_INVALID_HEADER:
+            std::cerr << "invalid proof of work or time too old" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_MUTATED:
+            std::cerr << "the block's data didn't match the data committed to by the PoW" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_MISSING_PREV:
+            std::cerr << "We don't have the previous block the checked one is built on" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_INVALID_PREV:
+            std::cerr << "A block this one builds on is invalid" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_TIME_FUTURE:
+            std::cerr << "block timestamp was > 2 hours in the future (or our clock is bad)" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_CHECKPOINT:
+            std::cerr << "the block failed to meet one of our checkpoints" << std::endl;
+            break;
+        }
+    }
+
+epilogue:
+    // Without this precise shutdown sequence, there will be a lot of nullptr
+    // dereferencing and UB.
+    scheduler.stop();
+    if (chainman.m_load_block.joinable()) chainman.m_load_block.join();
+    StopScriptCheckWorkerThreads();
+
+    GetMainSignals().FlushBackgroundCallbacks();
+    {
+        LOCK(cs_main);
+        for (CChainState* chainstate : chainman.GetAll()) {
+            if (chainstate->CanFlushToDisk()) {
+                chainstate->ForceFlushStateToDisk();
+                chainstate->ResetCoinsViews();
+            }
+        }
+    }
+    GetMainSignals().UnregisterBackgroundSignalScheduler();
+
+    UnloadBlockIndex(nullptr, chainman);
+
+    init::UnsetGlobals();
+}


### PR DESCRIPTION
## Summary
Backports bitcoin/bitcoin#24304

- Introduces the experimental `dash-chainstate` executable as part of the libbitcoinkernel project
- Adds build system support via `--enable-experimental-util-chainstate` configure flag (disabled by default)
- Renames CI script to reflect the kernel build configuration
- The executable is currently non-functional in Dash due to `LoadChainstate` API differences (requires Dash-specific parameters for masternodes, governance, etc.)

Original Bitcoin commit: 619f8a27ad0f6a44f0ad1a1e55a0aaaef7a91312

## Dash-specific adaptations
- Renamed `bitcoin-chainstate` to `dash-chainstate`
- Updated configure.ac and Makefile.am to use Dash naming conventions
- Removed .cirrus.yml changes (Dash doesn't use Cirrus CI)
- Preserved Dash CI configuration in renamed script

## Test plan
- [ ] Build succeeds (executable is disabled by default)
- [ ] Configure script accepts `--enable-experimental-util-chainstate` flag

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental dash-chainstate utility for inspecting and exercising chainstate; enable via a new configure option.

* **Chores**
  * Build system updated to integrate the new utility and expose the chainstate enable flag.
  * CI adjusted to exercise the new build variant.

* **Chores**
  * .gitignore updated to exclude the dash-chainstate source directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->