### PR TITLE
Merge bitcoin/bitcoin#25664: refactor: Redefine `IsSolvable()` using descriptors

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -381,21 +381,6 @@ public:
 const BaseSignatureCreator& DUMMY_SIGNATURE_CREATOR = DummySignatureCreator(32, 32);
 const BaseSignatureCreator& DUMMY_MAXIMUM_SIGNATURE_CREATOR = DummySignatureCreator(33, 32);
 
-bool IsSolvable(const SigningProvider& provider, const CScript& script)
-{
-    // This check is to make sure that the script we created can actually be solved for and signed by us
-    // if we were to have the private keys. This is just to make sure that the script is valid and that,
-    // if found in a transaction, we would still accept and relay that transaction.
-    SignatureData sigs;
-    if (ProduceSignature(provider, DUMMY_SIGNATURE_CREATOR, script, sigs)) {
-        // VerifyScript check is just defensive, and should never fail.
-        bool verified = VerifyScript(sigs.scriptSig, script, STANDARD_SCRIPT_VERIFY_FLAGS, DUMMY_CHECKER);
-        assert(verified);
-        return true;
-    }
-    return false;
-}
-
 bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, int nHashType, std::map<int, bilingual_str>& input_errors)
 {
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -86,11 +86,6 @@ bool SignSignature(const SigningProvider &provider, const CTransaction& txFrom, 
 SignatureData DataFromTransaction(const CMutableTransaction& tx, unsigned int nIn, const CTxOut& txout);
 void UpdateInput(CTxIn& input, const SignatureData& data);
 
-/* Check whether we know how to sign for an output like this, assuming we
- * have all private keys. While this function does not need private keys, the passed
- * provider is used to look up public keys and redeemscripts by hash.
- * Solvability is unrelated to whether we consider this output to be ours. */
-bool IsSolvable(const SigningProvider& provider, const CScript& script);
 
 /** Sign the CMutableTransaction */
 bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* provider, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors);

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -234,7 +234,6 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
             // For each of the produced scripts, verify solvability, and when possible, try to sign a transaction spending it.
             for (size_t n = 0; n < spks.size(); ++n) {
                 BOOST_CHECK_EQUAL(ref[n], HexStr(spks[n]));
-                BOOST_CHECK_EQUAL(IsSolvable(FlatSigningProvider{key_provider}.Merge(FlatSigningProvider{script_provider}), spks[n]), (flags & UNSOLVABLE) == 0);
 
                 if (flags & SIGNABLE) {
                     CMutableTransaction spend;
@@ -251,7 +250,7 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
                 BOOST_CHECK(inferred->Expand(0, provider_inferred, spks_inferred, provider_inferred));
                 BOOST_CHECK_EQUAL(spks_inferred.size(), 1U);
                 BOOST_CHECK(spks_inferred[0] == spks[n]);
-                BOOST_CHECK_EQUAL(IsSolvable(provider_inferred, spks_inferred[0]), !(flags & UNSOLVABLE));
+                BOOST_CHECK_EQUAL(InferDescriptor(spks_inferred[0], provider_inferred)->IsSolvable(), !(flags & UNSOLVABLE));
                 BOOST_CHECK(provider_inferred.origins == script_provider.origins);
             }
 

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -83,7 +83,6 @@ FUZZ_TARGET(script, .init = initialize_script)
 
     const FlatSigningProvider signing_provider;
     (void)InferDescriptor(script, signing_provider);
-    (void)IsSolvable(signing_provider, script);
 
     (void)RecursiveDynamicUsage(script);
 

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -499,11 +499,15 @@ RPCHelpMan getaddressinfo()
     isminetype mine = pwallet->IsMine(dest);
     ret.pushKV("ismine", bool(mine & ISMINE_SPENDABLE));
 
-    bool solvable = provider && IsSolvable(*provider, scriptPubKey);
-    ret.pushKV("solvable", solvable);
-
-    if (solvable) {
-        ret.pushKV("desc", InferDescriptor(scriptPubKey, *provider)->ToString());
+    if (provider) {
+        auto inferred = InferDescriptor(scriptPubKey, *provider);
+        bool solvable = inferred->IsSolvable();
+        ret.pushKV("solvable", solvable);
+        if (solvable) {
+            ret.pushKV("desc", inferred->ToString());
+        }
+    } else {
+        ret.pushKV("solvable", false);
     }
 
     DescriptorScriptPubKeyMan* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(pwallet->GetScriptPubKeyMan(scriptPubKey));


### PR DESCRIPTION
## Summary

Backport of bitcoin/bitcoin#25664

This refactoring removes the `IsSolvable()` function from `src/script/sign.cpp` and replaces its usages with descriptor-based solvability checks using `InferDescriptor()->IsSolvable()`.

### Changes:
- Remove `IsSolvable()` function from `sign.cpp` and its declaration from `sign.h`
- Update `getaddressinfo` RPC to use `InferDescriptor()->IsSolvable()` instead
- Update descriptor tests to use descriptor-based solvability checks
- Remove `IsSolvable` fuzz target from `script.cpp`

### Dash-specific notes:
- Some Bitcoin files were not changed in Dash because they relate to SegWit/Witness code which Dash doesn't support:
  - `outputtype.cpp` - Dash only has LEGACY output type, no BECH32/SegWit code
  - `scriptpubkeyman.cpp` - Dash doesn't have `LearnRelatedScripts()` which is SegWit-related  
  - `fuzz/key.cpp` - Dash doesn't have `IsSegWitOutput()` function

Original Bitcoin commit: e078ee9d9d0a7505c38cf22ee4cc757bf31b62c0

🤖 Generated with [Claude Code](https://claude.com/claude-code)