### PR TITLE
Merge bitcoin/bitcoin#25773: test: Target exact weight in MiniWallet _bulk_tx

### DIFF
--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -33,8 +33,8 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         self.test_anc_count_limits_2()
         self.test_anc_count_limits_bushy()
 
-        # The node will accept our (nonstandard) extra large OP_RETURN outputs
-        self.restart_node(0, extra_args=["-acceptnonstdtxn=1"])
+        # The node will accept (nonstandard) extra large OP_RETURN outputs
+        self.restart_node(0, extra_args=["-datacarriersize=100000"])
         self.test_anc_size_limits()
         self.test_desc_size_limits()
 

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -99,12 +99,12 @@ class MiniWallet:
         returns the tx
         """
         tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, b'a'])))
-        # In Dash, get_weight() returns vsize directly (no witness scaling)
-        # We need to account for compact size encoding overhead
-        current_weight = tx.get_weight()
-        # Estimate bytes needed, accounting for potential compact size encoding changes
-        # The +3 accounts for worst-case rounding in compact size encoding
-        dummy_vbytes = max(0, target_weight - current_weight + 3)
+        # In Dash, get_weight() returns vsize directly (no witness scaling factor like Bitcoin's 4)
+        # Bitcoin's formula: (target_weight - tx.get_weight() + 3) // 4
+        # - The +3 ensures rounding up when dividing by 4
+        # - After division, this adds 0-3 vbytes depending on remainder
+        # For Dash (no division by 4), we calculate bytes needed directly
+        dummy_vbytes = target_weight - tx.get_weight()
         tx.vout[-1].scriptPubKey = CScript([OP_RETURN, b'a' * dummy_vbytes])
         # Lower bound should always be off by at most 3
         assert_greater_than_or_equal(tx.get_weight(), target_weight)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -99,7 +99,12 @@ class MiniWallet:
         returns the tx
         """
         tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, b'a'])))
-        dummy_vbytes = (target_weight - tx.get_weight() + 3) // 4
+        # In Dash, get_weight() returns vsize directly (no witness scaling)
+        # We need to account for compact size encoding overhead
+        current_weight = tx.get_weight()
+        # Estimate bytes needed, accounting for potential compact size encoding changes
+        # The +3 accounts for worst-case rounding in compact size encoding
+        dummy_vbytes = max(0, target_weight - current_weight + 3)
         tx.vout[-1].scriptPubKey = CScript([OP_RETURN, b'a' * dummy_vbytes])
         # Lower bound should always be off by at most 3
         assert_greater_than_or_equal(tx.get_weight(), target_weight)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -29,9 +29,10 @@ from test_framework.messages import (
 )
 from test_framework.script import (
     CScript,
-    SignatureHash,
-    OP_TRUE,
     OP_NOP,
+    OP_RETURN,
+    OP_TRUE,
+    SignatureHash,
     SIGHASH_ALL,
 )
 from test_framework.script_util import (
@@ -97,11 +98,13 @@ class MiniWallet:
         """Pad a transaction with extra outputs until it reaches a target weight (or higher).
         returns the tx
         """
-        assert_greater_than_or_equal(target_weight, tx.get_weight())
-        while tx.get_weight() < target_weight:
-            script_pubkey = ( b"6a4d0200"  # OP_RETURN OP_PUSH2 512 bytes
-                + b"01" * 512 )
-            tx.vout.append(CTxOut(0, script_pubkey))
+        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, b'a'])))
+        dummy_vbytes = (target_weight - tx.get_weight() + 3) // 4
+        tx.vout[-1].scriptPubKey = CScript([OP_RETURN, b'a' * dummy_vbytes])
+        # Lower bound should always be off by at most 3
+        assert_greater_than_or_equal(tx.get_weight(), target_weight)
+        # Higher bound should always be off by at most 3 + 12 weight (for encoding the length)
+        assert_greater_than_or_equal(target_weight + 15, tx.get_weight())
 
     def get_balance(self):
         return sum(u['value'] for u in self._utxos)


### PR DESCRIPTION
## Summary
Backports bitcoin/bitcoin#25773

- Improves `_bulk_tx` method in MiniWallet to target exact weight instead of a weight that may be over 2000 WU larger
- Replaces `-acceptnonstdtxn=1` with `-datacarriersize=100000` to better document test assumptions

## Dependency
This PR depends on #1202 (bitcoin#25379) which adds the `_bulk_tx` method.

## Changes
- Added `OP_RETURN` import needed for exact weight targeting
- Updated `_bulk_tx` implementation to calculate exact bytes needed for target weight
- Changed test configuration from `-acceptnonstdtxn=1` to `-datacarriersize=100000`

## Scope
- Bitcoin: 17 lines changed
- Dash: 21 lines changed
- Ratio: 124% (within 80-200% acceptable range)

## Test Plan
- [x] Build succeeds
- [ ] Functional tests (`mempool_package_limits.py`) - environment issue prevented execution (file descriptor limits)

Original commit: fa2537cf0a7629d81df1bc5b4ae6a22dc572647b

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mempool package limit tests to use data carrier size parameter for handling larger OP_RETURN outputs
  * Refined transaction padding mechanism in test framework with dynamic weight calculations and improved validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->