### PR TITLE
Merge bitcoin/bitcoin#26294: build: move util/url to common/url

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -180,6 +180,7 @@ BITCOIN_CORE_H = \
   coins.h \
   common/bloom.h \
   common/run_command.h \
+  common/url.h \
   compat/assumptions.h \
   compat/byteswap.h \
   compat/compat.h \
@@ -418,7 +419,6 @@ BITCOIN_CORE_H = \
   util/translation.h \
   util/types.h \
   util/ui_change_type.h \
-  util/url.h \
   util/vector.h \
   util/wpipe.h \
   validation.h \
@@ -937,6 +937,11 @@ libbitcoin_common_a_SOURCES = \
   script/standard.cpp \
   warnings.cpp \
   $(BITCOIN_CORE_H)
+
+if USE_LIBEVENT
+libbitcoin_common_a_CPPFLAGS += $(EVENT_CFLAGS)
+libbitcoin_common_a_SOURCES += common/url.cpp
+endif
 #
 
 # util #
@@ -993,10 +998,6 @@ libbitcoin_util_a_SOURCES = \
   util/tokenpipe.cpp \
   util/wpipe.cpp \
   $(BITCOIN_CORE_H)
-
-if USE_LIBEVENT
-libbitcoin_util_a_SOURCES += util/url.cpp
-endif
 #
 
 # cli #
@@ -1061,6 +1062,7 @@ endif
 dash_cli_LDADD = \
   $(LIBBITCOIN_CLI) \
   $(LIBUNIVALUE) \
+  $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CRYPTO)
 dash_cli_LDADD += $(BACKTRACE_LIBS) $(EVENT_LIBS) $(GMP_LIBS)

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -10,6 +10,7 @@
 
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>
 #include <policy/feerate.h>
@@ -23,7 +24,6 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 
 #include <algorithm>
 #include <chrono>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,16 +8,16 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <util/strencodings.h>
-#include <clientversion.h>
 #include <key.h>
 #include <pubkey.h>
 #include <tinyformat.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <wallet/wallettool.h>
 
 #include <exception>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -10,6 +10,7 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <init.h>
 #include <interfaces/chain.h>
@@ -26,7 +27,6 @@
 #include <util/tokenpipe.h>
 #include <util/translation.h>
 #include <stacktraces.h>
-#include <util/url.h>
 
 #include <cstdio>
 #include <functional>

--- a/src/common/url.cpp
+++ b/src/common/url.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/url.h>
+#include <common/url.h>
 
 #include <event2/http.h>
 

--- a/src/common/url.h
+++ b/src/common/url.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_URL_H
-#define BITCOIN_UTIL_URL_H
+#ifndef BITCOIN_COMMON_URL_H
+#define BITCOIN_COMMON_URL_H
 
 #include <string>
 
@@ -11,4 +11,4 @@ using UrlDecodeFn = std::string(const std::string& url_encoded);
 UrlDecodeFn urlDecode;
 extern UrlDecodeFn* const URL_DECODE;
 
-#endif // BITCOIN_UTIL_URL_H
+#endif // BITCOIN_COMMON_URL_H

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -4,9 +4,9 @@
 
 #include <qt/bitcoin.h>
 
+#include <common/url.h>
 #include <compat/compat.h>
 #include <util/translation.h>
-#include <util/url.h>
 
 #include <QCoreApplication>
 

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -4,6 +4,7 @@
 
 #include <blockfilter.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -25,7 +26,6 @@
 #include <util/string.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <version.h>
 
 #include <cstdint>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -7,6 +7,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <chainparams.h>
+#include <common/url.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/params.h>
@@ -42,7 +43,6 @@
 #include <util/threadnames.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <util/vector.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/rpc/util.h>
 
+#include <common/url.h>
 #include <rpc/util.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -15,7 +15,7 @@
 #include <util/bip32.h>
 #include <util/fees.h>
 #include <util/translation.h>
-#include <util/url.h>
+#include <common/url.h>
 #include <util/vector.h>
 #include <wallet/context.h>
 #include <wallet/receive.h>


### PR DESCRIPTION
## Summary

Backports bitcoin/bitcoin#26294

This commit moves `util/url.h` and `util/url.cpp` to `common/url.h` and `common/url.cpp` as part of Bitcoin's library reorganization.

### Changes:
- Renamed `src/util/url.{h,cpp}` to `src/common/url.{h,cpp}`
- Updated include paths in all affected source files
- Updated `src/Makefile.am` to reflect new file locations
- Added `$(EVENT_CFLAGS)` to `libbitcoin_common_a_CPPFLAGS`
- Added `$(LIBBITCOIN_COMMON)` to `dash_cli_LDADD`

### Dash-specific adaptations:
- Skipped `build_msvc/` files (not present in Dash)
- Skipped `ci/test/06_script_b.sh` (not present in Dash)  
- Updated `src/wallet/rpc/wallet.cpp` (Dash-specific file that references url.h)
- Preserved `<stacktraces.h>` include in `src/bitcoind.cpp` (Dash-specific)

### Verification:
- ✅ Build passed
- ✅ Unit tests passed
- ✅ Scope: 92% of Bitcoin changes (within 80-200% range)

Original commit: 27e76afe24c390cc091e246bdbc691bdf5bb090c