### PR TITLE
Merge bitcoin/bitcoin#25772: test: Add missing static to IsStandardTx helper

### DIFF
--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -18,15 +18,13 @@
 #include <boost/test/unit_test.hpp>
 
 // Helpers:
-static std::vector<unsigned char>
-Serialize(const CScript& s)
+static std::vector<unsigned char> Serialize(const CScript& s)
 {
     std::vector<unsigned char> sSerialized(s.begin(), s.end());
     return sSerialized;
 }
 
-static bool
-Verify(const CScript& scriptSig, const CScript& scriptPubKey, bool fStrict, ScriptError& err)
+static bool Verify(const CScript& scriptSig, const CScript& scriptPubKey, bool fStrict, ScriptError& err)
 {
     // Create dummy to/from transactions:
     CMutableTransaction txFrom;


### PR DESCRIPTION
## Summary

Backports bitcoin/bitcoin#25772

This is a **partial backport** that applies only the formatting changes (removing line breaks from `Serialize()` and `Verify()` helper function declarations).

**Why partial?** The original Bitcoin commit also adds an `IsStandardTx()` helper function. However, Dash already has a global `IsStandardTx()` helper in `src/policy/settings.h` that the test file uses, so adding a local one would be redundant.

## Changes Applied
- Removed line break from `Serialize()` function declaration (lines 21-22 → single line)
- Removed line break from `Verify()` function declaration (lines 28-29 → single line)

## Changes Not Applied
- `IsStandardTx()` helper addition - Dash already has this as a global inline function in `src/policy/settings.h`

## Test Plan
- [x] Build succeeds (`make -j12`)
- [x] Unit test `script_p2sh_tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)