### PR TITLE
Merge bitcoin/bitcoin#26388: ci: Use `macos-ventura-xcode:14.1` image for "macOS native" task

### DIFF
--- a/ci/test/00_setup_env_mac_native_arm64.sh
+++ b/ci/test/00_setup_env_mac_native_arm64.sh
@@ -6,14 +6,11 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_macos
-export HOST=x86_64-apple-darwin
-export PIP_PACKAGES="zmq lief"
+export HOST=arm64-apple-darwin
+export PIP_PACKAGES="zmq"
 export GOAL="install"
-export BITCOIN_CONFIG="--with-gui --enable-reduce-exports --disable-miner"
+export BITCOIN_CONFIG="--with-gui --with-miniupnpc --with-natpmp --enable-reduce-exports"
 export CI_OS_NAME="macos"
 export NO_DEPENDS=1
 export OSX_SDK=""
-export CCACHE_MAXSIZE=300M
-
-export RUN_SECURITY_TESTS="true"
+export CCACHE_SIZE=300M

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -89,7 +89,7 @@ if [ -n "$PIP_PACKAGES" ]; then
   if [ "$CI_OS_NAME" == "macos" ]; then
     sudo -H pip3 install --upgrade pip
     # shellcheck disable=SC2086
-    IN_GETOPT_BIN="/usr/local/opt/gnu-getopt/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
+    IN_GETOPT_BIN="$(brew --prefix gnu-getopt)/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
   else
     # shellcheck disable=SC2086
     ${CI_RETRY_EXE} CI_EXEC pip3 install --user $PIP_PACKAGES


### PR DESCRIPTION
Backports bitcoin/bitcoin#26388

## Summary
- Renames `ci/test/00_setup_env_mac_native_x86_64.sh` to `ci/test/00_setup_env_mac_native_arm64.sh` and updates for arm64 architecture
- Makes getopt path architecture-agnostic using `brew --prefix` instead of hardcoded x86_64 path

## Notes
- `.cirrus.yml` changes from Bitcoin not applicable (Dash uses different CI infrastructure)
- Security tests removed as they don't pass on arm64 in CI

Original commit: bd478890c513aafe2c65d4199c9f3c558670eaa3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UPnP and NAT-PMP network protocols for automatic port mapping and improved peer discovery capabilities.

* **Chores**
  * Enhanced native ARM64 macOS environment support with optimized configuration settings.
  * Streamlined system dependencies by removing unused packages for reduced overhead.
  * Optimized build cache configuration for improved compilation performance.
  * Improved macOS installation script compatibility across different system configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->