### PR TITLE
Merge bitcoin/bitcoin#26508: RPC/Blockchain: Minor improvements for scanblocks & scantxoutset docs/errors

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2584,7 +2584,7 @@ static RPCHelpMan scantxoutset()
         result.pushKV("unspents", unspents);
         result.pushKV("total_amount", ValueFromAmount(total_in));
     } else {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
     }
     return result;
 },

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -128,8 +128,8 @@ class ScantxoutsetTest(BitcoinTestFramework):
         # Check that second arg is needed for start
         assert_raises_rpc_error(-1, "scanobjects argument is required for the start action", self.nodes[0].scantxoutset, "start")
 
-        # Check that invalid command give error
-        assert_raises_rpc_error(-8, "Invalid command", self.nodes[0].scantxoutset, "invalid_command")
+        # Check that invalid action gives error
+        assert_raises_rpc_error(-8, "Invalid action 'invalid_command'", self.nodes[0].scantxoutset, "invalid_command")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Partial backport of bitcoin/bitcoin#26508

## Changes

Only the `scantxoutset` changes are applicable as Dash does not have the `scanblocks` RPC function.

This PR improves the error message for invalid action in `scantxoutset`:
- Old: `"Invalid command"`
- New: `"Invalid action 'X'"` (includes the invalid action name for better debugging)

## Bitcoin PR Summary

Original Bitcoin PR added:
1. ~~`scanblocks`: Improved error message~~ (not in Dash)
2. ~~`scanblocks`: Documentation improvements~~ (not in Dash)
3. `scantxoutset`: Improved error message ✓

## Testing

- Build: ✓ Passed
- Unit tests (rpc_tests): ✓ Passed
- Updated `test/functional/rpc_scantxoutset.py` to match new error format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for invalid scantxoutset command actions to display the specific invalid action value provided, improving debugging clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->