### PR TITLE
Merge bitcoin/bitcoin#25307: doc: fix typo in kernel/context.h and add `desig` to ignore-words

### DIFF
--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -4,6 +4,7 @@ blockin
 cachable
 creat
 crypted
+desig
 fo
 fpr
 hights


### PR DESCRIPTION
## Summary
- Adds `desig` to the spelling ignore words list (`test/lint/spelling.ignore-words.txt`)
- The `src/kernel/context.h` typo fix from the Bitcoin commit is not applicable as this file does not exist in Dash Core (the kernel library has a different structure)

## Original Bitcoin PR
Backports bitcoin/bitcoin#25307

Original commit: e3c08eb620a2f317fc09fdf20969fa26f02afb91

## Changes Applied
- ✅ `test/lint/spelling.ignore-words.txt`: Added `desig` to ignore-words (1 line)
- ⏭️ `src/kernel/context.h`: Skipped - file does not exist in Dash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tooling and configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->