### PR TITLE
Merge bitcoin/bitcoin#25963: CBlockLocator: performance-move-const-arg Clang tidy fixup

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -54,7 +54,7 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
             nStep *= 2;
     }
 
-    return CBlockLocator(vHave);
+    return CBlockLocator(std::move(vHave));
 }
 
 const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -242,7 +242,7 @@ struct CBlockLocator
 
     CBlockLocator() {}
 
-    explicit CBlockLocator(const std::vector<uint256>& vHaveIn) : vHave(vHaveIn) {}
+    explicit CBlockLocator(std::vector<uint256>&& have) : vHave(std::move(have)) {}
 
     SERIALIZE_METHODS(CBlockLocator, obj)
     {


### PR DESCRIPTION
## Summary
Backports bitcoin/bitcoin#25963 to Dash.

This PR applies the Clang-tidy `performance-move-const-arg` fix for `CBlockLocator`:
- Changes `CBlockLocator` constructor from `const std::vector<uint256>&` to `std::vector<uint256>&&` for move semantics
- Updates call site in `CChain::GetLocator()` to use `std::move()` appropriately

**Note**: Bitcoin's `src/chain.cpp` had a different implementation (free-standing `GetLocator` with `LocatorEntries` function), while Dash uses a member function pattern. The fix is adapted accordingly - Bitcoin removed unnecessary `std::move` from a return value (already an rvalue), while Dash adds `std::move` to the local variable to work with the new move-only constructor.

Original commit: b9361231105bdd1f64a0396562d756910e37370d

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal block locator construction for improved performance efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->