### PR TITLE
Merge bitcoin/bitcoin#25216: Doc: Fix parameter in hwm example block

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -104,7 +104,7 @@ The option to set the PUB socket's outbound message high water mark
     -zmqpubrawgovernanceobjecthwm=n
     -zmqpubrawinstantsenddoublespendhwm=n
     -zmqpubrawrecoveredsighwm=n
-    -zmqpubsequencehwm=address
+    -zmqpubsequencehwm=n
 
 The high water mark value must be an integer greater than or equal to 0.
 


### PR DESCRIPTION
Backports bitcoin/bitcoin#25216

Original commit: 48eec32347494da781f26478fa488b28336afbd2

## Summary
- Fixes a copy/paste error in the ZMQ documentation
- The `-zmqpubsequencehwm` parameter incorrectly showed `=address` instead of `=n`
- This matches the format of all other HWM (high water mark) parameters which take an integer value

## Changes
- `doc/zmq.md`: Changed `-zmqpubsequencehwm=address` to `-zmqpubsequencehwm=n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)