### PR TITLE
Merge bitcoin/bitcoin#26424: doc: correct deriveaddresses RPC name

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -241,6 +241,6 @@ ones. For larger numbers of errors, or other types of errors, there is a
 roughly 1 in a trillion chance of not detecting the errors.
 
 All RPCs in Dash Core will include the checksum in their output. Only
-certain RPCs require checksums on input, including `deriveaddress` and
+certain RPCs require checksums on input, including `deriveaddresses` and
 `importmulti`. The checksum for a descriptor without one can be computed
 using the `getdescriptorinfo` RPC.


### PR DESCRIPTION
Backports bitcoin/bitcoin#26424

Original commit: c75c0d8e1147079ab1aef088e0a2486d295ab625

## Summary
- Fixes typo in `doc/descriptors.md` - changes `deriveaddress` to `deriveaddresses` (the correct RPC name)
- Documentation-only change, no functional impact

## Changes
- 1 file changed, 1 insertion, 1 deletion (100% match with Bitcoin commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an RPC API name reference in the documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->