### PR TITLE
Merge bitcoin/bitcoin#25590: wallet: Precompute Txdata after setting PSBT inputs' UTXOs

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2051,7 +2051,6 @@ TransactionError CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& comp
     if (n_signed) {
         *n_signed = 0;
     }
-    const PrecomputedTransactionData txdata = PrecomputePSBTData(psbtx);
     LOCK(cs_wallet);
     // Get all of the previous transactions
     for (unsigned int i = 0; i < psbtx.tx->vin.size(); ++i) {
@@ -2074,6 +2073,8 @@ TransactionError CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& comp
             }
         }
     }
+
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(psbtx);
 
     // Fill in information from ScriptPubKeyMans
     for (ScriptPubKeyMan* spk_man : GetAllScriptPubKeyMans()) {


### PR DESCRIPTION
Backports bitcoin/bitcoin#25590

## Summary
If we are given a PSBT that is missing one or more input UTXOs, our PrecomputedTransactionData will be incorrect and missing information that it should otherwise have, and therefore we may not produce a signature when we should. To avoid this problem, we can do the precomputation after we have set the UTXOs the wallet is able to set for the PSBT.

## Changes
- Moves the `PrecomputedTransactionData` computation to **after** the loop that sets PSBT inputs' UTXOs

## Notes
- The Taproot test from the original Bitcoin PR was excluded because Dash does not support Taproot/SegWit (bech32m addresses)

Original commit: 1b285b7807076b9b9c2863c27776c5f1354c1f5b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal PSBT data processing sequence to improve performance and data handling efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->