### PR TITLE
Merge bitcoin/bitcoin#26302: refactor: Use type-safe time point for CWallet::m_next_resend

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1970,10 +1970,10 @@ void CWallet::ResendWalletTransactions()
 
     // Do this infrequently and randomly to avoid giving away
     // that these are our transactions.
-    if (GetTime() < m_next_resend || !fBroadcastTransactions) return;
-    bool fFirst = (m_next_resend == 0);
+    if (NodeClock::now() < m_next_resend.load() || !fBroadcastTransactions) return;
+    bool fFirst = (m_next_resend.load() == NodeClock::time_point{});
     // resend 1-3 hours from now, ~2 hours on average.
-    m_next_resend = GetTime() + (1 * 60 * 60) + GetRand(2 * 60 * 60);
+    m_next_resend = FastRandomContext{}.rand_uniform_delay(NodeClock::now() + 1h, 2h);
     if (fFirst) return;
 
     int submitted_tx_count = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -23,6 +23,7 @@
 #include <util/string.h>
 #include <util/system.h>
 #include <util/strencodings.h>
+#include <util/time.h>
 #include <util/ui_change_type.h>
 #include <validationinterface.h>
 #include <wallet/crypter.h>
@@ -275,7 +276,7 @@ private:
     int nWalletVersion GUARDED_BY(cs_wallet){FEATURE_BASE};
 
     /** The next scheduled rebroadcast of wallet transactions. */
-    std::atomic<int64_t> m_next_resend{};
+    std::atomic<NodeClock::time_point> m_next_resend{};
     /** Whether this wallet will submit newly created transactions to the node's mempool and
      * prompt rebroadcasts (see ResendWalletTransactions()). */
     bool fBroadcastTransactions = false;


### PR DESCRIPTION
Backports bitcoin/bitcoin#26302

Original commit: 50cc8ef5a7

## Changes
- Uses `NodeClock::now()` instead of `GetTime()` for type safety
- Changes `m_next_resend` from `std::atomic<int64_t>` to `std::atomic<NodeClock::time_point>`
- Uses `FastRandomContext{}.rand_uniform_delay()` for type-safe random delay
- Adds `#include <util/time.h>` to wallet.h

## Dash-specific adaptations
- Preserved `std::atomic` wrapper around `m_next_resend` (Dash uses atomic for thread safety)
- Added `.load()` calls for atomic access in comparisons

## Original PR description
`GetTime` is not type-safe, thus deprecated.

ACKs for top commit:
  shaavan: Code Review ACK fa51cc965110e14661c848364a29c493287673be
  aureleoules: ACK fa51cc965110e14661c848364a29c493287673be