### PR TITLE
Merge bitcoin/bitcoin#25171: rpc: wallet: remove `-deprecatedrpc=exclude_coinbase` logic

### DIFF
--- a/doc/release-notes-25171.md
+++ b/doc/release-notes-25171.md
@@ -1,0 +1,8 @@
+Updated RPCs
+------------
+
+- The `deprecatedrpc=exclude_coinbase` configuration option has been removed.
+  The `receivedby` RPCs (`listreceivedbyaddress`, `listreceivedbylabel`,
+  `getreceivedbyaddress` and `getreceivedbylabel`) now always return results
+  accounting for received coins from coinbase outputs, without an option to
+  change that behaviour. Excluding coinbases was previously deprecated in 23.0.

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -49,21 +49,13 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
     bool fAddLocked = (!params[2].isNull() && params[2].get_bool());
     const bool include_immature_coinbase{params[3].isNull() ? false : params[3].get_bool()};
 
-    // Excluding coinbase outputs is deprecated
-    // It can be enabled by setting deprecatedrpc=exclude_coinbase
-    const bool include_coinbase{!wallet.chain().rpcEnableDeprecated("exclude_coinbase")};
-
-    if (include_immature_coinbase && !include_coinbase) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "include_immature_coinbase is incompatible with deprecated exclude_coinbase");
-    }
-
     // Tally
     CAmount amount = 0;
     for (const std::pair<const uint256, CWalletTx>& wtx_pair : wallet.mapWallet) {
         const CWalletTx& wtx = wtx_pair.second;
         int depth{wallet.GetTxDepthInMainChain(wtx)};
         if (// Coinbase with less than 1 confirmation is no longer in the main chain
-            (wtx.IsCoinBase() && (depth < 1 || !include_coinbase))
+            (wtx.IsCoinBase() && (depth < 1))
             || (wallet.IsTxImmatureCoinBase(wtx) && !include_immature_coinbase))
         {
             continue;

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -95,14 +95,6 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
         filtered_address = DecodeDestination(params[4].get_str());
     }
 
-    // Excluding coinbase outputs is deprecated
-    // It can be enabled by setting deprecatedrpc=exclude_coinbase
-    const bool include_coinbase{!wallet.chain().rpcEnableDeprecated("exclude_coinbase")};
-
-    if (include_immature_coinbase && !include_coinbase) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "include_immature_coinbase is incompatible with deprecated exclude_coinbase");
-    }
-
     // Tally
     std::map<CTxDestination, tallyitem> mapTally;
     for (const std::pair<const uint256, CWalletTx>& pairWtx : wallet.mapWallet) {
@@ -113,7 +105,7 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
             continue;
 
         // Coinbase with less than 1 confirmation is no longer in the main chain
-        if ((wtx.IsCoinBase() && (nDepth < 1 || !include_coinbase))
+        if ((wtx.IsCoinBase() && (nDepth < 1))
             || (wallet.IsTxImmatureCoinBase(wtx) && !include_immature_coinbase))
         {
             continue;

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -19,8 +19,7 @@ class ReceivedByTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         # whitelist peers to speed up tx relay / mempool sync
-        # Test deprecated exclude coinbase on second node
-        self.extra_args = [["-whitelist=noban@127.0.0.1"], ["-whitelist=noban@127.0.0.1", "-deprecatedrpc=exclude_coinbase"]]
+        self.extra_args = [["-whitelist=noban@127.0.0.1"], ["-whitelist=noban@127.0.0.1"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -255,35 +254,6 @@ class ReceivedByTest(BitcoinTestFramework):
         assert_array_result(self.nodes[0].listreceivedbylabel(minconf=0, include_immature_coinbase=True),
                             {"label": label},
                             {}, True)
-
-        # Test exclude_coinbase
-        address2 = self.nodes[1].getnewaddress(label)
-        self.generatetoaddress(self.nodes[1], COINBASE_MATURITY + 1, address2, sync_fun=self.no_op)
-
-        self.log.info("getreceivedbyaddress returns nothing when excluding coinbase")
-        balance = self.nodes[1].getreceivedbyaddress(address2)
-        assert_equal(balance, 0)
-
-        self.log.info("getreceivedbylabel returns nothing when excluding coinbase")
-        balance = self.nodes[1].getreceivedbylabel("label")
-        assert_equal(balance, 0)
-
-        self.log.info("listreceivedbyaddress does not include address when excluding coinbase")
-        assert_array_result(self.nodes[1].listreceivedbyaddress(),
-                            {"address": address2},
-                            {}, True)
-
-        self.log.info("listreceivedbylabel does not include label when excluding coinbase")
-        assert_array_result(self.nodes[1].listreceivedbylabel(),
-                            {"label": label},
-                            {}, True)
-
-        self.log.info("getreceivedbyaddress throws when setting include_immature_coinbase with deprecated exclude_coinbase")
-        assert_raises_rpc_error(-8, 'include_immature_coinbase is incompatible with deprecated exclude_coinbase', self.nodes[1].getreceivedbyaddress, address2, 1, False, True)
-
-
-        self.log.info("listreceivedbyaddress throws when setting include_immature_coinbase with deprecated exclude_coinbase")
-        assert_raises_rpc_error(-8, 'include_immature_coinbase is incompatible with deprecated exclude_coinbase', self.nodes[1].listreceivedbyaddress, 1, False, False, False, "", True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backports bitcoin/bitcoin#25171

Original commit: a7e3afb22136367a236f1fbc6e30b43b6b366471

## Summary
Removes the deprecated `-deprecatedrpc=exclude_coinbase` configuration option. The `receivedby` RPCs (`listreceivedbyaddress`, `listreceivedbylabel`, `getreceivedbyaddress` and `getreceivedbylabel`) now always include coinbase outputs.

## Changes
- Removed deprecated `exclude_coinbase` handling from `src/wallet/rpc/coins.cpp`
- Removed deprecated `exclude_coinbase` handling from `src/wallet/rpc/transactions.cpp`
- Removed deprecated test cases from `test/functional/wallet_listreceivedby.py`

## Dash-specific adaptations
- Kept Dash's whitelist args in functional test (`-whitelist=noban@127.0.0.1`)
- Kept Dash's `fAddLocked` InstantSend parameter handling
- Did not modify Dash's release-notes.md (different format/content)