### PR TITLE
Merge bitcoin/bitcoin#25689: fuzz: Remove no-op SetMempoolConstraints

### DIFF
--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -129,7 +129,6 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
     auto& chainstate{static_cast<DummyChainState&>(node.chainman->ActiveChainstate())};
 
     MockTime(fuzzed_data_provider, chainstate);
-    SetMempoolConstraints(*node.args, fuzzed_data_provider);
 
     // All RBF-spendable outpoints
     std::set<COutPoint> outpoints_rbf;
@@ -143,6 +142,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
     // The sum of the values of all spendable outpoints
     constexpr CAmount SUPPLY_TOTAL{COINBASE_MATURITY * 50 * COIN};
 
+    SetMempoolConstraints(*node.args, fuzzed_data_provider);
     CTxMemPool tx_pool_{/*estimator=*/nullptr, /*check_ratio=*/1};
     MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(&tx_pool_);
 
@@ -210,9 +210,6 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 
         if (fuzzed_data_provider.ConsumeBool()) {
             MockTime(fuzzed_data_provider, chainstate);
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            SetMempoolConstraints(*node.args, fuzzed_data_provider);
         }
         if (fuzzed_data_provider.ConsumeBool()) {
             tx_pool.RollingFeeUpdate();
@@ -307,7 +304,6 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
     auto& chainstate{static_cast<DummyChainState&>(node.chainman->ActiveChainstate())};
 
     MockTime(fuzzed_data_provider, chainstate);
-    SetMempoolConstraints(*node.args, fuzzed_data_provider);
 
     std::vector<uint256> txids;
     for (const auto& outpoint : g_outpoints_coinbase_init_mature) {
@@ -319,6 +315,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
         txids.push_back(ConsumeUInt256(fuzzed_data_provider));
     }
 
+    SetMempoolConstraints(*node.args, fuzzed_data_provider);
     CTxMemPool tx_pool_{/*estimator=*/nullptr, /*check_ratio=*/1};
     MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(&tx_pool_);
 
@@ -330,9 +327,6 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
 
         if (fuzzed_data_provider.ConsumeBool()) {
             MockTime(fuzzed_data_provider, chainstate);
-        }
-        if (fuzzed_data_provider.ConsumeBool()) {
-            SetMempoolConstraints(*node.args, fuzzed_data_provider);
         }
         if (fuzzed_data_provider.ConsumeBool()) {
             tx_pool.RollingFeeUpdate();


### PR DESCRIPTION
Backports bitcoin/bitcoin#25689

Original commit: 31c1b1475

## Summary

This PR removes no-op `SetMempoolConstraints` calls from the fuzz tests. Now that the mempool no longer uses the args manager (after a previous commit), there is no point setting the mempool limits after it is constructed.

The fix moves the `SetMempoolConstraints` call to just before the mempool is constructed in both fuzz targets, and removes the redundant calls from inside the `LIMITED_WHILE` loops.

## Changes
- Moved `SetMempoolConstraints` calls to be immediately before `CTxMemPool` construction
- Removed conditional `SetMempoolConstraints` calls from inside the main test loops (no-ops after mempool construction)

## Validation
- Build: ✅ Passed
- Change ratio: 100% (exactly matches Bitcoin: 2 insertions, 8 deletions)