### PR TITLE
partial bitcoin/bitcoin#25125: test: Slim down versionbits_tests.cpp

### DIFF
--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -7,7 +7,6 @@
 #include <consensus/params.h>
 #include <deploymentstatus.h>
 #include <test/util/setup_common.h>
-#include <validation.h>
 #include <versionbits.h>
 
 #include <boost/test/unit_test.hpp>
@@ -185,7 +184,7 @@ public:
     CBlockIndex* Tip() { return vpblock.empty() ? nullptr : vpblock.back(); }
 };
 
-BOOST_FIXTURE_TEST_SUITE(versionbits_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(versionbits_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(versionbits_test)
 {


### PR DESCRIPTION
Backports bitcoin/bitcoin#25125

## Summary
- Removes unnecessary `#include <validation.h>` from versionbits_tests.cpp
- Changes test fixture from `TestingSetup` to `BasicTestingSetup` since full chainman is not needed

## Notes
Bitcoin's commit also removed a comment from `VersionBitsCache vbcache;` declaration. This change doesn't apply to Dash because Dash uses the global `g_versionbitscache` instead of a local variable.

Original commit: 6b87fa540c407d167535561ac25e3225bf76d6cc