### PR TITLE
Merge bitcoin/bitcoin#25595: Verify PSBT inputs rather than check for fields being empty

### DIFF
--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -58,7 +58,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
         }
 
         // Check if it is final
-        if (!utxo.IsNull() && !PSBTInputSigned(input)) {
+        if (!PSBTInputSignedAndVerified(psbtx, i, &txdata)) {
             input_analysis.is_final = false;
 
             // Figure out what is missing

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -181,6 +181,33 @@ void PSBTOutput::Merge(const PSBTOutput& output)
     if (redeem_script.empty() && !output.redeem_script.empty()) redeem_script = output.redeem_script;
 }
 
+bool PSBTInputSignedAndVerified(const PartiallySignedTransaction psbt, unsigned int input_index, const PrecomputedTransactionData* txdata)
+{
+    CTxOut utxo;
+    assert(psbt.inputs.size() >= input_index);
+    const PSBTInput& input = psbt.inputs[input_index];
+
+    if (input.non_witness_utxo) {
+        // If we're taking our information from a non-witness UTXO, verify that it matches the prevout.
+        COutPoint prevout = psbt.tx->vin[input_index].prevout;
+        if (prevout.n >= input.non_witness_utxo->vout.size()) {
+            return false;
+        }
+        if (input.non_witness_utxo->GetHash() != prevout.hash) {
+            return false;
+        }
+        utxo = input.non_witness_utxo->vout[prevout.n];
+    } else {
+        return false;
+    }
+
+    if (txdata) {
+        return VerifyScript(input.final_script_sig, utxo.scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker{&(*psbt.tx), input_index, utxo.nValue, *txdata, MissingDataBehavior::FAIL});
+    } else {
+        return VerifyScript(input.final_script_sig, utxo.scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker{&(*psbt.tx), input_index, utxo.nValue, MissingDataBehavior::FAIL});
+    }
+}
+
 size_t CountPSBTUnsignedInputs(const PartiallySignedTransaction& psbt) {
     size_t count = 0;
     for (const auto& input : psbt.inputs) {
@@ -238,7 +265,7 @@ bool SignPSBTInput(const SigningProvider& provider, PartiallySignedTransaction& 
     PSBTInput& input = psbt.inputs.at(index);
     const CMutableTransaction& tx = *psbt.tx;
 
-    if (PSBTInputSigned(input)) {
+    if (PSBTInputSignedAndVerified(psbt, index, txdata)) {
         return true;
     }
 

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -865,8 +865,11 @@ std::string PSBTRoleName(PSBTRole role);
 /** Compute a PrecomputedTransactionData object from a psbt. */
 PrecomputedTransactionData PrecomputePSBTData(const PartiallySignedTransaction& psbt);
 
-/** Checks whether a PSBTInput is already signed. */
+/** Checks whether a PSBTInput is already signed by checking for non-null finalized fields. */
 bool PSBTInputSigned(const PSBTInput& input);
+
+/** Checks whether a PSBTInput is already signed by doing script verification using final fields. */
+bool PSBTInputSignedAndVerified(const PartiallySignedTransaction psbt, unsigned int input_index, const PrecomputedTransactionData* txdata);
 
 /** Signs a PSBTInput, verifying that all provided data matches what is being signed.
  *

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -504,5 +504,6 @@ class PSBTTest(BitcoinTestFramework):
         self.log.info("Test we don't crash when making a 0-value funded transaction at 0 fee without forcing an input selection")
         assert_raises_rpc_error(-4, "Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input", self.nodes[0].walletcreatefundedpsbt, [], [{"data": "deadbeef"}], 0, {"fee_rate": "0"})
 
+
 if __name__ == '__main__':
     PSBTTest().main()


### PR DESCRIPTION
## Summary

Backport of bitcoin/bitcoin#25595

This PR adds proper PSBT input verification by calling `VerifyScript` on finalized inputs rather than just checking for non-empty fields. This ensures that signatures are actually valid before proceeding.

### Changes

- Added `PSBTInputSignedAndVerified()` function that performs script verification
- Updated `SignPSBTInput()` to use the new verification function
- Updated `AnalyzePSBT()` to use the new verification function

### Dash Adaptations

- Removed `witness_utxo` check (Dash does not support SegWit)
- Removed `final_script_witness` from checks (not present in Dash)
- Adapted `VerifyScript` calls for Dash's API (no witness parameter)
- Test changes omitted: requires `test_framework/psbt.py` from bitcoin#25625 which is not yet backported

Original commit: 2ac71d20b2ebbfea76ee7369fddffbd78bd2c010

## Test Plan

- [x] Build succeeds
- [ ] Existing PSBT tests pass (requires dash_hash module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PSBT finalization to include comprehensive signature verification against precomputed transaction data, ensuring stricter validation of signed inputs before finalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->