### PR TITLE
Merge bitcoin/bitcoin#27683: ci: remove `RUN_SECURITY_TESTS`

### DIFF
--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -57,7 +57,3 @@ fi
 if [ "${RUN_TIDY}" = "true" ] && [ "${GITHUB_ACTIONS}" != "true" ]; then
   "${BASE_ROOT_DIR}/ci/dash/lint-tidy.sh"
 fi
-
-if [ "$RUN_SECURITY_TESTS" = "true" ]; then
-  make test-security-check
-fi

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -39,7 +39,6 @@ export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
 export RUN_UNIT_TESTS=${RUN_UNIT_TESTS:-true}
 export RUN_FUNCTIONAL_TESTS=${RUN_FUNCTIONAL_TESTS:-true}
 export RUN_TIDY=${RUN_TIDY:-false}
-export RUN_SECURITY_TESTS=${RUN_SECURITY_TESTS:-false}
 # By how much to scale the test_runner timeouts (option --timeout-factor).
 # This is needed because some ci machines have slow CPU or disk, so sanitizers
 # might be slow or a reindex might be waiting on disk IO.

--- a/ci/test/00_setup_env_mac_native_x86_64.sh
+++ b/ci/test/00_setup_env_mac_native_x86_64.sh
@@ -15,5 +15,3 @@ export CI_OS_NAME="macos"
 export NO_DEPENDS=1
 export OSX_SDK=""
 export CCACHE_MAXSIZE=300M
-
-export RUN_SECURITY_TESTS="true"

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -11,7 +11,6 @@ export HOST=x86_64-w64-mingw32
 export DPKG_ADD_ARCH="i386"
 export PACKAGES="python3 nsis g++-mingw-w64-x86-64-posix wine-binfmt wine64 wine32 file"
 export RUN_FUNCTIONAL_TESTS=false
-export RUN_SECURITY_TESTS="false"
 export GOAL="deploy"
 # Prior to 11.0.0, the mingw-w64 headers were missing noreturn attributes, causing warnings when
 # cross-compiling for Windows. https://sourceforge.net/p/mingw-w64/bugs/306/


### PR DESCRIPTION
Backports bitcoin/bitcoin#27683

Original commit: f998eb766227d55a7a6da876971fd2a28374eee8

**Changes:**
- Removes `RUN_SECURITY_TESTS` variable from CI configuration
- Removes security tests execution block from CI scripts

**Dash-specific notes:**
- Bitcoin's `ci/test/06_script_b.sh` doesn't exist in Dash; equivalent change made to `ci/dash/build_src.sh`
- Also removed `RUN_SECURITY_TESTS` from Dash-specific CI configs (`00_setup_env_mac_native_x86_64.sh`, `00_setup_env_win64.sh`)

**Scope:**
- Bitcoin: 5 line deletions
- Dash: 8 line deletions (160% ratio, within normal range)