### PR TITLE
Merge bitcoin/bitcoin#25933: wallet: AvailableCoins, simplify output script type acquisition

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -215,26 +215,18 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             // Filter by spendable outputs only
             if (!spendable && only_spendable) continue;
 
-            // When parsing a scriptPubKey, Solver returns the parsed pubkeys or hashes (depending on the script)
-            // We don't need those here, so we are leaving them in return_values_unused
-            std::vector<std::vector<uint8_t>> return_values_unused;
-            TxoutType type;
+            // Obtain script type
+            std::vector<std::vector<uint8_t>> script_solutions;
+            TxoutType type = Solver(output.scriptPubKey, script_solutions);
 
-            // If the Output is P2SH and spendable, we want to know if it is
+            // If the output is P2SH and solvable, we want to know if it is
             // a P2SH (legacy). We can determine this from the redeemScript.
-            // If the Output is not spendable, it will be classified as a P2SH (legacy),
+            // If the output is not solvable, it will be classified as a P2SH (legacy),
             // since we have no way of knowing otherwise without the redeemScript
-            if (output.scriptPubKey.IsPayToScriptHash() && solvable) {
-                CScript redeemScript;
-                CTxDestination destination;
-                if (!ExtractDestination(output.scriptPubKey, destination))
-                    continue;
-                const CScriptID& hash = CScriptID(std::get<ScriptHash>(destination));
-                if (!provider->GetCScript(hash, redeemScript))
-                    continue;
-                type = Solver(redeemScript, return_values_unused);
-            } else {
-                type = Solver(output.scriptPubKey, return_values_unused);
+            if (type == TxoutType::SCRIPTHASH && solvable) {
+                CScript script;
+                if (!provider->GetCScript(CScriptID(uint160(script_solutions[0])), script)) continue;
+                type = Solver(script, script_solutions);
             }
 
             COutput coin(outpoint, output, nDepth, input_bytes, spendable, solvable, safeTx, wtx.GetTxTime(), tx_from_me, feerate);


### PR DESCRIPTION
Backports bitcoin/bitcoin#25933

Original commit: 25cd47de7

## Summary
- Simplifies output script type acquisition in AvailableCoins
- Removes unnecessary ExtractDestination() call
- Uses Solver() result directly to get the script hash for P2SH outputs
- Adapts Bitcoin's optimization while preserving Dash's simpler output categorization (legacy/other)

## Changes
- Bitcoin: 32 lines changed (12+, 20-)
- Dash: 26 lines changed (9+, 17-)
- Scope ratio: 81% (within acceptable range)

## Notes
- Dash uses a simpler CoinsResult structure with `legacy` and `other` vectors instead of Bitcoin's `Add(GetOutputType(...))` approach
- SegWit references in comments removed since Dash doesn't support SegWit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal wallet script processing logic with optimized script resolution for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->