### PR TITLE
Merge bitcoin/bitcoin#24735: ci: use DWARF-4 for Valgrind jobs

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -98,16 +98,6 @@
    fun:wcsnrtombs
 }
 {
-   Suppress boost warning
-   Memcheck:Leak
-   fun:_Znwm
-   ...
-   fun:_ZN5boost9unit_test9framework5state17execute_test_treeEmjPKNS2_23random_generator_helperE
-   fun:_ZN5boost9unit_test9framework3runEmb
-   fun:_ZN5boost9unit_test14unit_test_mainEPFbvEiPPc
-   fun:main
-}
-{
    Suppress boost still reachable memory warning
    Memcheck:Leak
    match-leak-kinds: reachable


### PR DESCRIPTION
Backports bitcoin/bitcoin#24735

This commit removes the Boost Valgrind suppression from `contrib/valgrind.supp`.

**Note:** The CI changes (adding DWARF-4 flags) were already present in Dash's CI configuration with more recent toolchain updates (clang-19), so only the valgrind.supp cleanup was needed.

Original commit: 67dc002aaeaadf251883b0bd36f41950192bd89b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development testing configuration to improve memory leak detection during development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->